### PR TITLE
COMPAT: Always return delimiter

### DIFF
--- a/lib/algos/list/MPU.js
+++ b/lib/algos/list/MPU.js
@@ -115,7 +115,6 @@ class MultipartUploads {
      *  @return {Object} - The result.
      */
     result() {
-        const delimiter = this.CommonPrefixes.length > 0 ? this.delimiter : '';
         return {
             CommonPrefixes: this.CommonPrefixes,
             Uploads: this.Uploads,
@@ -123,7 +122,7 @@ class MultipartUploads {
             NextKeyMarker: this.NextKeyMarker,
             MaxKeys: this.maxKeys,
             NextUploadIdMarker: this.NextUploadIdMarker,
-            Delimiter: delimiter,
+            Delimiter: this.delimiter,
         };
     }
 }


### PR DESCRIPTION
Currently, when using the S3 file-backend, if a `Delimiter` parameter is
defined and it does not result in a `CommonPrefixes` array that is
greater than 0, `Delimiter` is set to ''. This causes the XML response
to omit the `Delimeter` key. For compatibility with AWS, this commit
fixes the `Delimiter` response to include any `Delimiter` string given 
as a parameter or return a `Delimiter` that is `undefined`.

See the associated fix in S3: https://github.com/scality/S3/pull/435