### PR TITLE
FT: Add BadSessionIndex for SAML integration

### DIFF
--- a/errors/arsenalErrors.json
+++ b/errors/arsenalErrors.json
@@ -610,6 +610,10 @@
     "description": "metadata document not ok",
     "code": 5044
   },
+  "BadSessionIndex": {
+    "description": "session index not ok",
+    "code": 5045  
+  },
   "Unauthorized": {
     "description": "not authenticated",
     "code": 401


### PR DESCRIPTION
Calling for opinions.

This commit was introduced in Arsenal#master as part of the SAML effort in Vault (which was taking place in Vault#master at the time, hence the reason why).

However, Vault#rel/1.1 now breaks because Arsenal#rel/1.0 doesn't have this commit. I see two solutions:
a. Point Vault#rel/1.1 to Arsenal#master
b. Include this commit in Arsenal#rel/1.0

Option b will produce a small conflict each time we port, but I find it preferable to a. What's your opinion on this?
