### PR TITLE
S3C-35 change metadata timeout from 5 to 30s

### DIFF
--- a/lib/network/level-net/index.js
+++ b/lib/network/level-net/index.js
@@ -10,7 +10,7 @@ const assert = require('assert');
 const flattenError = require('./utils').flattenError;
 const reconstructError = require('./utils').reconstructError;
 
-const DEFAULT_CALL_TIMEOUT_MS = 5000;
+const DEFAULT_CALL_TIMEOUT_MS = 30000;
 
 class SocketIOConnection {
 


### PR DESCRIPTION
The rationale is that tests have failed with timeout errors, it seems 5 seconds is too short for our test VMS. 

Hopefully 30s is long enough that these errors will not occur again.