### PR TITLE
Handle space for all clients in post request auth

### DIFF
--- a/lib/auth/v4/createCanonicalRequest.js
+++ b/lib/auth/v4/createCanonicalRequest.js
@@ -27,13 +27,10 @@ function createCanonicalRequest(params) {
             payloadChecksum = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b' +
                 '934ca495991b7852b855';
         } else if (pHttpVerb === 'POST') {
-            const userAgent = pHeaders['user-agent'];
             let payload = queryString.stringify(pQuery, null, null, {
                 encodeURIComponent: awsURIencode,
             });
-            if (userAgent.startsWith('aws-cli')) {
-                payload = payload.replace(/%20/g, '+');
-            }
+            payload = payload.replace(/%20/g, '+');
             payloadChecksum = crypto.createHash('sha256').update(payload)
                 .digest('hex').toLowerCase();
         }


### PR DESCRIPTION
This change is needed in the signature calculation for the go sdk to work.  Instead of adding to the "if" clause, I have removed the "if" check.  Without it, the signature works for AWS-CLI, the go sdk and the node sdk. 