### PR TITLE
[CanonicalRequest](fix): Fix spaces from aws-cli

### DIFF
--- a/lib/auth/v4/createCanonicalRequest.js
+++ b/lib/auth/v4/createCanonicalRequest.js
@@ -27,9 +27,13 @@ function createCanonicalRequest(params) {
             payloadChecksum = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b' +
                 '934ca495991b7852b855';
         } else if (pHttpVerb === 'POST') {
-            const payload = queryString.stringify(pQuery, null, null, {
-                encodeURIComponent,
+            const userAgent = pHeaders['user-agent'];
+            let payload = queryString.stringify(pQuery, null, null, {
+                encodeURIComponent: awsURIencode,
             });
+            if (userAgent.startsWith('aws-cli')) {
+                payload = payload.replace(/%20/g, '+');
+            }
             payloadChecksum = crypto.createHash('sha256').update(payload)
                 .digest('hex').toLowerCase();
         }


### PR DESCRIPTION
- Aws cli has a bug that convert spaces into '+' into request
  body, add a check for the userAgent to fix the
  payload computation