### PR TITLE
S3C-35 init metadata storage in arsenal

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,5 +47,6 @@ module.exports = {
             server: require('./lib/storage/metadata/file/server'),
             client: require('./lib/storage/metadata/file/client'),
         },
+        utils: require('./lib/storage/utils'),
     },
 };

--- a/lib/storage/metadata/file/server.js
+++ b/lib/storage/metadata/file/server.js
@@ -1,8 +1,13 @@
 'use strict'; // eslint-disable-line
 
+const fs = require('fs');
+const os = require('os');
 const assert = require('assert');
+const uuid = require('uuid');
+
 const Logger = require('werelogs').Logger;
 const constants = require('../../../constants');
+const storageUtils = require('../../utils');
 
 const level = require('level');
 const levelNet = require('../../../network/level-net');
@@ -50,12 +55,53 @@ class MetadataFileServer {
         this.logger = new Logger('MetadataFileServer', options);
     }
 
+    genUUIDIfNotExists() {
+        const uuidFile = `${this.metadataPath}/uuid`;
+
+        try {
+            fs.accessSync(uuidFile, fs.F_OK | fs.R_OK);
+        } catch (e) {
+            if (e.code === 'ENOENT') {
+                const v = uuid.v4();
+                const fd = fs.openSync(uuidFile, 'w');
+                fs.writeSync(fd, v.toString());
+                fs.closeSync(fd);
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    printUUID() {
+        const uuidFile = `${this.metadataPath}/uuid`;
+        const uuidValue = fs.readFileSync(uuidFile);
+        this.logger.info(`This deployment's identifier is ${uuidValue}`);
+    }
+
     /**
      * Start the metadata server and listen to incoming connections
      *
      * @return {undefined}
      */
     startServer() {
+        fs.accessSync(this.metadataPath, fs.F_OK | fs.R_OK | fs.W_OK);
+
+        const warning =
+                  'WARNING: Synchronization directory updates are not ' +
+                  'supported on this platform. Newly written data could ' +
+                  'be lost if your system crashes before the operating ' +
+                  'system is able to write directory updates.';
+        if (os.type() === 'Linux' && os.endianness() === 'LE') {
+            try {
+                storageUtils.setDirSyncFlag(this.metadataPath);
+            } catch (err) {
+                this.logger.warn(warning, { error: err.message,
+                                            errorStack: err.stack });
+            }
+        } else {
+            this.logger.warn(warning);
+        }
+
         const rootDB = level(`${this.metadataPath}/${ROOT_DB}`);
         this.db = sublevel(rootDB);
         this.logger.info('starting metadata file backend server');
@@ -67,6 +113,9 @@ class MetadataFileServer {
                        streamAckTimeoutMs: this.streamAckTimeoutMs });
         server.initMetadataService(constants.metadataFileNamespace);
         server.listen(this.metadataPort);
+
+        this.genUUIDIfNotExists();
+        this.printUUID();
     }
 }
 

--- a/lib/storage/utils.js
+++ b/lib/storage/utils.js
@@ -1,0 +1,29 @@
+'use strict'; // eslint-disable-line
+
+const fs = require('fs');
+const assert = require('assert');
+
+module.exports.setDirSyncFlag = function setDirSyncFlag(path) {
+    // may throw if ioctl is not available
+    const ioctl = require('ioctl');
+
+    const GETFLAGS = 2148034049;
+    const SETFLAGS = 1074292226;
+    const FS_DIRSYNC_FL = 65536;
+    const buffer = Buffer.alloc(8, 0);
+    const pathFD = fs.openSync(path, 'r');
+    const status = ioctl(pathFD, GETFLAGS, buffer);
+    assert.strictEqual(status, 0);
+    const currentFlags = buffer.readUIntLE(0, 8);
+    const flags = currentFlags | FS_DIRSYNC_FL;
+    buffer.writeUIntLE(flags, 0, 8);
+    const status2 = ioctl(pathFD, SETFLAGS, buffer);
+    assert.strictEqual(status2, 0);
+    fs.closeSync(pathFD);
+    const pathFD2 = fs.openSync(path, 'r');
+    const confirmBuffer = Buffer.alloc(8, 0);
+    ioctl(pathFD2, GETFLAGS, confirmBuffer);
+    assert.strictEqual(confirmBuffer.readUIntLE(0, 8),
+        currentFlags | FS_DIRSYNC_FL, 'FS_DIRSYNC_FL not set');
+    fs.closeSync(pathFD2);
+};

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "uuid": "~3.0.1",
     "werelogs": "scality/werelogs"
   },
+  "optionalDependencies": {
+      "ioctl": "2.0.0"
+  },
   "devDependencies": {
     "eslint": "2.13.1",
     "eslint-plugin-react": "^4.3.0",


### PR DESCRIPTION
Follow-up of https://github.com/scality/Arsenal/pull/230

Note: base branch is ft/S3C-35-metadataServer in order to see the changes on top, but this shall be merged to master.