### PR TITLE
BF: Sort query params for v4 auth.

### DIFF
--- a/lib/auth/v4/createCanonicalRequest.js
+++ b/lib/auth/v4/createCanonicalRequest.js
@@ -41,31 +41,11 @@ function createCanonicalRequest(params) {
     // canonical query string
     let canonicalQueryStr = '';
     if (pQuery && !(service === 'iam' && pHttpVerb === 'POST')) {
-        const queryParams = Object.keys(pQuery).map(key => {
+        const sortedQueryParams = Object.keys(pQuery).sort().map(key => {
+            const encodedKey = awsURIencode(key);
             const value = pQuery[key] ? awsURIencode(pQuery[key]) : '';
-            return {
-                qParam: awsURIencode(key),
-                value,
-            };
+            return `${encodedKey}=${value}`;
         });
-
-        queryParams.sort((a, b) => {
-            if (a.qParam[0] && b.qParam[0]) {
-                if (a.qParam[0].toUpperCase() === a.qParam[0]
-                    && b.qParam[0].toUpperCase() !== b.qParam[0]) {
-                    // a is capitalized so comes first
-                    return -1;
-                }
-                if (b.qParam[0].toUpperCase() === b.qParam[0]
-                    && a.qParam[0].toUpperCase() !== a.qParam[0]) {
-                    // b is capitalized so comes first
-                    return 1;
-                }
-            }
-            return a.qParam.localeCompare(b.qParam);
-        });
-        const sortedQueryParams = queryParams.map(item =>
-            `${item.qParam}=${item.value}`);
         canonicalQueryStr = sortedQueryParams.join('&');
     }
 

--- a/tests/unit/auth/v4/createCanonicalRequest.js
+++ b/tests/unit/auth/v4/createCanonicalRequest.js
@@ -136,6 +136,8 @@ describe('createCanonicalRequest function', () => {
                 'X-Amz-Date': '20130524T000000Z',
                 'X-Amz-Credential': 'AKIAIOSFODNN7EXAMPLE/20130524/' +
                     'us-east-1/s3/aws4_request',
+                'X-Amz-Meta-camelCase': 'before',
+                'X-Amz-Meta-camelcase': 'after',
             },
             pHeaders: {
                 host: 'examplebucket.s3.amazonaws.com',
@@ -148,7 +150,10 @@ describe('createCanonicalRequest function', () => {
             'X-Amz-Algorithm=AWS4-HMAC-SHA256&' +
             'X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130524%2' +
             'Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20130524T000000' +
-            'Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host' +
+            'Z&X-Amz-Expires=86400' +
+            '&X-Amz-Meta-camelCase=before' +
+            '&X-Amz-Meta-camelcase=after' +
+            '&X-Amz-SignedHeaders=host' +
             '&x-amz-acl=public\n' +
             'host:examplebucket.s3.amazonaws.com\n' +
             'x-amz-acl:public\n\n' +


### PR DESCRIPTION
Before this change we were only taking into account
capital letters that appeared at the beginning of a query
param key.  With this change we take into account
capital letters throughout the key.

Fixes https://github.com/scality/Arsenal/issues/188