### PR TITLE
FIX: Handle empty signed headers

### DIFF
--- a/lib/auth/v4/createCanonicalRequest.js
+++ b/lib/auth/v4/createCanonicalRequest.js
@@ -76,7 +76,7 @@ function createCanonicalRequest(params) {
 
     // canonical headers
     const canonicalHeadersList = signedHeadersList.map(signedHeader => {
-        if (pHeaders[signedHeader]) {
+        if (pHeaders[signedHeader] !== undefined) {
             return `${signedHeader}:${pHeaders[signedHeader]}\n`;
         }
         // handle case where signed 'header' is actually query param

--- a/tests/unit/auth/v4/createCanonicalRequest.js
+++ b/tests/unit/auth/v4/createCanonicalRequest.js
@@ -157,4 +157,27 @@ describe('createCanonicalRequest function', () => {
         const actualOutput = createCanonicalRequest(params);
         assert.strictEqual(actualOutput, expectedOutput);
     });
+
+    it('should construct a canonical request that contains a ' +
+        'signed header with an empty string value', () => {
+        const params = {
+            pHttpVerb: 'PUT',
+            pResource: '/test.txt',
+            pQuery: {},
+            pHeaders: {
+                'content-type': '',
+                'host': 'examplebucket.s3.amazonaws.com',
+            },
+            pSignedHeaders: 'host;content-type',
+            payloadChecksum: 'UNSIGNED-PAYLOAD',
+        };
+        const expectedOutput = 'PUT\n' +
+            '/test.txt\n\n' +
+            'content-type:\n' +
+            'host:examplebucket.s3.amazonaws.com\n\n' +
+            'content-type;host\n' +
+            'UNSIGNED-PAYLOAD';
+        const actualOutput = createCanonicalRequest(params);
+        assert.strictEqual(actualOutput, expectedOutput);
+    });
 });


### PR DESCRIPTION
Since an empty string is interpreted as false, just checking whether the header value existed was resulting in missing a signed header that had an empty string as its value.

Fixes https://github.com/scality/Arsenal/issues/163