### PR TITLE
COMPAT: check for bad authorization header

### DIFF
--- a/lib/auth/auth.js
+++ b/lib/auth/auth.js
@@ -67,7 +67,7 @@ function extractParams(request, log, awsService, data) {
         } else {
             log.trace('missing authorization security header',
                       { header: authHeader });
-            return { err: errors.MissingSecurityHeader };
+            return { err: errors.AccessDenied };
         }
     } else if (data.Signature) {
         method = 'query';

--- a/tests/unit/auth/v2/publicAccess.js
+++ b/tests/unit/auth/v2/publicAccess.js
@@ -54,7 +54,7 @@ describe('Public Access', () => {
             undefined, undefined,
             'bucketGet', 's3')];
         auth(request, logger, err => {
-            assert.deepStrictEqual(err, errors.MissingSecurityHeader);
+            assert.deepStrictEqual(err, errors.AccessDenied);
             done();
         }, 's3', requestContext);
     });


### PR DESCRIPTION
Fixes https://github.com/scality/Arsenal/issues/182

When authorization header is incorrect: return AccessDenied error
**On [ceph/s3-tests](https://github.com/ceph/s3-tests), these changes fix**:

_bucket:_
- `FAIL: s3tests.functional.test_headers.test_bucket_create_bad_authorization_unreadable`
  expect `<Code>AccessDenied</Code><Message>Anonymous access is forbidden for this operation</Message>`

_object:_
- `FAIL: s3tests.functional.test_headers.test_object_create_bad_authorization_unreadable`
  expect `<Code>AccessDenied</Code><Message>Access Denied</Message>`
