### PR TITLE
FIX: AccountNotFound invalid error code

### DIFF
--- a/errors/arsenalErrors.json
+++ b/errors/arsenalErrors.json
@@ -416,7 +416,7 @@
     "description": "The request was denied due to request throttling."
   },
   "AccountNotFound": {
-    "code": 500,
+    "code": 404,
     "description": "No account was found in Vault, please contact your system administrator."
   },
   "_comment": "-------------- Special non-AWS S3 errors --------------",


### PR DESCRIPTION
Actually, we return back to the client a 500 error, it's
supose to be a 404 NotFound http error.
This pull request do the changes to return the
proper error code.

- Send back 404 for AccountNotFound error

Fixes https://github.com/scality/Vault/issues/509