### PR TITLE
Linter: Check end-of-lines at the end of files

### DIFF
--- a/eslintrc
+++ b/eslintrc
@@ -20,6 +20,7 @@
         "camelcase": [2, {"properties": "always"}],
         "id-length": 0,
         "no-shadow": 0,
-        "valid-jsdoc": 1
+        "valid-jsdoc": 1,
+        "eol-last": 2
     }
 }


### PR DESCRIPTION
Trailing newlines in non-empty files are a common UNIX idiom, with
several benefits. Git complains when you omit them. As well as the
GitHub web interface does. Let's lint this.

http://eslint.org/docs/rules/eol-last.html
