### PR TITLE
fix(arsenal): remove circular dependency

### DIFF
--- a/lib/auth/v2/headerAuthCheck.js
+++ b/lib/auth/v2/headerAuthCheck.js
@@ -1,6 +1,6 @@
 'use strict'; // eslint-disable-line strict
 
-const errors = require('../../../index').errors;
+const errors = require('../../errors');
 const constructStringToSign = require('./constructStringToSign');
 const checkRequestExpiry = require('./checkRequestExpiry');
 const algoCheck = require('./algoCheck');

--- a/lib/auth/v2/queryAuthCheck.js
+++ b/lib/auth/v2/queryAuthCheck.js
@@ -1,6 +1,6 @@
 'use strict'; // eslint-disable-line strict
 
-const errors = require('../../../index').errors;
+const errors = require('../../errors');
 
 const algoCheck = require('./algoCheck');
 const constructStringToSign = require('./constructStringToSign');

--- a/lib/auth/v4/queryAuthCheck.js
+++ b/lib/auth/v4/queryAuthCheck.js
@@ -1,6 +1,6 @@
 'use strict'; // eslint-disable-line strict
 
-const errors = require('../../../index').errors;
+const errors = require('../../errors');
 
 const constructStringToSign = require('./constructStringToSign');
 const checkTimeSkew = require('./timeUtils').checkTimeSkew;

--- a/lib/auth/vault.js
+++ b/lib/auth/vault.js
@@ -1,9 +1,8 @@
 'use strict'; // eslint-disable-line strict
 
-const errors = require('../../index').errors;
-
 const AuthInfo = require('./AuthInfo');
 const backend = require('./in_memory/backend');
+const errors = require('../errors');
 
 const client = backend;
 


### PR DESCRIPTION
This was creating odd behaviours when importing these functionalities and the errors themselves.