### PR TITLE
Linter: Add environment vars to avoid warning on mocha

### DIFF
--- a/eslintrc
+++ b/eslintrc
@@ -2,6 +2,12 @@
     "extends": "airbnb",
 
     // Overrides
+    "env": {
+        "browser": false,
+        "node": true,
+        "mocha": true
+    },
+
     "rules": {
         "strict": [2, "global"],
         "indent": [2, 4],


### PR DESCRIPTION
Eslint complains when linting test source files: `describe` and `it` are
not defined. Set some environment for the linter to know that we are
doing Node.JS and using mocha.
