### PR TITLE
Compat: Check for invalid Authorization header

### DIFF
--- a/lib/auth/v2/headerAuthCheck.js
+++ b/lib/auth/v2/headerAuthCheck.js
@@ -37,7 +37,7 @@ function check(request, log, data) {
     const semicolonIndex = authInfo.indexOf(':');
     if (semicolonIndex < 0) {
         log.debug('invalid authorization header', { authInfo });
-        return { err: errors.MissingSecurityHeader };
+        return { err: errors.InvalidArgument };
     }
     const accessKey = semicolonIndex > 4 ?
         authInfo.substring(4, semicolonIndex).trim() : undefined;

--- a/lib/auth/v4/headerAuthCheck.js
+++ b/lib/auth/v4/headerAuthCheck.js
@@ -29,6 +29,12 @@ function check(request, log, data, awsService) {
         return { err: errors.MissingSecurityHeader };
     }
 
+    const authHeaderItems = extractAuthItems(authHeader, log);
+    if (Object.keys(authHeaderItems).length < 3) {
+        log.debug('invalid authorization header', { authHeader });
+        return { err: errors.InvalidArgument };
+    }
+
     const payloadChecksum = request.headers['x-amz-content-sha256'];
     if (!payloadChecksum && awsService !== 'iam') {
         log.debug('missing payload checksum');
@@ -48,10 +54,6 @@ function check(request, log, data, awsService) {
 
     log.trace('authorization header from request', { authHeader });
 
-    const authHeaderItems = extractAuthItems(authHeader, log);
-    if (Object.keys(authHeaderItems).length < 3) {
-        return { err: errors.MissingSecurityHeader };
-    }
     const signatureFromRequest = authHeaderItems.signatureFromRequest;
     const credentialsArr = authHeaderItems.credentialsArr;
     const signedHeaders = authHeaderItems.signedHeaders;

--- a/tests/unit/auth/v4/headerAuthCheck.js
+++ b/tests/unit/auth/v4/headerAuthCheck.js
@@ -90,7 +90,7 @@ describe('v4 headerAuthCheck', () => {
                 '24c06abf8772c670064d22eacd6ccb85c06befa15f' +
                 '4a789b0bae19307bc' }, 'headers', request, headers);
         const res = headerAuthCheck(alteredRequest, log);
-        assert.deepStrictEqual(res.err, errors.MissingSecurityHeader);
+        assert.deepStrictEqual(res.err, errors.InvalidArgument);
         done();
     });
 
@@ -104,7 +104,7 @@ describe('v4 headerAuthCheck', () => {
                 '70064d22eacd6ccb85c06befa15f' +
                 '4a789b0bae19307bc' }, 'headers', request, headers);
         const res = headerAuthCheck(alteredRequest, log);
-        assert.deepStrictEqual(res.err, errors.MissingSecurityHeader);
+        assert.deepStrictEqual(res.err, errors.InvalidArgument);
         done();
     });
 
@@ -118,7 +118,7 @@ describe('v4 headerAuthCheck', () => {
                 '70064d22eacd6ccb85c06befa15f' +
                 '4a789b0bae19307bc' }, 'headers', request, headers);
         const res = headerAuthCheck(alteredRequest, log);
-        assert.deepStrictEqual(res.err, errors.MissingSecurityHeader);
+        assert.deepStrictEqual(res.err, errors.InvalidArgument);
         done();
     });
 


### PR DESCRIPTION
Fixes #178 

When invalid Authorization header : return InvalidArgument error
AWS checks `authorization` header before `x-amz-content-sha256`
**On [ceph/s3-tests](https://github.com/ceph/s3-tests), these changes fix**:
- `FAIL: s3tests.functional.test_headers.test_object_create_bad_authorization_invalid_aws2`
- `FAIL: s3tests.functional.test_headers.test_object_create_bad_authorization_invalid_aws4`
- `FAIL: s3tests.functional.test_headers.test_bucket_create_bad_authorization_invalid_aws2`
- `FAIL: s3tests.functional.test_headers.test_bucket_create_bad_authorization_invalid_aws4`