### PR TITLE
fix(listing): handle prefixes 

### DIFF
--- a/lib/algos/list/delimiter.js
+++ b/lib/algos/list/delimiter.js
@@ -22,6 +22,7 @@ class Delimiter {
         this.delimiter = parameters.delimiter;
         this.delimLen = this.delimiter ? this.delimiter.length : 0;
         this.searchStart = this._getStartIndex(parameters);
+        this.prefix = parameters.start;
         this.maxKeys = checkLimit(parameters.maxKeys, DEFAULT_MAX_KEYS);
 
         this.logger = logger;
@@ -91,7 +92,9 @@ class Delimiter {
      *       -> this.delimiter is not present in the key after the prefix
      *  else
      *       -> the key is `${this.prefix}${this.delimiter}${objName}`
-     *  @param {String} obj - The key and value of the element
+     *  @param {Object} obj - The key and value of the element
+     *  @param {String} obj.key - The key and value of the element
+     *  @param {String} obj.value - The key and value of the element
      *  @return {Boolean} - True: Continue, False: Stop
      */
     filter(obj) {
@@ -103,6 +106,9 @@ class Delimiter {
         }
         const key = obj.key;
         const value = obj.value;
+        if (this.prefix && !key.startsWith(this.prefix)) {
+            return true;
+        }
         if (this.delimiter) {
             const commonPrefixIndex =
                 key.indexOf(this.delimiter, this.searchStart);

--- a/lib/algos/list/delimiter.js
+++ b/lib/algos/list/delimiter.js
@@ -30,10 +30,10 @@ class Delimiter {
     }
 
     _getStartIndex(params) {
-        if (params.gt) {
-            return params.gt.length;
-        } else if (params.start) {
+        if (params.start) {
             return params.start.length;
+        } else if (params.gt) {
+            return params.gt.length;
         }
         return 0;
     }

--- a/tests/unit/algos/list/delimiter.js
+++ b/tests/unit/algos/list/delimiter.js
@@ -162,6 +162,16 @@ describe('Delimiter listing algorithm', () => {
             IsTruncated: false,
             NextMarker: undefined,
         }, (e, input) => e.key > input.start && e.key < input.lt),
+        new Test('delimiter and prefix (related to #147)', {
+            delimiter: '/',
+            start: '/notes/',
+        }, {
+            Contents: [receivedData[6]],
+            CommonPrefixes: ['/notes/spring/', '/notes/summer/'],
+            Delimiter: '/',
+            IsTruncated: false,
+            NextMarker: undefined,
+        }),
     ];
     tests.forEach(test => {
         it(`Should list ${test.name}`, done => {

--- a/tests/unit/algos/list/delimiter.js
+++ b/tests/unit/algos/list/delimiter.js
@@ -36,26 +36,20 @@ describe('Delimiter listing algorithm', () => {
         creationDate: undefined,
         partLocations: undefined,
     };
-    const data = [
-        { key: '/notes/spring/1.txt', value: '{}' },
-        { key: '/notes/spring/2.txt', value: '{}' },
-        { key: '/notes/spring/march/1.txt', value: '{}' },
-        { key: '/notes/summer/1.txt', value: '{}' },
-        { key: '/notes/summer/2.txt', value: '{}' },
-        { key: '/notes/summer/august/1.txt', value: '{}' },
-        { key: '/notes/year.txt', value: '{}' },
-        { key: '/Pâtisserie=中文-español-English', value: '{}' },
+    const files = [
+        '/notes/spring/1.txt',
+        '/notes/spring/2.txt',
+        '/notes/spring/march/1.txt',
+        '/notes/summer/1.txt',
+        '/notes/summer/2.txt',
+        '/notes/summer/august/1.txt',
+        '/notes/year.txt',
+        '/notes/yore.rs',
+        '/notes/zaphod/Beeblebrox.txt',
+        '/Pâtisserie=中文-español-English',
     ];
-    const receivedData = [
-        { key: '/notes/spring/1.txt', value },
-        { key: '/notes/spring/2.txt', value },
-        { key: '/notes/spring/march/1.txt', value },
-        { key: '/notes/summer/1.txt', value },
-        { key: '/notes/summer/2.txt', value },
-        { key: '/notes/summer/august/1.txt', value },
-        { key: '/notes/year.txt', value },
-        { key: '/Pâtisserie=中文-español-English', value },
-    ];
+    const data = files.map(item => ({ key: item, value: '{}' }));
+    const receivedData = files.map(item => ({ key: item, value }));
     const tests = [
         new Test('all elements', {}, {
             Contents: receivedData,
@@ -71,6 +65,8 @@ describe('Delimiter listing algorithm', () => {
             Contents: [
                 receivedData[4],
                 receivedData[6],
+                receivedData[7],
+                receivedData[8],
             ],
             CommonPrefixes: ['/notes/summer/august/'],
             Delimiter: '/',
@@ -145,6 +141,8 @@ describe('Delimiter listing algorithm', () => {
                 receivedData[2],
                 receivedData[6],
                 receivedData[7],
+                receivedData[8],
+                receivedData[9],
             ],
             CommonPrefixes: ['/notes/summer'],
             Delimiter: '/notes/summer',
@@ -156,8 +154,15 @@ describe('Delimiter listing algorithm', () => {
             start: '/notes/',
             lt: '/notes0',
         }, {
-            Contents: [receivedData[6]],
-            CommonPrefixes: ['/notes/spring/', '/notes/summer/'],
+            Contents: [
+                receivedData[6],
+                receivedData[7],
+            ],
+            CommonPrefixes: [
+                '/notes/spring/',
+                '/notes/summer/',
+                '/notes/zaphod/',
+            ],
             Delimiter: '/',
             IsTruncated: false,
             NextMarker: undefined,
@@ -166,12 +171,34 @@ describe('Delimiter listing algorithm', () => {
             delimiter: '/',
             start: '/notes/',
         }, {
-            Contents: [receivedData[6]],
-            CommonPrefixes: ['/notes/spring/', '/notes/summer/'],
+            Contents: [
+                receivedData[6],
+                receivedData[7],
+            ],
+            CommonPrefixes: [
+                '/notes/spring/',
+                '/notes/summer/',
+                '/notes/zaphod/',
+            ],
             Delimiter: '/',
             IsTruncated: false,
             NextMarker: undefined,
         }),
+        new Test('delimiter, prefix and marker (related to #147)', {
+            delimiter: '/',
+            start: '/notes/',
+            gt: '/notes/year.txt',
+        }, {
+            Contents: [
+                receivedData[7],
+            ],
+            CommonPrefixes: [
+                '/notes/zaphod/',
+            ],
+            Delimiter: '/',
+            IsTruncated: false,
+            NextMarker: undefined,
+        }, (e, input) => e.key > input.gt),
     ];
     tests.forEach(test => {
         it(`Should list ${test.name}`, done => {


### PR DESCRIPTION
### fix(listing): add handling of prefix filtering
Related to issue #147


### fix(listing): prioritise prefix
Ensure that every `CommonPrefixes` entry is correctly picked up instead
of registering them as a `Contents` entry

