### PR TITLE
Fix: Compute canonicalRequest for post request

### DIFF
--- a/lib/auth/auth.js
+++ b/lib/auth/auth.js
@@ -31,7 +31,7 @@ auth.check = (request, log, awsService, data) => {
             return authV2.headerAuthCheck.check(request, log, data);
         } else if (authHeader.startsWith('AWS4')) {
             log.trace('authenticating request with Auth V4 using headers');
-            return authV4.headerAuthCheck.check(request, log, awsService);
+            return authV4.headerAuthCheck.check(request, log, data, awsService);
         }
         log.debug('missing authorization security header');
         return { err: errors.MissingSecurityHeader };
@@ -89,15 +89,26 @@ auth.generateV4Headers =
         const credentialScope =
             `${scopeDate}/${region}/${service}/aws4_request`;
         const timestamp = amzDate;
-        const query = request.query || {};
+        const query = request.query || data;
         const algorithm = 'AWS4-HMAC-SHA256';
 
-        const payload = !!data ? data : '';
+        let payload = '';
+        if (request.method === 'POST') {
+            const formattedData = [];
+            Object.keys(data).forEach(key => {
+                const formattedKey = encodeURIComponent(key);
+                const formattedValue = encodeURIComponent(data[key]);
+                if (formattedData.length > 0) {
+                    formattedData.push('&');
+                }
+                formattedData.push(`${formattedKey}=${formattedValue}`);
+            });
+            payload = formattedData.join('');
+        }
         const payloadChecksum = crypto.createHash('sha256').update(payload)
                                       .digest('hex');
         const path = request.path;
         Object.assign(request, { path: '/' });
-
         request.setHeader('host', request._headers.host);
         request.setHeader('x-amz-date', amzDate);
         request.setHeader('x-amz-content-sha256', payloadChecksum);

--- a/lib/auth/auth.js
+++ b/lib/auth/auth.js
@@ -1,7 +1,7 @@
 'use strict'; // eslint-disable-line strict
 
 const errors = require('../errors');
-
+const queryString = require('querystring');
 const AuthInfo = require('./AuthInfo');
 const authV2 = require('./v2/authV2');
 const authV4 = require('./v4/authV4');
@@ -18,6 +18,16 @@ auth.setAuthHandler = handler => {
     return auth;
 };
 
+/**
+ * This function will check validity of request parameters to authenticate
+ *
+ * @param {Http.Request} request - Http request object
+ * @param {object} log - Logger object
+ * @param {string} awsService - Aws service related
+ * @param {object} data - Parameters from queryString parsing or body of
+ *      POST request
+ * @return {object} Return object with information to authenticate
+ */
 auth.check = (request, log, awsService, data) => {
     log.debug('running auth checks', { method: 'auth' });
     const authHeader = request.headers.authorization;
@@ -89,21 +99,13 @@ auth.generateV4Headers =
         const credentialScope =
             `${scopeDate}/${region}/${service}/aws4_request`;
         const timestamp = amzDate;
-        const query = request.query || data;
         const algorithm = 'AWS4-HMAC-SHA256';
 
         let payload = '';
         if (request.method === 'POST') {
-            const formattedData = [];
-            Object.keys(data).forEach(key => {
-                const formattedKey = encodeURIComponent(key);
-                const formattedValue = encodeURIComponent(data[key]);
-                if (formattedData.length > 0) {
-                    formattedData.push('&');
-                }
-                formattedData.push(`${formattedKey}=${formattedValue}`);
+            payload = queryString.stringify(data, null, null, {
+                encodeURIComponent,
             });
-            payload = formattedData.join('');
         }
         const payloadChecksum = crypto.createHash('sha256').update(payload)
                                       .digest('hex');
@@ -118,7 +120,8 @@ auth.generateV4Headers =
                       { 'x-amz-content-sha256': payloadChecksum });
 
         const params = { request, signedHeaders, payloadChecksum,
-                         credentialScope, timestamp, query };
+                         credentialScope, timestamp, query: data,
+                         awsService: service };
         const stringToSign = constructStringToSignV4(params);
         const signingKey = vaultUtilities.calculateSigningKey(secretKeyValue,
                                                               region,

--- a/lib/auth/v4/constructStringToSign.js
+++ b/lib/auth/v4/constructStringToSign.js
@@ -25,6 +25,7 @@ function constructStringToSign(params) {
         pHeaders: request.headers,
         pSignedHeaders: signedHeaders,
         payloadChecksum,
+        service: params.awsService,
     });
 
     if (canonicalReqResult instanceof Error) {

--- a/lib/auth/v4/createCanonicalRequest.js
+++ b/lib/auth/v4/createCanonicalRequest.js
@@ -2,6 +2,7 @@
 
 const awsURIencode = require('./awsURIencode');
 const crypto = require('crypto');
+const queryString = require('querystring');
 
 /**
  * createCanonicalRequest - creates V4 canonical request
@@ -17,24 +18,18 @@ function createCanonicalRequest(params) {
     const pQuery = params.pQuery;
     const pHeaders = params.pHeaders;
     const pSignedHeaders = params.pSignedHeaders;
+    const service = params.service;
 
     let payloadChecksum = params.payloadChecksum;
 
     if (!payloadChecksum) {
         if (pHttpVerb === 'GET') {
-            payloadChecksum = crypto.createHash('sha256').update('')
-                .digest('hex').toLowerCase();
+            payloadChecksum = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b' +
+                '934ca495991b7852b855';
         } else if (pHttpVerb === 'POST') {
-            const formattedData = [];
-            Object.keys(pQuery).forEach(key => {
-                const formattedKey = encodeURIComponent(key);
-                const formattedValue = encodeURIComponent(pQuery[key]);
-                if (formattedData.length > 0) {
-                    formattedData.push('&');
-                }
-                formattedData.push(`${formattedKey}=${formattedValue}`);
+            const payload = queryString.stringify(pQuery, null, null, {
+                encodeURIComponent,
             });
-            const payload = formattedData.join('');
             payloadChecksum = crypto.createHash('sha256').update(payload)
                 .digest('hex').toLowerCase();
         }
@@ -44,7 +39,7 @@ function createCanonicalRequest(params) {
 
     // canonical query string
     let canonicalQueryStr = '';
-    if (pQuery && pHttpVerb === 'GET') {
+    if (pQuery && !(service === 'iam' && pHttpVerb === 'POST')) {
         const queryParams = Object.keys(pQuery).map(key => {
             const value = pQuery[key] ? awsURIencode(pQuery[key]) : '';
             return {

--- a/lib/auth/v4/createCanonicalRequest.js
+++ b/lib/auth/v4/createCanonicalRequest.js
@@ -17,18 +17,34 @@ function createCanonicalRequest(params) {
     const pQuery = params.pQuery;
     const pHeaders = params.pHeaders;
     const pSignedHeaders = params.pSignedHeaders;
+
     let payloadChecksum = params.payloadChecksum;
 
     if (!payloadChecksum) {
-        payloadChecksum = crypto.createHash('sha256').update('').digest('hex')
-            .toLowerCase();
+        if (pHttpVerb === 'GET') {
+            payloadChecksum = crypto.createHash('sha256').update('')
+                .digest('hex').toLowerCase();
+        } else if (pHttpVerb === 'POST') {
+            const formattedData = [];
+            Object.keys(pQuery).forEach(key => {
+                const formattedKey = encodeURIComponent(key);
+                const formattedValue = encodeURIComponent(pQuery[key]);
+                if (formattedData.length > 0) {
+                    formattedData.push('&');
+                }
+                formattedData.push(`${formattedKey}=${formattedValue}`);
+            });
+            const payload = formattedData.join('');
+            payloadChecksum = crypto.createHash('sha256').update(payload)
+                .digest('hex').toLowerCase();
+        }
     }
 
     const canonicalURI = !!pResource ? awsURIencode(pResource, false) : '/';
 
     // canonical query string
     let canonicalQueryStr = '';
-    if (pQuery) {
+    if (pQuery && pHttpVerb === 'GET') {
         const queryParams = Object.keys(pQuery).map(key => {
             const value = pQuery[key] ? awsURIencode(pQuery[key]) : '';
             return {
@@ -60,7 +76,6 @@ function createCanonicalRequest(params) {
     const canonicalRequest = `${pHttpVerb}\n${canonicalURI}\n` +
         `${canonicalQueryStr}\n${canonicalHeaders}\n` +
         `${signedHeaders}\n${payloadChecksum}`;
-
     return canonicalRequest;
 }
 

--- a/lib/auth/v4/createCanonicalRequest.js
+++ b/lib/auth/v4/createCanonicalRequest.js
@@ -1,6 +1,7 @@
 'use strict'; // eslint-disable-line strict
 
 const awsURIencode = require('./awsURIencode');
+const crypto = require('crypto');
 
 /**
  * createCanonicalRequest - creates V4 canonical request
@@ -16,7 +17,12 @@ function createCanonicalRequest(params) {
     const pQuery = params.pQuery;
     const pHeaders = params.pHeaders;
     const pSignedHeaders = params.pSignedHeaders;
-    const payloadChecksum = params.payloadChecksum;
+    let payloadChecksum = params.payloadChecksum;
+
+    if (!payloadChecksum) {
+        payloadChecksum = crypto.createHash('sha256').update('').digest('hex')
+            .toLowerCase();
+    }
 
     const canonicalURI = !!pResource ? awsURIencode(pResource, false) : '/';
 

--- a/lib/auth/v4/headerAuthCheck.js
+++ b/lib/auth/v4/headerAuthCheck.js
@@ -14,10 +14,11 @@ const headerAuthCheck = {};
  * V4 header auth check
  * @param {object} request - HTTP request object
  * @param {object} log - logging object
+ * @param {object} data - Data of request
  * @param {string} awsService - Aws service
  * @return {callback} calls callback
  */
-headerAuthCheck.check = (request, log, awsService) => {
+headerAuthCheck.check = (request, log, data, awsService) => {
     log.trace('running header auth check');
     // authorization header
     const authHeader = request.headers.authorization;
@@ -93,7 +94,7 @@ headerAuthCheck.check = (request, log, awsService) => {
     const stringToSign = constructStringToSign({
         log,
         request,
-        query: request.query,
+        query: data,
         signedHeaders,
         credentialScope,
         timestamp,

--- a/lib/auth/v4/headerAuthCheck.js
+++ b/lib/auth/v4/headerAuthCheck.js
@@ -14,9 +14,10 @@ const headerAuthCheck = {};
  * V4 header auth check
  * @param {object} request - HTTP request object
  * @param {object} log - logging object
+ * @param {string} awsService - Aws service
  * @return {callback} calls callback
  */
-headerAuthCheck.check = (request, log) => {
+headerAuthCheck.check = (request, log, awsService) => {
     log.trace('running header auth check');
     // authorization header
     const authHeader = request.headers.authorization;
@@ -26,7 +27,7 @@ headerAuthCheck.check = (request, log) => {
     }
 
     const payloadChecksum = request.headers['x-amz-content-sha256'];
-    if (!payloadChecksum) {
+    if (!payloadChecksum && awsService !== 'iam') {
         log.debug('missing payload checksum');
         return { err: errors.MissingSecurityHeader };
     }

--- a/lib/auth/v4/headerAuthCheck.js
+++ b/lib/auth/v4/headerAuthCheck.js
@@ -14,8 +14,9 @@ const headerAuthCheck = {};
  * V4 header auth check
  * @param {object} request - HTTP request object
  * @param {object} log - logging object
- * @param {object} data - Data of request
- * @param {string} awsService - Aws service
+ * @param {object} data - Parameters from queryString parsing or body of
+ *      POST request
+ * @param {string} awsService - Aws service ('iam' or 's3')
  * @return {callback} calls callback
  */
 headerAuthCheck.check = (request, log, data, awsService) => {
@@ -99,6 +100,7 @@ headerAuthCheck.check = (request, log, data, awsService) => {
         credentialScope,
         timestamp,
         payloadChecksum,
+        awsService,
     });
     log.trace('constructed stringToSign', { stringToSign });
     if (stringToSign instanceof Error) {

--- a/lib/auth/v4/queryAuthCheck.js
+++ b/lib/auth/v4/queryAuthCheck.js
@@ -67,6 +67,7 @@ queryAuthCheck.check = (request, log, data) => {
         timestamp,
         credentialScope:
             `${scopeDate}/${region}/${service}/${requestType}`,
+        awsService: service,
     });
     if (stringToSign instanceof Error) {
         return { err: stringToSign };


### PR DESCRIPTION
- Aws cli don't use payload to iam request, so the payload is compute with an empty string
- POST request compute the body into the payload even is the payload is missing

Should be merge with https://github.com/scality/Vault/pull/392 and https://github.com/scality/vaultclient/pull/83