### PR TITLE
Change v2 query auth window to 1 hour 1 second

### DIFF
--- a/lib/auth/v2/queryAuthCheck.js
+++ b/lib/auth/v2/queryAuthCheck.js
@@ -4,7 +4,6 @@ const errors = require('../../errors');
 
 const algoCheck = require('./algoCheck');
 const constructStringToSign = require('./constructStringToSign');
-const checkRequestExpiry = require('./checkRequestExpiry');
 
 const queryAuthCheck = {};
 
@@ -16,7 +15,7 @@ queryAuthCheck.check = (request, log, data) => {
     }
     /*
     Check whether request has expired or if
-    expires parameter is more than 15 minutes in the future.
+    expires parameter is more than 60 minutes (and 1 second) in the future.
     Expires time is provided in seconds so need to
     multiply by 1000 to obtain
     milliseconds to compare to Date.now()
@@ -27,8 +26,17 @@ queryAuthCheck.check = (request, log, data) => {
             { expires: data.Expires });
         return { err: errors.MissingSecurityHeader };
     }
-    const timeout = checkRequestExpiry(expirationTime, log);
-    if (timeout) {
+
+    const currentTime = Date.now();
+    // One hour and 1 second in milliseconds: 3601000
+    if (expirationTime > currentTime + 3601000) {
+        log.debug('expires parameter too far in future',
+        { expires: request.query.Expires });
+        return { err: errors.AccessDenied };
+    }
+    if (currentTime > expirationTime) {
+        log.debug('current time exceeds expires time',
+        { expires: request.query.Expires });
         return { err: errors.RequestTimeTooSkewed };
     }
     const accessKey = data.AWSAccessKeyId;


### PR DESCRIPTION
This is a sort of forward port of https://github.com/scality/S3/pull/169
Since auth moved to arsenal after rel/1.1, the changes need to be made here and the tests added to s3 separately.

Once this is merged here and into master, we can forward port the s3 tests in scality/S3#169 from rel/1.1 into s3 rel/6.2.0-beta5 and master.