### PR TITLE
Compat: Check for invalid Date header

### DIFF
--- a/lib/auth/v2/headerAuthCheck.js
+++ b/lib/auth/v2/headerAuthCheck.js
@@ -14,8 +14,11 @@ function check(request, log, data) {
         headers['x-amz-date'] : headers.date;
     timestamp = Date.parse(timestamp);
     if (!timestamp) {
-        log.debug('missing security header: invalid date/timestamp');
-        return { err: errors.MissingSecurityHeader };
+        log.debug('missing or invalid date header',
+        { method: 'auth/v2/headerAuthCheck.check' });
+        return { err: errors.AccessDenied.
+          customizeDescription('Authentication requires a valid Date or ' +
+          'x-amz-date header') };
     }
 
     const timeout = checkRequestExpiry(timestamp, log);

--- a/lib/auth/v4/headerAuthCheck.js
+++ b/lib/auth/v4/headerAuthCheck.js
@@ -38,7 +38,7 @@ function check(request, log, data, awsService) {
         log.trace('requesting streaming v4 auth');
         if (request.method !== 'PUT') {
             log.debug('streaming v4 auth for put only',
-                { method: 'v4HeaderAuthCheck' });
+                { method: 'auth/v4/headerAuthCheck.check' });
             return { err: errors.InvalidArgument };
         }
         if (!request.headers['x-amz-decoded-content-length']) {
@@ -70,8 +70,11 @@ function check(request, log, data, awsService) {
         timestamp = convertUTCtoISO8601(request.headers.date);
     }
     if (!timestamp) {
-        log.debug('missing date header');
-        return { err: errors.MissingSecurityHeader };
+        log.debug('missing or invalid date header',
+          { method: 'auth/v4/headerAuthCheck.check' });
+        return { err: errors.AccessDenied.
+          customizeDescription('Authentication requires a valid Date or ' +
+          'x-amz-date header') };
     }
 
     if (!validateCredentials(credentialsArr, timestamp, log)) {

--- a/tests/unit/auth/v4/headerAuthCheck.js
+++ b/tests/unit/auth/v4/headerAuthCheck.js
@@ -126,7 +126,9 @@ describe('v4 headerAuthCheck', () => {
         const alteredRequest = createAlteredRequest({
             'x-amz-date': undefined }, 'headers', request, headers);
         const res = headerAuthCheck(alteredRequest, log);
-        assert.deepStrictEqual(res.err, errors.MissingSecurityHeader);
+        assert.deepStrictEqual(res.err, errors.AccessDenied.
+          customizeDescription('Authentication requires a valid Date or ' +
+          'x-amz-date header'));
         done();
     });
 


### PR DESCRIPTION
Fixes https://github.com/scality/Arsenal/issues/179

When empty/invalid/unreadable/none Date header : return AccessDenied error
**On [ceph/s3-tests](https://github.com/ceph/s3-tests), these changes fix**:

_on object with V2 auth:_
- `FAIL: s3tests.functional.test_headers.test_object_create_bad_date_empty_aws2`
- `FAIL: s3tests.functional.test_headers.test_object_create_bad_date_invalid_aws2`
- `FAIL: s3tests.functional.test_headers.test_object_create_bad_date_unreadable_aws2`
- `FAIL: s3tests.functional.test_headers.test_object_create_bad_date_none_aws2`

_on bucket with V2 auth:_
- `FAIL: s3tests.functional.test_headers.test_bucket_create_bad_date_empty_aws2`
- `FAIL: s3tests.functional.test_headers.test_bucket_create_bad_date_invalid_aws2`
- `FAIL: s3tests.functional.test_headers.test_bucket_create_bad_date_unreadable_aws2`
- `FAIL: s3tests.functional.test_headers.test_bucket_create_bad_date_none_aws2`

_on object with V4 auth:_
- `FAIL: s3tests.functional.test_headers.test_object_create_bad_amz_date_empty_aws4`
- `FAIL: s3tests.functional.test_headers.test_object_create_bad_amz_date_invalid_aws4`
- `FAIL: s3tests.functional.test_headers.test_object_create_bad_amz_date_unreadable_aws4`
- `FAIL: s3tests.functional.test_headers.test_object_create_bad_amz_date_none_aws4`

_on bucket with V4 auth:_
- `FAIL: s3tests.functional.test_headers.test_bucket_create_bad_amz_date_empty_aws4`
- `FAIL: s3tests.functional.test_headers.test_bucket_create_bad_amz_date_invalid_aws4`
- `FAIL: s3tests.functional.test_headers.test_bucket_create_bad_amz_date_unreadable_aws4`
- `FAIL: s3tests.functional.test_headers.test_bucket_create_bad_amz_date_none_aws4`
