### PR TITLE
Add metadata errors

### DIFF
--- a/errors/arsenalErrors.json
+++ b/errors/arsenalErrors.json
@@ -480,7 +480,7 @@
   },
   "ok": {
     "description": "No error",
-    "code": 5015
+    "code": 200
   },
   "badUser": {
     "description": "user not ok",


### PR DESCRIPTION
#### Add metadata errors to arsenalErrors.json

---
#### Update the "ok" error code to 200
- This update is for having the same error code in Vault and  metadata
