### PR TITLE
FT: Fix crypto encoding

### DIFF
--- a/lib/auth/auth.js
+++ b/lib/auth/auth.js
@@ -164,8 +164,8 @@ function generateV4Headers(request, data, accessKey, secretKeyValue,
             encodeURIComponent,
         });
     }
-    const payloadChecksum = crypto.createHash('sha256').update(payload)
-                                  .digest('hex');
+    const payloadChecksum = crypto.createHash('sha256')
+        .update(payload, 'binary').digest('hex');
     request.setHeader('host', request._headers.host);
     request.setHeader('x-amz-date', amzDate);
     request.setHeader('x-amz-content-sha256', payloadChecksum);
@@ -185,7 +185,7 @@ function generateV4Headers(request, data, accessKey, secretKeyValue,
                                                           scopeDate,
                                                           service);
     const signature = crypto.createHmac('sha256', signingKey)
-                        .update(stringToSign).digest('hex');
+        .update(stringToSign, 'binary').digest('hex');
     const authorizationHeader = `${algorithm} Credential=${accessKey}` +
         `/${credentialScope}, SignedHeaders=${signedHeaders}, ` +
         `Signature=${signature}`;

--- a/lib/auth/in_memory/backend.js
+++ b/lib/auth/in_memory/backend.js
@@ -68,7 +68,7 @@ const backend = {
         const secretKey = account.secretKey;
         const signingKey = calculateSigningKey(secretKey, region, scopeDate);
         const reconstructedSig = crypto.createHmac('sha256', signingKey)
-            .update(stringToSign).digest('hex');
+            .update(stringToSign, 'binary').digest('hex');
         if (signatureFromRequest !== reconstructedSig) {
             return callback(errors.SignatureDoesNotMatch);
         }

--- a/lib/auth/in_memory/vaultUtilities.js
+++ b/lib/auth/in_memory/vaultUtilities.js
@@ -10,7 +10,7 @@ const crypto = require('crypto');
  */
 function hashSignature(stringToSign, secretKey, algorithm) {
     const hmacObject = crypto.createHmac(algorithm, secretKey);
-    return hmacObject.update(stringToSign).digest('base64');
+    return hmacObject.update(stringToSign, 'binary').digest('base64');
 }
 
 /** calculateSigningKey for v4 Auth
@@ -22,13 +22,13 @@ function hashSignature(stringToSign, secretKey, algorithm) {
  */
 function calculateSigningKey(secretKey, region, scopeDate, service) {
     const dateKey = crypto.createHmac('sha256', `AWS4${secretKey}`)
-        .update(scopeDate).digest('binary');
+        .update(scopeDate, 'binary').digest();
     const dateRegionKey = crypto.createHmac('sha256', dateKey)
-        .update(region).digest('binary');
+        .update(region, 'binary').digest();
     const dateRegionServiceKey = crypto.createHmac('sha256', dateRegionKey)
-        .update(service || 's3').digest('binary');
+        .update(service || 's3', 'binary').digest();
     const signingKey = crypto.createHmac('sha256', dateRegionServiceKey)
-        .update('aws4_request').digest('binary');
+        .update('aws4_request', 'binary').digest('binary');
     return signingKey;
 }
 

--- a/lib/auth/v4/constructStringToSign.js
+++ b/lib/auth/v4/constructStringToSign.js
@@ -38,8 +38,10 @@ function constructStringToSign(params) {
         log.debug('constructed canonicalRequest', { canonicalReqResult });
     }
     const sha256 = crypto.createHash('sha256');
+    const canonicalHex = sha256.update(canonicalReqResult, 'binary')
+        .digest('hex');
     const stringToSign = `AWS4-HMAC-SHA256\n${timestamp}\n` +
-    `${credentialScope}\n${sha256.update(canonicalReqResult).digest('hex')}`;
+    `${credentialScope}\n${canonicalHex}`;
     return stringToSign;
 }
 

--- a/lib/auth/v4/createCanonicalRequest.js
+++ b/lib/auth/v4/createCanonicalRequest.js
@@ -31,8 +31,8 @@ function createCanonicalRequest(params) {
                 encodeURIComponent: awsURIencode,
             });
             payload = payload.replace(/%20/g, '+');
-            payloadChecksum = crypto.createHash('sha256').update(payload)
-                .digest('hex').toLowerCase();
+            payloadChecksum = crypto.createHash('sha256')
+                .update(payload, 'binary').digest('hex').toLowerCase();
         }
     }
 


### PR DESCRIPTION
in Node v4, default crypto encoding is binary, this
PR specify this encoding to avoid any change in the future
(node v6 in mind)