### PR TITLE
BF: Errors not being imported

### DIFF
--- a/lib/auth/v2/headerAuthCheck.js
+++ b/lib/auth/v2/headerAuthCheck.js
@@ -1,6 +1,6 @@
 'use strict'; // eslint-disable-line strict
 
-const errors = require('../../../index').errors;
+const errors = require('../../../lib/errors');
 const constructStringToSign = require('./constructStringToSign');
 const checkRequestExpiry = require('./checkRequestExpiry');
 const algoCheck = require('./algoCheck');

--- a/lib/auth/v2/queryAuthCheck.js
+++ b/lib/auth/v2/queryAuthCheck.js
@@ -1,6 +1,6 @@
 'use strict'; // eslint-disable-line strict
 
-const errors = require('../../errors');
+const errors = require('../../../lib/errors');
 
 const algoCheck = require('./algoCheck');
 const constructStringToSign = require('./constructStringToSign');

--- a/lib/auth/v4/queryAuthCheck.js
+++ b/lib/auth/v4/queryAuthCheck.js
@@ -1,6 +1,6 @@
 'use strict'; // eslint-disable-line strict
 
-const errors = require('../../../index').errors;
+const errors = require('../../../lib/errors');
 
 const constructStringToSign = require('./constructStringToSign');
 const checkTimeSkew = require('./timeUtils').checkTimeSkew;


### PR DESCRIPTION
It appears that due to the order in which the require statements were running, errors was undefined in v2 header auth check and v4 query auth check.  

Fixes #156 