### PR TITLE
fix: wrong check of delimiter index

### DIFF
--- a/lib/algos/list/delimiterMaster.js
+++ b/lib/algos/list/delimiterMaster.js
@@ -82,8 +82,10 @@ class DelimiterMaster extends Delimiter {
             // - foo/ : skipping foo/
             // - foo  : skipping foo.
             const index = this.NextMarker.lastIndexOf(this.delimiter);
-            return this.NextMarker +
-                (index === this.NextMarker.length ? '' : VID_SEP);
+            if (index === this.NextMarker.length - 1) {
+                return this.NextMarker;
+            }
+            return this.NextMarker + VID_SEP;
         }
         return SKIP_NONE;
     }

--- a/lib/algos/list/delimiterVersions.js
+++ b/lib/algos/list/delimiterVersions.js
@@ -132,7 +132,7 @@ class DelimiterVersions extends Delimiter {
     skipping() {
         if (this.NextMarker) {
             const index = this.NextMarker.lastIndexOf(this.delimiter);
-            if (index === this.NextMarker.length) {
+            if (index === this.NextMarker.length - 1) {
                 return this.NextMarker;
             }
         }

--- a/tests/unit/algos/list/delimiter.js
+++ b/tests/unit/algos/list/delimiter.js
@@ -8,6 +8,7 @@ const DelimiterMaster =
 const Werelogs = require('werelogs').Logger;
 const logger = new Werelogs('listTest');
 const performListing = require('../../../utils/performListing');
+const zpad = require('../../helpers').zpad;
 
 class Test {
     constructor(name, input, output, filter) {
@@ -264,6 +265,15 @@ const tests = [
 ];
 
 describe('Delimiter listing algorithm', () => {
+    it('Should return good skipping value for DelimiterMaster', done => {
+        const delimiter = new DelimiterMaster({ delimiter: '/' });
+        for (let i = 0; i < 100; i++) {
+            delimiter.filter({ key: `foo/${zpad(i)}`, value: '{}' });
+        }
+        assert.strictEqual(delimiter.skipping(), 'foo/');
+        done();
+    });
+
     tests.forEach(test => {
         it(`Should list ${test.name}`, done => {
             // Simulate skip scan done by LevelDB

--- a/tests/unit/algos/list/delimiterVersions.js
+++ b/tests/unit/algos/list/delimiterVersions.js
@@ -6,6 +6,7 @@ const DelimiterVersions =
 const Werelogs = require('werelogs').Logger;
 const logger = new Werelogs('listTest');
 const performListing = require('../../../utils/performListing');
+const zpad = require('../../helpers').zpad;
 
 class Test {
     constructor(name, input, output, filter) {
@@ -283,6 +284,15 @@ const tests = [
 ];
 
 describe('Delimiter All Versions listing algorithm', () => {
+    it('Should return good skipping value for DelimiterVersions', done => {
+        const delimiter = new DelimiterVersions({ delimiter: '/' });
+        for (let i = 0; i < 100; i++) {
+            delimiter.filter({ key: `foo/${zpad(i)}`, value: '{}' });
+        }
+        assert.strictEqual(delimiter.skipping(), 'foo/');
+        done();
+    });
+
     tests.forEach(test => {
         it(`Should list ${test.name}`, done => {
             // Simulate skip scan done by LevelDB

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -44,6 +44,18 @@ function createAlteredRequest(alteredItems, objToAlter,
     return alteredRequest;
 }
 
+/**
+ * Create a zero left padded string with the default length of 15 bytes.
+ * The default value represents the estimated average object key length.
+ *
+ * @param {any} key - the key to be zero padded
+ * @param {number} length - the length of the key
+ * @return {string} - the zero padded string
+ */
+function zpad(key, length = 15) {
+    return `${'0'.repeat(length + 1)}${key}`.slice(-length);
+}
+
 class DummyRequestLogger {
 
     constructor() {
@@ -99,4 +111,4 @@ class DummyRequestLogger {
 }
 
 module.exports = { makeid, timeDiff, makeAuthInfo,
-                   createAlteredRequest, DummyRequestLogger };
+                   createAlteredRequest, zpad, DummyRequestLogger };


### PR DESCRIPTION
This fixes a false assumption in #228 that the index of the last character of a string equaled to the length of the string https://github.com/scality/Arsenal/pull/228#discussion_r109256720.
Thanks @jonathan-gramain for pointing out this bug.