### PR TITLE
CLEANUP(kinetic) rm kinetic submodule(.gitmodule)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tests/dependencies/kinetic-java"]
-	path = tests/dependencies/kinetic-java
-	url = https://github.com/Kinetic/kinetic-java.git


### PR DESCRIPTION
- Remove the kinetic-java dependencie
  - this dependencie is not needed since the kinetic lib is not in this
    repository anymore
