### PR TITLE
chore(typescript): add a small definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,14 @@
+interface Ciphers {
+    ciphers: string;
+}
+
+interface Dhparam {
+    dhparam: string;
+}
+
+declare module "arsenal" {
+    namespace https {
+        var ciphers: Ciphers;
+        var dhparam: Dhparam;
+    }
+}


### PR DESCRIPTION
Enable the use of the https part of arsenal for typescript users.