### PR TITLE
Fix/listing limit

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,5 +10,6 @@ module.exports = {
         dhparam: require('./lib/https/dh2048.js'),
     },
     delimiter: require('./lib/extension/delimiter.extension'),
+    list: require('./lib/extension/list.extension'),
     listMPU: require('./lib/extension/listMPU.extension'),
 };

--- a/lib/extension/delimiter.extension.js
+++ b/lib/extension/delimiter.extension.js
@@ -1,5 +1,7 @@
 'use strict'; // eslint-disable-line strict
 
+const checkLimit = require('./tools').checkLimit;
+const DEFAULT_MAX_KEYS = 1000;
 /**
  *  Class for the delimiter extension
  */
@@ -20,8 +22,7 @@ class Delimiter {
         this.delimiter = parameters.delimiter;
         this.delimLen = this.delimiter ? this.delimiter.length : 0;
         this.searchStart = this._getStartIndex(parameters);
-        this.maxKeys = Number.parseInt(parameters.maxKeys, 10);
-        this.maxKeys = Number.isNaN(this.maxKeys) ? 1000 : this.maxKeys;
+        this.maxKeys = checkLimit(parameters.maxKeys, DEFAULT_MAX_KEYS);
 
         this.logger = logger;
         this.keys = 0;
@@ -94,6 +95,12 @@ class Delimiter {
      *  @return {Boolean} - True: Continue, False: Stop
      */
     filter(obj) {
+        // Check first in case of maxkeys <= 0
+        if (this.keys >= this.maxKeys) {
+            // In cases of maxKeys <= 0 => IsTruncated = false
+            this.IsTruncated = this.maxKeys > 0;
+            return false;
+        }
         const key = obj.key;
         const value = obj.value;
         if (this.delimiter) {
@@ -108,11 +115,6 @@ class Delimiter {
         } else {
             this.addContents(key, value);
         }
-        if (this.keys === this.maxKeys) {
-            this.IsTruncated = true;
-            return false;
-        }
-        this.NextMarker = undefined;
         return true;
     }
     /**
@@ -120,11 +122,12 @@ class Delimiter {
      *  @return {Object} - The result.
      */
     result() {
+        // Unset NextMarker when not truncated
         return {
             CommonPrefixes: this.CommonPrefixes,
             Contents: this.Contents,
             IsTruncated: this.IsTruncated,
-            NextMarker: this.NextMarker,
+            NextMarker: this.IsTruncated ? this.NextMarker : undefined,
             Delimiter: this.delimiter,
         };
     }

--- a/lib/extension/list.extension.js
+++ b/lib/extension/list.extension.js
@@ -1,4 +1,8 @@
 'use strict'; // eslint-disable-line strict
+
+const checkLimit = require('./tools').checkLimit;
+const DEFAULT_MAX_KEYS = 10000;
+
 /**
  *  Class of an extension doing the simple listing
  */
@@ -13,6 +17,12 @@ class List {
     constructor(parameters, logger) {
         this.logger = logger;
         this.res = [];
+        if (parameters) {
+            this.maxKeys = checkLimit(parameters.maxKeys, DEFAULT_MAX_KEYS);
+        } else {
+            this.maxKeys = DEFAULT_MAX_KEYS;
+        }
+        this.keys = 0;
     }
 
     /**
@@ -22,7 +32,12 @@ class List {
      *  @return {Boolean} - True = continue the stream
      */
     filter(elem) {
+        // Check first in case of maxkeys <= 0
+        if (this.keys >= this.maxKeys) {
+            return false;
+        }
         this.res.push(elem);
+        this.keys++;
         return true;
     }
 

--- a/lib/extension/listMPU.extension.js
+++ b/lib/extension/listMPU.extension.js
@@ -1,9 +1,13 @@
 'use strict'; // eslint-disable-line strict
 
+const checkLimit = require('./tools').checkLimit;
+const DEFAULT_MAX_KEYS = 1000;
+
 function numberDefault(num, defaultNum) {
     const parsedNum = Number.parseInt(num, 10);
     return Number.isNaN(parsedNum) ? defaultNum : parsedNum;
 }
+
 /**
  *  Class for the ListMultipartUploads extension
  */
@@ -24,7 +28,7 @@ class ListMultipartUploads {
         this.prefixLength = 0;
         this.queryPrefixLength = numberDefault(params.queryPrefixLength, 0);
         this.keys = 0;
-        this.maxKeys = numberDefault(params.maxKeys, 1000);
+        this.maxKeys = checkLimit(params.maxKeys, DEFAULT_MAX_KEYS);
         this.delimiter = params.delimiter;
         this.splitter = params.splitter;
         this.logger = logger;
@@ -80,6 +84,12 @@ class ListMultipartUploads {
      *  @return {Boolean} - True: Continue, False: Stop
      */
     filter(obj) {
+        // Check first in case of maxkeys = 0
+        if (this.keys >= this.maxKeys) {
+            // In cases of maxKeys <= 0 => IsTruncated = false
+            this.IsTruncated = this.maxKeys > 0;
+            return false;
+        }
         const key = obj.key;
         const value = obj.value;
         if (this.delimiter) {
@@ -96,10 +106,6 @@ class ListMultipartUploads {
             }
         } else {
             this.addUpload(value);
-        }
-        if (this.keys === this.maxKeys) {
-            this.IsTruncated = true;
-            return false;
         }
         return true;
     }

--- a/lib/extension/tools.js
+++ b/lib/extension/tools.js
@@ -1,0 +1,18 @@
+/**
+ * This function check if number is valid
+ * To be valid a number need to be an Integer and be lower than the limit
+ *                  if specified
+ * If the number is not valid the limit is returned
+ * @param {Number} number - The number to check
+ * @param {Number} limit - The limit to respect
+ * @return {Number} - The parsed number || limit
+ */
+function checkLimit(number, limit) {
+    const parsed = Number.parseInt(number, 10);
+    const valid = !Number.isNaN(parsed) && (!limit || parsed <= limit);
+    return valid ? parsed : limit;
+}
+
+module.exports = {
+    checkLimit,
+};

--- a/tests/unit/extension/delimiter.js
+++ b/tests/unit/extension/delimiter.js
@@ -1,0 +1,175 @@
+'use strict'; // eslint-disable-line strict
+
+const assert = require('assert');
+const Delimiter =
+    require('../../../lib/extension/delimiter.extension').Delimiter;
+const Werelogs = require('werelogs');
+const logger = new Werelogs('listTest');
+const performListing = require('../../utils/performListing');
+
+class Test {
+    constructor(name, input, output, filter) {
+        this.name = name;
+        this.input = input;
+        this.output = output;
+        this.filter = filter || this._defaultFilter;
+    }
+
+    _defaultFilter() {
+        return true;
+    }
+}
+
+describe('Delimiter extension', () => {
+    const value = {
+        ETag: undefined,
+        EventualStorageBucket: undefined,
+        Initiated: undefined,
+        Initiator: undefined,
+        LastModified: undefined,
+        Owner: {
+            DisplayName: undefined,
+            ID: undefined,
+        },
+        Size: undefined,
+        StorageClass: undefined,
+        creationDate: undefined,
+        partLocations: undefined,
+    };
+    const data = [
+        { key: '/notes/spring/1.txt', value: '{}' },
+        { key: '/notes/spring/2.txt', value: '{}' },
+        { key: '/notes/spring/march/1.txt', value: '{}' },
+        { key: '/notes/summer/1.txt', value: '{}' },
+        { key: '/notes/summer/2.txt', value: '{}' },
+        { key: '/notes/summer/august/1.txt', value: '{}' },
+        { key: '/notes/year.txt', value: '{}' },
+        { key: '/Pâtisserie=中文-español-English', value: '{}' },
+    ];
+    const receivedData = [
+        { key: '/notes/spring/1.txt', value },
+        { key: '/notes/spring/2.txt', value },
+        { key: '/notes/spring/march/1.txt', value },
+        { key: '/notes/summer/1.txt', value },
+        { key: '/notes/summer/2.txt', value },
+        { key: '/notes/summer/august/1.txt', value },
+        { key: '/notes/year.txt', value },
+        { key: '/Pâtisserie=中文-español-English', value },
+    ];
+    const tests = [
+        new Test('all elements', {}, {
+            Contents: receivedData,
+            CommonPrefixes: [],
+            Delimiter: undefined,
+            IsTruncated: false,
+            NextMarker: undefined,
+        }),
+        new Test('with valid marker', {
+            gt: '/notes/summer/1.txt',
+            delimiter: '/',
+        }, {
+            Contents: [
+                receivedData[4],
+                receivedData[6],
+            ],
+            CommonPrefixes: ['/notes/summer/august/'],
+            Delimiter: '/',
+            IsTruncated: false,
+            NextMarker: undefined,
+        }, (e, input) => e.key > input.gt),
+        new Test('with bad marker', {
+            gt: 'zzzz',
+            delimiter: '/',
+        }, {
+            Contents: [],
+            CommonPrefixes: [],
+            Delimiter: '/',
+            IsTruncated: false,
+            NextMarker: undefined,
+        }, (e, input) => e.key > input.gt),
+        new Test('with prefix', {
+            start: '/notes/summer/',
+            lt: '/notes/summer0',
+            delimiter: '/',
+        }, {
+            Contents: receivedData.slice(3, 5),
+            CommonPrefixes: ['/notes/summer/august/'],
+            Delimiter: '/',
+            IsTruncated: false,
+            NextMarker: undefined,
+        }, (e, input) => e.key > input.start && e.key < input.lt),
+        new Test('with bad prefix', {
+            start: 'zzzy',
+            lt: 'zzzz',
+            delimiter: '/',
+        }, {
+            Contents: [],
+            CommonPrefixes: [],
+            Delimiter: '/',
+            IsTruncated: false,
+            NextMarker: undefined,
+        }, (e, input) => e.key > input.start && e.key < input.lt),
+        new Test('with makKeys', {
+            maxKeys: 3,
+        }, {
+            Contents: receivedData.slice(0, 3),
+            CommonPrefixes: [],
+            Delimiter: undefined,
+            IsTruncated: true,
+            NextMarker: '/notes/spring/march/1.txt',
+        }),
+        new Test('with big makKeys', {
+            maxKeys: 15000,
+        }, {
+            Contents: receivedData,
+            CommonPrefixes: [],
+            Delimiter: undefined,
+            IsTruncated: false,
+            NextMarker: undefined,
+        }),
+        new Test('with delimiter', {
+            delimiter: '/',
+        }, {
+            Contents: [],
+            CommonPrefixes: ['/'],
+            Delimiter: '/',
+            IsTruncated: false,
+            NextMarker: undefined,
+        }),
+        new Test('with long delimiter', {
+            delimiter: '/notes/summer',
+        }, {
+            Contents: [
+                receivedData[0],
+                receivedData[1],
+                receivedData[2],
+                receivedData[6],
+                receivedData[7],
+            ],
+            CommonPrefixes: ['/notes/summer'],
+            Delimiter: '/notes/summer',
+            IsTruncated: false,
+            NextMarker: undefined,
+        }),
+        new Test('with delimiter and prefix', {
+            delimiter: '/',
+            start: '/notes/',
+            lt: '/notes0',
+        }, {
+            Contents: [receivedData[6]],
+            CommonPrefixes: ['/notes/spring/', '/notes/summer/'],
+            Delimiter: '/',
+            IsTruncated: false,
+            NextMarker: undefined,
+        }, (e, input) => e.key > input.start && e.key < input.lt),
+    ];
+    tests.forEach(test => {
+        it(`Should list ${test.name}`, done => {
+            // Simulate skip scan done by LevelDB
+            const d = data.filter(e => test.filter(e, test.input));
+            const res = performListing(d, Delimiter, test.input, logger);
+            assert.deepStrictEqual(res, test.output);
+            done();
+        });
+    });
+});

--- a/tests/unit/extension/list.js
+++ b/tests/unit/extension/list.js
@@ -1,0 +1,41 @@
+'use strict'; // eslint-disable-line strict
+
+const assert = require('assert');
+const List = require('../../../lib/extension/list.extension').List;
+const Werelogs = require('werelogs');
+const logger = new Werelogs('listTest');
+const performListing = require('../../utils/performListing');
+
+class Test {
+    constructor(name, input, output) {
+        this.name = name;
+        this.input = input;
+        this.output = output;
+    }
+}
+
+describe('List extension', () => {
+    const data = [];
+    for (let i = 0; i < 15000; ++i) {
+        data.push({
+            key: `key${i}`,
+            value: `value${i}`,
+        });
+    }
+    const tests = [
+        new Test('0 elements', { maxKeys: 0 }, []),
+        new Test('15 elements', { maxKeys: 15 }, data.slice(0, 15)),
+        new Test('10000 elements', { maxKeys: 10000 }, data.slice(0, 10000)),
+        new Test('more than limit', { maxKeys: 15000 }, data.slice(0, 10000)),
+        new Test('default limit', {}, data.slice(0, 10000)),
+        new Test('without parameters', undefined, data.slice(0, 10000)),
+        new Test('with bad parameters', 'lala', data.slice(0, 10000)),
+    ];
+    tests.forEach(test => {
+        it(`Should list ${test.name}`, done => {
+            const res = performListing(data, List, test.input, logger);
+            assert.deepStrictEqual(res, test.output);
+            done();
+        });
+    });
+});

--- a/tests/unit/extension/listMpuExtension.js
+++ b/tests/unit/extension/listMpuExtension.js
@@ -2,10 +2,11 @@
 
 const assert = require('assert');
 const ListMultipartUploads =
-    require('../../lib/extension/listMPU.extension').
+    require('../../../lib/extension/listMPU.extension').
     ListMultipartUploads;
 const werelogs = require('werelogs');
 const logger = new werelogs('listMpuTest');
+const performListing = require('../../utils/performListing');
 describe('List Multipart Uploads extension', () => {
     const splitter = '**';
     const overviewPrefix = `overview${splitter}`;
@@ -83,11 +84,6 @@ describe('List Multipart Uploads extension', () => {
     ];
     let listingParams;
     let expectedResult;
-    function performListing(keys, params, logger) {
-        const mpuListing = new ListMultipartUploads(params, logger);
-        keys.every(a => mpuListing.filter(a));
-        return mpuListing.result();
-    }
 
     beforeEach(done => {
         listingParams = {
@@ -127,7 +123,8 @@ describe('List Multipart Uploads extension', () => {
     });
 
     it('should perform a listing of all keys', done => {
-        const listingResult = performListing(keys, listingParams, logger);
+        const listingResult = performListing(keys, ListMultipartUploads,
+            listingParams, logger);
         assert.deepStrictEqual(listingResult, expectedResult);
         done();
     });
@@ -143,7 +140,8 @@ describe('List Multipart Uploads extension', () => {
         expectedResult.NextKeyMarker = 'prefixTest/';
         expectedResult.NextUploadIdMarker = '';
 
-        const listingResult = performListing(keys, listingParams, logger);
+        const listingResult = performListing(keys, ListMultipartUploads,
+            listingParams, logger);
         assert.deepStrictEqual(listingResult, expectedResult);
         done();
     });
@@ -159,7 +157,8 @@ describe('List Multipart Uploads extension', () => {
         expectedResult.IsTruncated = true;
         expectedResult.MaxKeys = 3;
 
-        const listingResult = performListing(keys, listingParams, logger);
+        const listingResult = performListing(keys, ListMultipartUploads,
+            listingParams, logger);
         assert.deepStrictEqual(listingResult, expectedResult);
         done();
     });

--- a/tests/unit/extension/tools.js
+++ b/tests/unit/extension/tools.js
@@ -1,0 +1,25 @@
+'use strict';// eslint-disable-line strict
+
+const assert = require('assert');
+
+const checkLimit = require('../../../lib/extension/tools').checkLimit;
+
+describe('checkLimit function', () => {
+    const tests = [
+        { input: [1000, 2500], output: 1000 },
+        { input: [5000, 2500], output: 2500 },
+        { input: ['lala', 2500], output: 2500 },
+        { input: [15000, 0], output: 15000 },
+        { input: ['lala', 0], output: 0 },
+        { input: [2000, undefined], output: 2000 },
+        { input: ['lala', undefined], output: undefined },
+        { input: [0, 0], output: 0 },
+    ];
+    tests.forEach((test, index) => {
+        it(`test${index}`, done => {
+            const res = checkLimit(test.input[0], test.input[1]);
+            assert.deepStrictEqual(res, test.output);
+            done();
+        });
+    });
+});

--- a/tests/utils/performListing.js
+++ b/tests/utils/performListing.js
@@ -1,0 +1,5 @@
+module.exports = function performListing(data, Extension, params, logger) {
+    const listing = new Extension(params, logger);
+    data.every(e => listing.filter(e));
+    return listing.result();
+};


### PR DESCRIPTION
#### Extension(fix): Default value:
- Add 'checkLlimit' into tools.js to check the maxKeys of all extensions
  in one function.
- The default value is now set in the extension itself.
- ListExtension: Add a limit on max elementes returned.
- ListExtension, DelimiterExtension, ListMPUExtension: Check if reached
  maxKeys at start of fiter function to deal with the case of
  maxKeys <= 0

#### Extension(tests): Add unit tests:
- Added unit test for DelimiterExtension, ListExtension and checkLimit
  function.

#### Add missing extension to index.js