### PR TITLE
Move extensions to Arsenal

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,4 +7,6 @@ module.exports = {
         ciphers: require('./lib/https/ciphers.js'),
         dhparam: require('./lib/https/dh2048.js'),
     },
+    delimiter: require('./lib/extension/delimiter.extension'),
+    listMPU: require('./lib/extension/listMPU.extension'),
 };

--- a/lib/extension/delimiter.extension.js
+++ b/lib/extension/delimiter.extension.js
@@ -1,0 +1,135 @@
+'use strict'; // eslint-disable-line strict
+
+/**
+ *  Class for the delimiter extension
+ */
+class Delimiter {
+    /**
+     *  Constructor of the extension
+     *  Init and check parameters
+     *  @param {Object} parameters - parameters sent to DBD
+     *  @param {RequestLogger} logger - werelogs request logger
+     *  @return {undefined}
+     */
+    constructor(parameters, logger) {
+        this.CommonPrefixes = [];
+        this.Contents = [];
+        this.IsTruncated = false;
+        this.NextMarker = undefined;
+
+        this.delimiter = parameters.delimiter;
+        this.delimLen = this.delimiter ? this.delimiter.length : 0;
+        this.searchStart = this._getStartIndex(parameters);
+        this.maxKeys = Number.parseInt(parameters.maxKeys, 10);
+        this.maxKeys = Number.isNaN(this.maxKeys) ? 1000 : this.maxKeys;
+
+        this.logger = logger;
+        this.keys = 0;
+    }
+
+    _getStartIndex(params) {
+        if (params.gt) {
+            return params.gt.length;
+        } else if (params.start) {
+            return params.start.length;
+        }
+        return 0;
+    }
+
+    /**
+     *  This function add the element to the Contents
+     *  Set the NextMarker to the current key
+     *  Increment the keys counter
+     *  @param {String} key - The key to add
+     *  @param {String} value - The value of the key
+     *  @return {undefined}
+     */
+    addContents(key, value) {
+        const tmp = JSON.parse(value);
+        this.Contents.push({
+            key,
+            value: {
+                Size: tmp['content-length'],
+                ETag: tmp['content-md5'],
+                LastModified: tmp['last-modified'],
+                Owner: {
+                    DisplayName: tmp['owner-display-name'],
+                    ID: tmp['owner-id'],
+                },
+                StorageClass: tmp['x-amz-storage-class'],
+                Initiated: tmp.initiated,
+                Initiator: tmp.initiator,
+                EventualStorageBucket: tmp.eventualStorageBucket,
+                partLocations: tmp.partLocations,
+                creationDate: tmp.creationDate,
+            },
+        });
+        this.NextMarker = key;
+        ++this.keys;
+    }
+
+    /**
+     *  This function add a common prefix to the CommonPrefixes
+     *  Set the NextMarker to the current commonPrefix
+     *  Increment the keys counter
+     *  @param {String} commonPrefix - The commonPrefix to process
+     *  @return {undefined}
+     */
+    addCommonPrefix(commonPrefix) {
+        if (this.CommonPrefixes.indexOf(commonPrefix) === -1) {
+            this.CommonPrefixes.push(commonPrefix);
+            this.NextMarker = commonPrefix;
+            ++this.keys;
+        }
+    }
+
+    /**
+     *  This function apply the filter to each element
+     *  It's looking for the next delimiter
+     *  if nextDelim === -1 can mean two things
+     *       -> this.delimiter is not present in the key after the prefix
+     *  else
+     *       -> the key is `${this.prefix}${this.delimiter}${objName}`
+     *  @param {String} obj - The key and value of the element
+     *  @return {Boolean} - True: Continue, False: Stop
+     */
+    filter(obj) {
+        const key = obj.key;
+        const value = obj.value;
+        if (this.delimiter) {
+            const commonPrefixIndex =
+                key.indexOf(this.delimiter, this.searchStart);
+            if (commonPrefixIndex === -1) {
+                this.addContents(key, value);
+            } else {
+                this.addCommonPrefix(key.substring(0,
+                                        commonPrefixIndex + this.delimLen));
+            }
+        } else {
+            this.addContents(key, value);
+        }
+        if (this.keys === this.maxKeys) {
+            this.IsTruncated = true;
+            return false;
+        }
+        this.NextMarker = undefined;
+        return true;
+    }
+    /**
+     *  This function format the result to return
+     *  @return {Object} - The result.
+     */
+    result() {
+        return {
+            CommonPrefixes: this.CommonPrefixes,
+            Contents: this.Contents,
+            IsTruncated: this.IsTruncated,
+            NextMarker: this.NextMarker,
+            Delimiter: this.delimiter,
+        };
+    }
+}
+
+module.exports = {
+    Delimiter,
+};

--- a/lib/extension/list.extension.js
+++ b/lib/extension/list.extension.js
@@ -1,0 +1,40 @@
+'use strict'; // eslint-disable-line strict
+/**
+ *  Class of an extension doing the simple listing
+ */
+class List {
+    /**
+     *  Constructor
+     *  Set the logger and the res
+     *  @param {Object} parameters - The parameters you sent to DBD
+     *  @param {RequestLogger} logger - The logger of the request
+     *  @return {undefined}
+     */
+    constructor(parameters, logger) {
+        this.logger = logger;
+        this.res = [];
+    }
+
+    /**
+     *  Function apply on each element
+     *  Just add it to the array
+     *  @param {Object} elem - The data from the database
+     *  @return {Boolean} - True = continue the stream
+     */
+    filter(elem) {
+        this.res.push(elem);
+        return true;
+    }
+
+    /**
+     *  Function returning the result
+     *  @return {Array} - The listed elements
+     */
+    result() {
+        return this.res;
+    }
+}
+
+module.exports = {
+    List,
+};

--- a/lib/extension/listMPU.extension.js
+++ b/lib/extension/listMPU.extension.js
@@ -1,0 +1,127 @@
+'use strict'; // eslint-disable-line strict
+
+function numberDefault(num, defaultNum) {
+    const parsedNum = Number.parseInt(num, 10);
+    return Number.isNaN(parsedNum) ? defaultNum : parsedNum;
+}
+/**
+ *  Class for the ListMultipartUploads extension
+ */
+class ListMultipartUploads {
+    /**
+     *  Constructor of the extension
+     *  Init and check parameters
+     *  @param {Object} params - The parameters you sent to DBD
+     *  @param {RequestLogger} logger - The logger of the request
+     *  @return {undefined}
+     */
+    constructor(params, logger) {
+        this.CommonPrefixes = [];
+        this.Uploads = [];
+        this.IsTruncated = false;
+        this.NextKeyMarker = '';
+        this.NextUploadIdMarker = '';
+        this.prefixLength = 0;
+        this.queryPrefixLength = numberDefault(params.queryPrefixLength, 0);
+        this.keys = 0;
+        this.maxKeys = numberDefault(params.maxKeys, 1000);
+        this.delimiter = params.delimiter;
+        this.splitter = params.splitter;
+        this.logger = logger;
+    }
+
+    /**
+     *  This function adds the elements to the Uploads
+     *  Set the NextKeyMarker to the current key
+     *  Increment the keys counter
+     *  @param {String} value - The value of the key
+     *  @return {undefined}
+     */
+    addUpload(value) {
+        const tmp = JSON.parse(value);
+        this.Uploads.push({
+            key: tmp.key,
+            value: {
+                UploadId: tmp.uploadId,
+                Initiator: {
+                    ID: tmp.initiator.ID,
+                    DisplayName: tmp.initiator.DisplayName,
+                },
+                Owner: {
+                    ID: tmp['owner-id'],
+                    DisplayName: tmp['owner-display-name'],
+                },
+                StorageClass: tmp.storageClass,
+                Initiated: tmp.initiated,
+            },
+        });
+        this.NextKeyMarker = tmp.key;
+        this.NextUploadIdMarker = tmp.uploadId;
+        ++this.keys;
+    }
+    /**
+     *  This function adds a common prefix to the CommonPrefixes array
+     *  Set the NextKeyMarker to the current commonPrefix
+     *  Increment the keys counter
+     *  @param {String} commonPrefix - The commonPrefix to add
+     *  @return {undefined}
+     */
+    addCommonPrefix(commonPrefix) {
+        if (this.CommonPrefixes.indexOf(commonPrefix) === -1) {
+            this.CommonPrefixes.push(commonPrefix);
+            this.NextKeyMarker = commonPrefix;
+            ++this.keys;
+        }
+    }
+
+    /**
+     *  This function applies filter on each element
+     *  @param {String} obj - The key and value of the element
+     *  @return {Boolean} - True: Continue, False: Stop
+     */
+    filter(obj) {
+        const key = obj.key;
+        const value = obj.value;
+        if (this.delimiter) {
+            const mpuPrefixSlice = `overview${this.splitter}`.length;
+            const mpuKey = key.slice(mpuPrefixSlice);
+            const commonPrefixIndex = mpuKey.indexOf(this.delimiter,
+                this.queryPrefixLength);
+
+            if (commonPrefixIndex === -1) {
+                this.addUpload(value);
+            } else {
+                this.addCommonPrefix(mpuKey.substring(0,
+                    commonPrefixIndex + this.delimiter.length));
+            }
+        } else {
+            this.addUpload(value);
+        }
+        if (this.keys === this.maxKeys) {
+            this.IsTruncated = true;
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     *  Returns the formatted result
+     *  @return {Object} - The result.
+     */
+    result() {
+        const delimiter = this.CommonPrefixes.length > 0 ? this.delimiter : '';
+        return {
+            CommonPrefixes: this.CommonPrefixes,
+            Uploads: this.Uploads,
+            IsTruncated: this.IsTruncated,
+            NextKeyMarker: this.NextKeyMarker,
+            MaxKeys: this.maxKeys,
+            NextUploadIdMarker: this.NextUploadIdMarker,
+            Delimiter: delimiter,
+        };
+    }
+}
+
+module.exports = {
+    ListMultipartUploads,
+};

--- a/lib/extension/sumSample.extension.js
+++ b/lib/extension/sumSample.extension.js
@@ -1,0 +1,45 @@
+'use strict'; // eslint-disable-line strict
+
+/**
+ * Class of an extension doing the sum of listed elements
+ */
+class Sum {
+    /**
+     *  Constructor of the Extension
+     *  Init somes parameters
+     *  @param {Object} parameters - The parameters you sent to DBD
+     *  @param {RequestLogger} logger - The logger of the request
+     *  @return {undefined}
+     */
+    constructor(parameters, logger) {
+        this.max = parameters.max;
+        this.res = 0;
+        this.logger = logger;
+    }
+
+    /**
+     *  Function apply on each element
+     *  Continue until it return false
+     *  @param {Object} data - The data from the database
+     *  @return {Boolean} - False = stop the stream, True = continue the stream
+     */
+    filter(data) {
+        this.res += data.value;
+        if (this.res >= this.max) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     *  Function used to get what to return
+     *  @return {Object} - The resultat of the sum
+     */
+    result() {
+        return this.res;
+    }
+}
+
+module.exports = {
+    Sum,
+};

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "eslint-config-scality": "scality/Guidelines#rel/1.0",
     "level": "^1.3.0",
     "mocha": "^2.3.3",
-    "temp": "^0.8.3"
+    "temp": "^0.8.3",
+    "werelogs": "scality/werelogs#rel/1.0"
   },
   "scripts": {
     "lint": "eslint $(git ls-files '*.js')",

--- a/tests/unit/listMpuExtension.js
+++ b/tests/unit/listMpuExtension.js
@@ -1,0 +1,166 @@
+'use strict'; // eslint-disable-line strict
+
+const assert = require('assert');
+const ListMultipartUploads =
+    require('../../lib/extension/listMPU.extension').
+    ListMultipartUploads;
+const werelogs = require('werelogs');
+const logger = new werelogs('listMpuTest');
+describe('List Multipart Uploads extension', () => {
+    const splitter = '**';
+    const overviewPrefix = `overview${splitter}`;
+    const storageClass = 'STANDARD';
+    const initiator1 = { ID: '1', DisplayName: 'initiator1' };
+    const initiator2 = { ID: '2', DisplayName: 'initiator2' };
+    const keys = [
+        {
+            key: `${overviewPrefix}test/1${splitter}uploadId1`,
+            value: JSON.stringify({
+                'key': 'test/1',
+                'uploadId': 'uploadId1',
+                'initiator': initiator1,
+                'owner-id': '1',
+                'owner-display-name': 'owner1',
+                storageClass,
+                'initiated': '',
+            }),
+        }, {
+            key: `${overviewPrefix}test/2${splitter}uploadId2`,
+            value: JSON.stringify({
+                'key': 'test/2',
+                'uploadId': 'uploadId2',
+                'initiator': initiator2,
+                'owner-id': '1',
+                'owner-display-name': 'owner2',
+                storageClass,
+                'initiated': '',
+            }),
+        }, {
+            key: `${overviewPrefix}test/3${splitter}uploadId3`,
+            value: JSON.stringify({
+                'key': 'test/3',
+                'uploadId': 'uploadId3',
+                'initiator': initiator1,
+                'owner-id': '1',
+                'owner-display-name': 'owner1',
+                storageClass,
+                'initiated': '',
+            }),
+        }, {
+            key: `${overviewPrefix}testMore/4${splitter}uploadId4`,
+            value: JSON.stringify({
+                'key': 'testMore/4',
+                'uploadId': 'uploadId4',
+                'initiator': initiator2,
+                'owner-id': '1',
+                'owner-display-name': 'owner2',
+                storageClass,
+                'initiated': '',
+            }),
+        }, {
+            key: `${overviewPrefix}testMore/5${splitter}uploadId5`,
+            value: JSON.stringify({
+                'key': 'testMore/5',
+                'uploadId': 'uploadId5',
+                'initiator': initiator1,
+                'owner-id': '1',
+                'owner-display-name': 'owner1',
+                storageClass,
+                'initiated': '',
+            }),
+        }, {
+            key: `${overviewPrefix}prefixTest/5${splitter}uploadId5`,
+            value: JSON.stringify({
+                'key': 'prefixTest/5',
+                'uploadId': 'uploadId5',
+                'initiator': initiator1,
+                'owner-id': '1',
+                'owner-display-name': 'owner1',
+                storageClass,
+                'initiated': '',
+            }),
+        },
+    ];
+    let listingParams;
+    let expectedResult;
+    function performListing(keys, params, logger) {
+        const mpuListing = new ListMultipartUploads(params, logger);
+        keys.every(a => mpuListing.filter(a));
+        return mpuListing.result();
+    }
+
+    beforeEach(done => {
+        listingParams = {
+            delimiter: '',
+            splitter,
+            maxKeys: undefined,
+            queryPrefixLength: 0,
+        };
+
+        expectedResult = {
+            CommonPrefixes: [],
+            Delimiter: '',
+            Uploads: [],
+            IsTruncated: false,
+            NextKeyMarker: 'prefixTest/5',
+            MaxKeys: 1000,
+            NextUploadIdMarker: 'uploadId5',
+        };
+
+        expectedResult.Uploads = keys.map(obj => {
+            const tmp = JSON.parse(obj.value);
+            return {
+                key: tmp.key,
+                value: {
+                    UploadId: tmp.uploadId,
+                    Initiator: tmp.initiator,
+                    Owner: {
+                        ID: tmp['owner-id'],
+                        DisplayName: tmp['owner-display-name'],
+                    },
+                    StorageClass: tmp.storageClass,
+                    Initiated: tmp.initiated,
+                },
+            };
+        });
+        done();
+    });
+
+    it('should perform a listing of all keys', done => {
+        const listingResult = performListing(keys, listingParams, logger);
+        assert.deepStrictEqual(listingResult, expectedResult);
+        done();
+    });
+
+    it('should perform a listing with delimiter', done => {
+        const delimiter = '/';
+        listingParams.delimiter = delimiter;
+        // format result
+        expectedResult.Uploads = [];
+        expectedResult.CommonPrefixes = ['test/', 'testMore/', 'prefixTest/'];
+        expectedResult.Delimiter = delimiter;
+        expectedResult.MaxKeys = 1000;
+        expectedResult.NextKeyMarker = 'prefixTest/';
+        expectedResult.NextUploadIdMarker = '';
+
+        const listingResult = performListing(keys, listingParams, logger);
+        assert.deepStrictEqual(listingResult, expectedResult);
+        done();
+    });
+
+    it('should perform a listing with max keys', done => {
+        listingParams.maxKeys = 3;
+        // format result
+        expectedResult.Uploads.pop();
+        expectedResult.Uploads.pop();
+        expectedResult.Uploads.pop();
+        expectedResult.NextKeyMarker = 'test/3';
+        expectedResult.NextUploadIdMarker = 'uploadId3';
+        expectedResult.IsTruncated = true;
+        expectedResult.MaxKeys = 3;
+
+        const listingResult = performListing(keys, listingParams, logger);
+        assert.deepStrictEqual(listingResult, expectedResult);
+        done();
+    });
+});


### PR DESCRIPTION
S3 metadata file backend uses the same extensions than metadata to process delimiter and MPU queries.

At some point in time, Metadata would need to load extensions from here with an associative array (no need to dynamically load those files).