### PR TITLE
S3C-35 Implement a new communication channel to use functionality of level-sublevel remotely

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,5 +40,12 @@ module.exports = {
         http: {
             server: require('./lib/network/http/server'),
         },
+        level: require('./lib/network/level-net'),
+    },
+    storage: {
+        metadata: {
+            server: require('./lib/storage/metadata/file/server'),
+            client: require('./lib/storage/metadata/file/client'),
+        },
     },
 };

--- a/lib/network/level-net/index.js
+++ b/lib/network/level-net/index.js
@@ -84,13 +84,13 @@ class SocketIOConnection {
 const dbAsyncCommandNames = ['put', 'get', 'del', 'batch'];
 const dbStreamCommandNames = ['createReadStream'];
 
-const otherSyncCommands = {
+const miscSyncCommands = {
     ping: function ping() {
         return 'pong';
     },
 };
 
-const otherAsyncCommands = {
+const miscAsyncCommands = {
     pingAsync: function pingAsync(cb) {
         setImmediate(() => cb(null, 'pong'));
     },
@@ -119,8 +119,8 @@ module.exports.client = function LevelClient(logger) {
                                       args, cb, this.timeoutMs);
         };
     }
-    for (const remoteCall of Object.keys(otherSyncCommands).concat(
-        Object.keys(otherAsyncCommands))) {
+    for (const remoteCall of Object.keys(miscSyncCommands).concat(
+        Object.keys(miscAsyncCommands))) {
         dbClient[remoteCall] = function onCall(...args) {
             const cb = args.pop();
             this.miscClient.callTimeout(remoteCall, false,
@@ -218,20 +218,20 @@ module.exports.createServer = function LevelServer(db) {
     miscSock.on('connection', conn => {
         conn.on('error', () => {});
         conn.on('call', (remoteCall, args, cb) => {
-            if (remoteCall in otherAsyncCommands) {
+            if (remoteCall in miscAsyncCommands) {
                 try {
                     args.push((err, data) => {
                         cb(serializeError(err), data);
                     });
-                    otherAsyncCommands[remoteCall].apply(null, args);
+                    miscAsyncCommands[remoteCall].apply(null, args);
                 } catch (err) {
                     return cb(serializeError(err));
                 }
-            } else if (remoteCall in otherSyncCommands) {
+            } else if (remoteCall in miscSyncCommands) {
                 let result;
 
                 try {
-                    result = otherSyncCommands[remoteCall].apply(null, args);
+                    result = miscSyncCommands[remoteCall].apply(null, args);
                     return cb(null, result);
                 } catch (err) {
                     return cb(serializeError(err));

--- a/lib/network/level-net/index.js
+++ b/lib/network/level-net/index.js
@@ -1,0 +1,248 @@
+'use strict'; // eslint-disable-line
+
+const http = require('http');
+const io = require('socket.io');
+const ioClient = require('socket.io-client');
+const ioStream = require('socket.io-stream');
+
+function serializeError(err) {
+    if (!err) {
+        return err;
+    }
+    const serializedErr = Object.assign({}, err);
+
+    serializedErr.message = err.message;
+    for (const k in err) {
+        if (!(k in serializedErr)) {
+            serializedErr[k] = err[k];
+        }
+    }
+    return serializedErr;
+}
+
+function deserializeError(err) {
+    if (!err) {
+        return err;
+    }
+    const deserializedErr = new Error(err.message);
+
+    for (const k in err) {
+        if (!(k in deserializedErr)) {
+            deserializedErr[k] = err[k];
+        }
+    }
+    return deserializedErr;
+}
+
+class SocketIOConnection {
+    constructor(url, logger) {
+        this.logger = logger;
+        this.socket = ioClient(url);
+        this.socketStreamed = ioStream(this.socket);
+        this.socket.on('error', err => {
+            this.logger.warn('connectivity error to storage daemon',
+                             { error: err });
+            return undefined;
+        });
+    }
+
+    callTimeout(remoteCall, isStreamed, args, cb, timeoutMs = 5000) {
+        if (typeof cb !== 'function') {
+            return cb(new Error(`argument cb=${cb} is not a callback`));
+        }
+        let timedOut = false;
+        const timeoutHandle = setTimeout(() => {
+            timedOut = true;
+            const err = new Error(`operation ${remoteCall} timed out`);
+            err.timeout = true;
+            cb(err);
+        }, timeoutMs);
+
+        let socket;
+        let eventName;
+        if (isStreamed) {
+            socket = this.socketStreamed;
+            eventName = 'callStream';
+        } else {
+            socket = this.socket;
+            eventName = 'call';
+        }
+        socket.emit(eventName, remoteCall, args, function callback(err, data) {
+            if (!timedOut) {
+                clearTimeout(timeoutHandle);
+                cb(deserializeError(err), data);
+            } else {
+                this.logger.warn(
+                    'call to remote function ended after timeout expired',
+                    { error: err });
+            }
+        });
+        return undefined;
+    }
+}
+
+const dbAsyncCommandNames = ['put', 'get', 'del', 'batch'];
+const dbStreamCommandNames = ['createReadStream'];
+
+const otherSyncCommands = {
+    ping: function ping() {
+        return 'pong';
+    },
+};
+
+const otherAsyncCommands = {
+    pingAsync: function pingAsync(cb) {
+        setImmediate(() => cb(null, 'pong'));
+    },
+    slowCommand: function slowCommand(cb) {
+        setTimeout(() => cb(null, 'ok'), 2000);
+    },
+};
+
+module.exports.client = function LevelClient(logger) {
+    const dbClient = {};
+
+    dbClient.path = [];
+    dbClient.logger = logger;
+    dbClient.connect = function connect(host, port) {
+        this.dbClient = new SocketIOConnection(
+            `http://${host}:${port}/metadata`, this.logger);
+        this.miscClient = new SocketIOConnection(
+            `http://${host}:${port}/misc`, this.logger);
+    };
+    for (const remoteCall of dbStreamCommandNames.concat(dbAsyncCommandNames)) {
+        dbClient[remoteCall] = function onCall(...args) {
+            const cb = args.pop();
+            args.push(this.path);
+            const isStreamed = dbStreamCommandNames.includes(remoteCall);
+            this.dbClient.callTimeout(remoteCall, isStreamed,
+                                      args, cb, this.timeoutMs);
+        };
+    }
+    for (const remoteCall of Object.keys(otherSyncCommands).concat(
+        Object.keys(otherAsyncCommands))) {
+        dbClient[remoteCall] = function onCall(...args) {
+            const cb = args.pop();
+            this.miscClient.callTimeout(remoteCall, false,
+                                        args, cb, this.timeoutMs);
+        };
+    }
+    dbClient.openSub = function openSub(subName) {
+        const subLevel = {};
+        for (const prop in this) {
+            if (!(prop in subLevel)) {
+                subLevel[prop] = this[prop];
+            }
+        }
+        // maintain path as a list of nested sublevels
+        subLevel.path = subLevel.path.slice();
+        subLevel.path.push(subName);
+        return subLevel;
+    };
+
+    dbClient.timeoutMs = 5000;
+    dbClient.getTimeout = function getTimeout() {
+        return this.timeoutMs;
+    };
+    dbClient.setTimeout = function setNewTimeout(newTimeoutMs) {
+        this.timeoutMs = newTimeoutMs;
+    };
+
+    return dbClient;
+};
+
+module.exports.createServer = function LevelServer(db) {
+    const httpServer = http.createServer();
+    const ioServer = io(httpServer);
+
+    const mdSock = ioServer.of('/metadata');
+    mdSock.on('connection', conn => {
+        function openSub(path) {
+            let subDb = db;
+            path.forEach(pathItem => {
+                subDb = subDb.sublevel(pathItem);
+            });
+            return subDb;
+        }
+
+        conn.on('error', () => {});
+        conn.on('call', (remoteCall, args, cb) => {
+            if (dbAsyncCommandNames.includes(remoteCall)) {
+                try {
+                    const path = args.pop();
+                    args.push((err, data) => {
+                        cb(serializeError(err), data);
+                    });
+
+                    const subDb = openSub(path);
+                    subDb[remoteCall].apply(subDb, args);
+                } catch (err) {
+                    return cb(serializeError(err));
+                }
+            } else {
+                return cb(serializeError(
+                    new Error(`Unknown remote call ${remoteCall}`)));
+            }
+            return undefined;
+        });
+
+        // add streaming support for commands that return a streamed result
+        const connStreamed = ioStream(conn);
+        connStreamed.on('callStream', (remoteCall, args, cb) => {
+            if (dbStreamCommandNames.includes(remoteCall)) {
+                let result;
+
+                try {
+                    const path = args.pop();
+                    const subDb = openSub(path);
+                    result = subDb[remoteCall].apply(subDb, args);
+                    if (typeof result === 'object'
+                        && result.pipe !== undefined) {
+                        // looks like a stream object, wrap it with
+                        // RPC stream support
+                        const stream =
+                            ioStream.createStream({ objectMode: true });
+                        result.pipe(stream);
+                        result = stream;
+                    }
+                } catch (err) {
+                    return cb(serializeError(err));
+                }
+                return cb(null, result);
+            }
+            return undefined;
+        });
+    });
+
+    const miscSock = ioServer.of('/misc');
+    miscSock.on('connection', conn => {
+        conn.on('error', () => {});
+        conn.on('call', (remoteCall, args, cb) => {
+            if (remoteCall in otherAsyncCommands) {
+                try {
+                    args.push((err, data) => {
+                        cb(serializeError(err), data);
+                    });
+                    otherAsyncCommands[remoteCall].apply(null, args);
+                } catch (err) {
+                    return cb(serializeError(err));
+                }
+            } else if (remoteCall in otherSyncCommands) {
+                let result;
+
+                try {
+                    result = otherSyncCommands[remoteCall].apply(null, args);
+                    return cb(null, result);
+                } catch (err) {
+                    return cb(serializeError(err));
+                }
+            } else {
+                return cb(serializeError(
+                    new Error(`Unknown remote misc call ${remoteCall}`)));
+            }
+            return undefined;
+        });
+    });
+
+    return ioServer;
+};

--- a/lib/storage/data/file/backend.js
+++ b/lib/storage/data/file/backend.js
@@ -1,0 +1,113 @@
+import { errors, stringHash } from 'arsenal';
+import crypto from 'crypto';
+import fs from 'fs';
+import config from '../../Config';
+import constants from '../../../constants';
+import { Logger } from 'werelogs';
+
+const logger = new Logger('FileDataBackend', {
+    logLevel: config.log.logLevel,
+    dumpLevel: config.log.dumpLevel,
+});
+const STORAGE_PATH = config.filePaths.dataPath;
+const FOLDER_HASH = constants.folderHash;
+
+function createLogger(reqUids) {
+    return reqUids ?
+        logger.newRequestLoggerFromSerializedUids(reqUids) :
+        logger.newRequestLogger();
+}
+
+/*
+* Each object/part becomes a file and the files are stored
+* in a directory hash structure
+* under STORAGE_PATH
+*/
+
+
+function getFilePath(key) {
+    const hash = stringHash(key);
+    const folderHashPath = ((hash % FOLDER_HASH)).toString();
+    return `${STORAGE_PATH}/${folderHashPath}/${key}`;
+}
+
+export const backend = {
+    put: function putFile(request, size, keyContext, reqUids, callback) {
+        const log = createLogger(reqUids);
+        // Consider making async
+        const key = crypto.randomBytes(20).toString('hex');
+        const filePath = getFilePath(key);
+        request.pause();
+        fs.open(filePath, 'wx', (err, fd) => {
+            if (err) {
+                log.error('error opening filePath', { error: err });
+                return callback(errors.InternalError);
+            }
+            const fileStream = fs.createWriteStream(filePath, { fd });
+
+            request.resume();
+            request.pipe(fileStream, { end: false }).on('error', err => {
+                log.error('error streaming data from request on write',
+                    { error: err });
+                return callback(errors.InternalError);
+            });
+            request.on('error', err => {
+                log.error('error streaming data from request on read',
+                    { error: err });
+                // close fileStream
+                return fs.close(fd, () => callback(errors.InternalError));
+            }).on('end', () => {
+                fs.fsync(fd, err => {
+                    fileStream.end();
+                    if (err) {
+                        log.error('error streaming data from request on fsync',
+                            { error: err });
+                        return callback(errors.InternalError);
+                    }
+                    log.debug('finished writing data', { key });
+                    return callback(null, key);
+                });
+                return undefined;
+            });
+            return undefined;
+        });
+    },
+
+    get: function getFile(key, range, reqUids, callback) {
+        const log = createLogger(reqUids);
+        const filePath = getFilePath(key);
+        log.debug('opening readStream to get data', { filePath });
+        const readStreamOptions = {
+            flags: 'r',
+            encoding: null,
+            fd: null,
+            autoClose: true,
+        };
+        if (range) {
+            readStreamOptions.start = range[0];
+            readStreamOptions.end = range[1];
+        }
+        const rs = fs.createReadStream(filePath, readStreamOptions)
+            .on('error', err => {
+                log.error('error retrieving file', { error: err });
+                return callback(errors.InternalError);
+            })
+            .on('open', () => { callback(null, rs); });
+    },
+
+    delete: function delFile(key, reqUids, callback) {
+        const log = createLogger(reqUids);
+        const filePath = getFilePath(key);
+        log.debug('deleting file', { filePath });
+        return fs.unlink(filePath, err => {
+            if (err) {
+                log.error('error deleting file', { error: err,
+                    file: key });
+                return callback(errors.InternalError);
+            }
+            return callback();
+        });
+    },
+};
+
+export default backend;

--- a/lib/storage/metadata/file/client.js
+++ b/lib/storage/metadata/file/client.js
@@ -1,0 +1,41 @@
+'use strict'; // eslint-disable-line
+
+const assert = require('assert');
+const Logger = require('werelogs').Logger;
+
+const levelNet = require('../../../network/level-net');
+
+class MetadataFileClient {
+
+    constructor(params) {
+        assert.notStrictEqual(params.metadataPath, undefined);
+        assert.notStrictEqual(params.metadataPort, undefined);
+        this.metadataPath = params.metadataPath;
+        this.metadataPort = params.metadataPort;
+        this.setupLogging(params.log);
+    }
+
+    setupLogging(config) {
+        let options = undefined;
+        if (config !== undefined) {
+            options = {
+                level: config.logLevel,
+                dump: config.dumpLevel,
+            };
+        }
+        this.logger = new Logger('MetadataFileClient', options)
+            .newRequestLogger();
+    }
+
+    /**
+     * Setup the leveldb server
+     * @return {undefined}
+     */
+    openDB() {
+        this.client = levelNet.client(this.logger);
+        this.client.connect('localhost', this.metadataPort);
+        return this.client;
+    }
+}
+
+module.exports = MetadataFileClient;

--- a/lib/storage/metadata/file/client.js
+++ b/lib/storage/metadata/file/client.js
@@ -7,10 +7,21 @@ const levelNet = require('../../../network/level-net');
 
 class MetadataFileClient {
 
+    /**
+     * Construct a metadata client
+     *
+     * @param {Object} params the following parameters are used:
+
+     * - metadataHost {String} [mandatory] name or IP address of
+         metadata server host
+     * - metadataPort {Number} [mandatory] TCP port to connect to the
+         metadata server
+     * - log [optional] logging configuration
+     */
     constructor(params) {
-        assert.notStrictEqual(params.metadataPath, undefined);
+        assert.notStrictEqual(params.metadataHost, undefined);
         assert.notStrictEqual(params.metadataPort, undefined);
-        this.metadataPath = params.metadataPath;
+        this.metadataHost = params.metadataHost;
         this.metadataPort = params.metadataPort;
         this.setupLogging(params.log);
     }
@@ -28,12 +39,13 @@ class MetadataFileClient {
     }
 
     /**
-     * Setup the leveldb server
-     * @return {undefined}
+     * Open the remote metadata database (backed by leveldb)
+     *
+     * @return {Object} handle to the remote database
      */
     openDB() {
         this.client = levelNet.client(this.logger);
-        this.client.connect('localhost', this.metadataPort);
+        this.client.connect(this.metadataHost, this.metadataPort);
         return this.client;
     }
 }

--- a/lib/storage/metadata/file/server.js
+++ b/lib/storage/metadata/file/server.js
@@ -1,0 +1,53 @@
+'use strict'; // eslint-disable-line
+
+const assert = require('assert');
+const Logger = require('werelogs').Logger;
+
+const level = require('level');
+const levelNet = require('../../../network/level-net');
+const sublevel = require('level-sublevel');
+
+const ROOT_DB = 'rootDB';
+
+class MetadataFileServer {
+
+    constructor(params) {
+        assert.notStrictEqual(params.metadataPath, undefined);
+        assert.notStrictEqual(params.metadataPort, undefined);
+        this.metadataPath = params.metadataPath;
+        this.metadataPort = params.metadataPort;
+        this.setupLogging(params.log);
+    }
+
+    setupLogging(config) {
+        let options = undefined;
+        if (config !== undefined) {
+            options = {
+                level: config.logLevel,
+                dump: config.dumpLevel,
+            };
+        }
+        this.logger = new Logger('MetadataFileServer', options)
+            .newRequestLogger();
+    }
+
+    /**
+     * Start the server
+     * @return {undefined}
+     */
+    startServer() {
+        const rootDB = level(this.metadataPath + ROOT_DB);
+        this.db = sublevel(rootDB);
+        this.logger.info('starting metadata file backend server');
+        /* We start a server that will serve the sublevel
+           capable rootDB to clients */
+        const server = levelNet.createServer(this.db);
+        server.listen(this.metadataPort);
+    }
+
+    getDB() {
+        return this.db;
+    }
+}
+
+module.exports = MetadataFileServer;

--- a/lib/storage/metadata/file/server.js
+++ b/lib/storage/metadata/file/server.js
@@ -11,6 +11,17 @@ const ROOT_DB = 'rootDB';
 
 class MetadataFileServer {
 
+    /**
+     * Construct a metadata server
+     *
+     * @param {Object} params the following parameters are used:
+
+     * - metadataPath {String} [mandatory] local path where the root
+         database is stored
+     * - metadataPort {Number} [mandatory] TCP port that listens to
+         incoming connections
+     * - log {Object} [optional] logging configuration
+     */
     constructor(params) {
         assert.notStrictEqual(params.metadataPath, undefined);
         assert.notStrictEqual(params.metadataPort, undefined);
@@ -32,7 +43,8 @@ class MetadataFileServer {
     }
 
     /**
-     * Start the server
+     * Start the metadata server and listen to incoming connections
+     *
      * @return {undefined}
      */
     startServer() {
@@ -43,10 +55,6 @@ class MetadataFileServer {
            capable rootDB to clients */
         const server = levelNet.createServer(this.db);
         server.listen(this.metadataPort);
-    }
-
-    getDB() {
-        return this.db;
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
   "dependencies": {
     "ajv": "4.10.0",
     "ipaddr.js": "1.2.0",
-    "utf8": "2.1.2"
+    "utf8": "2.1.2",
+    "socket.io": "1.7.3",
+    "socket.io-client": "1.7.3",
+    "socket.io-stream": "0.9.1"
   },
   "devDependencies": {
     "eslint": "2.13.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "ajv": "4.10.0",
     "ipaddr.js": "1.2.0",
     "utf8": "2.1.2",
+    "level": "1.6.0",
+    "level-sublevel": "6.6.1",
     "socket.io": "1.7.3",
     "socket.io-client": "1.7.3",
     "socket.io-stream": "0.9.1"
@@ -29,7 +31,6 @@
     "eslint-plugin-react": "^4.3.0",
     "eslint-config-airbnb": "6.2.0",
     "eslint-config-scality": "scality/Guidelines",
-    "level": "1.6.0",
     "lolex": "1.5.2",
     "mocha": "2.5.3",
     "temp": "0.8.3",

--- a/tests/unit/network/level-net/index.js
+++ b/tests/unit/network/level-net/index.js
@@ -6,7 +6,7 @@ const temp = require('temp');
 const assert = require('assert');
 const levelNet = require('../../../../lib/network/level-net');
 
-describe('level-net - LevelDB over network', function () {
+describe('level-net - LevelDB over network', () => {
     let db;
     let client;
 
@@ -17,8 +17,8 @@ describe('level-net - LevelDB over network', function () {
         client = levelNet.client();
         client.connect('localhost', 6677, 'testnsp');
     }
-    before(function (done) {
-        temp.mkdir('level-net-testdb-', function (err, dbDir) {
+    before(done => {
+        temp.mkdir('level-net-testdb-', (err, dbDir) => {
             const rootDb = level(dbDir);
             db = sublevel(rootDb);
             setupLevelNet();
@@ -26,8 +26,8 @@ describe('level-net - LevelDB over network', function () {
         });
     });
 
-    describe('simple tests', function () {
-        it('should ping a level-net server (sync on server)', function (done) {
+    describe('simple tests', () => {
+        it('should ping a level-net server (sync on server)', done => {
             client.ping((err, args) => {
                 if (err) {
                     return done(err);
@@ -36,7 +36,7 @@ describe('level-net - LevelDB over network', function () {
                 return done();
             });
         });
-        it('should ping a level-net server (async on server)', function (done) {
+        it('should ping a level-net server (async on server)', done => {
             client.pingAsync((err, args) => {
                 if (err) {
                     return done(err);
@@ -45,7 +45,7 @@ describe('level-net - LevelDB over network', function () {
                 return done();
             });
         });
-        it('should be able to put data and read it back', function (done) {
+        it('should be able to put data and read it back', done => {
             client.put('testkey1', 'value of testkey1', err => {
                 assert.ifError(err);
                 client.get('testkey1', (err, data) => {
@@ -55,7 +55,7 @@ describe('level-net - LevelDB over network', function () {
                 });
             });
         });
-        it('should timeout if command is too long to respond', function (done) {
+        it('should timeout if command is too long to respond', done => {
             // shorten the timeout to 200ms to speed up the test
             const oldTimeout = client.getTimeout();
             client.setTimeout(200);
@@ -67,7 +67,7 @@ describe('level-net - LevelDB over network', function () {
             client.setTimeout(oldTimeout);
         });
     });
-    describe('multiple keys tests', function () {
+    describe('multiple keys tests', () => {
         const nbKeys = 100;
 
         function keyOfIter(i) {
@@ -91,10 +91,10 @@ describe('level-net - LevelDB over network', function () {
                 client.put(keyOfIter(i), valueOfIter(i), putCb);
             }
         }
-        before(function (done) {
+        before(done => {
             prefillKeys(done);
         });
-        it('should be able to read keys back at random', function (done) {
+        it('should be able to read keys back at random', done => {
             const nbGet = 100;
             let nbGetDone = 0;
 
@@ -114,7 +114,7 @@ describe('level-net - LevelDB over network', function () {
             }
         });
         it('should be able to list all keys through a stream and rewrite' +
-           'them on-the-fly', function (done) {
+           'them on-the-fly', done => {
             client.createReadStream((err, keyStream) => {
                 assert.ifError(err);
 
@@ -137,7 +137,7 @@ describe('level-net - LevelDB over network', function () {
                 });
             });
         });
-        it('should delete all keys successfully', function (done) {
+        it('should delete all keys successfully', done => {
             let nbDelDone = 0;
 
             function checkAllDeleted(done) {

--- a/tests/unit/network/level-net/index.js
+++ b/tests/unit/network/level-net/index.js
@@ -1,0 +1,170 @@
+'use strict'; // eslint-disable-line
+
+const level = require('level');
+const sublevel = require('level-sublevel');
+const temp = require('temp');
+const assert = require('assert');
+const levelNet = require('../../../../lib/network/level-net');
+
+describe('level-net - LevelDB over network', function () {
+    let db;
+    let client;
+
+    function setupLevelNet() {
+        const server = levelNet.createServer(db);
+        server.of('/testnsp');
+        server.listen(6677);
+        client = levelNet.client();
+        client.connect('localhost', 6677, 'testnsp');
+    }
+    before(function (done) {
+        temp.mkdir('level-net-testdb-', function (err, dbDir) {
+            const rootDb = level(dbDir);
+            db = sublevel(rootDb);
+            setupLevelNet();
+            return done();
+        });
+    });
+
+    describe('simple tests', function () {
+        it('should ping a level-net server (sync on server)', function (done) {
+            client.ping((err, args) => {
+                if (err) {
+                    return done(err);
+                }
+                assert.strictEqual(args, 'pong');
+                return done();
+            });
+        });
+        it('should ping a level-net server (async on server)', function (done) {
+            client.pingAsync((err, args) => {
+                if (err) {
+                    return done(err);
+                }
+                assert.strictEqual(args, 'pong');
+                return done();
+            });
+        });
+        it('should be able to put data and read it back', function (done) {
+            client.put('testkey1', 'value of testkey1', err => {
+                assert.ifError(err);
+                client.get('testkey1', (err, data) => {
+                    assert.ifError(err);
+                    assert.strictEqual(data, 'value of testkey1');
+                    return done();
+                });
+            });
+        });
+        it('should timeout if command is too long to respond', function (done) {
+            // shorten the timeout to 200ms to speed up the test
+            const oldTimeout = client.getTimeout();
+            client.setTimeout(200);
+            client.slowCommand(err => {
+                assert(err);
+                assert(err.timeout);
+                return done();
+            });
+            client.setTimeout(oldTimeout);
+        });
+    });
+    describe('multiple keys tests', function () {
+        const nbKeys = 100;
+
+        function keyOfIter(i) {
+            return `key of ${i}`;
+        }
+        function valueOfIter(i) {
+            return `value of key ${i}`;
+        }
+        function prefillKeys(done) {
+            let nbPutDone = 0;
+
+            function putCb(err) {
+                assert.ifError(err);
+                ++nbPutDone;
+                if (nbPutDone === nbKeys) {
+                    return done();
+                }
+                return undefined;
+            }
+            for (let i = 0; i < nbKeys; ++i) {
+                client.put(keyOfIter(i), valueOfIter(i), putCb);
+            }
+        }
+        before(function (done) {
+            prefillKeys(done);
+        });
+        it('should be able to read keys back at random', function (done) {
+            const nbGet = 100;
+            let nbGetDone = 0;
+
+            for (let i = 0; i < nbGet; ++i) {
+                const randI = Math.floor(Math.random() * nbKeys);
+                // linter complains with 'no-loop-func' but we need a
+                // new randI each time
+                function getCb(err, data) { // eslint-disable-line
+                    assert.ifError(err);
+                    assert.strictEqual(data, valueOfIter(randI));
+                    ++nbGetDone;
+                    if (nbGetDone === nbGet) {
+                        return done();
+                    }
+                }
+                client.get(keyOfIter(randI), getCb);
+            }
+        });
+        it('should be able to list all keys through a stream and rewrite' +
+           'them on-the-fly', function (done) {
+            client.createReadStream((err, keyStream) => {
+                assert.ifError(err);
+
+                let nbKeysListed = 0;
+                let nbPutDone = 0;
+                let prevKey = undefined;
+                keyStream.on('data', entry => {
+                    ++nbKeysListed;
+                    assert(!prevKey || entry.key > prevKey);
+                    prevKey = entry.key;
+                    client.put(entry.key,
+                               `new data for key ${entry.key}`, err => {
+                                   assert.ifError(err);
+                                   ++nbPutDone;
+                                   if (nbPutDone === nbKeys) {
+                                       return done();
+                                   }
+                                   return undefined;
+                               });
+                });
+            });
+        });
+        it('should delete all keys successfully', function (done) {
+            let nbDelDone = 0;
+
+            function checkAllDeleted(done) {
+                let nbGetDone = 0;
+
+                function checkCb(err) {
+                    assert(err.notFound);
+                    ++nbGetDone;
+                    if (nbGetDone === nbKeys) {
+                        return done();
+                    }
+                    return undefined;
+                }
+                for (let i = 0; i < nbKeys; ++i) {
+                    client.get(keyOfIter(i), checkCb);
+                }
+            }
+            function delCb(err) {
+                assert.ifError(err);
+                ++nbDelDone;
+                if (nbDelDone === nbKeys) {
+                    checkAllDeleted(done);
+                }
+            }
+            for (let i = 0; i < nbKeys; ++i) {
+                client.del(keyOfIter(i), delCb);
+            }
+        });
+    });
+});


### PR DESCRIPTION
It allows the client to do the normal levelDB operations (put, get,
delete, list keys via createReadStream) as well as creating new
sublevels. (Note that this is a purely virtual operation, nothing is
created initially but the client gets a handle to manipulate the new
sublevel).

It's built on top of socket.io which provides messaging abstraction
and helps maintaining a reliable channel (detects connection failures,
attempts to reconnect etc.). It also allows to use several namespaces
and "rooms" on the same communication channel, which may be useful
later.

There is an additional timeout for each operation, which triggers an
error after 5 seconds without an answer by default.

Unit tests added: ping, basic put and get, listing of keys and
rewrite, deletes, timeout test.