### PR TITLE
FIX: werelogs in dependencies of http server

### DIFF
--- a/lib/network/http/server.js
+++ b/lib/network/http/server.js
@@ -3,7 +3,6 @@
 const http = require('http');
 const https = require('https');
 const assert = require('assert');
-const Logger = require('werelogs').Logger;
 const dhparam = require('../../https/dh2048').dhparam;
 const ciphers = require('../../https/ciphers').ciphers;
 const errors = require('../../errors');
@@ -18,8 +17,6 @@ class Server {
      */
     constructor(port, logger) {
         assert.strictEqual(typeof port, 'number', 'Port must be a number');
-        assert.strictEqual(logger instanceof Logger, true,
-            'Logger must be an instance of werelogs');
         this._noDelay = true;
         this._cbOnListening = () => {};
         this._cbOnRequest = (req, res) => this._noHandlerCb(req, res);


### PR DESCRIPTION
Werelogs is actually require by the http server
of arsenal, it should not, since its not a prod
dependencies.
This PR fix that