### PR TITLE
Ft/policy auth

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,5 +20,6 @@ module.exports = {
         evaluators: require('./lib/policyEvaluator/evaluator.js'),
         validateUserPolicy: require('./lib/policy/policyValidator')
             .validateUserPolicy,
+        RequestContext: require('./lib/policyEvaluator/RequestContext.js'),
     },
 };

--- a/lib/auth/auth.js
+++ b/lib/auth/auth.js
@@ -41,7 +41,8 @@ auth.check = (request, log, awsService, data) => {
             return authV2.headerAuthCheck.check(request, log, data);
         } else if (authHeader.startsWith('AWS4')) {
             log.trace('authenticating request with Auth V4 using headers');
-            return authV4.headerAuthCheck.check(request, log, data, awsService);
+            return authV4.headerAuthCheck.check(request, log, data,
+                awsService);
         }
         log.debug('missing authorization security header');
         return { err: errors.MissingSecurityHeader };
@@ -61,14 +62,17 @@ auth.check = (request, log, awsService, data) => {
     return { err: null, data: authInfo };
 };
 
-auth.doAuth = (request, log, cb, awsService, data) => {
-    const res = auth.check(request, log, awsService, data);
+auth.doAuth = (request, log, cb, awsService, requestContext) => {
+    const res = auth.check(request, log, awsService, request.query);
+    requestContext.setAuthType(res.authType);
+    requestContext.setSignatureVersion(res.signatureVersion);
+    requestContext.setSignatureAge(res.signatureAge);
     if (res.err) {
         return cb(res.err);
     } else if (res.version === 2) {
         return vault.authenticateV2Request(res.data.accessKey,
             res.data.signatureFromRequest,
-            res.data.stringToSign, res.data.algo, log,
+            res.data.stringToSign, res.data.algo, requestContext, log,
             (err, authInfo) => {
                 if (err) {
                     return cb(err);
@@ -77,7 +81,8 @@ auth.doAuth = (request, log, cb, awsService, data) => {
             });
     } else if (res.version === 4) {
         res.data.log = log;
-        return vault.authenticateV4Request(res.data, cb, awsService);
+        return vault.authenticateV4Request(res.data, requestContext,
+            cb, awsService);
     } else if (res.data instanceof AuthInfo) {
         return cb(null, res.data);
     }

--- a/lib/auth/v2/headerAuthCheck.js
+++ b/lib/auth/v2/headerAuthCheck.js
@@ -58,11 +58,14 @@ headerAuthCheck.check = (request, log, data) => {
     return {
         err: null,
         version: 2,
+        signatureAge: Date.now() - timestamp,
         data: {
             accessKey,
             signatureFromRequest,
             stringToSign,
             algo,
+            authType: 'REST-HEADER',
+            signatureVersion: 'AWS',
         },
     };
 };

--- a/lib/auth/v2/queryAuthCheck.js
+++ b/lib/auth/v2/queryAuthCheck.js
@@ -55,6 +55,8 @@ queryAuthCheck.check = (request, log, data) => {
             signatureFromRequest,
             stringToSign,
             algo,
+            authType: 'REST-QUERY-STRING',
+            signatureVersion: 'AWS',
         },
     };
 };

--- a/lib/auth/v4/headerAuthCheck.js
+++ b/lib/auth/v4/headerAuthCheck.js
@@ -5,6 +5,7 @@ const errors = require('../../../lib/errors');
 const constructStringToSign = require('./constructStringToSign');
 const checkTimeSkew = require('./timeUtils').checkTimeSkew;
 const convertUTCtoISO8601 = require('./timeUtils').convertUTCtoISO8601;
+const convertAmzTimeToMs = require('./timeUtils').convertAmzTimeToMs;
 const extractAuthItems = require('./validateInputs').extractAuthItems;
 const validateCredentials = require('./validateInputs').validateCredentials;
 
@@ -106,15 +107,20 @@ headerAuthCheck.check = (request, log, data, awsService) => {
     if (stringToSign instanceof Error) {
         return { err: stringToSign };
     }
+
+
     return {
         err: null,
         version: 4,
+        signatureAge: Date.now() - convertAmzTimeToMs(timestamp),
         data: {
             accessKey,
             signatureFromRequest,
             region,
             scopeDate,
             stringToSign,
+            authType: 'REST-HEADER',
+            signatureVersion: 'AWS4-HMAC-SHA256',
         },
     };
 };

--- a/lib/auth/v4/queryAuthCheck.js
+++ b/lib/auth/v4/queryAuthCheck.js
@@ -4,6 +4,7 @@ const errors = require('../../../index').errors;
 
 const constructStringToSign = require('./constructStringToSign');
 const checkTimeSkew = require('./timeUtils').checkTimeSkew;
+const convertAmzTimeToMs = require('./timeUtils').convertAmzTimeToMs;
 const validateCredentials = require('./validateInputs').validateCredentials;
 const extractQueryParams = require('./validateInputs').extractQueryParams;
 
@@ -76,12 +77,15 @@ queryAuthCheck.check = (request, log, data) => {
     return {
         err: null,
         version: 4,
+        signatureAge: Date.now() - convertAmzTimeToMs(timestamp),
         data: {
             accessKey,
             signatureFromRequest,
             region,
             scopeDate,
             stringToSign,
+            authType: 'REST-QUERY-STRING',
+            signatureVersion: 'AWS4-HMAC-SHA256',
         },
     };
 };

--- a/lib/auth/vault.js
+++ b/lib/auth/vault.js
@@ -37,15 +37,17 @@ const vault = {};
  * @param {string} signatureFromRequest - signature sent with request
  * @param {string} stringToSign - string to sign built per AWS rules
  * @param {string} algo - either SHA256 or SHA1
+* @param {RequestContext} requestContext - an instance of a RequestContext
+ * object containing information for policy authorization check
  * @param {object} log - Werelogs logger
  * @param {function} callback - callback with either error or user info
  * @return {undefined}
  */
 vault.authenticateV2Request = (accessKey, signatureFromRequest,
-    stringToSign, algo, log, callback) => {
+    stringToSign, algo, requestContext, log, callback) => {
     log.debug('authenticating V2 request');
     client.verifySignatureV2(stringToSign, signatureFromRequest, accessKey,
-        { algo, reqUid: log.getSerializedUids() },
+        { algo, reqUid: log.getSerializedUids(), requestContext },
     (err, userInfo) => vaultSignatureCb(err, userInfo, log, callback));
 };
 
@@ -53,10 +55,11 @@ vault.authenticateV2Request = (accessKey, signatureFromRequest,
  * @param {object} params - contains accessKey (string),
  * signatureFromRequest (string), region (string),
  * stringToSign (string) and log (object)
+ * @param {object} requestContext - info for policy auth check
  * @param {function} callback - callback with either error or user info
  * @return {undefined}
 */
-vault.authenticateV4Request = (params, callback) => {
+vault.authenticateV4Request = (params, requestContext, callback) => {
     const accessKey = params.accessKey;
     const signatureFromRequest = params.signatureFromRequest;
     const region = params.region;
@@ -66,7 +69,8 @@ vault.authenticateV4Request = (params, callback) => {
 
     log.debug('authenticating V4 request');
     client.verifySignatureV4(stringToSign, signatureFromRequest,
-        accessKey, region, scopeDate, { reqUid: log.getSerializedUids() },
+        accessKey, region, scopeDate, { reqUid: log.getSerializedUids(),
+            requestContext },
     (err, userInfo) => vaultSignatureCb(err, userInfo, log, callback));
 };
 

--- a/lib/policyEvaluator/RequestContext.js
+++ b/lib/policyEvaluator/RequestContext.js
@@ -1,0 +1,417 @@
+'use strict'; // eslint-disable-line strict
+
+
+// http://docs.aws.amazon.com/IAM/latest/UserGuide/list_s3.html
+// For MPU actions:
+// http://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html
+// For bucket head and object head:
+// http://docs.aws.amazon.com/AmazonS3/latest/dev/
+// using-with-s3-actions.html
+const _actionMap = {
+    bucketDelete: 's3:DeleteBucket',
+    bucketGet: 's3:ListBucket',
+    bucketGetACL: 's3:GetBucketAcl',
+    bucketHead: 's3:ListBucket',
+    bucketPut: 's3:CreateBucket',
+    bucketPutACL: 's3:PutBucketAcl',
+    completeMultipartUpload: 's3:PutObject',
+    initiateMultipartUpload: 's3:PutObject',
+    listMultipartUploads: 's3:ListBucketMultipartUploads',
+    listParts: 's3:ListMultipartUploadParts',
+    multipartDelete: 's3:AbortMultipartUpload',
+    objectDelete: 's3:DeleteObject',
+    objectGet: 's3:GetObject',
+    objectGetACL: 's3:GetObjectAcl',
+    objectHead: 's3:GetObject',
+    objectPut: 's3:PutObject',
+    objectPutACL: 's3:PutObjectAcl',
+    objectPutPart: 's3:PutObject',
+    serviceGet: 's3:ListAllMyBuckets',
+};
+
+
+function _findAction(service, method) {
+    if (service === 's3') {
+        return _actionMap[method];
+    }
+    return undefined;
+}
+
+function _buildArn(service, bucket, object) {
+    if (service === 's3') {
+        if (bucket && object) {
+            return `arn:aws:s3:::${bucket}/${object}`;
+        } else if (bucket) {
+            return `arn:aws:s3:::${bucket}`;
+        }
+        return 'arn:aws:s3:::';
+    }
+    return undefined;
+}
+
+/**
+ * Class containing RequestContext for policy auth check
+ * @param {object} headers - request headers
+ * @param {query} query - request query
+ * @param {string} bucketName - bucket name from request if any
+ * @param {string} objectName - object name from request if any
+ * @param {string} requesterIp - ip of requester
+ * @param {boolean} sslEnabled - whether request was https
+ * @param {string} apiMethod - type of request
+ * @param {string} awsService - service receiving request
+ * @param {string} locationConstraint - location constraint
+ * for put bucket operation
+ * @param {object} requesterInfo - info about entity making request
+ * @param {string} signatureVersion - auth signature type used
+ * @param {string} authType - type of authentication used
+ * @param {number} signatureAge - age of signature in milliseconds
+ * @return {RequestContext} a RequestContext instance
+ */
+
+class RequestContext {
+    constructor(headers, query, bucketName, objectName,
+        requesterIp, sslEnabled, apiMethod,
+        awsService, locationConstraint, requesterInfo,
+        signatureVersion, authType, signatureAge) {
+        this._headers = headers;
+        this._query = query;
+        this._requesterIp = requesterIp;
+        this._sslEnabled = sslEnabled;
+        this._apiMethod = apiMethod;
+        this._awsService = awsService;
+        this._bucket = bucketName;
+        this._object = objectName;
+        this._locationConstraint = locationConstraint;
+        // Not implemented
+        this._multiFactorAuthPresent = null;
+        // Not implemented
+        this._multiFactorAuthAge = null;
+        // Not implemented
+        this._tokenIssueTime = null;
+
+        // Remainder not set when originally instantiated
+        // (unless if instantiated from deSerialize)
+        this._requesterInfo = requesterInfo;
+        // See http://docs.aws.amazon.com/AmazonS3/latest/
+        // API/bucket-policy-s3-sigv4-conditions.html
+        this._signatureVersion = signatureVersion;
+        this._authType = authType;
+        this._signatureAge = signatureAge;
+
+        return this;
+    }
+
+    /**
+    * Serialize the object
+    * @return {string} - stringified object
+    */
+    serialize() {
+        const requestInfo = {
+            apiMethod: this._apiMethod,
+            headers: this._headers,
+            query: this._query,
+            requersterInfo: this._requesterInfo,
+            requesterIp: this._requesterIp,
+            sslEnabled: this._sslEnabled,
+            awsService: this._awsService,
+            bucket: this._bucket,
+            object: this._object,
+            multiFactorAuthPresent: this._multiFactorAuthPresent,
+            multiFactorAuthAge: this._multiFactorAuthAge,
+            signatureVersion: this._signatureVersion,
+            authType: this._authType,
+            signatureAge: this._signatureAge,
+            locationConstraint: this._locationConstraint,
+            tokenIssueTime: this._tokenIssueTime,
+        };
+        return JSON.stringify(requestInfo);
+    }
+
+    /**
+     * deSerialize the JSON string
+     * @param {string} stringRequest - the stringified requestContext
+     * @return {object} - parsed string
+     */
+    static deSerialize(stringRequest) {
+        let obj;
+        try {
+            obj = JSON.parse(stringRequest);
+        } catch (err) {
+            return new Error(err);
+        }
+        return new RequestContext(obj.headers, obj.query, obj.bucket,
+            obj.object, obj.requesterIp, obj.sslEnabled, obj.apiMethod,
+            obj.awsService, obj.locationConstraint, obj.requesterInfo,
+            obj.signatureVersion, obj.authType, obj.signatureAge);
+    }
+
+    /**
+    * Get the request action
+    * @return {string} action
+    */
+    getAction() {
+        if (this._foundAction) {
+            return this._foundAction;
+        }
+        this._foundAction = _findAction(this._awsService, this._apiMethod);
+        return this._foundAction;
+    }
+
+    /**
+    * Get the resource impacted by the request
+    * @return {string} arn for the resource
+    */
+    getResource() {
+        if (this._foundResource) {
+            return this._foundResource;
+        }
+        this._foundResource =
+            _buildArn(this._awsService, this._bucket, this._object);
+        return this._foundResource;
+    }
+
+
+    /**
+     * Set headers
+     * @param {object} headers - request headers
+     * @return {RequestContext} - RequestContext instance
+     */
+    setHeaders(headers) {
+        this._headers = headers;
+        return this;
+    }
+    /**
+     * Get headers
+     * @return {object} request headers
+     */
+    getHeaders() {
+        return this._headers;
+    }
+
+    /**
+     * Set query
+     * @param {object} query - request query
+     * @return {RequestContext} - RequestContext instance
+     */
+    setQuery(query) {
+        this._query = query;
+        return this;
+    }
+    /**
+     * Get query
+     * @return {object} request query
+     */
+    getQuery() {
+        return this._query;
+    }
+
+    /**
+     * Set requesterInfo
+     * @param {object} requesterInfo - info about entity making request
+     * @return {RequestContext} - RequestContext instance
+     */
+    setRequesterInfo(requesterInfo) {
+        this._requesterInfo = requesterInfo;
+        return this;
+    }
+    /**
+     * Get requesterInfo
+     * @return {object} requesterInfo
+     */
+    getRequesterInfo() {
+        return this._requesterInfo;
+    }
+
+    /**
+     * Set requesterIp
+     * @param {string} requesterIp - ip address of requester
+     * @return {RequestContext} - RequestContext instance
+     */
+    setRequesterIp(requesterIp) {
+        this._requesterIp = requesterIp;
+        return this;
+    }
+    /**
+     * Get requesterIp
+     * @return {object} requesterIp
+     */
+    getRequesterIp() {
+        return this._requesterIp;
+    }
+
+    /**
+     * Set sslEnabled
+     * @param {boolean} sslEnabled - true if https used
+     * @return {RequestContext} - RequestContext instance
+     */
+    setSslEnabled(sslEnabled) {
+        this._sslEnabled = sslEnabled;
+        return this;
+    }
+
+    /**
+     * Get sslEnabled
+     * @return {boolean} true if sslEnabled, false if not
+     */
+    getSslEnabled() {
+        return !!this._sslEnabled;
+    }
+
+    /**
+     * Set signatureVersion
+     * @param {string} signatureVersion - "AWS" identifies Signature Version 2
+     * and "AWS4-HMAC-SHA256" identifies Signature Version 4
+     * @return {RequestContext} - RequestContext instance
+     */
+    setSignatureVersion(signatureVersion) {
+        this._signatureVersion = signatureVersion;
+        return this;
+    }
+
+    /**
+     * Get signatureVersion
+     *
+     * @return {string} authentication signature version
+     * "AWS" identifies Signature Version 2 and
+     * "AWS4-HMAC-SHA256" identifies Signature Version 4
+     */
+    getSignatureVersion() {
+        return this._signatureVersion;
+    }
+
+    /**
+     * Set authType
+     * @param {string} authType - REST-HEADER, REST-QUERY-STRING or POST
+     * @return {RequestContext} - RequestContext instance
+     */
+    setAuthType(authType) {
+        this._authType = authType;
+        return this;
+    }
+
+    /**
+     * Get authType
+     * @return {string} authentication type:
+     * REST-HEADER, REST-QUERY-STRING or POST
+     */
+    getAuthType() {
+        return this._authType;
+    }
+
+    /**
+     * Set signatureAge
+     * @param {number} signatureAge -- age of signature in milliseconds
+     * Note that for v2 query auth this will be undefined (since these
+     * requests are pre-signed and only come with an expires time so
+     * do not know age)
+     * @return {RequestContext} - RequestContext instance
+     */
+    setSignatureAge(signatureAge) {
+        this._signatureAge = signatureAge;
+        return this;
+    }
+    /**
+     * Get signatureAge
+     * @return {number} age of signature in milliseconds
+     * Note that for v2 query auth this will be undefined (since these
+     * requests are pre-signed and only come with an expires time so
+     * do not know age)
+     */
+    getSignatureAge() {
+        return this._signatureAge;
+    }
+
+    /**
+     * Set locationConstraint
+     * @param {string} locationConstraint - bucket region constraint
+     * @return {RequestContext} - RequestContext instance
+     */
+    setLocationConstraint(locationConstraint) {
+        this._locationConstraint = locationConstraint;
+        return this;
+    }
+    /**
+     * Get locationConstraint
+     * @return {string} location constraint of put bucket request
+     */
+    getLocationConstraint() {
+        return this._locationConstraint;
+    }
+
+    /**
+     * Set awsService
+     * @param {string} awsService receiving request
+     * @return {RequestContext} - RequestContext instance
+     */
+    setAwsService(awsService) {
+        this._awsService = awsService;
+        return this;
+    }
+    /**
+     * Get awsService
+     * @return {string} awsService receiving request
+     */
+    getAwsService() {
+        return this._awsService;
+    }
+
+    /**
+     * Set tokenIssueTime
+     * @param {string} tokenIssueTime - Date/time that
+     * temporary security credentials were issued
+     * Only present in requests that are signed using
+     * temporary security credentials.
+     * @return {RequestContext} - RequestContext instance
+     */
+    setTokenIssueTime(tokenIssueTime) {
+        this._tokenIssueTime = tokenIssueTime;
+        return this;
+    }
+    /**
+     * Get tokenIssueTime
+     * @return {string} tokenIssueTime
+     */
+    getTokenIssueTime() {
+        return this._tokenIssueTime;
+    }
+
+
+    /**
+     * Set multiFactorAuthPresent
+     * @param {boolean} multiFactorAuthPresent - sets out whether MFA used
+     * for request
+     * @return {RequestContext} - RequestContext instance
+     */
+    setMultiFactorAuthPresent(multiFactorAuthPresent) {
+        this._multiFactorAuthPresent = multiFactorAuthPresent;
+        return this;
+    }
+    /**
+     * Get multiFactorAuthPresent
+     * @return {boolean} multiFactorAuthPresent
+     */
+    getMultiFactorAuthPresent() {
+        return this._multiFactorAuthPresent;
+    }
+
+    /**
+     * Set multiFactorAuthAge
+     * @param {number} multiFactorAuthAge - seconds since
+     * MFA credentials were issued
+     * @return {RequestContext} - RequestContext instance
+     */
+    setMultiFactorAuthAge(multiFactorAuthAge) {
+        this._multiFactorAuthAge = multiFactorAuthAge;
+        return this;
+    }
+    /**
+     * Get multiFactorAuthAge
+     * @return {number} multiFactorAuthAge - seconds since
+     *  MFA credentials were issued
+     */
+    getMultiFactorAuthAge() {
+        return this._multiFactorAuthAge;
+    }
+}
+
+module.exports = RequestContext;

--- a/lib/policyEvaluator/evaluator.js
+++ b/lib/policyEvaluator/evaluator.js
@@ -19,7 +19,7 @@ const evaluators = {};
  * @return {boolean} true if applicable, false if not
  */
 function isResourceApplicable(requestContext, statementResource, log) {
-    const resource = requestContext.resource;
+    const resource = requestContext.getResource();
     if (!Array.isArray(statementResource)) {
         // eslint-disable-next-line no-param-reassign
         statementResource = [statementResource];
@@ -85,7 +85,7 @@ function isActionApplicable(requestAction, statementAction, log) {
 
 /**
  * Check whether request meets policy conditions
- * @param {Object} requestContext - info about request
+ * @param {RequestContext} requestContext - info about request
  * @param {Object} statementCondition - Condition statement from policy
  * @param {Object} log - logger
  * @return {boolean} true if meet conditions, false if not
@@ -134,16 +134,18 @@ function meetConditions(requestContext, statementCondition, log) {
             const keyBasedOnRequestContext =
                 findConditionKey(key, requestContext);
             // Handle IfExists
-            if (keyBasedOnRequestContext === undefined
-                && hasIfExistsCondition) {
+            if ((keyBasedOnRequestContext === undefined ||
+                keyBasedOnRequestContext === null) &&
+                hasIfExistsCondition) {
                 log.trace('satisfies condition due to IfExists operator');
                 continue;
             }
             // If no IfExists qualifier, the key does not exist and the
             // condition operator is not Null, the
             // condition is not met so return false.
-            if (keyBasedOnRequestContext === undefined
-                && bareOperator !== 'Null') {
+            if ((keyBasedOnRequestContext === null ||
+                keyBasedOnRequestContext === undefined) &&
+                bareOperator !== 'Null') {
                 log.trace('condition not satisfied due to ' +
                 'missing info', { operator,
                     conditionKey: key, policyValue: value });
@@ -166,31 +168,10 @@ function meetConditions(requestContext, statementCondition, log) {
 
 /**
  * Evaluate whether a request is permitted under a policy.
- * @param {object} requestContext - Info necessary to evaluate permission
+ * @param {RequestContext} requestContext - Info necessary to
+ * evaluate permission
  * See http://docs.aws.amazon.com/IAM/latest/UserGuide/
  * reference_policies_evaluation-logic.html#policy-eval-reqcontext
- * @param {object} requestContext.resource - arn of requested resource
- * @param {string} requestContext.action - Action type of request
- * (i.e. s3:CreateBucket)
- * @param {Object} requestContext.requesterInfo - Info about requester including
- * username, userid, and principalType
- * @param {Object} requestContext.headers - Request headers from client request
- * @param {Object} requestContext.query - Query string from client request
- * converted to an object
- * @param {string} requestContext.requesterIp - IP Address of requester
- * @param {boolean} requestContext.sslEnabled - Whether the request was https
- * @param {boolean} [requestContext.multiFactorAuthPresent] - If MFA used, true
- * @param {string} [requestContext.multiFactorAuthAge] - If MFA used, number of
- * seconds since token issued
- * @param {string} [requestContext.locationConstraint] -
- * LocationConstraint sent in xml body of CreateBucket s3 request
- * @param {string} requestContext.signatureVersion -
- * either AWS (if v2) or AWS4-HMAC-SHA256 for v4
- * @param {string} requestContext.authType -
- * Method of authentication: either "REST-HEADER",
- * "REST-QUERY-STRING" or "POST"
- * @param {string} requestContext.signatureAge -
- * age of signature in milliseconds
  * @param {object} policy - An IAM or resource policy
  * @param {object} log - logger
  * @return {string} Allow if permitted, Deny if not permitted or Neutral
@@ -222,14 +203,14 @@ evaluators.evaluatePolicy = (requestContext, policy, log) => {
         // If affirmative action is in policy and request action is not
         // applicable, move on to next statement
         if (currentStatement.Action &&
-            !isActionApplicable(requestContext.action,
+            !isActionApplicable(requestContext.getAction(),
             currentStatement.Action, log)) {
             continue;
         }
         // If NotAction is in policy and action matches NotAction in policy,
         // move on to next statement
         if (currentStatement.NotAction &&
-            isActionApplicable(requestContext.action,
+            isActionApplicable(requestContext.getAction(),
             currentStatement.NotAction, log)) {
             continue;
         }
@@ -254,7 +235,8 @@ evaluators.evaluatePolicy = (requestContext, policy, log) => {
 
 /**
  * Evaluate whether a request is permitted under a policy.
- * @param {object} requestContext - Info necessary to evaluate permission
+ * @param {RequestContext} requestContext - Info necessary to
+ * evaluate permission
  * See http://docs.aws.amazon.com/IAM/latest/UserGuide/
  * reference_policies_evaluation-logic.html#policy-eval-reqcontext
  * @param {[object]} allPolicies - all applicable IAM or resource policies

--- a/lib/policyEvaluator/utils/conditions.js
+++ b/lib/policyEvaluator/utils/conditions.js
@@ -10,12 +10,16 @@ const conditions = {};
 /**
  * findConditionKey finds the value of a condition key based on requestContext
  * @param {string} key - condition key name
- * @param {object} requestContext - info sent with request
+ * @param {RequestContext} requestContext - info sent with request
  * @return {string} condition key value
  */
 conditions.findConditionKey = (key, requestContext) => {
     // TODO: Consider combining with findVariable function if no benefit
     // to keeping separate
+    const headers = requestContext.getHeaders();
+    const query = requestContext.getQuery();
+    const requesterInfo = requestContext.getRequesterInfo();
+
     const map = new Map();
     // Possible AWS Condition keys (http://docs.aws.amazon.com/IAM/latest/
     // UserGuide/reference_policies_elements.html#AvailableKeys)
@@ -30,7 +34,7 @@ conditions.findConditionKey = (key, requestContext) => {
     // credentials were issued (see Date Condition Operators).
     // Only present in requests that are signed using temporary security
     // credentials.
-    map.set('aws:TokenIssueTime', requestContext.tokenIssueTime);
+    map.set('aws:TokenIssueTime', requestContext.getTokenIssueTime());
     // aws:MultiFactorAuthPresent – Used to check whether MFA was used
     // (see Boolean Condition Operators).
     // Note: This key is only present if MFA was used. So, the following
@@ -41,31 +45,31 @@ conditions.findConditionKey = (key, requestContext) => {
         //     "Condition" :
         //     { "Null" : { "aws:MultiFactorAuthPresent" : true } }
     map.set('aws:MultiFactorAuthPresent',
-        requestContext.multiFactorAuthPresent);
+        requestContext.getMultiFactorAuthPresent());
     // aws:MultiFactorAuthAge – Used to check how many seconds since
     // MFA credentials were issued. If MFA was not used,
     // this key is not present
-    map.set('aws:MultiFactorAuthAge', requestContext.multiFactorAuthAge);
+    map.set('aws:MultiFactorAuthAge', requestContext.getMultiFactorAuthAge());
     // aws:principaltype states whether the principal is an account,
     // user, federated, or assumed role
     // Note: Docs for conditions have "PrincipalType" but simulator
     // and docs for variables have lowercase
-    map.set('aws:principaltype', requestContext.requesterInfo.principaltype);
+    map.set('aws:principaltype', requesterInfo.principaltype);
     // aws:Referer – Used to check who referred the client browser to
     // the address the request is being sent to. Only supported by some
     // services, such as S3. Value comes from the referer header in the
     // HTTPS request made to AWS.
-    map.set('aws:referer', requestContext.headers.referer);
+    map.set('aws:referer', headers.referer);
     // aws:SecureTransport – Used to check whether the request was sent
     // using SSL (see Boolean Condition Operators).
     map.set('aws:SecureTransport',
-        requestContext.sslEnabled ? 'true' : 'false');
+        requestContext.getSslEnabled() ? 'true' : 'false');
     // aws:SourceArn – Used check the source of the request,
     // using the ARN of the source. N/A here.
     map.set('aws:SourceArn', undefined);
     // aws:SourceIp – Used to check the requester's IP address
     // (see IP Address Condition Operators)
-    map.set('aws:SourceIp', requestContext.requesterIp);
+    map.set('aws:SourceIp', requestContext.getRequesterIp());
     // aws:SourceVpc – Used to restrict access to a specific
     // AWS Virtual Private Cloud. N/A here.
     map.set('aws:SourceVpc', undefined);
@@ -74,76 +78,68 @@ conditions.findConditionKey = (key, requestContext) => {
     map.set('aws:SourceVpce', undefined);
     // aws:UserAgent – Used to check the requester's client app.
     // (see String Condition Operators)
-    map.set('aws:UserAgent', requestContext.headers['user-agent']);
+    map.set('aws:UserAgent', headers['user-agent']);
     // aws:userid – Used to check the requester's unique user ID.
     // (see String Condition Operators)
-    map.set('aws:userid', requestContext.requesterInfo.userid);
+    map.set('aws:userid', requesterInfo.userid);
     // aws:username – Used to check the requester's friendly user name.
     // (see String Condition Operators)
-    map.set('aws:username', requestContext.requesterInfo.username);
+    map.set('aws:username', requesterInfo.username);
     // Possible condition keys for S3:
     // s3:x-amz-acl is acl request for bucket or object put request
-    map.set('s3:x-amz-acl', requestContext.headers['x-amz-acl']);
+    map.set('s3:x-amz-acl', headers['x-amz-acl']);
     // s3:x-amz-grant-PERMISSION (where permission can be:
     // read, write, read-acp, write-acp or full-control)
     // Value is the value of that header (ex. id of grantee)
-    map.set('s3:x-amz-grant-read', requestContext.headers['x-amz-grant-read']);
-    map.set('s3:x-amz-grant-write',
-        requestContext.headers['x-amz-grant-write']);
-    map.set('s3:x-amz-grant-read-acp',
-        requestContext.headers['x-amz-grant-read-acp']);
-    map.set('s3:x-amz-grant-write-acp',
-        requestContext.headers['x-amz-grant-write-acp']);
-    map.set('s3:x-amz-grant-full-control',
-        requestContext.headers['x-amz-grant-full-control']);
+    map.set('s3:x-amz-grant-read', headers['x-amz-grant-read']);
+    map.set('s3:x-amz-grant-write', headers['x-amz-grant-write']);
+    map.set('s3:x-amz-grant-read-acp', headers['x-amz-grant-read-acp']);
+    map.set('s3:x-amz-grant-write-acp', headers['x-amz-grant-write-acp']);
+    map.set('s3:x-amz-grant-full-control', headers['x-amz-grant-full-control']);
     // s3:x-amz-copy-source is x-amz-copy-source header if applicable on
     // a put object
-    map.set('s3:x-amz-copy-source',
-        requestContext.headers['x-amz-copy-source']);
+    map.set('s3:x-amz-copy-source', headers['x-amz-copy-source']);
     // s3:x-amz-metadata-directive is x-amz-metadata-directive header if
     // applicable on a put object copy.  Determines whether metadata will
     // be copied from original object or replaced. Values or "COPY" or
     // "REPLACE".  Default is "COPY"
-    map.set('s3:x-amz-metadata-directive',
-        requestContext.headers['metadata-directive']);
+    map.set('s3:x-amz-metadata-directive', headers['metadata-directive']);
     // s3:x-amz-server-side-encryption -- Used to require that object put
     // use server side encryption.  Value is the encryption algo such as
     // "AES256"
     map.set('s3:x-amz-server-side-encryption',
-        requestContext.headers['x-amz-server-side-encryption']);
+        headers['x-amz-server-side-encryption']);
     // s3:x-amz-storage-class -- x-amz-storage-class header value
     // (STANDARD, etc.)
-    map.set('s3:x-amz-storage-class',
-        requestContext.headers['x-amz-storage-class']);
+    map.set('s3:x-amz-storage-class', headers['x-amz-storage-class']);
     // s3:VersionId -- version id of object
-    map.set('s3:VersionId', requestContext.headers['x-amz-version-id']);
+    map.set('s3:VersionId', headers['x-amz-version-id']);
     // s3:LocationConstraint -- Used to restrict creation of bucket
     // in certain region.  Only applicable for CreateBucket
-    map.set('s3:LocationConstraint', requestContext.locationConstraint);
+    map.set('s3:LocationConstraint', requestContext.getLocationConstraint());
     // s3:delimiter is delimiter for listing request
-    map.set('s3:delimiter', requestContext.query.delimiter);
+    map.set('s3:delimiter', query.delimiter);
     // s3:max-keys is max-keys for listing request
-    map.set('s3:max-keys', requestContext.query['max-keys']);
+    map.set('s3:max-keys', query['max-keys']);
     // s3:prefix is prefix for listing request
-    map.set('s3:prefix', requestContext.query.prefix);
+    map.set('s3:prefix', query.prefix);
     // s3 auth v4 additional condition keys
     // (See http://docs.aws.amazon.com/AmazonS3/latest/API/
     // bucket-policy-s3-sigv4-conditions.html)
     // s3:signatureversion -- Either "AWS" for v2 or
     // "AWS4-HMAC-SHA256" for v4
-    map.set('s3:signatureversion', requestContext.signatureVersion);
+    map.set('s3:signatureversion', requestContext.getSignatureVersion());
     // s3:authType -- Method of authentication: either "REST-HEADER",
     // "REST-QUERY-STRING" or "POST"
-    map.set('s3:authType', requestContext.authType);
+    map.set('s3:authType', requestContext.getAuthType());
     // s3:signatureAge is the length of time, in milliseconds,
     // that a signature is valid in an authenticated request.  So,
     // can use this to limit the age to less than 7 days
-    map.set('s3:signatureAge', requestContext.signatureAge);
+    map.set('s3:signatureAge', requestContext.getSignatureAge());
     // s3:x-amz-content-sha256 - Valid value is "UNSIGNED-PAYLOAD"
     // so can use this in a deny policy to deny any requests that do not
     // have a signed payload
-    map.set('s3:x-amz-content-sha256',
-        requestContext.headers['x-amz-content-sha256']);
+    map.set('s3:x-amz-content-sha256', headers['x-amz-content-sha256']);
     return map.get(key);
 };
 
@@ -414,8 +410,10 @@ conditions.convertConditionOperator = operator => {
          // The policy statement value should be either true (the key doesn't
          // exist — it is null) or false (the key exists and its value is
          // not null).
-            if (key === undefined && value[0] === 'true' ||
-                key !== undefined && value[0] === 'false') {
+            if ((key === undefined || key === null)
+                && value[0] === 'true' ||
+                (key !== undefined && key !== null)
+                && value[0] === 'false') {
                 return true;
             }
             return false;

--- a/lib/policyEvaluator/utils/variables.js
+++ b/lib/policyEvaluator/utils/variables.js
@@ -11,12 +11,16 @@
 /**
  * findVariable finds the value of a variable based on the requestContext
  * @param {string} variable - variable name
- * @param {object} requestContext - info sent with request
+ * @param {RequestContext} requestContext - info sent with request
  * @return {string} variable value
  */
 function findVariable(variable, requestContext) {
     // See http://docs.aws.amazon.com/IAM/latest/UserGuide/
     // reference_policies_variables.html
+    const headers = requestContext.getHeaders();
+    const query = requestContext.getQuery();
+    const requesterInfo = requestContext.getRequesterInfo();
+
     const map = new Map();
     // aws:CurrentTime can be used for conditions
     // that check the date and time.
@@ -27,23 +31,23 @@ function findVariable(variable, requestContext) {
     // were issued. can be used with date/time conditions.
     // this key is only available in requests that are signed using
     // temporary security credentials.
-    map.set('aws:TokenIssueTime', requestContext.tokenIssueTime);
+    map.set('aws:TokenIssueTime', requestContext.getTokenIssueTime());
     // aws:principaltype states whether the principal is an account,
     // user, federated, or assumed role
-    map.set('aws:principaltype', requestContext.requesterInfo.principaltype);
+    map.set('aws:principaltype', requesterInfo.principaltype);
     // aws:SecureTransport is boolean value that represents whether the
     // request was sent using SSL
     map.set('aws:SecureTransport',
-        requestContext.sslEnabled ? 'true' : 'false');
+        requestContext.getSslEnabled() ? 'true' : 'false');
     // aws:SourceIp is requester's IP address, for use with IP address
     // conditions
-    map.set('aws:SourceIp', requestContext.requesterIp);
+    map.set('aws:SourceIp', requestContext.getRequesterIp());
     // aws:UserAgent is information about the requester's client application
-    map.set('aws:UserAgent', requestContext.headers['user-agent']);
+    map.set('aws:UserAgent', headers['user-agent']);
     // aws:userid is unique ID for the current user
-    map.set('aws:userid', requestContext.requesterInfo.userid);
+    map.set('aws:userid', requesterInfo.userid);
     // aws:username is friendly name of the current user
-    map.set('aws:username', requestContext.requesterInfo.username);
+    map.set('aws:username', requesterInfo.username);
     // ec2:SourceInstanceARN is the Amazon EC2 instance from which the
     // request was made. Present only when the request comes from an Amazon
     // EC2 instance using an IAM role associated with an EC2
@@ -51,11 +55,11 @@ function findVariable(variable, requestContext) {
     map.set('ec2:SourceInstanceARN', undefined);
     // s3 - specific:
     // s3:prefix is prefix for listing request
-    map.set('s3:prefix', requestContext.query.prefix);
+    map.set('s3:prefix', query.prefix);
     // s3:max-keys is max-keys for listing request
-    map.set('s3:max-keys', requestContext.query['max-keys']);
+    map.set('s3:max-keys', query['max-keys']);
     // s3:x-amz-acl is acl request for bucket or object put request
-    map.set('s3:x-amz-acl', requestContext.headers['x-amz-acl']);
+    map.set('s3:x-amz-acl', query['x-amz-acl']);
     return map.get(variable);
 }
 
@@ -63,7 +67,7 @@ function findVariable(variable, requestContext) {
  * substituteVariables replaces variable values for variables in the form of
  * ${variablename}
  * @param {string} string potentially containing a variable
- * @param {object} requestContext - info sent with request
+ * @param {RequestContext} requestContext - info sent with request
  * @return {string} string with variable values substituted for variables
  */
 function substituteVariables(string, requestContext) {

--- a/tests/unit/auth/v2/errorHandling.js
+++ b/tests/unit/auth/v2/errorHandling.js
@@ -5,6 +5,8 @@ const assert = require('assert');
 const errors = require('../../../../lib/errors');
 const auth = require('../../../../lib/auth/auth');
 const DummyRequestLogger = require('../../helpers').DummyRequestLogger;
+const RequestContext =
+    require('../../../../lib/policyEvaluator/RequestContext.js');
 
 auth.setAuthHandler(require('../../../../lib/auth/vault'));
 
@@ -12,7 +14,7 @@ const logger = new DummyRequestLogger();
 
 describe('Error handling in checkAuth', () => {
     it('should return an error message if no ' +
-       'such access key access key', done => {
+       'such access key', done => {
         const date = new Date();
         const request = {
             method: 'GET',
@@ -26,10 +28,13 @@ describe('Error handling in checkAuth', () => {
             url: '/bucket',
             query: {},
         };
+        const requestContext = new RequestContext(request.headers,
+            request.query, request.bucketName, request.objectKey,
+            undefined, undefined, 'bucketGet', 's3');
         auth.doAuth(request, logger, err => {
             assert.deepStrictEqual(err, errors.InvalidAccessKeyId);
             done();
-        }, 's3', request.query);
+        }, 's3', requestContext);
     });
 
     it('should return an error message if no date header ' +
@@ -44,11 +49,14 @@ describe('Error handling in checkAuth', () => {
             },
             url: '/bucket',
         };
+        const requestContext = new RequestContext(request.headers,
+            request.query, request.bucketName, request.objectKey,
+            undefined, undefined, 'bucketGet', 's3');
 
         auth.doAuth(request, logger, err => {
             assert.deepStrictEqual(err, errors.MissingSecurityHeader);
             done();
-        }, 's3', request.query);
+        }, 's3', requestContext);
     });
 
     it('should return an error message if the Expires ' +
@@ -66,10 +74,13 @@ describe('Error handling in checkAuth', () => {
             },
             headers: {},
         };
+        const requestContext = new RequestContext(request.headers,
+            request.query, request.bucketName, request.objectKey,
+            undefined, undefined, 'bucketGet', 's3');
         auth.doAuth(request, logger, err => {
             assert.deepStrictEqual(err, errors.RequestTimeTooSkewed);
             done();
-        }, 's3', request.query);
+        }, 's3', requestContext);
     });
 
     it('should return an error message if ' +
@@ -91,10 +102,13 @@ describe('Error handling in checkAuth', () => {
             },
             headers: { host: 's3.amazonaws.com' },
         };
+        const requestContext = new RequestContext(request.headers,
+            request.query, request.bucketName, request.objectKey,
+            undefined, undefined, 'bucketGet', 's3');
         auth.doAuth(request, logger, err => {
             assert.deepStrictEqual(err, errors.SignatureDoesNotMatch);
             done();
-        }, 's3', request.query);
+        }, 's3', requestContext);
     });
 
     it('should return an error message if the ' +
@@ -112,10 +126,13 @@ describe('Error handling in checkAuth', () => {
             url: '/bucket',
             query: {},
         };
+        const requestContext = new RequestContext(request.headers,
+            request.query, request.bucketName, request.objectKey,
+            undefined, undefined, 'bucketGet', 's3');
         auth.doAuth(request, logger, err => {
             assert.deepStrictEqual(err, errors.SignatureDoesNotMatch);
             done();
-        }, 's3', request.query);
+        }, 's3', requestContext);
     });
 
     it('should return an error message if accessKey is empty for' +
@@ -133,10 +150,12 @@ describe('Error handling in checkAuth', () => {
             url: '/bucket',
             query: {},
         };
+        const requestContext = new RequestContext(request.headers,
+            request.query, request.bucketName, request.objectKey,
+            undefined, undefined, 'bucketGet', 's3');
         auth.doAuth(request, logger, err => {
             assert.deepStrictEqual(err, errors.MissingSecurityHeader);
             done();
-        }, 's3', request.query);
+        }, 's3', requestContext);
     });
 });
-

--- a/tests/unit/auth/v2/publicAccess.js
+++ b/tests/unit/auth/v2/publicAccess.js
@@ -7,6 +7,8 @@ const auth = require('../../../../lib/auth/auth').doAuth;
 const AuthInfo = require('../../../../lib/auth/AuthInfo');
 const constants = require('../../../../lib/constants');
 const DummyRequestLogger = require('../../helpers.js').DummyRequestLogger;
+const RequestContext =
+    require('../../../../lib/policyEvaluator/RequestContext.js');
 
 const logger = new DummyRequestLogger();
 
@@ -20,6 +22,10 @@ describe('Public Access', () => {
             url: '/bucket',
             query: {},
         };
+        const requestContext = new RequestContext(request.headers,
+            request.query, request.bucketName, request.objectKey,
+            undefined, undefined,
+            'bucketGet', 's3');
         const publicAuthInfo = new AuthInfo({
             canonicalID: constants.publicId,
         });
@@ -28,7 +34,7 @@ describe('Public Access', () => {
             assert.strictEqual(authInfo.getCanonicalID(),
                                publicAuthInfo.getCanonicalID());
             done();
-        }, 's3', request.query);
+        }, 's3', requestContext);
     });
 
     it('should not grant access to a request that contains ' +
@@ -42,9 +48,13 @@ describe('Public Access', () => {
             url: '/bucket',
             query: {},
         };
+        const requestContext = new RequestContext(request.headers,
+            request.query, request.bucketName, request.objectKey,
+            undefined, undefined,
+            'bucketGet', 's3');
         auth(request, logger, err => {
             assert.deepStrictEqual(err, errors.MissingSecurityHeader);
             done();
-        }, 's3', request.query);
+        }, 's3', requestContext);
     });
 });


### PR DESCRIPTION
1) Creates a RequestContext class to be used in S3 and Vault to gather the information needed to evaluate IAM policies.

2) Pulls information from the authentication code to add to a RequestContext instance.

@DavidPineauScality, I had to mess with the authentication code a bit...