### PR TITLE
S3C-35 New communication channel for remote sublevel

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,5 +40,12 @@ module.exports = {
         http: {
             server: require('./lib/network/http/server'),
         },
+        level: require('./lib/network/level-net'),
+    },
+    storage: {
+        metadata: {
+            server: require('./lib/storage/metadata/file/server'),
+            client: require('./lib/storage/metadata/file/client'),
+        },
     },
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -5,4 +5,5 @@ module.exports = {
     // no authentication information.  Requestor can access
     // only public resources
     publicId: 'http://acs.amazonaws.com/groups/global/AllUsers',
+    metadataFileNamespace: '/MDFile',
 };

--- a/lib/network/level-net/index.js
+++ b/lib/network/level-net/index.js
@@ -1,0 +1,343 @@
+'use strict'; // eslint-disable-line
+
+const http = require('http');
+const io = require('socket.io');
+const ioClient = require('socket.io-client');
+const sioStream = require('./sio-stream');
+const async = require('async');
+const assert = require('assert');
+
+const flattenError = require('./utils').flattenError;
+const reconstructError = require('./utils').reconstructError;
+
+const DEFAULT_CALL_TIMEOUT_MS = 5000;
+
+class SocketIOConnection {
+
+    /**
+     * @constructor
+     * @param {String} url URL of the socket.io namespace,
+     *   e.g. 'http://localhost:9990/metadata'
+     * @param {Object} params constructor additional params
+     * @param {Logger} params.logger logger object
+     * @param {Number} [params.streamMaxPendingAck] max number of
+     *   in-flight output stream packets sent to the server without an ack
+     *   received yet
+     * @param {Number} [params.streamAckTimeoutMs] timeout for receiving
+     *   an ack after an output stream packet is sent to the server
+     */
+    constructor(url, params) {
+        assert(params.logger);
+        this.logger = params.logger;
+        this.socket = ioClient(url);
+        this.socketStreams = sioStream.createSocket(
+            this.socket,
+            params.logger,
+            params.streamMaxPendingAck,
+            params.streamAckTimeoutMs);
+        this.socket.on('error', err => {
+            this.logger.warn('connectivity error to storage daemon',
+                             { error: err });
+            return undefined;
+        });
+    }
+
+    /**
+     * @brief internal RPC implementation w/o timeout
+     *
+     * @param {String} remoteCall name of the remote function to call
+     * @param {Array} args list of arguments to the remote function
+     * @param {function} cb callback called when done
+     * @return {undefined}
+     */
+    _call(remoteCall, args, cb) {
+        const wrapCb = (err, data) => {
+            cb(reconstructError(err),
+               this.socketStreams.decodeStreams(data));
+        };
+        this.logger.debug('remote call', { remoteCall, args });
+        this.socket.emit('call', remoteCall,
+                         this.socketStreams.encodeStreams(args), wrapCb);
+        return undefined;
+    }
+
+    /**
+     * @brief call a remote function named @a remoteCall, with
+     * arguments @a args and callback @a cb
+     *
+     * @a cb is called when the remote function returns an ack, or
+     * when the timeout set by @a timeoutMs expires, whichever comes
+     * first. When an ack is received, the callback gets the arguments
+     * sent by the remote function in the ack response. In the case of
+     * timeout, it's passed a single Error argument with the code:
+     * 'ETIMEDOUT' property, and a self-described string in the 'info'
+     * property.
+     *
+     * @param {String} remoteCall name of the remote function to call
+     * @param {Array} args list of arguments to the remote function
+     * @param {function} cb callback called when done or timeout
+     * @param {Number} timeoutMs timeout in milliseconds
+     * @return {undefined}
+     */
+    callTimeout(remoteCall, args, cb, timeoutMs = DEFAULT_CALL_TIMEOUT_MS) {
+        if (typeof cb !== 'function') {
+            throw new Error(`argument cb=${cb} is not a callback`);
+        }
+        async.timeout(this._call.bind(this), timeoutMs,
+                      `operation ${remoteCall} timed out`)(remoteCall,
+                                                           args, cb);
+        return undefined;
+    }
+}
+
+const dbAsyncCommandNames = ['put', 'get', 'del', 'batch'];
+const dbSyncCommandNames = ['createReadStream'];
+
+const miscSyncCommands = {
+    ping: function ping() {
+        return 'pong';
+    },
+};
+
+const miscAsyncCommands = {
+    pingAsync: function pingAsync(cb) {
+        setImmediate(() => cb(null, 'pong'));
+    },
+    slowCommand: function slowCommand(cb) {
+        setTimeout(() => cb(null, 'ok'), 2000);
+    },
+};
+
+/**
+ * @brief get a LevelDB client object that proxies requests to a
+ * remote DB server through socket.io events
+ *
+ * NOTE: synchronous calls on the server-side API (i.e those which
+ * take no callback argument) become asynchronous on the client, take
+ * one additional parameter (the callback), then:
+ *
+ * - if it throws, the error is passed as callback's first argument,
+ *   otherwise null is passed
+ * - the return value is passed as callback's second argument (unless
+ *   an error occurred).
+ *
+ * The only DB call in this case currently is createReadStream().
+ *
+ * @param {Object} options options object
+ * @param {Logger} options.logger logger object
+ * @param {String} [options.baseNs=] custom namespace to use
+ * @param {Number} [options.callTimeoutMs] timeout for remote calls
+ * @param {Number} [options.streamMaxPendingAck] max number of
+ *   in-flight output stream packets sent to the server without an ack
+ *   received yet
+ * @param {Number} [options.streamAckTimeoutMs] timeout for receiving
+ *   an ack after an output stream packet is sent to the server
+ * @return {Object} a LevelDB proxy object that can be called with
+ * leveldb API functions directly, or sub-leveled with openSub()
+ */
+module.exports.client = function LevelClient(options) {
+    assert(options.logger);
+
+    const dbClient = {
+        path: [],
+        baseNs: options.baseNs || '',
+        logger: options.logger,
+        callTimeoutMs: options.callTimeoutMs,
+    };
+    assert(dbClient.baseNs === '' || dbClient.baseNs.startsWith('/'));
+
+    dbClient.getCallTimeout = function getCallTimeout() {
+        return this.callTimeoutMs;
+    };
+    dbClient.setCallTimeout = function setCallTimeout(newTimeoutMs) {
+        this.callTimeoutMs = newTimeoutMs;
+    };
+
+    dbClient.connect = function connect(host, port) {
+        this.mdClient = new SocketIOConnection(
+            `http://${host}:${port}${this.baseNs}/metadata`, options);
+        this.miscClient = new SocketIOConnection(
+            `http://${host}:${port}${this.baseNs}/misc`, options);
+    };
+    for (const remoteCall of dbSyncCommandNames.concat(dbAsyncCommandNames)) {
+        dbClient[remoteCall] = function onCall(...rpcArgs) {
+            const cb = rpcArgs.pop();
+            const args = { rpcArgs, subLevel: this.path };
+            this.mdClient.callTimeout(remoteCall, args, cb,
+                                      this.callTimeoutMs);
+        };
+    }
+    for (const remoteCall of Object.keys(miscSyncCommands).concat(
+        Object.keys(miscAsyncCommands))) {
+        dbClient[remoteCall] = function onCall(...rpcArgs) {
+            const cb = rpcArgs.pop();
+            const args = { rpcArgs };
+            this.miscClient.callTimeout(remoteCall, args, cb,
+                                        this.callTimeoutMs);
+        };
+    }
+
+    /**
+     * @brief return a handle to a sublevel database
+     *
+     * @note this function has no side-effect on the db, it just
+     * returns a handle properly configured to access the sublevel db
+     * from the client.
+     *
+     * @param {String} subName name of sublevel
+     * @return {Object} a handle to the sublevel database that has the
+     * same API as its parent
+     */
+    dbClient.openSub = function openSub(subName) {
+        const subLevel = {};
+        Object.assign(subLevel, this);
+        // maintain path as a list of nested sublevels
+        subLevel.path = subLevel.path.slice();
+        subLevel.path.push(subName);
+        return subLevel;
+    };
+
+    return dbClient;
+};
+
+/**
+ * @brief create a server object that serves remote LevelDB requests
+ * through socket.io events
+ *
+ * @param {Object} db The root LevelDB database object to expose to
+ * remote clients
+ * @param {Object} options options object
+ * @param {Object} options.logger logger object
+ * @param {Number} [options.streamMaxPendingAck] max number of
+ *   in-flight output stream packets sent to the server without an ack
+ *   received yet
+ * @param {Number} [options.streamAckTimeoutMs] timeout for receiving
+ *   an ack after an output stream packet is sent to the server
+ * @return {Object} a server object, not yet listening on a TCP port
+ * (you must call listen(port) on the returned object)
+ */
+module.exports.createServer = function LevelServer(db, options) {
+    assert(options.logger);
+
+    const httpServer = http.createServer();
+    const ioServer = io(httpServer);
+    const log = options.logger;
+
+    ioServer.initMetadataService = function initMetadataService(baseNs = '') {
+        assert(baseNs === '' || baseNs.startsWith('/'));
+
+        // all metadata operations executed by leveldb go through this
+        // namespace, other operations (ping etc.) go through /misc.
+        const mdSock = this.of(`${baseNs}/metadata`);
+        mdSock.on('connection', conn => {
+            /**
+             * lookup a sublevel db given by the @a path array from
+             * the main db handle.
+             *
+             * @param {String []} path path to the sublevel, as a
+             * piecewise array of sub-levels
+             * @return {Object} the handle to the sublevel
+             */
+            function lookupSubLevel(path) {
+                let subDb = db;
+                path.forEach(pathItem => {
+                    subDb = subDb.sublevel(pathItem);
+                });
+                return subDb;
+            }
+
+            const mdStreams = sioStream.createSocket(
+                conn,
+                options.logger,
+                options.streamMaxPendingAck,
+                options.streamAckTimeoutMs);
+            conn.on('error', err => {
+                log.error('error on socket.io /metadata connection',
+                          { error: err });
+            });
+            conn.on('call', (remoteCall, args, cb) => {
+                // DB commands expect a 'subLevel' property as the
+                // path to the sublevel DB (array of path items).
+                const decodedArgs = mdStreams.decodeStreams(args);
+                if (dbAsyncCommandNames.includes(remoteCall)) {
+                    try {
+                        // We're pushing the callback to arguments
+                        // that async DB sublevel calls expect as
+                        // their last argument.
+                        decodedArgs.rpcArgs.push((err, data) => {
+                            cb(flattenError(err),
+                               mdStreams.encodeStreams(data));
+                        });
+
+                        const subDb = lookupSubLevel(decodedArgs.subLevel);
+                        subDb[remoteCall].apply(subDb, decodedArgs.rpcArgs);
+                    } catch (err) {
+                        return cb(flattenError(err));
+                    }
+                } else if (dbSyncCommandNames.includes(remoteCall)) {
+                    let result;
+
+                    try {
+                        const subDb = lookupSubLevel(decodedArgs.subLevel);
+                        result = subDb[remoteCall].apply(
+                            subDb, decodedArgs.rpcArgs);
+                        result = mdStreams.encodeStreams(result);
+                    } catch (err) {
+                        return cb(flattenError(err));
+                    }
+                    return cb(null, result);
+                } else {
+                    return cb(flattenError(
+                        new Error(`Unknown remote call ${remoteCall}`)));
+                }
+                return undefined;
+            });
+        });
+
+        const miscSock = this.of(`${baseNs}/misc`);
+        miscSock.on('connection', conn => {
+            const miscStreams = sioStream.createSocket(
+                conn,
+                options.logger,
+                options.streamMaxPendingAck,
+                options.streamAckTimeoutMs);
+
+            conn.on('error', err => {
+                log.error('error on socket.io /misc connection',
+                          { error: err });
+            });
+            conn.on('call', (remoteCall, args, cb) => {
+                const decodedArgs = miscStreams.decodeStreams(args);
+                if (remoteCall in miscAsyncCommands) {
+                    try {
+                        decodedArgs.rpcArgs.push((err, data) => {
+                            cb(flattenError(err),
+                               miscStreams.encodeStreams(data));
+                        });
+                        miscAsyncCommands[remoteCall].apply(
+                            null, decodedArgs.rpcArgs);
+                    } catch (err) {
+                        return cb(flattenError(err));
+                    }
+                } else if (remoteCall in miscSyncCommands) {
+                    let result;
+
+                    try {
+                        result = miscSyncCommands[remoteCall].apply(
+                            null, decodedArgs.rpcArgs);
+                        result = miscStreams.encodeStreams(result);
+                        return cb(null, result);
+                    } catch (err) {
+                        return cb(flattenError(err));
+                    }
+                } else {
+                    return cb(flattenError(
+                        new Error(`Unknown remote misc call ${remoteCall}`)));
+                }
+                return undefined;
+            });
+        });
+    };
+
+    return ioServer;
+};

--- a/lib/network/level-net/sio-stream.js
+++ b/lib/network/level-net/sio-stream.js
@@ -1,0 +1,439 @@
+'use strict'; // eslint-disable-line
+
+const uuid = require('uuid');
+const stream = require('stream');
+const debug = require('debug')('sio-stream');
+const assert = require('assert');
+const async = require('async');
+
+const flattenError = require('./utils').flattenError;
+const reconstructError = require('./utils').reconstructError;
+
+const DEFAULT_MAX_PENDING_ACK = 4;
+const DEFAULT_ACK_TIMEOUT_MS = 5000;
+
+class SIOOutputStream extends stream.Writable {
+    constructor(socket, streamId, maxPendingAck, ackTimeoutMs) {
+        super({ objectMode: true });
+        this._initOutputStream(socket, streamId, maxPendingAck,
+                               ackTimeoutMs);
+    }
+
+    _initOutputStream(socket, streamId, maxPendingAck, ackTimeoutMs) {
+        this.socket = socket;
+        this.streamId = streamId;
+        this.on('finish', () => {
+            this.socket._finish(this.streamId, err => {
+                // no-op on client ack, it's not excluded we add
+                // things later here
+                debug('ack finish', this.streamId, 'err', err);
+            });
+        });
+        this.on('error', err => {
+            debug('output stream error', this.streamId);
+            // notify remote of the error
+            this.socket._error(this.streamId, err);
+        });
+
+        // This is used for queuing flow control, don't issue more
+        // than maxPendingAck requests (events) that have not been
+        // acked yet
+        this.maxPendingAck = maxPendingAck;
+        this.ackTimeoutMs = ackTimeoutMs;
+
+        this.nPendingAck = 0;
+    }
+
+    _write(chunk, encoding, callback) {
+        return this._writev([{ chunk }], callback);
+    }
+
+    _writev(chunks, callback) {
+        const payload = chunks.map(chunk => chunk.chunk);
+
+        debug(`_writev(${JSON.stringify(payload)}, ...)`);
+        this.nPendingAck += 1;
+        const timeoutInfo =
+            `stream timeout: did not receive ack after ${this.ackTimeoutMs}ms`;
+        async.timeout(cb => {
+            this.socket._write(this.streamId, payload, cb);
+        }, this.ackTimeoutMs, timeoutInfo)(
+            err => {
+                debug(`ack stream-data ${this.streamId}
+                      (${JSON.stringify(payload)}):`, err);
+                if (this.nPendingAck === this.maxPendingAck) {
+                    callback();
+                }
+                this.nPendingAck -= 1;
+                if (err) {
+                    // notify remote of the error (timeout notably)
+                    debug('stream error:', err);
+                    this.socket._error(this.streamId, err);
+                    // stop the producer
+                    this.socket.destroyStream(this.streamId);
+                }
+            });
+        if (this.nPendingAck < this.maxPendingAck) {
+            callback();
+        }
+    }
+}
+
+class SIOInputStream extends stream.Readable {
+    constructor(socket, streamId) {
+        super({ objectMode: true });
+        this.socket = socket;
+        this.streamId = streamId;
+        this._readState = {
+            pushBuffer: [],
+            readable: false,
+        };
+    }
+
+    destroy() {
+        debug('destroy called', this.streamId);
+        this._destroyed = true;
+        this.pause();
+        this.removeAllListeners('data');
+        this.removeAllListeners('end');
+        this._readState = {
+            pushBuffer: [],
+            readable: false,
+        };
+        // do this in case the client piped this stream to other ones
+        this.unpipe();
+        // emit 'stream-hangup' event to notify the remote producer
+        // that we're not interested in further results
+        this.socket._hangup(this.streamId);
+        this.emit('close');
+    }
+
+    _pushData() {
+        debug('pushData _readState:', this._readState);
+        if (this._destroyed) {
+            return;
+        }
+        while (this._readState.pushBuffer.length > 0) {
+            const item = this._readState.pushBuffer.shift();
+            debug('pushing item', item);
+            if (!this.push(item)) {
+                this._readState.readable = false;
+                break;
+            }
+        }
+    }
+
+    _read(size) {
+        debug(`_read(${size})`);
+        this._readState.readable = true;
+        this._pushData();
+    }
+
+    _ondata(data) {
+        debug('_ondata', this.streamId, data);
+        if (this._destroyed) {
+            return;
+        }
+        this._readState.pushBuffer.push.apply(this._readState.pushBuffer,
+                                              data);
+        if (this._readState.readable) {
+            this._pushData();
+        }
+    }
+
+    _onend() {
+        debug('_onend', this.streamId);
+        this._readState.pushBuffer.push(null);
+        if (this._readState.readable) {
+            this._pushData();
+        }
+        this.emit('close');
+    }
+
+    _onerror(receivedErr) {
+        debug('_onerror', this.streamId, 'error', receivedErr);
+        const err = reconstructError(receivedErr);
+        err.remote = true;
+        this.emit('error', err);
+    }
+}
+
+/**
+ * @class
+ * @classdesc manage a set of user streams over a socket.io connection
+ */
+class SIOStreamSocket {
+    constructor(socket, logger, maxPendingAck, ackTimeoutMs) {
+        assert(socket);
+        assert(logger);
+
+        /** @member {Object} socket.io connection */
+        this.socket = socket;
+
+        /** @member {Object} logger object */
+        this.logger = logger;
+
+        /** @member {Number} max number of in-flight output stream
+         *   packets sent to the client without an ack received yet */
+        this.maxPendingAck = maxPendingAck;
+
+        /** @member {Number} timeout for receiving an ack after an
+         *   output stream packet is sent to the client */
+        this.ackTimeoutMs = ackTimeoutMs;
+
+        /** @member {Object} map of stream proxies initiated by the
+         * remote side */
+        this.remoteStreams = {};
+
+        /** @member {Object} map of stream-like objects initiated
+         * locally and connected to the remote side */
+        this.localStreams = {};
+
+        const log = logger;
+
+        // stream data message, contains an array of one or more data objects
+        this.socket.on('stream-data', (payload, cb) => {
+            const { streamId, data } = payload;
+            log.debug('received \'stream-data\' event',
+                      { streamId, size: data.length });
+            const stream = this.remoteStreams[streamId];
+            if (!stream) {
+                log.debug('no such remote stream registered', { streamId });
+                return;
+            }
+            stream._ondata(data);
+            cb(null);
+        });
+
+        // signals normal end of stream to the consumer
+        this.socket.on('stream-end', (payload, cb) => {
+            const { streamId } = payload;
+            log.debug('received \'stream-end\' event', { streamId });
+            const stream = this.remoteStreams[streamId];
+            if (!stream) {
+                log.debug('no such remote stream registered', { streamId });
+                return;
+            }
+            stream._onend();
+            cb(null);
+        });
+
+        // error message sent by the stream producer to the consumer
+        this.socket.on('stream-error', payload => {
+            const { streamId, error } = payload;
+            log.debug('received \'stream-error\' event', { streamId, error });
+            const stream = this.remoteStreams[streamId];
+            if (!stream) {
+                log.debug('no such remote stream registered', { streamId });
+                return;
+            }
+            stream._onerror(error);
+        });
+
+        // hangup message sent by the stream consumer to the producer
+        this.socket.on('stream-hangup', payload => {
+            const { streamId } = payload;
+            log.debug('received \'stream-hangup\' event', { streamId });
+            const stream = this.localStreams[streamId];
+            if (!stream) {
+                log.debug('no such local stream registered' +
+                          '(may have already reached the end)', { streamId });
+                return;
+            }
+            this.destroyStream(streamId);
+        });
+    }
+
+    /**
+     * @brief encode all stream-like objects found inside a user
+     * object into a serialized form that can be tramsmitted through a
+     * socket.io connection, then decoded back to a stream proxy
+     * object by the other end with decodeStreams()
+     *
+     * @param {Object} arg any flat object or value that may be or
+     * contain stream-like objects
+     * @return {Object} an object of the same nature than @a arg with
+     * streams encoded for transmission to the remote side
+     */
+    encodeStreams(arg) {
+        if (!arg) {
+            return arg;
+        }
+        const log = this.logger;
+        const isReadStream = (typeof(arg.pipe) === 'function'
+                              && typeof (arg.read) === 'function');
+        const isWriteStream = (typeof(arg.write) === 'function');
+
+        if (isReadStream || isWriteStream) {
+            if (isReadStream && isWriteStream) {
+                throw new Error('duplex streams not supported');
+            }
+            const streamId = uuid();
+            const encodedStream = {
+                $streamId: streamId,
+                readable: isReadStream,
+                writable: isWriteStream,
+            };
+            let transportStream;
+            if (isReadStream) {
+                transportStream = new SIOOutputStream(this, streamId,
+                                                      this.maxPendingAck,
+                                                      this.ackTimeoutMs);
+            } else {
+                transportStream = new SIOInputStream(this, streamId);
+            }
+            this.localStreams[streamId] = arg;
+            arg.once('close', () => {
+                log.debug('stream closed, removing from local streams',
+                          { streamId });
+                delete this.localStreams[streamId];
+            });
+            arg.on('error', error => {
+                log.error('stream error', { streamId, error });
+            });
+            if (isReadStream) {
+                arg.pipe(transportStream);
+            }
+            if (isWriteStream) {
+                transportStream.pipe(arg);
+            }
+            return encodedStream;
+        }
+        if (typeof(arg) === 'object') {
+            let encodedObj;
+            if (Array.isArray(arg)) {
+                encodedObj = [];
+                for (let k = 0; k < arg.length; ++k) {
+                    encodedObj.push(this.encodeStreams(arg[k]));
+                }
+            } else {
+                encodedObj = {};
+                // user objects are simple flat objects and we want to
+                // copy all their properties
+                // eslint-disable-next-line
+                for (const k in arg) {
+                    encodedObj[k] = this.encodeStreams(arg[k]);
+                }
+            }
+            return encodedObj;
+        }
+        return arg;
+    }
+
+    /**
+     * @brief decode all encoded stream markers (produced by
+     * encodeStreams()) found inside the object received from the
+     * remote side, turn them into actual readable/writable stream
+     * proxies that are forwarding data from/to the remote side stream
+     *
+     * @param {Object} arg the object as received from the remote side
+     * @return {Object} an object of the same nature than @a arg with
+     * stream markers decoded into actual readable/writable stream
+     * objects
+     */
+    decodeStreams(arg) {
+        if (!arg) {
+            return arg;
+        }
+        const log = this.logger;
+
+        if (arg.$streamId !== undefined) {
+            if (arg.readable && arg.writable) {
+                throw new Error('duplex streams not supported');
+            }
+            const streamId = arg.$streamId;
+            let stream;
+            if (arg.readable) {
+                stream = new SIOInputStream(this, streamId);
+            } else if (arg.writable) {
+                stream = new SIOOutputStream(this, streamId,
+                                             this.maxPendingAck,
+                                             this.ackTimeoutMs);
+            } else {
+                throw new Error('can\'t decode stream neither readable ' +
+                                'nor writable');
+            }
+            this.remoteStreams[streamId] = stream;
+            if (arg.readable) {
+                stream.once('close', () => {
+                    log.debug('stream closed, removing from remote streams',
+                              { streamId });
+                    delete this.remoteStreams[streamId];
+                });
+            }
+            if (arg.writable) {
+                stream.once('finish', () => {
+                    log.debug('stream finished, removing from remote streams',
+                              { streamId });
+                    delete this.remoteStreams[streamId];
+                });
+            }
+            stream.on('error', error => {
+                log.error('stream error', { streamId, error });
+            });
+            return stream;
+        }
+        if (typeof(arg) === 'object') {
+            let decodedObj;
+            if (Array.isArray(arg)) {
+                decodedObj = [];
+                for (let k = 0; k < arg.length; ++k) {
+                    decodedObj.push(this.decodeStreams(arg[k]));
+                }
+            } else {
+                decodedObj = {};
+                // user objects are simple flat objects and we want to
+                // copy all their properties
+                // eslint-disable-next-line
+                for (const k in arg) {
+                    decodedObj[k] = this.decodeStreams(arg[k]);
+                }
+            }
+            return decodedObj;
+        }
+        return arg;
+    }
+
+    _write(streamId, data, cb) {
+        this.logger.debug('emit \'stream-data\' event',
+                          { streamId, size: data.length });
+        this.socket.emit('stream-data', { streamId, data }, cb);
+    }
+
+    _finish(streamId, cb) {
+        this.logger.debug('emit \'stream-end\' event', { streamId });
+        this.socket.emit('stream-end', { streamId }, cb);
+    }
+
+    _error(streamId, error) {
+        this.logger.debug('emit \'stream-error\' event', { streamId, error });
+        this.socket.emit('stream-error', { streamId,
+                                           error: flattenError(error) });
+    }
+
+    _hangup(streamId) {
+        this.logger.debug('emit \'stream-hangup\' event', { streamId });
+        this.socket.emit('stream-hangup', { streamId });
+    }
+
+    destroyStream(streamId) {
+        this.logger.debug('destroyStream', { streamId });
+        if (!this.localStreams[streamId]) {
+            return;
+        }
+        if (this.localStreams[streamId].destroy) {
+            // a 'close' event shall be emitted by destroy()
+            this.localStreams[streamId].destroy();
+        }
+        // if no destroy function exists in the input stream, let it
+        // go through the end
+    }
+}
+
+module.exports.createSocket = function createSocket(
+    socket,
+    logger,
+    maxPendingAck = DEFAULT_MAX_PENDING_ACK,
+    ackTimeoutMs = DEFAULT_ACK_TIMEOUT_MS) {
+    return new SIOStreamSocket(socket, logger, maxPendingAck, ackTimeoutMs);
+};

--- a/lib/network/level-net/utils.js
+++ b/lib/network/level-net/utils.js
@@ -1,0 +1,48 @@
+'use strict'; // eslint-disable-line
+
+/**
+ * @brief turn all @a err own and prototype attributes into own attributes
+ *
+ * This is done so that JSON.stringify() can properly serialize those
+ * attributes (e.g. err.notFound)
+ *
+ * @param {Error} err error object
+ * @return {Object} flattened object containing @a err attributes
+ */
+module.exports.flattenError = function flattenError(err) {
+    if (!err) {
+        return err;
+    }
+    const flattenedErr = {};
+
+    flattenedErr.message = err.message;
+    for (const k in err) {
+        if (!(k in flattenedErr)) {
+            flattenedErr[k] = err[k];
+        }
+    }
+    return flattenedErr;
+};
+
+/**
+ * @brief recreate a proper Error object from its flattened
+ * representation created with flattenError().
+ *
+ * @note Its internals may differ from the original Error object but
+ * its attributes should be the same.
+ *
+ * @param {Object} err flattened error object
+ * @return {Error} a reconstructed Error object inheriting @a err
+ *   attributes
+ */
+module.exports.reconstructError = function reconstructError(err) {
+    if (!err) {
+        return err;
+    }
+    const reconstructedErr = new Error(err.message);
+
+    Object.keys(err).forEach(k => {
+        reconstructedErr[k] = err[k];
+    });
+    return reconstructedErr;
+};

--- a/lib/storage/metadata/file/client.js
+++ b/lib/storage/metadata/file/client.js
@@ -1,0 +1,55 @@
+'use strict'; // eslint-disable-line
+
+const assert = require('assert');
+const Logger = require('werelogs').Logger;
+const constants = require('../../../constants');
+
+const levelNet = require('../../../network/level-net');
+
+class MetadataFileClient {
+
+    /**
+     * Construct a metadata client
+     *
+     * @param {Object} params the following parameters are used:
+     * @param {String} params.metadataHost name or IP address of
+     *   metadata server host
+     * @param {Number} params.metadataPort TCP port to connect to the
+     *   metadata server
+     * @param {Object} [params.log] logging configuration
+     */
+    constructor(params) {
+        assert.notStrictEqual(params.metadataHost, undefined);
+        assert.notStrictEqual(params.metadataPort, undefined);
+        this.metadataHost = params.metadataHost;
+        this.metadataPort = params.metadataPort;
+        this.callTimeoutMs = params.callTimeoutMs;
+        this.setupLogging(params.log);
+    }
+
+    setupLogging(config) {
+        let options = undefined;
+        if (config !== undefined) {
+            options = {
+                level: config.logLevel,
+                dump: config.dumpLevel,
+            };
+        }
+        this.logger = new Logger('MetadataFileClient', options);
+    }
+
+    /**
+     * Open the remote metadata database (backed by leveldb)
+     *
+     * @return {Object} handle to the remote database
+     */
+    openDB() {
+        this.client = levelNet.client({ baseNs: constants.metadataFileNamespace,
+                                        logger: this.logger,
+                                        callTimeoutMs: this.callTimeoutMs });
+        this.client.connect(this.metadataHost, this.metadataPort);
+        return this.client;
+    }
+}
+
+module.exports = MetadataFileClient;

--- a/lib/storage/metadata/file/server.js
+++ b/lib/storage/metadata/file/server.js
@@ -1,0 +1,73 @@
+'use strict'; // eslint-disable-line
+
+const assert = require('assert');
+const Logger = require('werelogs').Logger;
+const constants = require('../../../constants');
+
+const level = require('level');
+const levelNet = require('../../../network/level-net');
+const sublevel = require('level-sublevel');
+
+const ROOT_DB = 'rootDB';
+
+class MetadataFileServer {
+
+    /**
+     * Construct a metadata server
+     *
+     * @param {Object} params constructor params
+     * @param {String} params.metadataPath local path where the root
+     *   database is stored
+     * @param {Number} params.metadataPort TCP port that listens to
+     *   incoming connections
+     * @param {Number} [params.streamMaxPendingAck] max number of
+     *   in-flight output stream packets sent to the client without an
+     *   ack received yet
+     * @param {Number} [params.streamAckTimeoutMs] timeout for
+     *   receiving an ack after an output stream packet is sent to the
+     *   client
+     * @param {Object} [params.log] logging configuration
+     */
+    constructor(params) {
+        assert.notStrictEqual(params.metadataPath, undefined);
+        assert.notStrictEqual(params.metadataPort, undefined);
+        this.metadataPath = params.metadataPath;
+        this.metadataPort = params.metadataPort;
+        this.streamMaxPendingAck = params.streamMaxPendingAck;
+        this.streamAckTimeoutMs = params.streamAckTimeoutMs;
+
+        this.setupLogging(params.log);
+    }
+
+    setupLogging(config) {
+        let options = undefined;
+        if (config !== undefined) {
+            options = {
+                level: config.logLevel,
+                dump: config.dumpLevel,
+            };
+        }
+        this.logger = new Logger('MetadataFileServer', options);
+    }
+
+    /**
+     * Start the metadata server and listen to incoming connections
+     *
+     * @return {undefined}
+     */
+    startServer() {
+        const rootDB = level(`${this.metadataPath}/${ROOT_DB}`);
+        this.db = sublevel(rootDB);
+        this.logger.info('starting metadata file backend server');
+        /* We start a server that will serve the sublevel capable
+           rootDB to clients */
+        const server = levelNet.createServer(
+            this.db, { logger: this.logger,
+                       streamMaxPendingAck: this.streamMaxPendingAck,
+                       streamAckTimeoutMs: this.streamAckTimeoutMs });
+        server.initMetadataService(constants.metadataFileNamespace);
+        server.listen(this.metadataPort);
+    }
+}
+
+module.exports = MetadataFileServer;

--- a/package.json
+++ b/package.json
@@ -18,15 +18,21 @@
   "homepage": "https://github.com/scality/Arsenal#readme",
   "dependencies": {
     "ajv": "4.10.0",
+    "async": "~2.1.5",
+    "debug": "~2.3.3",
     "ipaddr.js": "1.2.0",
-    "utf8": "2.1.2"
+    "level": "~1.6.0",
+    "level-sublevel": "~6.6.1",
+    "socket.io": "~1.7.3",
+    "socket.io-client": "~1.7.3",
+    "utf8": "2.1.2",
+    "uuid": "~3.0.1"
   },
   "devDependencies": {
     "eslint": "2.13.1",
     "eslint-plugin-react": "^4.3.0",
     "eslint-config-airbnb": "6.2.0",
     "eslint-config-scality": "scality/Guidelines",
-    "level": "1.6.0",
     "lolex": "1.5.2",
     "mocha": "2.5.3",
     "temp": "0.8.3",

--- a/tests/unit/network/level-net/index.js
+++ b/tests/unit/network/level-net/index.js
@@ -1,0 +1,363 @@
+'use strict'; // eslint-disable-line
+
+const level = require('level');
+const sublevel = require('level-sublevel');
+const temp = require('temp');
+const assert = require('assert');
+const levelNet = require('../../../../lib/network/level-net');
+const async = require('async');
+const Logger = require('werelogs').Logger;
+const debug = require('debug')('level-net:test');
+
+describe('level-net - LevelDB over network', () => {
+    let db;
+    let client;
+
+    function setupLevelNet() {
+        const server = levelNet.createServer(
+            db, { logger: new Logger('level-net:test-server',
+                                     { level: 'info', dump: 'error' }) });
+        server.initMetadataService('/test');
+        server.listen(6677);
+
+        client = levelNet.client({ baseNs: '/test',
+                                   logger: new Logger('level-net:test-client',
+                                                      { level: 'info',
+                                                        dump: 'error' }) });
+        client.connect('localhost', 6677);
+    }
+
+    /**
+     * create-read-update-delete simple test
+     *
+     * @param {Object} db database object
+     * @param {String} crudSelect string containing one or more of
+     * 'C', 'R', 'U' and 'D' letters to enable each type of test
+     * @param {String} key object key to work with
+     * @param {function} cb callback when done
+     * @return {undefined}
+     */
+    function doCRUDTest(db, crudSelect, key, cb) {
+        const crudList = crudSelect.split('');
+        const opList = [];
+        if (crudList.includes('U')) {
+            crudList.push('C'); // force creation before update
+        }
+        if (crudList.includes('C')) {
+            const value = `${key}:testvalue1`;
+            opList.push(done => {
+                const dbg = (`put sub '${db.path.join(':')}' ` +
+                             `key '${key}' value '${value}'`);
+                debug(`BEGIN ${dbg}`);
+                db.put(key, value, err => {
+                    debug(`END ${dbg} -> ${err}`);
+                    done(err);
+                });
+            });
+        }
+        if (crudList.includes('R')) {
+            const expectedValue = `${key}:testvalue1`;
+            opList.push(done => {
+                const dbg = `get sub '${db.path.join(':')}' key '${key}'`;
+                debug(`BEGIN ${dbg}`);
+                db.get(key, (err, data) => {
+                    if (!err) {
+                        assert.strictEqual(data, expectedValue);
+                    }
+                    debug(`END ${dbg} -> (${err},'${data}')`);
+                    done(err);
+                });
+            });
+        }
+        if (crudList.includes('U')) {
+            const value = `${key}:testvalue2`;
+            opList.push(done => {
+                const dbg = (`update sub '${db.path.join(':')}' ` +
+                             `key '${key}' value '${value}'`);
+                debug(`BEGIN ${dbg}`);
+                db.put(key, value, err => {
+                    debug(`END ${dbg} -> ${err}`);
+                    done(err);
+                });
+            });
+            // read after write to check contents have been updated
+            opList.push(done => {
+                const dbg = (`get (check) sub '${db.path.join(':')}' ` +
+                             `key '${key}'`);
+                debug(`BEGIN ${dbg}`);
+                db.get(key, (err, data) => {
+                    debug(`END ${dbg} -> (${err},'${data}')`);
+                    assert.ifError(err);
+                    assert.strictEqual(data, value);
+                    done();
+                });
+            });
+        }
+        if (crudList.includes('D')) {
+            opList.push(done => {
+                const dbg = `del sub '${db.path.join(':')}' key '${key}'`;
+                debug(`BEGIN ${dbg}`);
+                db.del(key, err => {
+                    debug(`END ${dbg} -> ${err}`);
+                    done(err);
+                });
+            });
+            // check that contents have effectively been deleted
+            opList.push(done => {
+                const dbg = (`get (check) sub '${db.path.join(':')}' ` +
+                             `key '${key}'`);
+                debug(`BEGIN ${dbg}`);
+                db.get(key, err => {
+                    debug(`END ${dbg} -> ${err}`);
+                    assert(err);
+                    assert(err.notFound);
+                    done();
+                });
+            });
+        }
+
+        async.series(opList, cb);
+    }
+
+    before(done => {
+        temp.mkdir('level-net-testdb-', (err, dbDir) => {
+            const rootDb = level(dbDir);
+            db = sublevel(rootDb);
+            setupLevelNet();
+            return done();
+        });
+    });
+
+    describe('simple tests', () => {
+        it('should ping a level-net server (sync on server)', done => {
+            client.ping((err, args) => {
+                if (err) {
+                    return done(err);
+                }
+                assert.strictEqual(args, 'pong');
+                return done();
+            });
+        });
+        it('should ping a level-net server (async on server)', done => {
+            client.pingAsync((err, args) => {
+                if (err) {
+                    return done(err);
+                }
+                assert.strictEqual(args, 'pong');
+                return done();
+            });
+        });
+        it('should be able to perform a complete CRUD test', done => {
+            doCRUDTest(client, 'CRUD', 'testkey', done);
+        });
+    });
+    describe('sublevel tests', () => {
+        it('should be able to do CRUD on sublevel', done => {
+            const subLevel = client.openSub('sub1');
+            assert(subLevel);
+            doCRUDTest(subLevel, 'CRUD', 'subkey', done);
+        });
+        it('should be able to re-open a sublevel', done => {
+            const subLevel = client.openSub('sub2');
+            doCRUDTest(subLevel, 'C', 'subkey', err => {
+                assert.ifError(err);
+                const subLevel2 = client.openSub('sub2');
+                doCRUDTest(subLevel2, 'RD', 'subkey', done);
+            });
+        });
+        it('should separate sublevel namespaces correctly', done => {
+            const subLevel = client.openSub('sub3');
+            doCRUDTest(subLevel, 'C', 'subkey', err => {
+                assert.ifError(err);
+                const otherSub = client.openSub('sub4');
+                doCRUDTest(otherSub, 'RD', 'subkey', err => {
+                    assert(err);
+                    assert(err.notFound);
+                    return done();
+                });
+            });
+        });
+        it('should be able to nest multiple sub-levels', done => {
+            const subLevel = client.openSub('sub4');
+            const nestedSub1 = subLevel.openSub('sub4-nested1');
+            const nestedSub2 = nestedSub1.openSub('nested-nested');
+            doCRUDTest(nestedSub2, 'CRU', 'key', err => {
+                assert.ifError(err);
+                const nestedSub22 = nestedSub1.openSub('nested-nested2');
+                doCRUDTest(nestedSub22, 'R', 'key', err => {
+                    // expect get error, it's another sub-level
+                    assert(err);
+                    assert(err.notFound);
+                    done();
+                });
+            });
+        });
+    });
+    describe('multiple keys tests', () => {
+        const nbKeys = 100;
+
+        function keyOfIter(i) {
+            return `key of ${i}`;
+        }
+        function valueOfIter(i) {
+            return `value of key ${i}`;
+        }
+        function prefillKeys(done) {
+            let nbPutDone = 0;
+
+            function putCb(err) {
+                assert.ifError(err);
+                ++nbPutDone;
+                if (nbPutDone === nbKeys) {
+                    return done();
+                }
+                return undefined;
+            }
+            for (let i = 0; i < nbKeys; ++i) {
+                client.put(keyOfIter(i), valueOfIter(i), putCb);
+            }
+        }
+        before(done => {
+            prefillKeys(done);
+        });
+        it('should be able to read keys back at random', done => {
+            const nbGet = 100;
+            let nbGetDone = 0;
+
+            for (let i = 0; i < nbGet; ++i) {
+                const randI = Math.floor(Math.random() * nbKeys);
+                // linter complains with 'no-loop-func' but we need a
+                // new randI each time
+                function getCb(err, data) { // eslint-disable-line
+                    assert.ifError(err);
+                    assert.strictEqual(data, valueOfIter(randI));
+                    ++nbGetDone;
+                    if (nbGetDone === nbGet) {
+                        return done();
+                    }
+                }
+                client.get(keyOfIter(randI), getCb);
+            }
+        });
+        it('should be able to list all keys through a stream and ' +
+           'rewrite them on-the-fly', done => {
+            client.createReadStream((err, keyStream) => {
+                assert.ifError(err);
+
+                let nbKeysListed = 0;
+                let nbPutDone = 0;
+                let prevKey = undefined;
+                let receivedEnd = false;
+                keyStream.on('error', err => {
+                    debug('stream error:', err);
+                    assert.ifError(err);
+                });
+                keyStream.on('data', entry => {
+                    debug('next key:', entry);
+                    ++nbKeysListed;
+                    assert(entry.key);
+                    assert(!prevKey || entry.key > prevKey);
+                    prevKey = entry.key;
+                    client.put(entry.key,
+                               `new data for key ${entry.key}`, err => {
+                                   assert.ifError(err);
+                                   ++nbPutDone;
+                                   if (nbPutDone === nbKeys && receivedEnd) {
+                                       done();
+                                   }
+                                   return undefined;
+                               });
+                });
+                keyStream.on('end', () => {
+                    receivedEnd = true;
+                    assert.strictEqual(nbKeysListed, nbKeys);
+                    if (nbPutDone === nbKeys) {
+                        done();
+                    }
+                });
+            });
+        });
+        it('should be able to abort key listing properly when client ' +
+           'destroys the stream', done => {
+            client.createReadStream((err, keyStream) => {
+                assert.ifError(err);
+
+                let nbKeysListed = 0;
+                keyStream.on('error', err => {
+                    assert.ifError(err);
+                });
+                keyStream.on('data', entry => {
+                    debug('next key:', entry);
+                    // guard against further 'data' events after
+                    // destroy() has been called
+                    assert(nbKeysListed < nbKeys / 2);
+                    ++nbKeysListed;
+                    if (nbKeysListed === nbKeys / 2) {
+                        debug('calling destroy() on read stream');
+                        keyStream.destroy();
+                        // wait 100ms to make sure no further data is issued
+                        setTimeout(() => {
+                            assert(nbKeysListed === nbKeys / 2);
+                            debug('after abort: keyStream._readState=',
+                                  keyStream._readState);
+                            done();
+                        }, 100);
+                    }
+                });
+                keyStream.on('end', () => {
+                    // should not reach end of stream
+                    assert.fail("'end' event received after destroy()");
+                });
+            });
+        });
+        it('should delete all keys successfully', done => {
+            let nbDelDone = 0;
+
+            function checkAllDeleted(done) {
+                let nbGetDone = 0;
+
+                function checkCb(err) {
+                    assert(err.notFound);
+                    ++nbGetDone;
+                    if (nbGetDone === nbKeys) {
+                        return done();
+                    }
+                    return undefined;
+                }
+                for (let i = 0; i < nbKeys; ++i) {
+                    client.get(keyOfIter(i), checkCb);
+                }
+            }
+            function delCb(err) {
+                assert.ifError(err);
+                ++nbDelDone;
+                if (nbDelDone === nbKeys) {
+                    checkAllDeleted(done);
+                }
+            }
+            for (let i = 0; i < nbKeys; ++i) {
+                client.del(keyOfIter(i), delCb);
+            }
+        });
+    });
+
+    describe('error tests', () => {
+        it('should timeout if command is too long to respond', done => {
+            // shorten the timeout to 200ms to speed up the test
+            const oldTimeout = client.getCallTimeout();
+            client.setCallTimeout(200);
+            client.slowCommand(err => {
+                assert(err);
+                assert.strictEqual(err.code, 'ETIMEDOUT');
+                return done();
+            });
+            client.setCallTimeout(oldTimeout);
+        });
+        it('should throw if last argument of call is not a callback', done => {
+            assert.throws(() => {
+                client.pingAsync('not a callback');
+            }, Error);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
It allows the client to do the normal levelDB operations (put, get,
delete, list keys via createReadStream) as well as creating new
sublevels. (Note that this is a purely virtual operation, nothing is
created initially but the client gets a handle to manipulate the new
sublevel).

It's built on top of socket.io which provides messaging abstraction
and helps maintaining a reliable channel (detects connection failures,
attempts to reconnect etc.). It also allows to use several namespaces
and "rooms" on the same communication channel, which may be useful
later.

There is an additional timeout for each operation, which triggers an
error after 5 seconds without an answer by default.

A custom object stream implementation has been added in order to list
keys more efficiently than the third-party "socket.io-stream" module
which does a round-trip for every entry. This implementation both
gathers written objects in a single packet, and can pipeline multiple
packets to the server while waiting for acks (max 5 by default, should
be configurable). This should help a lot when the remote latency is
high.

Note that levelDB createReadStream() becomes asynchronous, the user
must pass a callback and the stream is returned as a callback
argument.

Unit tests added:

 - ping
 - basic CRUD test
 - sublevels (separation of namespace, nesting)
 - listing of keys (to the end and aborted by the client) + parallel rewrites
 - parallel random reads
 - parallel deletes
 - command timeout