### PR TITLE
BF: update regex for policy Sid

### DIFF
--- a/lib/policy/userPolicySchema.json
+++ b/lib/policy/userPolicySchema.json
@@ -203,7 +203,7 @@
                         "properties": {
                             "Sid": {
                                 "type": "string",
-                                "pattern": "[a-zA-Z0-9]+"
+                                "pattern": "^[a-zA-Z0-9]+$"
                             },
                             "Effect": {
                                 "type": "string",
@@ -306,7 +306,7 @@
                     "properties": {
                         "Sid": {
                             "type": "string",
-                            "pattern": "[a-zA-Z0-9]+"
+                            "pattern": "^[a-zA-Z0-9]+$"
                         },
                         "Effect": {
                             "type": "string",

--- a/tests/unit/policy/test_policyValidator.js
+++ b/tests/unit/policy/test_policyValidator.js
@@ -140,6 +140,11 @@ describe('Policies validation - Statement::Sid_block', () => {
         check(policy, successRes);
     });
 
+    it('should fail if Sid is not a valid format', () => {
+        policy.Statement.Sid = 'foo bar()';
+        check(policy, failRes());
+    });
+
     it('should fail if Sid is not a string', () => {
         policy.Statement.Sid = 1234;
         check(policy, failRes());


### PR DESCRIPTION
Regex was returning partial matches, so for invalid formats string
was not failing the match.

Fix #130