### PR TITLE
COMPAT: Check for invalid amz-date header

### DIFF
--- a/lib/auth/v4/headerAuthCheck.js
+++ b/lib/auth/v4/headerAuthCheck.js
@@ -65,9 +65,16 @@ function check(request, log, data, awsService) {
 
     let timestamp;
     // check request timestamp
-    if (request.headers['x-amz-date']) {
-        // format of x-amz- date is ISO 8601: YYYYMMDDTHHMMSSZ
-        timestamp = request.headers['x-amz-date'];
+    const xAmzDate = request.headers['x-amz-date'];
+    if (xAmzDate) {
+        const xAmzDateArr = xAmzDate.split('T');
+        // check that x-amz- date has the correct format and after epochTime
+        if (xAmzDateArr.length === 2 && xAmzDateArr[0].length === 8
+          && xAmzDateArr[1].length === 7
+          && Number.parseInt(xAmzDateArr[0], 10) > 19700101) {
+            // format of x-amz- date is ISO 8601: YYYYMMDDTHHMMSSZ
+            timestamp = request.headers['x-amz-date'];
+        }
     } else if (request.headers.date) {
         timestamp = convertUTCtoISO8601(request.headers.date);
     }
@@ -79,9 +86,12 @@ function check(request, log, data, awsService) {
           'x-amz-date header') };
     }
 
-    if (!validateCredentials(credentialsArr, timestamp, log)) {
-        log.debug('credentials in improper format', { credentialsArr });
-        return { err: errors.InvalidArgument };
+    const validationResult = validateCredentials(credentialsArr, timestamp,
+      log);
+    if (validationResult instanceof Error) {
+        log.debug('credentials in improper format', { credentialsArr,
+          timestamp, validationResult });
+        return { err: validationResult };
     }
     // credentialsArr is [accessKey, date, region, aws-service, aws4_request]
     const scopeDate = credentialsArr[1];

--- a/lib/auth/v4/queryAuthCheck.js
+++ b/lib/auth/v4/queryAuthCheck.js
@@ -34,9 +34,12 @@ function check(request, log, data) {
         return { err: errors.AccessDenied };
     }
 
-    if (!validateCredentials(credential, timestamp, log)) {
-        log.debug('credential param format incorrect', { credential });
-        return { err: errors.InvalidArgument };
+    const validationResult = validateCredentials(credential, timestamp,
+      log);
+    if (validationResult instanceof Error) {
+        log.debug('credentials in improper format', { credential,
+          timestamp, validationResult });
+        return { err: validationResult };
     }
     const accessKey = credential[0];
     const scopeDate = credential[1];

--- a/lib/auth/v4/validateInputs.js
+++ b/lib/auth/v4/validateInputs.js
@@ -1,5 +1,7 @@
 'use strict'; // eslint-disable-line strict
 
+const errors = require('../../../lib/errors');
+
 /**
  * Validate Credentials
  * @param  {array} credentials - contains accessKey, scopeDate,
@@ -12,7 +14,7 @@
 function validateCredentials(credentials, timestamp, log) {
     if (!Array.isArray(credentials) || credentials.length !== 5) {
         log.warn('credentials in improper format', { credentials });
-        return false;
+        return errors.InvalidArgument;
     }
     // credentials[2] (region) is not read intentionally
     const accessKey = credentials[0];
@@ -21,34 +23,34 @@ function validateCredentials(credentials, timestamp, log) {
     const requestType = credentials[4];
     if (accessKey.length < 1) {
         log.warn('accessKey provided is wrong format', { accessKey });
-        return false;
+        return errors.InvalidArgument;
     }
-    // The scope date (format YYYYMMDD) must be same date as the timestamp
-    // on the request from the x-amz-date param (if queryAuthCheck)
-    // or from the x-amz-date header or date header (if headerAuthCheck)
-    // Format of timestamp is ISO 8601: YYYYMMDDTHHMMSSZ.
-    // http://docs.aws.amazon.com/AmazonS3/latest/API/
-    // sigv4-query-string-auth.html
-    // http://docs.aws.amazon.com/general/latest/gr/
-    // sigv4-date-handling.html
+     // The scope date (format YYYYMMDD) must be same date as the timestamp
+     // on the request from the x-amz-date param (if queryAuthCheck)
+     // or from the x-amz-date header or date header (if headerAuthCheck)
+     // Format of timestamp is ISO 8601: YYYYMMDDTHHMMSSZ.
+     // http://docs.aws.amazon.com/AmazonS3/latest/API/
+     // sigv4-query-string-auth.html
+     // http://docs.aws.amazon.com/general/latest/gr/
+     // sigv4-date-handling.html
 
-    // convert timestamp to format of scopeDate YYYYMMDD
+     // convert timestamp to format of scopeDate YYYYMMDD
     const timestampDate = timestamp.split('T')[0];
     if (scopeDate.length !== 8 || scopeDate !== timestampDate) {
         log.warn('scope date must be the same date as the timestamp date',
-            { scopeDate, timestampDate });
-        return false;
+           { scopeDate, timestampDate });
+        return errors.RequestTimeTooSkewed;
     }
     if (service !== 's3' && service !== 'iam') {
         log.warn('service in credentials is not s3', { service });
-        return false;
+        return errors.InvalidArgument;
     }
     if (requestType !== 'aws4_request') {
         log.warn('requestType contained in params is not aws4_request',
-            { requestType });
-        return false;
+           { requestType });
+        return errors.InvalidArgument;
     }
-    return true;
+    return {};
 }
 
 /**

--- a/tests/unit/auth/v4/headerAuthCheck.js
+++ b/tests/unit/auth/v4/headerAuthCheck.js
@@ -138,7 +138,25 @@ describe('v4 headerAuthCheck', () => {
         const alteredRequest = createAlteredRequest({
             'x-amz-date': '20150208T201405Z' }, 'headers', request, headers);
         const res = headerAuthCheck(alteredRequest, log);
-        assert.deepStrictEqual(res.err, errors.InvalidArgument);
+        assert.deepStrictEqual(res.err, errors.RequestTimeTooSkewed);
+        done();
+    });
+
+    it('should return error if timestamp from x-amz-date header' +
+        'is before epochTime', done => {
+        // Different date (2095 instead of 2016)
+        const alteredRequest = createAlteredRequest({
+            'x-amz-date': '19500707T215304Z',
+            'authorization': 'AWS4-HMAC-SHA256 Credential' +
+                '=accessKey1/20160208/us-east-1/s3/aws4_request, ' +
+                'SignedHeaders=host;x-amz-content-sha256;' +
+                'x-amz-date, Signature=abed924c06abf8772c67' +
+                '0064d22eacd6ccb85c06befa15f' +
+                '4a789b0bae19307bc' }, 'headers', request, headers);
+        const res = headerAuthCheck(alteredRequest, log);
+        assert.deepStrictEqual(res.err, errors.AccessDenied.
+        customizeDescription('Authentication requires a valid Date or ' +
+        'x-amz-date header'));
         done();
     });
 

--- a/tests/unit/auth/v4/queryAuthCheck.js
+++ b/tests/unit/auth/v4/queryAuthCheck.js
@@ -185,7 +185,7 @@ describe('v4 queryAuthCheck', () => {
         }, 'query', request, query);
         const res = queryAuthCheck(alteredRequest, log, alteredRequest.query);
         clock.uninstall();
-        assert.deepStrictEqual(res.err, errors.InvalidArgument);
+        assert.deepStrictEqual(res.err, errors.RequestTimeTooSkewed);
         done();
     });
 


### PR DESCRIPTION
Fixes https://github.com/scality/Arsenal/issues/180

When amz-date header is unreadable: return AccessDenied error
**On [ceph/s3-tests](https://github.com/ceph/s3-tests), these changes fix**:

Ceph test creating unreadable x-amz-date `'X-Amz-Date': '\x07'`
- `FAIL: s3tests.functional.test_headers.test_object_create_bad_amz_date_unreadable_aws4`
- `FAIL: s3tests.functional.test_headers.test_bucket_create_bad_amz_date_unreadable_aws4`

Ceph test creating  x-amz-date in past `'X-Amz-Date': '20100707T215304Z'`
- `FAIL: s3tests.functional.test_headers.test_object_create_bad_amz_date_before_today_aws4`
- `FAIL: s3tests.functional.test_headers.test_bucket_create_bad_amz_date_before_today_aws4`

Ceph test creating  x-amz-date in future `'X-Amz-Date': '20300707T215304Z'` 
- `FAIL: s3tests.functional.test_headers.test_object_create_bad_amz_date_after_today_aws4`
- `FAIL: s3tests.functional.test_headers.test_bucket_create_bad_amz_date_after_today_aws4`

Ceph test creating  x-amz-date before epochTime `'X-Amz-Date': '19500707T215304Z'` 
- `FAIL: s3tests.functional.test_headers.test_object_create_bad_amz_date_before_epoch_aws4`
- `FAIL: s3tests.functional.test_headers.test_bucket_create_bad_amz_date_before_epoch_aws4`

Ceph test creating  x-amz-date after 9999 `'X-Amz-Date': '99990707T215304Z'` 
- `FAIL: s3tests.functional.test_headers.test_object_create_bad_amz_date_after_end_aws4`
