### PR TITLE
S3C-158 REST interface for datafile backend

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ module.exports = {
     shuffle: require('./lib/shuffle'),
     stringHash: require('./lib/stringHash'),
     ipCheck: require('./lib/ipCheck'),
+    jsutil: require('./lib/jsutil'),
     https: {
         ciphers: require('./lib/https/ciphers.js'),
         dhparam: require('./lib/https/dh2048.js'),

--- a/index.js
+++ b/index.js
@@ -44,11 +44,23 @@ module.exports = {
         },
         rpc: require('./lib/network/rpc/rpc'),
         level: require('./lib/network/rpc/level-net'),
+        rest: {
+            RESTServer: require('./lib/network/rest/RESTServer'),
+            RESTClient: require('./lib/network/rest/RESTClient'),
+        },
     },
     storage: {
         metadata: {
-            server: require('./lib/storage/metadata/file/server'),
-            client: require('./lib/storage/metadata/file/client'),
+            MetadataFileServer:
+            require('./lib/storage/metadata/file/MetadataFileServer'),
+            MetadataFileClient:
+            require('./lib/storage/metadata/file/MetadataFileClient'),
+        },
+        data: {
+            file: {
+                DataFileStore:
+                require('./lib/storage/data/file/DataFileStore'),
+            },
         },
         utils: require('./lib/storage/utils'),
     },

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -6,4 +6,5 @@ module.exports = {
     // only public resources
     publicId: 'http://acs.amazonaws.com/groups/global/AllUsers',
     metadataFileNamespace: '/MDFile',
+    dataFileURL: '/DataFile',
 };

--- a/lib/jsutil.js
+++ b/lib/jsutil.js
@@ -1,0 +1,32 @@
+'use strict'; // eslint-disable-line
+
+const debug = require('util').debuglog('jsutil');
+
+// JavaScript utility functions
+
+/**
+ * force @a func to be called only once, even if actually called
+ * multiple times. The cached result of the first call is then
+ * returned (if any).
+ *
+ * @note underscore.js provides this functionality but not worth
+ * adding a new dependency for such a small use case.
+ *
+ * @param {function} func function to call at most once
+
+ * @return {function} a callable wrapper mirroring @a func but
+ * only calls @a func at first invocation.
+ */
+module.exports.once = function once(func) {
+    const state = { called: false, res: undefined };
+    return function wrapper(...args) {
+        if (!state.called) {
+            state.called = true;
+            state.res = func.apply(func, args);
+        } else {
+            debug('function already called:', func,
+                  'returning cached result:', state.res);
+        }
+        return state.res;
+    };
+};

--- a/lib/jsutil.js
+++ b/lib/jsutil.js
@@ -5,7 +5,7 @@ const debug = require('util').debuglog('jsutil');
 // JavaScript utility functions
 
 /**
- * force @a func to be called only once, even if actually called
+ * force <tt>func</tt> to be called only once, even if actually called
  * multiple times. The cached result of the first call is then
  * returned (if any).
  *
@@ -14,8 +14,8 @@ const debug = require('util').debuglog('jsutil');
  *
  * @param {function} func function to call at most once
 
- * @return {function} a callable wrapper mirroring @a func but
- * only calls @a func at first invocation.
+ * @return {function} a callable wrapper mirroring <tt>func</tt> but
+ * only calls <tt>func</tt> at first invocation.
  */
 module.exports.once = function once(func) {
     const state = { called: false, res: undefined };

--- a/lib/network/http/server.js
+++ b/lib/network/http/server.js
@@ -32,6 +32,7 @@ class Server {
             rejectUnauthorized: true,
         };
         this._port = port;
+        this._address = '::';
         this._server = null;
         this._logger = logger;
     }
@@ -70,7 +71,7 @@ class Server {
      * Setter to the listening port
      *
      * @param {number} port - Port to listen into
-     * @return {Server} itself
+     * @return {undefined}
      */
     setPort(port) {
         this._port = port;
@@ -83,6 +84,25 @@ class Server {
      */
     getPort() {
         return this._port;
+    }
+
+    /**
+     * Setter to the bind address
+     *
+     * @param {String} address - address bound to the socket
+     * @return {undefined}
+     */
+    setBindAddress(address) {
+        this._address = address;
+    }
+
+    /**
+     * Getter to access the bind address
+     *
+     * @return {String} address bound to the socket
+     */
+    getBindAddress() {
+        return this._address;
     }
 
     /**
@@ -333,7 +353,8 @@ class Server {
             this._onClientError(err, sock));
         this._server.on('clientError', (err, sock) =>
             this._onClientError(err, sock));
-        this._server.listen(this._port, () => this._onListening());
+        this._server.listen(this._port, this._address,
+                            () => this._onListening());
         return this;
     }
 

--- a/lib/network/http/utils.js
+++ b/lib/network/http/utils.js
@@ -1,0 +1,109 @@
+'use strict'; // eslint-disable-line
+
+const errors = require('../../errors');
+
+/**
+ * Parse the Range header into an object
+ *
+ * @param {String} rangeHeader - The 'Range' header value
+
+ * @return {Object} object containing a range specification, with
+ * either of:
+ * - start and end attributes: a fully specified range request
+ * - a single start attribute: no end is specified in the range request
+ * - a suffix attribute: suffix range request
+ * - an error attribute of type errors.InvalidArgument if the range
+ *     syntax is invalid
+ */
+function parseRangeSpec(rangeHeader) {
+    const rangeMatch = /^bytes=([0-9]+)?-([0-9]+)?$/.exec(rangeHeader);
+    if (rangeMatch) {
+        const rangeValues = rangeMatch.slice(1, 3);
+        if (rangeValues[0] === undefined) {
+            if (rangeValues[1] !== undefined) {
+                return { suffix: Number.parseInt(rangeValues[1], 10) };
+            }
+        } else {
+            const rangeSpec = { start: Number.parseInt(rangeValues[0], 10) };
+            if (rangeValues[1] === undefined) {
+                return rangeSpec;
+            }
+            rangeSpec.end = Number.parseInt(rangeValues[1], 10);
+            if (rangeSpec.start <= rangeSpec.end) {
+                return rangeSpec;
+            }
+        }
+    }
+    return { error: errors.InvalidArgument };
+}
+
+/**
+ * Convert a range specification as given by parseRangeSpec() into a
+ * fully specified absolute byte range
+ *
+ * @param {Number []} rangeSpec - Parsed range specification as returned
+ *   by parseRangeSpec()
+ * @param {Number} objectSize - Total byte size of the whole object
+
+ * @return {Object} object containing either:
+ * - a 'range' attribute which is a fully specified byte range [start,
+       end], as the inclusive absolute byte range to request from the
+       object
+ * - or no attribute if the requested range is a valid range request
+       for a whole empty object (non-zero suffix range)
+ * - or an 'error' attribute of type errors.InvalidRange if the
+ *     requested range is out of object's boundaries.
+ */
+function getByteRangeFromSpec(rangeSpec, objectSize) {
+    if (rangeSpec.suffix !== undefined) {
+        if (rangeSpec.suffix === 0) {
+            // 0-byte suffix is always invalid (even on empty objects)
+            return { error: errors.InvalidRange };
+        }
+        if (objectSize === 0) {
+            // any other suffix range on an empty object returns the
+            // full object (0 bytes)
+            return {};
+        }
+        return { range: [Math.max(objectSize - rangeSpec.suffix, 0),
+                         objectSize - 1] };
+    }
+    if (rangeSpec.start < objectSize) {
+        // test is false if end is undefined
+        return { range: [rangeSpec.start,
+                         (rangeSpec.end < objectSize ?
+                          rangeSpec.end : objectSize - 1)] };
+    }
+    return { error: errors.InvalidRange };
+}
+
+/**
+ * Convenience function that combines parseRangeSpec() and
+ * getByteRangeFromSpec()
+ *
+ * @param {String} rangeHeader - The 'Range' header value
+ * @param {Number} objectSize - Total byte size of the whole object
+
+ * @return {Object} object containing either:
+ * - a 'range' attribute which is a fully specified byte range [start,
+ *     end], as the inclusive absolute byte range to request from the
+ *     object
+ * - or no attribute if the requested range is either syntactically
+ *     incorrect or is a valid range request for an empty object
+ *     (non-zero suffix range)
+ * - or an 'error' attribute instead of type errors.InvalidRange if
+ *     the requested range is out of object's boundaries.
+ */
+function parseRange(rangeHeader, objectSize) {
+    const rangeSpec = parseRangeSpec(rangeHeader);
+    if (rangeSpec.error) {
+        // invalid range syntax is silently ignored in HTTP spec,
+        // hence returns the whole object
+        return {};
+    }
+    return getByteRangeFromSpec(rangeSpec, objectSize);
+}
+
+module.exports = { parseRangeSpec,
+                   getByteRangeFromSpec,
+                   parseRange };

--- a/lib/network/rest/RESTClient.js
+++ b/lib/network/rest/RESTClient.js
@@ -1,0 +1,255 @@
+'use strict'; // eslint-disable-line
+
+const assert = require('assert');
+const http = require('http');
+
+const Logger = require('werelogs').Logger;
+const constants = require('../../constants');
+const utils = require('./utils');
+const errors = require('../../errors');
+
+function setRequestUids(reqHeaders, reqUids) {
+    // inhibit 'assignment to property of function parameter' -
+    // this is what we want
+    // eslint-disable-next-line
+    reqHeaders['X-Scal-Request-Uids'] = reqUids;
+}
+
+function setRange(reqHeaders, range) {
+    const rangeStart = range[0] !== undefined ? range[0].toString() : '';
+    const rangeEnd = range[1] !== undefined ? range[1].toString() : '';
+    // inhibit 'assignment to property of function parameter' -
+    // this is what we want
+    // eslint-disable-next-line
+    reqHeaders['Range'] = `bytes=${rangeStart}-${rangeEnd}`;
+}
+
+function setContentType(reqHeaders, contentType) {
+    // inhibit 'assignment to property of function parameter' -
+    // this is what we want
+    // eslint-disable-next-line
+    reqHeaders['Content-Type'] = contentType;
+}
+
+function setContentLength(reqHeaders, size) {
+    // inhibit 'assignment to property of function parameter' -
+    // this is what we want
+    // eslint-disable-next-line
+    reqHeaders['Content-Length'] = size.toString();
+}
+
+function makeErrorFromHTTPResponse(response) {
+    const rawBody = response.read();
+    const body = (rawBody !== null ? rawBody.toString() : '');
+    let error;
+    try {
+        const fields = JSON.parse(body);
+        error = errors[fields.errorType]
+            .customizeDescription(fields.errorMessage);
+    } catch (err) {
+        error = new Error(body);
+    }
+    // error is always a newly created object, so we can modify its
+    // properties
+    error.remote = true;
+    return error;
+}
+
+
+/**
+ * @class
+ * @classdesc REST Client interface
+ *
+ * The API is usable when the object is constructed.
+ */
+class RESTClient {
+    /**
+     * Interface to the data file server
+     * @constructor
+     * @param {Object} params - Contains the basic configuration.
+     * @param {String} params.host - hostname or ip address of the
+     *   RESTServer instance
+     * @param {Number} params.port - port number that the RESTServer
+     *   instance listens to
+     * @param {Logger} [params.log] - logging configuration
+     */
+    constructor(params) {
+        assert(params.host);
+        assert(params.port);
+
+        this.host = params.host;
+        this.port = params.port;
+        this.setupLogging(params.log);
+        this.httpAgent = new http.Agent({ keepAlive: true });
+    }
+
+    setupLogging(config) {
+        let options = undefined;
+        if (config !== undefined) {
+            options = {
+                level: config.logLevel,
+                dump: config.dumpLevel,
+            };
+        }
+        this.logging = new Logger('DataFileRESTClient', options);
+    }
+
+    createLogger(reqUids) {
+        return reqUids ?
+            this.logging.newRequestLoggerFromSerializedUids(reqUids) :
+            this.logging.newRequestLogger();
+    }
+
+    doRequest(method, headers, key, log, responseCb) {
+        const reqHeaders = headers || {};
+        const urlKey = key || '';
+        const reqParams = {
+            hostname: this.host,
+            port: this.port,
+            method,
+            path: `${constants.dataFileURL}/${urlKey}`,
+            headers: reqHeaders,
+            agent: this.httpAgent,
+        };
+        log.debug(`about to send ${method} request`, {
+            hostname: reqParams.hostname,
+            port: reqParams.port,
+            path: reqParams.path,
+            headers: reqParams.headers });
+        const request = http.request(reqParams, responseCb);
+
+        // disable nagle algorithm
+        request.setNoDelay(true);
+        return request;
+    }
+
+    /**
+     * This sends a PUT request to the the REST server
+     * @param {http.IncomingMessage} stream - Request with the data to send
+     * @param {string} stream.contentHash - hash of the data to send
+     * @param {integer} size - size
+     * @param {string} reqUids - The serialized request ids
+     * @param {RESTClient~putCallback} callback - callback
+     * @returns {undefined}
+     */
+    put(stream, size, reqUids, callback) {
+        const log = this.createLogger(reqUids);
+        const headers = {};
+        setRequestUids(headers, reqUids);
+        setContentType(headers, 'application/octet-stream');
+        setContentLength(headers, size);
+
+        const request = this.doRequest('PUT', headers, null, log, response => {
+            response.once('readable', () => {
+                // expects '201 Created'
+                if (response.statusCode !== 201) {
+                    return callback(makeErrorFromHTTPResponse(response));
+                }
+                // retrieve the key from the Location response header
+                // containing the complete URL to the object, like
+                // /DataFile/abcdef.
+                const location = response.headers.location;
+                if (location === undefined) {
+                    return callback(new Error(
+                        'missing Location header in the response'));
+                }
+                const locationInfo = utils.explodePath(location);
+                if (!locationInfo) {
+                    return callback(new Error(
+                        `bad Location response header: ${location}`));
+                }
+                return callback(null, locationInfo.key);
+            });
+        }).on('finish', () => {
+            log.debug('finished sending PUT data to the REST server', {
+                component: 'RESTClient',
+                method: 'put',
+                contentLength: size,
+            });
+        }).on('error', callback);
+
+        stream.pipe(request);
+        stream.on('error', err => {
+            log.error('error from readable stream', {
+                error: err,
+                method: 'put',
+                component: 'RESTClient',
+            });
+            request.end();
+        });
+    }
+
+    /**
+     * send a GET request to the REST server
+     * @param {String} key - The key associated to the value
+     * @param { Number [] | Undefined} range - range (if any) a
+     *   [start, end] inclusive range specification, as defined in
+     *   HTTP/1.1 RFC.
+     * @param {String} reqUids - The serialized request ids
+     * @param {RESTClient~getCallback} callback - callback
+     * @returns {undefined}
+     */
+    get(key, range, reqUids, callback) {
+        const log = this.createLogger(reqUids);
+        const headers = {};
+        setRequestUids(headers, reqUids);
+        if (range) {
+            setRange(headers, range);
+        }
+        const request = this.doRequest('GET', headers, key, log, response => {
+            response.once('readable', () => {
+                if (response.statusCode !== 200 &&
+                    response.statusCode !== 206) {
+                    return callback(makeErrorFromHTTPResponse(response));
+                }
+                return callback(null, response);
+            });
+        }).on('error', callback);
+
+        request.end();
+    }
+
+    /**
+     * send a DELETE request to the REST server
+     * @param {String} key - The key associated to the values
+     * @param {String} reqUids - The serialized request ids
+     * @param {RESTClient~deleteCallback} callback - callback
+     * @returns {undefined}
+     */
+    delete(key, reqUids, callback) {
+        const log = this.createLogger(reqUids);
+        const headers = {};
+        setRequestUids(headers, reqUids);
+
+        const request = this.doRequest(
+            'DELETE', headers, key, log, response => {
+                response.once('readable', () => {
+                    if (response.statusCode !== 200 &&
+                        response.statusCode !== 204) {
+                        return callback(makeErrorFromHTTPResponse(response));
+                    }
+                    return callback(null);
+                });
+            }).on('error', callback);
+        request.end();
+    }
+}
+
+/**
+ * @callback RESTClient~putCallback
+ * @param {Error} - The encountered error
+ * @param {String} key - The key to access the data
+ */
+
+/**
+ * @callback RESTClient~getCallback
+ * @param {Error} - The encountered error
+ * @param {stream.Readable} stream - The stream of values fetched
+ */
+
+/**
+ * @callback RESTClient~deleteCallback
+ * @param {Error} - The encountered error
+ */
+
+module.exports = RESTClient;

--- a/lib/network/rest/RESTServer.js
+++ b/lib/network/rest/RESTServer.js
@@ -1,0 +1,304 @@
+'use strict'; // eslint-disable-line
+
+const assert = require('assert');
+const url = require('url');
+
+const Logger = require('werelogs').Logger;
+
+const httpServer = require('../http/server');
+const constants = require('../../constants');
+const utils = require('./utils');
+const httpUtils = require('../http/utils');
+const errors = require('../../errors');
+
+function setContentLength(response, contentLength) {
+    response.setHeader('Content-Length', contentLength.toString());
+}
+
+function setContentRange(response, byteRange, objectSize) {
+    const [start, end] = byteRange;
+    assert(start !== undefined && end !== undefined);
+    response.setHeader('Content-Range',
+                       `bytes ${start}-${end}/${objectSize}`);
+}
+
+function sendError(res, log, error, optMessage) {
+    res.writeHead(error.code);
+    let message;
+    if (optMessage) {
+        message = optMessage;
+    } else {
+        message = error.description || '';
+    }
+    log.debug('sending back error response', { httpCode: error.code,
+                                               errorType: error.message,
+                                               error: message });
+    res.end(`${JSON.stringify({ errorType: error.message,
+                                errorMessage: message })}\n`);
+}
+
+function createLoggingObject(config) {
+    let options = undefined;
+    if (config !== undefined) {
+        options = {
+            level: config.logLevel,
+            dump: config.dumpLevel,
+        };
+    }
+    return new Logger('DataFileRESTServer', options);
+}
+
+/**
+ * Parse the given url and return a pathInfo object. Sanity checks are
+ * performed.
+ *
+ * @param {String} urlStr - URL to parse
+ * @param {Boolean} expectKey - whether the command expects to see a
+ *   key in the URL
+ * @return {Object} a pathInfo object with URL items containing the
+ * following attributes:
+ *   - pathInfo.service {String} - The name of REST service ("DataFile")
+ *   - pathInfo.key {String} - The requested key
+ */
+function parseURL(urlStr, expectKey) {
+    const urlObj = url.parse(urlStr);
+    const pathInfo = utils.explodePath(urlObj.path);
+    if (pathInfo.service !== constants.dataFileURL) {
+        throw errors.InvalidAction.customizeDescription(
+            `unsupported service '${pathInfo.service}'`);
+    }
+    if (expectKey && pathInfo.key === undefined) {
+        throw errors.MissingParameter.customizeDescription(
+            'URL is missing key');
+    }
+    if (!expectKey && pathInfo.key !== undefined) {
+        // note: we may implement rewrite functionality by allowing a
+        // key in the URL, though we may still provide the new key in
+        // the Location header to keep immutability property and
+        // atomicity of the update (we would just remove the old
+        // object when the new one has been written entirely in this
+        // case, saving a request over an equivalent PUT + DELETE).
+        throw errors.InvalidURI.customizeDescription(
+            'PUT url cannot contain a key');
+    }
+    return pathInfo;
+}
+
+/**
+ * @class
+ * @classdesc REST Server interface
+ *
+ * You have to call setup() to initialize the storage backend, then
+ * start() to start listening to the configured port.
+ */
+class RESTServer extends httpServer {
+
+    /**
+     * @constructor
+     * @param {Object} params - constructor params
+     * @param {Number} params.port - TCP port where the server listens to
+     * @param {arsenal.storage.data.file.Store} params.dataStore -
+     *   data store object
+     * @param {Number} [params.bindAddress='localhost'] - address
+     * bound to the socket
+     * @param {Object} [params.log] - logger configuration
+     */
+    constructor(params) {
+        assert(params.port);
+
+        const logging = createLoggingObject(params.log);
+        super(params.port, logging);
+        this.logging = logging;
+        this.dataStore = params.dataStore;
+        this.setBindAddress(params.bindAddress || 'localhost');
+
+        // hooking our request processing function by calling the
+        // parent's method for that
+        this.onRequest(this._onRequest);
+        this.reqMethods = {
+            PUT: this._onPut.bind(this),
+            GET: this._onGet.bind(this),
+            DELETE: this._onDelete.bind(this),
+        };
+    }
+
+    /**
+     * Setup the storage backend
+     *
+     * @param {function} callback - called when finished
+     * @return {undefined}
+     */
+    setup(callback) {
+        this.dataStore.setup(callback);
+    }
+
+    /**
+     * Create a new request logger object
+     *
+     * @param {String} reqUids - serialized request UIDs (as received in
+     * the X-Scal-Request-Uids header)
+     * @return {Logger} new request logger
+     */
+    createLogger(reqUids) {
+        return reqUids ?
+            this.logging.newRequestLoggerFromSerializedUids(reqUids) :
+            this.logging.newRequestLogger();
+    }
+
+    /**
+     * Main incoming request handler, dispatches to method-specific
+     * handlers
+     *
+     * @param {http.IncomingMessage} req - HTTP request object
+     * @param {http.ServerResponse} res - HTTP response object
+     * @return {undefined}
+     */
+    _onRequest(req, res) {
+        const reqUids = req.headers['x-scal-request-uids'];
+        const log = this.createLogger(reqUids);
+        log.debug('request received', { method: req.method,
+                                        url: req.url });
+        if (req.method in this.reqMethods) {
+            this.reqMethods[req.method](req, res, log);
+        } else {
+            // Method Not Allowed
+            sendError(res, log, errors.MethodNotAllowed);
+        }
+    }
+
+    /**
+     * Handler for PUT requests
+     *
+     * @param {http.IncomingMessage} req - HTTP request object
+     * @param {http.ServerResponse} res - HTTP response object
+     * @param {Logger} log - logger object
+     * @return {undefined}
+     */
+    _onPut(req, res, log) {
+        let size;
+        try {
+            parseURL(req.url, false);
+            const contentLength = req.headers['content-length'];
+            if (contentLength === undefined) {
+                throw errors.MissingContentLength;
+            }
+            size = Number.parseInt(contentLength, 10);
+            if (isNaN(size)) {
+                throw errors.InvalidInput.customizeDescription(
+                    'bad Content-Length');
+            }
+        } catch (err) {
+            return sendError(res, log, err);
+        }
+        this.dataStore.put(req, size, log, (err, key) => {
+            if (err) {
+                return sendError(res, log, err);
+            }
+            log.debug('sending back 201 response to PUT', { key });
+            res.setHeader('Location', `${constants.dataFileURL}/${key}`);
+            setContentLength(res, 0);
+            res.writeHead(201);
+            return res.end(() => {
+                log.debug('PUT response sent', { key });
+            });
+        });
+        return undefined;
+    }
+
+    /**
+     * Handler for GET requests
+     *
+     * @param {http.IncomingMessage} req - HTTP request object
+     * @param {http.ServerResponse} res - HTTP response object
+     * @param {Logger} log - logger object
+     * @return {undefined}
+     */
+    _onGet(req, res, log) {
+        let pathInfo;
+        let rangeSpec = undefined;
+        try {
+            pathInfo = parseURL(req.url, true);
+            const rangeHeader = req.headers.range;
+            if (rangeHeader !== undefined) {
+                rangeSpec = httpUtils.parseRangeSpec(rangeHeader);
+                if (rangeSpec.error) {
+                    // ignore header if syntax is invalid
+                    rangeSpec = undefined;
+                }
+            }
+        } catch (err) {
+            return sendError(res, log, err);
+        }
+        this.dataStore.stat(pathInfo.key, log, (err, info) => {
+            if (err) {
+                return sendError(res, log, err);
+            }
+            let byteRange;
+            let contentLength;
+            if (rangeSpec) {
+                const { range, error } = httpUtils.getByteRangeFromSpec(
+                    rangeSpec, info.objectSize);
+                if (error) {
+                    return sendError(res, log, error);
+                }
+                byteRange = range;
+            }
+            if (byteRange) {
+                contentLength = byteRange[1] - byteRange[0] + 1;
+            } else {
+                contentLength = info.objectSize;
+            }
+            this.dataStore.get(pathInfo.key, byteRange, log, (err, rs) => {
+                if (err) {
+                    return sendError(res, log, err);
+                }
+                log.debug('sending back 200/206 response with contents',
+                          { key: pathInfo.key });
+                setContentLength(res, contentLength);
+                res.setHeader('Accept-Ranges', 'bytes');
+                if (byteRange) {
+                    // data is immutable, so objectSize is still correct
+                    setContentRange(res, byteRange, info.objectSize);
+                    res.writeHead(206);
+                } else {
+                    res.writeHead(200);
+                }
+                rs.pipe(res);
+                return undefined;
+            });
+            return undefined;
+        });
+        return undefined;
+    }
+
+    /**
+     * Handler for DELETE requests
+     *
+     * @param {http.IncomingMessage} req - HTTP request object
+     * @param {http.ServerResponse} res - HTTP response object
+     * @param {Logger} log - logger object
+     * @return {undefined}
+     */
+    _onDelete(req, res, log) {
+        let pathInfo;
+        try {
+            pathInfo = parseURL(req.url, true);
+        } catch (err) {
+            return sendError(res, log, err);
+        }
+        this.dataStore.delete(pathInfo.key, log, err => {
+            if (err) {
+                return sendError(res, log, err);
+            }
+            log.debug('sending back 204 response to DELETE',
+                      { key: pathInfo.key });
+            res.writeHead(204);
+            return res.end(() => {
+                log.debug('DELETE response sent', { key: pathInfo.key });
+            });
+        });
+        return undefined;
+    }
+}
+
+module.exports = RESTServer;

--- a/lib/network/rest/utils.js
+++ b/lib/network/rest/utils.js
@@ -1,0 +1,15 @@
+'use strict'; // eslint-disable-line
+
+const errors = require('../../errors');
+
+module.exports.explodePath = function explodePath(path) {
+    const pathMatch = /^(\/[a-zA-Z0-9]+)(\/([0-9a-f]*))?$/.exec(path);
+    if (pathMatch) {
+        return {
+            service: pathMatch[1],
+            key: (pathMatch[3] !== undefined && pathMatch[3].length > 0 ?
+                  pathMatch[3] : undefined),
+        };
+    }
+    throw errors.InvalidURI.customizeDescription('malformed URI');
+};

--- a/lib/network/rpc/level-net.js
+++ b/lib/network/rpc/level-net.js
@@ -110,8 +110,8 @@ class LevelDbService extends rpc.BaseService {
     }
 
     /**
-     * lookup a sublevel db given by the @a path array from the root
-     * leveldb handle.
+     * lookup a sublevel db given by the <tt>path</tt> array from the
+     * root leveldb handle.
      *
      * @param {String []} path - path to the sublevel, as a
      * piecewise array of sub-levels

--- a/lib/network/rpc/rpc.js
+++ b/lib/network/rpc/rpc.js
@@ -86,11 +86,11 @@ class BaseClient extends EventEmitter {
     }
 
     /**
-     * @brief call a remote function named @a remoteCall, with
-     * arguments @a args and callback @a cb
+     * @brief call a remote function named <tt>remoteCall</tt>, with
+     * arguments <tt>args</tt> and callback <tt>cb</tt>
      *
-     * @a cb is called when the remote function returns an ack, or
-     * when the timeout set by @a timeoutMs expires, whichever comes
+     * <tt>cb</tt> is called when the remote function returns an ack, or
+     * when the timeout set by <tt>timeoutMs</tt> expires, whichever comes
      * first. When an ack is received, the callback gets the arguments
      * sent by the remote function in the ack response. In the case of
      * timeout, it's passed a single Error argument with the code:
@@ -473,6 +473,10 @@ function RPCServer(params) {
                 conn.on('call', service._onCall.bind(service, streamsSocket));
             });
         });
+    };
+
+    server.listen = function listen(port, bindAddress = undefined) {
+        httpServer.listen(port, bindAddress);
     };
 
     return server;

--- a/lib/network/rpc/sio-stream.js
+++ b/lib/network/rpc/sio-stream.js
@@ -252,7 +252,7 @@ class SIOStreamSocket {
      *
      * @param {Object} arg any flat object or value that may be or
      * contain stream-like objects
-     * @return {Object} an object of the same nature than @a arg with
+     * @return {Object} an object of the same nature than <tt>arg</tt> with
      * streams encoded for transmission to the remote side
      */
     encodeStreams(arg) {
@@ -327,7 +327,7 @@ class SIOStreamSocket {
      * proxies that are forwarding data from/to the remote side stream
      *
      * @param {Object} arg the object as received from the remote side
-     * @return {Object} an object of the same nature than @a arg with
+     * @return {Object} an object of the same nature than <tt>arg</tt> with
      * stream markers decoded into actual readable/writable stream
      * objects
      */

--- a/lib/network/rpc/utils.js
+++ b/lib/network/rpc/utils.js
@@ -1,13 +1,13 @@
 'use strict'; // eslint-disable-line
 
 /**
- * @brief turn all @a err own and prototype attributes into own attributes
+ * @brief turn all <tt>err</tt> own and prototype attributes into own attributes
  *
  * This is done so that JSON.stringify() can properly serialize those
  * attributes (e.g. err.notFound)
  *
  * @param {Error} err error object
- * @return {Object} flattened object containing @a err attributes
+ * @return {Object} flattened object containing <tt>err</tt> attributes
  */
 module.exports.flattenError = function flattenError(err) {
     if (!err) {
@@ -32,7 +32,7 @@ module.exports.flattenError = function flattenError(err) {
  * its attributes should be the same.
  *
  * @param {Object} err flattened error object
- * @return {Error} a reconstructed Error object inheriting @a err
+ * @return {Error} a reconstructed Error object inheriting <tt>err</tt>
  *   attributes
  */
 module.exports.reconstructError = function reconstructError(err) {

--- a/lib/storage/data/file/DataFileStore.js
+++ b/lib/storage/data/file/DataFileStore.js
@@ -1,0 +1,300 @@
+'use strict'; // eslint-disable-line
+
+const fs = require('fs');
+const crypto = require('crypto');
+const async = require('async');
+
+const Logger = require('werelogs').Logger;
+const errors = require('../../../errors');
+const stringHash = require('../../../stringHash');
+const jsutil = require('../../../jsutil');
+const storageUtils = require('../../utils');
+
+// The FOLDER_HASH constant refers to the number of base directories
+// used for directory hashing of stored objects.
+//
+// It MUST not be changed on anything else than a clean new storage
+// backend.
+//
+// It may be changed for such system if the default hash value is too
+// low for the estimated number of objects to be stored and the file
+// system performance (be cautious though), and cannot be changed once
+// the system contains data.
+
+const FOLDER_HASH = 3511;
+
+
+/**
+ * @class
+ * @classdesc File-based object blob store
+ *
+ * Each object/part becomes a file and the files are stored in a
+ * directory hash structure under the configured dataPath.
+ */
+class DataFileStore {
+
+    /**
+     * @constructor
+     * @param {Object} dataConfig - configuration of the file backend
+     * @param {String} dataConfig.dataPath - absolute path where to
+     *   store the files
+     * @param {Boolean} [dataConfig.noSync=false] - If true, disable
+     *   sync calls that ensure files and directories are fully
+     *   written on the physical drive before returning an
+     *   answer. Used to speed up unit tests, may have other uses.
+     * @param {Object} logConfig - logging configuration
+     */
+    constructor(dataConfig, logConfig) {
+        this.logger = new Logger('DataFileStore', logConfig);
+        this.dataPath = dataConfig.dataPath;
+        this.noSync = dataConfig.noSync || false;
+    }
+
+    /**
+     * Setup the storage backend before starting to read or write
+     * files in it.
+     *
+     * The function ensures that dataPath is accessible and
+     * pre-creates the directory hashes under dataPath.
+     *
+     * @param {function} callback - called when done with no argument
+     * @return {undefined}
+     */
+    setup(callback) {
+        fs.access(this.dataPath, fs.F_OK | fs.R_OK | fs.W_OK, err => {
+            if (err) {
+                this.logger.error('Data path is not readable or writable',
+                                  { error: err });
+                return callback(err);
+            }
+
+            // Create FOLDER_HASH subdirectories
+            const subDirs = Array.from({ length: FOLDER_HASH },
+                                       (v, k) => (k).toString());
+            this.logger.info(`pre-creating ${subDirs.length} subdirs...`);
+            if (!this.noSync) {
+                storageUtils.setDirSyncFlag(this.dataPath, this.logger);
+            }
+            async.eachSeries(subDirs, (subDirName, next) => {
+                fs.mkdir(`${this.dataPath}/${subDirName}`, err => {
+                    // If already exists, move on
+                    if (err && err.code !== 'EEXIST') {
+                        return next(err);
+                    }
+                    return next();
+                });
+            },
+            err => {
+                if (err) {
+                    this.logger.error('Error creating subdirs',
+                                      { error: err });
+                    return callback(err);
+                }
+                this.logger.info('data file store init complete, ' +
+                                 'go forth and store data.');
+                return callback();
+            });
+            return undefined;
+        });
+    }
+
+    /**
+     * Get the filesystem path to a stored object file from its key
+     *
+     * @param {String} key - the object key
+     * @return {String} the absolute path to the file containing the
+     *   object contents
+     */
+    getFilePath(key) {
+        const hash = stringHash(key);
+        const folderHashPath = ((hash % FOLDER_HASH)).toString();
+        return `${this.dataPath}/${folderHashPath}/${key}`;
+    }
+
+    /**
+     * Put a new object to the storage backend
+     *
+     * @param {stream.Readable} dataStream - input stream providing the
+     *   object data
+     * @param {Number} size - Total byte size of the data to put
+     * @param {Logger} log - logging object
+     * @param {DataFileStore~putCallback} callback - called when done
+     * @return {undefined}
+     */
+    put(dataStream, size, log, callback) {
+        const key = crypto.pseudoRandomBytes(20).toString('hex');
+        const filePath = this.getFilePath(key);
+        log.debug('starting to write data', { method: 'put', key, filePath });
+        dataStream.pause();
+        fs.open(filePath, 'wx', (err, fd) => {
+            if (err) {
+                log.error('error opening filePath',
+                          { method: 'put', key, filePath, error: err });
+                return callback(err);
+            }
+            const cbOnce = jsutil.once(callback);
+            // disable autoClose so that we can close(fd) only after
+            // fsync() has been called
+            const fileStream = fs.createWriteStream(filePath,
+                                                    { fd,
+                                                      autoClose: false });
+
+            fileStream.on('finish', () => {
+                function ok() {
+                    log.debug('finished writing data',
+                              { method: 'put', key, filePath });
+                    return cbOnce(null, key);
+                }
+                if (this.noSync) {
+                    fs.close(fd);
+                    return ok();
+                }
+                fs.fsync(fd, err => {
+                    fs.close(fd);
+                    if (err) {
+                        log.error('fsync error',
+                                  { method: 'put', key, filePath,
+                                    error: err });
+                        return cbOnce(err);
+                    }
+                    return ok();
+                });
+                return undefined;
+            }).on('error', err => {
+                log.error('error streaming data on write',
+                          { method: 'put', key, filePath, error: err });
+                // destroying the write stream forces a close(fd)
+                fileStream.destroy();
+                return cbOnce(err);
+            });
+            dataStream.resume();
+            dataStream.pipe(fileStream);
+            dataStream.on('error', err => {
+                log.error('error streaming data on read',
+                    { method: 'put', key, filePath, error: err });
+                // destroying the write stream forces a close(fd)
+                fileStream.destroy();
+                return cbOnce(err);
+            });
+            return undefined;
+        });
+    }
+
+    /**
+     * Get info about a stored object (see DataFileStore~statCallback
+     * to know which info is returned)
+     *
+     * @param {String} key - key of the object
+     * @param {Logger} log - logging object
+     * @param {DataFileStore~statCallback} callback - called when done
+     * @return {undefined}
+     */
+    stat(key, log, callback) {
+        const filePath = this.getFilePath(key);
+        log.debug('stat file', { key, filePath });
+        fs.stat(filePath, (err, stat) => {
+            if (err) {
+                if (err.code === 'ENOENT') {
+                    return callback(errors.ObjNotFound);
+                }
+                log.error('error on \'stat\' of file',
+                          { key, filePath, error: err });
+                return callback(err);
+            }
+            const info = { objectSize: stat.size };
+            return callback(null, info);
+        });
+    }
+
+    /**
+     * Retrieve data of a stored object
+     *
+     * @param {String} key - key of the object
+     * @param {Object} [byteRange] - optional absolute inclusive byte
+     *   range to retrieve.
+     * @param {Logger} log - logging object
+     * @param {DataFileStore~getCallback} callback - called when done
+     * @return {undefined}
+     */
+    get(key, byteRange, log, callback) {
+        const filePath = this.getFilePath(key);
+
+        const readStreamOptions = {
+            flags: 'r',
+            encoding: null,
+            fd: null,
+            autoClose: true,
+        };
+        if (byteRange) {
+            readStreamOptions.start = byteRange[0];
+            readStreamOptions.end = byteRange[1];
+        }
+        log.debug('opening readStream to get data',
+                  { method: 'get', key, filePath, byteRange });
+        const cbOnce = jsutil.once(callback);
+        const rs = fs.createReadStream(filePath, readStreamOptions)
+                  .on('error', err => {
+                      if (err.code === 'ENOENT') {
+                          return cbOnce(errors.ObjNotFound);
+                      }
+                      log.error('error retrieving file',
+                                { method: 'get', key, filePath,
+                                  error: err });
+                      return cbOnce(err);
+                  })
+                  .on('open', () => { cbOnce(null, rs); });
+    }
+
+    /**
+     * Delete a stored object
+     *
+     * @param {String} key - key of the object
+     * @param {Logger} log - logging object
+     * @param {DataFileStore~deleteCallback} callback - called when done
+     * @return {undefined}
+     */
+    delete(key, log, callback) {
+        const filePath = this.getFilePath(key);
+        log.debug('deleting file', { method: 'delete', key, filePath });
+        return fs.unlink(filePath, err => {
+            if (err) {
+                if (err.code === 'ENOENT') {
+                    return callback(errors.ObjNotFound);
+                }
+                log.error('error deleting file', { method: 'delete',
+                                                   key, filePath,
+                                                   error: err });
+                return callback(err);
+            }
+            return callback();
+        });
+    }
+}
+
+/**
+ * @callback DataFileStore~putCallback
+ * @param {Error} - The encountered error
+ * @param {String} key - The key to access the data
+ */
+
+/**
+ * @callback DataFileStore~statCallback
+ * @param {Error} - The encountered error
+ * @param {Object} info - Information about the object
+ * @param {Number} info.objectSize - Byte size of the object
+ */
+
+/**
+ * @callback DataFileStore~getCallback
+ * @param {Error} - The encountered error
+ *   arsenal.errors.ObjNotFound is returned if the object does not exist
+ * @param {stream.Readable} stream - The stream of requested object data
+ */
+
+/**
+ * @callback DataFileStore~deleteCallback
+ * @param {Error} - The encountered error
+ *   arsenal.errors.ObjNotFound is returned if the object does not exist
+ */
+
+module.exports = DataFileStore;

--- a/lib/storage/metadata/file/MetadataFileClient.js
+++ b/lib/storage/metadata/file/MetadataFileClient.js
@@ -12,17 +12,17 @@ class MetadataFileClient {
      * Construct a metadata client
      *
      * @param {Object} params the following parameters are used:
-     * @param {String} params.metadataHost name or IP address of
-     *   metadata server host
-     * @param {Number} params.metadataPort TCP port to connect to the
-     *   metadata server
+     * @param {String} params.host name or IP address of metadata
+     *   server host
+     * @param {Number} params.port TCP port to connect to the metadata
+     *   server
      * @param {Object} [params.log] logging configuration
      */
     constructor(params) {
-        assert.notStrictEqual(params.metadataHost, undefined);
-        assert.notStrictEqual(params.metadataPort, undefined);
-        this.metadataHost = params.metadataHost;
-        this.metadataPort = params.metadataPort;
+        assert.notStrictEqual(params.host, undefined);
+        assert.notStrictEqual(params.port, undefined);
+        this.host = params.host;
+        this.port = params.port;
         this.callTimeoutMs = params.callTimeoutMs;
         this.setupLogging(params.log);
     }
@@ -45,7 +45,7 @@ class MetadataFileClient {
      * @return {Object} handle to the remote database
      */
     openDB(done) {
-        const url = `http://${this.metadataHost}:${this.metadataPort}` +
+        const url = `http://${this.host}:${this.port}` +
                   `${constants.metadataFileNamespace}/metadata`;
         this.logger.info(`connecting to RPC server at ${url}`);
         this.client = new levelNet.LevelDbClient({

--- a/lib/storage/metadata/file/MetadataFileServer.js
+++ b/lib/storage/metadata/file/MetadataFileServer.js
@@ -1,7 +1,6 @@
 'use strict'; // eslint-disable-line
 
 const fs = require('fs');
-const os = require('os');
 const assert = require('assert');
 const uuid = require('uuid');
 const level = require('level');
@@ -29,10 +28,12 @@ class MetadataFileServer {
      * Construct a metadata server
      *
      * @param {Object} params - constructor params
-     * @param {String} params.metadataPath - local path where the root
+     * @param {Number} params.port - TCP port that listens to incoming
+     *   connections
+     * @param {String} params.path - local path where the root
      *   database is stored
-     * @param {Number} params.metadataPort - TCP port that listens to
-     *   incoming connections
+     * @param {String} [params.bindAddress='localhost'] - address
+     * bound to the socket
      * @param {Number} [params.streamMaxPendingAck] - max number of
      *   in-flight output stream packets sent to the client without an
      *   ack received yet
@@ -42,11 +43,12 @@ class MetadataFileServer {
      * @param {Object} [params.log] - logging configuration
      */
     constructor(params) {
-        assert.notStrictEqual(params.metadataPath, undefined);
-        assert.notStrictEqual(params.metadataPort, undefined);
+        assert.notStrictEqual(params.path, undefined);
+        assert.notStrictEqual(params.port, undefined);
         assert(params.versioning && params.versioning.replicationGroupId);
-        this.metadataPath = params.metadataPath;
-        this.metadataPort = params.metadataPort;
+        this.path = params.path;
+        this.port = params.port;
+        this.bindAddress = params.bindAddress || 'localhost';
         this.streamMaxPendingAck = params.streamMaxPendingAck;
         this.streamAckTimeoutMs = params.streamAckTimeoutMs;
         this.versioning = params.versioning;
@@ -65,7 +67,7 @@ class MetadataFileServer {
     }
 
     genUUIDIfNotExists() {
-        const uuidFile = `${this.metadataPath}/uuid`;
+        const uuidFile = `${this.path}/uuid`;
 
         try {
             fs.accessSync(uuidFile, fs.F_OK | fs.R_OK);
@@ -82,7 +84,7 @@ class MetadataFileServer {
     }
 
     printUUID() {
-        const uuidFile = `${this.metadataPath}/uuid`;
+        const uuidFile = `${this.path}/uuid`;
         const uuidValue = fs.readFileSync(uuidFile);
         this.logger.info(`This deployment's identifier is ${uuidValue}`);
     }
@@ -93,23 +95,8 @@ class MetadataFileServer {
      * @return {undefined}
      */
     startServer() {
-        fs.accessSync(this.metadataPath, fs.F_OK | fs.R_OK | fs.W_OK);
-
-        const warning =
-                  'WARNING: Synchronization directory updates are not ' +
-                  'supported on this platform. Newly written data could ' +
-                  'be lost if your system crashes before the operating ' +
-                  'system is able to write directory updates.';
-        if (os.type() === 'Linux' && os.endianness() === 'LE') {
-            try {
-                storageUtils.setDirSyncFlag(this.metadataPath);
-            } catch (err) {
-                this.logger.warn(warning, { error: err.message,
-                                            errorStack: err.stack });
-            }
-        } else {
-            this.logger.warn(warning);
-        }
+        fs.accessSync(this.path, fs.F_OK | fs.R_OK | fs.W_OK);
+        storageUtils.setDirSyncFlag(this.path, this.logger);
 
         this.logger.info('starting metadata file backend server');
         /* We start a server that will serve the sublevel capable
@@ -120,7 +107,7 @@ class MetadataFileServer {
               streamAckTimeoutMs: this.streamAckTimeoutMs });
 
         this.initMetadataService();
-        this.server.listen(this.metadataPort);
+        this.server.listen(this.port, this.bindAddress);
 
         this.genUUIDIfNotExists();
         this.printUUID();
@@ -133,7 +120,7 @@ class MetadataFileServer {
         this.logger.info(`creating RPC service at ${namespace}`);
         const dbService = new levelNet.LevelDbService({
             server: this.server,
-            rootDb: sublevel(level(`${this.metadataPath}/${ROOT_DB}`)),
+            rootDb: sublevel(level(`${this.path}/${ROOT_DB}`)),
             namespace,
             logger: this.logger,
         });

--- a/lib/storage/utils.js
+++ b/lib/storage/utils.js
@@ -1,9 +1,10 @@
 'use strict'; // eslint-disable-line
 
 const fs = require('fs');
+const os = require('os');
 const assert = require('assert');
 
-module.exports.setDirSyncFlag = function setDirSyncFlag(path) {
+function trySetDirSyncFlag(path) {
     // may throw if ioctl is not available
     const ioctl = require('ioctl');
 
@@ -26,4 +27,37 @@ module.exports.setDirSyncFlag = function setDirSyncFlag(path) {
     assert.strictEqual(confirmBuffer.readUIntLE(0, 8),
         currentFlags | FS_DIRSYNC_FL, 'FS_DIRSYNC_FL not set');
     fs.closeSync(pathFD2);
+}
+
+
+let loggedWarning = false;
+
+module.exports.setDirSyncFlag = function setDirSyncFlag(path, logger) {
+    const warning =
+              'WARNING: Synchronization directory updates are not ' +
+              'supported on this platform. Newly written data could ' +
+              'be lost if your system crashes before the operating ' +
+              'system is able to write directory updates.';
+    let doLog = false;
+    let error;
+
+    if (os.type() === 'Linux' && os.endianness() === 'LE') {
+        try {
+            trySetDirSyncFlag(path);
+        } catch (err) {
+            doLog = !loggedWarning;
+            error = err;
+        }
+    } else {
+        doLog = !loggedWarning;
+    }
+    if (doLog) {
+        if (error) {
+            logger.warn(warning, { error: error.message,
+                                   errorStack: error.stack });
+        } else {
+            logger.warn(warning);
+        }
+        loggedWarning = true;
+    }
 };

--- a/tests/unit/jsutil.js
+++ b/tests/unit/jsutil.js
@@ -1,0 +1,31 @@
+'use strict';// eslint-disable-line
+
+const assert = require('assert');
+const jsutil = require('../../index').jsutil;
+
+describe('JSUtil', () => {
+    describe('once', () => {
+        it('should call the wrapped function only once when invoked ' +
+           'multiple times',
+           done => {
+               let value = 42;
+               let value2 = 51;
+
+               const wrapOnce = jsutil.once(expectArg => {
+                   assert.strictEqual(expectArg, 'foo');
+                   value += 1;
+                   return value;
+               });
+               const wrapOnce2 = jsutil.once(expectArg => {
+                   assert.strictEqual(expectArg, 'foo2');
+                   value2 += 1;
+                   return value2;
+               });
+               assert.strictEqual(wrapOnce('foo'), 43);
+               assert.strictEqual(wrapOnce2('foo2'), 52);
+               assert.strictEqual(wrapOnce('bar'), 43);
+               assert.strictEqual(wrapOnce2('bar2'), 52);
+               done();
+           });
+    });
+});

--- a/tests/unit/network/http/utils.js
+++ b/tests/unit/network/http/utils.js
@@ -1,0 +1,196 @@
+'use strict'; // eslint-disable-line
+
+const assert = require('assert');
+
+const errors = require('../../../../lib/errors');
+
+const { parseRange,
+        parseRangeSpec,
+        getByteRangeFromSpec } = require('../../../../lib/network/http/utils');
+
+function checkParseRange(rangeHeader, totalLength, expectedRange) {
+    const { range, error } = parseRange(rangeHeader, totalLength);
+    assert.ifError(error);
+    assert.deepStrictEqual(range, expectedRange);
+}
+
+describe('parseRangeSpec function', () => {
+    [{ rangeHeader: 'bytes=1000-2000',
+       expectedRangeSpec: { start: 1000, end: 2000 } },
+     { rangeHeader: 'bytes=1000-',
+       expectedRangeSpec: { start: 1000 } },
+     { rangeHeader: 'bytes=-',
+       expectedRangeSpec: { error: errors.InvalidArgument } },
+     { rangeHeader: 'bytes=10-9',
+       expectedRangeSpec: { error: errors.InvalidArgument } },
+    ].forEach(testCase => {
+        const { rangeHeader, expectedRangeSpec } = testCase;
+
+        it(`should return ${expectedRangeSpec} on range "${rangeHeader}"`,
+        () => {
+            const rangeSpec = parseRangeSpec(rangeHeader);
+            if (expectedRangeSpec.error) {
+                assert(rangeSpec.error);
+                assert.strictEqual(rangeSpec.error.message,
+                                   expectedRangeSpec.error.message);
+            } else {
+                assert.ifError(rangeSpec.error);
+            }
+            assert.strictEqual(rangeSpec.start, expectedRangeSpec.start);
+            assert.strictEqual(rangeSpec.end, expectedRangeSpec.end);
+            assert.strictEqual(rangeSpec.suffix, expectedRangeSpec.suffix);
+        });
+    });
+});
+
+describe('getByteRangeFromSpec function', () => {
+    [{ rangeSpec: { start: 1000, end: 2000 }, objectSize: 3000,
+       expectedByteRange: { range: [1000, 2000] } },
+     { rangeSpec: { start: 1000, end: 5000 }, objectSize: 3000,
+       expectedByteRange: { range: [1000, 2999] } },
+     { rangeSpec: { start: 1000 }, objectSize: 3000,
+       expectedByteRange: { range: [1000, 2999] } },
+     { rangeSpec: { suffix: 1000 }, objectSize: 3000,
+       expectedByteRange: { range: [2000, 2999] } },
+     { rangeSpec: { suffix: 4000 }, objectSize: 3000,
+       expectedByteRange: { range: [0, 2999] } },
+     { rangeSpec: { start: 2999 }, objectSize: 3000,
+       expectedByteRange: { range: [2999, 2999] } },
+     { rangeSpec: { start: 3000 }, objectSize: 3000,
+       expectedByteRange: { error: errors.InvalidRange } },
+     { rangeSpec: { start: 0, end: 10 }, objectSize: 0,
+       expectedByteRange: { error: errors.InvalidRange } },
+     { rangeSpec: { suffix: 10 }, objectSize: 0,
+       expectedByteRange: { } },
+     { rangeSpec: { suffix: 0 }, objectSize: 0,
+       expectedByteRange: { error: errors.InvalidRange } },
+    ].forEach(testCase => {
+        const { rangeSpec, objectSize, expectedByteRange } = testCase;
+
+        it(`should transform spec ${rangeSpec} with object size ` +
+           `${objectSize} to byte range ${expectedByteRange}`, () => {
+            const byteRange = getByteRangeFromSpec(rangeSpec, objectSize);
+            if (expectedByteRange.error) {
+                assert(byteRange.error);
+                assert.strictEqual(byteRange.error.message,
+                                   expectedByteRange.error.message);
+            } else {
+                assert.ifError(byteRange.error);
+            }
+            assert.deepStrictEqual(byteRange.range,
+                                   expectedByteRange.range);
+        });
+    });
+});
+
+describe('parseRange function', () => {
+    it('should return an object with the start and end if range is '
+       + 'valid', () => {
+        checkParseRange('bytes=0-9', 10, [0, 9]);
+    });
+
+    it('should set the end of the range at the total object length minus 1 ' +
+        'if the provided end of range goes beyond the end of the object ' +
+        'length', () => {
+        checkParseRange('bytes=0-9', 8, [0, 7]);
+    });
+
+    it('should handle incomplete range specifier where only end offset is ' +
+    'provided', () => {
+        checkParseRange('bytes=-500', 10000, [9500, 9999]);
+    });
+
+    it('should handle incomplete range specifier where only start ' +
+    'provided', () => {
+        checkParseRange('bytes=9500-', 10000, [9500, 9999]);
+    });
+
+    it('should return undefined for the range if the range header ' +
+        'format is invalid: missing equal', () => {
+        checkParseRange('bytes0-9', 10);
+    });
+
+    it('should return undefined for the range if the range header ' +
+        'format is invalid: missing dash', () => {
+        checkParseRange('bytes=09', 10);
+    });
+
+    it('should return undefined for the range if the range header ' +
+        'format is invalid: value invalid character', () => {
+        checkParseRange('bytes=%-4', 10);
+    });
+
+    it('should return undefined for the range if the range header ' +
+    'format is invalid: value not int', () => {
+        checkParseRange('bytes=4-a', 10);
+    });
+
+    it('should return undefined for the range if the range header ' +
+        'format is invalid: start > end', () => {
+        checkParseRange('bytes=5-4', 10);
+    });
+
+    it('should return undefined for the range if the range header ' +
+        'format is invalid: negative start bound', () => {
+        checkParseRange('bytes=-2-5', 10);
+    });
+
+    it('should return InvalidRange if the range of the resource ' +
+    'does not cover the byte range', () => {
+        const rangeHeader = 'bytes=10-30';
+        const totalLength = 10;
+        const { range, error } = parseRange(rangeHeader, totalLength);
+        assert.strictEqual(error.code, 416);
+        assert.strictEqual(range, undefined);
+    });
+    it('should return undefined for "bytes=-" request (invalid syntax) ',
+    () => {
+        checkParseRange('bytes=-', 10);
+    });
+    it('should return undefined for "bytes=-" request (invalid syntax, ' +
+    'empty object)', () => {
+        checkParseRange('bytes=-', 0);
+    });
+    it('should return undefined for "bytes=10-9" request (invalid syntax, ' +
+    'empty object)', () => {
+        checkParseRange('bytes=10-9', 0);
+    });
+    it('should return InvalidRange on 0-byte suffix range request', () => {
+        const rangeHeader = 'bytes=-0';
+        const { range, error } = parseRange(rangeHeader, 10);
+        assert.strictEqual(error.code, 416);
+        assert.strictEqual(range, undefined);
+    });
+    it('should return InvalidRange on 0-byte suffix range request ' +
+    '(empty object)', () => {
+        const rangeHeader = 'bytes=-0';
+        const { range, error } = parseRange(rangeHeader, 0);
+        assert.strictEqual(error.code, 416);
+        assert.strictEqual(range, undefined);
+    });
+    it('should return undefined on suffix range request on empty ' +
+    'object', () => {
+        checkParseRange('bytes=-10', 0);
+    });
+    it('should return InvalidRange on empty object when only start==0 ' +
+    'provided', () => {
+        const rangeHeader = 'bytes=0-';
+        const { range, error } = parseRange(rangeHeader, 0);
+        assert.strictEqual(error.code, 416);
+        assert.strictEqual(range, undefined);
+    });
+    it('should return InvalidRange on empty object when only start!=0 ' +
+    'provided', () => {
+        const rangeHeader = 'bytes=10-';
+        const { range, error } = parseRange(rangeHeader, 0);
+        assert.strictEqual(error.code, 416);
+        assert.strictEqual(range, undefined);
+    });
+    it('should return InvalidRange on empty object when start and end ' +
+    'are provided', () => {
+        const rangeHeader = 'bytes=10-30';
+        const { range, error } = parseRange(rangeHeader, 0);
+        assert.strictEqual(error.code, 416);
+        assert.strictEqual(range, undefined);
+    });
+});

--- a/tests/unit/network/rest/index.js
+++ b/tests/unit/network/rest/index.js
@@ -1,0 +1,210 @@
+'use strict'; // eslint-disable-line
+
+const temp = require('temp');
+const assert = require('assert');
+const async = require('async');
+const stream = require('stream');
+
+const DataFileStore = require(
+    '../../../../lib/storage/data/file/DataFileStore');
+const RESTClient = require('../../../../lib/network/rest/RESTClient');
+const RESTServer = require('../../../../lib/network/rest/RESTServer');
+
+function createReadStream(contents) {
+    const rs = new stream.Readable();
+    rs._read = function nop() {};
+    if (contents) {
+        rs.push(contents);
+    }
+    rs.push(null);
+    return rs;
+}
+
+describe('REST interface for blob data storage', () => {
+    let dataStore;
+    let server;
+    let client;
+
+    function setup(done) {
+        temp.mkdir('test-REST-data-dir', (err, tempDir) => {
+            dataStore = new DataFileStore({ dataPath: tempDir,
+                                            noSync: true,
+                                            log: { logLevel: 'info',
+                                                   dumpLevel: 'error' },
+                                          });
+            server = new RESTServer({ port: 6677,
+                                      dataStore,
+                                      log: { logLevel: 'info',
+                                             dumpLevel: 'error' },
+                                    });
+            server.setup(() => {
+                server.start();
+                client = new RESTClient({ host: 'localhost',
+                                          port: 6677,
+                                          log: { logLevel: 'info',
+                                                 dumpLevel: 'error' },
+                                        });
+                done();
+            });
+        });
+    }
+
+    before(done => {
+        setup(done);
+    });
+
+    after(done => {
+        server.stop();
+        done();
+    });
+
+    describe('simple tests', () => {
+        it('should be able to PUT, GET and DELETE an object', done => {
+            const contents = 'This is the contents of the new object';
+            let objKey;
+
+            async.series([
+                subDone => {
+                    const rs = createReadStream(contents);
+                    client.put(rs, contents.length, '1', (err, key) => {
+                        assert.ifError(err);
+                        assert(key !== undefined);
+                        const hexChars = '0123456789abcdefABCDEF';
+                        for (const c of key) {
+                            assert(hexChars.includes(c));
+                        }
+                        objKey = key;
+                        subDone();
+                    });
+                },
+                subDone => {
+                    client.get(objKey, null, '2', (err, resp) => {
+                        assert.ifError(err);
+                        const value = resp.read();
+                        assert.strictEqual(value.toString(), contents);
+                        subDone();
+                    });
+                },
+                subDone => {
+                    client.delete(objKey, '3', err => {
+                        assert.ifError(err);
+                        subDone();
+                    });
+                },
+                subDone => {
+                    client.get(objKey, null, '4', err => {
+                        assert(err);
+                        assert(err.code === 404);
+                        subDone();
+                    });
+                }],
+                         err => {
+                             done(err);
+                         });
+        });
+    });
+
+    describe('GET with range tests', () => {
+        const contents = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+        let objKey;
+        let emptyObjKey;
+
+        function checkContentRange(resp, expectedStart, expectedEnd) {
+            assert(resp.headers['content-range']);
+            assert.strictEqual(
+                resp.headers['content-range'],
+                `bytes ${expectedStart}-${expectedEnd}/${contents.length}`);
+        }
+
+        before(done => {
+            const rs = createReadStream(contents);
+            client.put(rs, contents.length, '1', (err, key) => {
+                assert.ifError(err);
+                objKey = key;
+                const emptyRs = createReadStream(null);
+                client.put(emptyRs, 0, '2', (err, key) => {
+                    assert.ifError(err);
+                    emptyObjKey = key;
+                    done();
+                });
+            });
+        });
+
+        // successful range queries
+
+        [{ range: [10, 20],
+           sliceArgs: [10, 21], contentRange: [10, 20] },
+         { range: [10, undefined],
+           sliceArgs: [10], contentRange: [10, contents.length - 1] },
+         { range: [10, 1000],
+           sliceArgs: [10], contentRange: [10, contents.length - 1] },
+         { range: [undefined, 10],
+           sliceArgs: [-10], contentRange: [contents.length - 10,
+                                            contents.length - 1] },
+         { range: [undefined, contents.length + 2],
+           sliceArgs: [-(contents.length + 2)],
+           contentRange: [0, contents.length - 1] },
+         { range: [contents.length - 1, undefined],
+           sliceArgs: [-1], contentRange: [contents.length - 1,
+                                           contents.length - 1] }]
+            .forEach((test, i) => {
+                const { range, sliceArgs, contentRange } = test;
+                it(`should get the correct range ${range[0]}-${range[1]}`,
+                   done => {
+                       client.get(
+                           objKey, range,
+                           (1000 + i).toString(), (err, resp) => {
+                               assert.ifError(err);
+                               const value = resp.read();
+                               assert.strictEqual(
+                                   value.toString(),
+                                   contents.slice.apply(contents, sliceArgs));
+                               checkContentRange(resp, contentRange[0],
+                                                 contentRange[1]);
+                               done();
+                           });
+                   });
+            });
+
+        // queries returning 416 Requested Range Not Satisfiable
+
+        [{ range: [1000, undefined], emptyObject: false },
+         { range: [contents.length, undefined], emptyObject: false },
+         { range: [0, undefined], emptyObject: true },
+         { range: [0, 10], emptyObject: true },
+         { range: [undefined, 0], emptyObject: true }]
+            .forEach((test, i) => {
+                const { range, emptyObject } = test;
+                it(`should get error 416 on ${range[0]}-${range[1]}` +
+                   `${emptyObject ? ' (empty object)' : ''}`,
+                   done => {
+                       const key = (emptyObject ? emptyObjKey : objKey);
+                       client.get(
+                           key, range,
+                           (2000 + i).toString(), err => {
+                               assert(err);
+                               assert.strictEqual(err.code, 416);
+                               done();
+                           });
+                   });
+            });
+
+        it('should get 200 OK on both range boundaries undefined', done => {
+            client.get(objKey, [undefined, undefined], '3001', (err, resp) => {
+                assert.ifError(err);
+                const value = resp.read();
+                assert.strictEqual(value.toString(), contents);
+                done();
+            });
+        });
+        it('should get 200 OK on range query "bytes=-10" of empty object',
+           done => {
+               client.get(emptyObjKey, [undefined, 10], '3002', (err, resp) => {
+                   assert.ifError(err);
+                   const value = resp.read();
+                   assert.strictEqual(value, null);
+                   done();
+               });
+           });
+    });
+});


### PR DESCRIPTION
This is how we will be able to do the data storage in a separate
storage daemon, running on another container or host. For now a data
REST server will be spawned locally by the S3 server at startup (in S3
PR).

There are actually three parts: the REST client, the REST server, and
the DataFileStore which handles the storage logic. The DataFileStore
implementation comes from the original data/file implementation in S3
server.

The REST API uses a service base path named /DataFile, and does roughly:

 - a PUT directly on /DataFile URL creates a new object file and
   returns its new random hex-encoded key through its URL in a
   Location response header, along with a '201 Created' response
   code. The REST client extracts the key from this URL and returns it
   in the callback.

 - GET and DELETE on the URL returned in the 'Location' header shall
   do their duty, though the file backend appends the known key to the
   base path to recreate the URL.
