### PR TITLE
S3C-35 bucketfile versioning support in Arsenal

### DIFF
--- a/lib/network/level-net/index.js
+++ b/lib/network/level-net/index.js
@@ -6,11 +6,103 @@ const ioClient = require('socket.io-client');
 const sioStream = require('./sio-stream');
 const async = require('async');
 const assert = require('assert');
+const errors = require('../../errors');
 
 const flattenError = require('./utils').flattenError;
 const reconstructError = require('./utils').reconstructError;
 
+const WGM = require('../../versioning/WriteGatheringManager');
+const WriteCache = require('../../versioning/WriteCache');
+const VRP = require('../../versioning/VersioningRequestProcessor');
+
 const DEFAULT_CALL_TIMEOUT_MS = 30000;
+
+const SYNC_OPTIONS = { sync: true };
+const SUBLEVEL_SEP = '::';
+
+
+/**
+ * lookup a sublevel db given by the @a path array from the main db handle.
+ *
+ * @param {Object} db The root LevelDB database object to expose to
+ * remote clients
+ * @param {String []} path path to the sublevel, as a
+ * piecewise array of sub-levels
+ * @return {Object} the handle to the sublevel
+ */
+function lookupSubLevel(db, path) {
+    let subDb = db;
+    path.forEach(pathItem => {
+        subDb = subDb.sublevel(pathItem);
+    });
+    return subDb;
+}
+
+function createDBAPI(db) {
+    return {
+        get: (request, logger, callback) => {
+            const dbPath = request.db.split(SUBLEVEL_SEP);
+            const subDb = lookupSubLevel(db, dbPath);
+            subDb.get(request.key, (err, data) => {
+                if (err && err.notFound) {
+                    return callback(errors.ObjNotFound);
+                }
+                return callback(err, data);
+            });
+        },
+        list: (request, logger, callback) => {
+            const dbPath = request.db.split(SUBLEVEL_SEP);
+            const subDb = lookupSubLevel(db, dbPath);
+            const stream = subDb.createReadStream(request.params);
+            const res = [];
+            let done = false;
+            stream.on('data', data => res.push(data));
+            stream.on('error', err => {
+                if (done === false) {
+                    done = true;
+                    callback(err);
+                }
+            });
+            stream.on('end', () => {
+                if (done === false) {
+                    done = true;
+                    callback(null, res);
+                }
+            });
+        },
+        batch: (request, logger, callback) => {
+            const dbPath = request.db.split(SUBLEVEL_SEP);
+            const subDb = lookupSubLevel(db, dbPath);
+            subDb.batch(request.array, SYNC_OPTIONS,
+                        err => callback(err));
+        },
+    };
+}
+
+function packRequestArgs(remoteCall, decodedArgs) {
+    const db = decodedArgs.subLevel.join(SUBLEVEL_SEP);
+    const { rpcArgs } = decodedArgs;
+    switch (remoteCall) {
+    case 'put':
+        return { db, type: 'put',
+                 key: rpcArgs[0], value: rpcArgs[1],
+                 options: rpcArgs[2], reqUids: rpcArgs[3] };
+    case 'del':
+        return { db, type: 'del',
+                 key: rpcArgs[0],
+                 options: rpcArgs[1], reqUids: rpcArgs[2] };
+    case 'get':
+        return { db,
+                 key: rpcArgs[0],
+                 options: rpcArgs[1], reqUids: rpcArgs[2] };
+    case 'batch':
+        return { db,
+                 array: rpcArgs[0],
+                 options: rpcArgs[1], reqUids: rpcArgs[2] };
+    default:
+        return {};
+    }
+}
 
 class SocketIOConnection {
 
@@ -223,6 +315,10 @@ module.exports.createServer = function LevelServer(db, options) {
     const ioServer = io(httpServer);
     const log = options.logger;
 
+    const wgm = new WGM(createDBAPI(db));
+    const writeCache = new WriteCache(wgm);
+    const vrp = new VRP(writeCache, wgm);
+
     ioServer.initMetadataService = function initMetadataService(baseNs = '') {
         assert(baseNs === '' || baseNs.startsWith('/'));
 
@@ -230,22 +326,6 @@ module.exports.createServer = function LevelServer(db, options) {
         // namespace, other operations (ping etc.) go through /misc.
         const mdSock = this.of(`${baseNs}/metadata`);
         mdSock.on('connection', conn => {
-            /**
-             * lookup a sublevel db given by the @a path array from
-             * the main db handle.
-             *
-             * @param {String []} path path to the sublevel, as a
-             * piecewise array of sub-levels
-             * @return {Object} the handle to the sublevel
-             */
-            function lookupSubLevel(path) {
-                let subDb = db;
-                path.forEach(pathItem => {
-                    subDb = subDb.sublevel(pathItem);
-                });
-                return subDb;
-            }
-
             const mdStreams = sioStream.createSocket(
                 conn,
                 options.logger,
@@ -261,36 +341,31 @@ module.exports.createServer = function LevelServer(db, options) {
                 const decodedArgs = mdStreams.decodeStreams(args);
                 if (dbAsyncCommandNames.includes(remoteCall)) {
                     try {
-                        // We're pushing the callback to arguments
-                        // that async DB sublevel calls expect as
-                        // their last argument.
-                        decodedArgs.rpcArgs.push((err, data) => {
+                        const requestArgs = packRequestArgs(remoteCall,
+                                                            decodedArgs);
+                        const logger = log.newRequestLoggerFromSerializedUids(
+                            requestArgs.reqUids);
+                        vrp[remoteCall](requestArgs, logger, (err, data) => {
                             cb(flattenError(err),
                                mdStreams.encodeStreams(data));
                         });
-
-                        const subDb = lookupSubLevel(decodedArgs.subLevel);
-                        subDb[remoteCall].apply(subDb, decodedArgs.rpcArgs);
                     } catch (err) {
-                        return cb(flattenError(err));
+                        cb(flattenError(err));
                     }
                 } else if (dbSyncCommandNames.includes(remoteCall)) {
-                    let result;
-
                     try {
-                        const subDb = lookupSubLevel(decodedArgs.subLevel);
-                        result = subDb[remoteCall].apply(
+                        const subDb = lookupSubLevel(db, decodedArgs.subLevel);
+                        let result = subDb[remoteCall].apply(
                             subDb, decodedArgs.rpcArgs);
                         result = mdStreams.encodeStreams(result);
+                        cb(null, result);
                     } catch (err) {
-                        return cb(flattenError(err));
+                        cb(flattenError(err));
                     }
-                    return cb(null, result);
                 } else {
-                    return cb(flattenError(
+                    cb(flattenError(
                         new Error(`Unknown remote call ${remoteCall}`)));
                 }
-                return undefined;
             });
         });
 

--- a/lib/versioning/Version.js
+++ b/lib/versioning/Version.js
@@ -1,8 +1,15 @@
 'use strict'; // eslint-disable-line strict
 
+const VID = require('./VersionID');
+
 /**
  * Class for manipulating an object version.
  * The format of a version: { isNull, isDeleteMarker, versionId, otherInfo }
+ *
+ * @note Some of these functions are optimized based on string search
+ * prior to a full JSON parse/stringify. (Vinh: 18K op/s are achieved
+ * with the full stringify/parse cycle, which is too low a number for
+ * use with a production setup with Metadata).
  */
 class Version {
     /**
@@ -45,6 +52,39 @@ class Version {
         } catch (exception) { // eslint-disable-line strict
             return false; // nice, Vault
         }
+    }
+
+    /**
+     * Generate a fixed size serialized place holder for deletion (PHD version).
+     * A PHD version is used internally by metadata (VersioningRequestProcessor)
+     * to indicate that the master version of an object has been deleted and it
+     * needs to be updated by the latest version if any.
+     *
+     * @param {string} versionId - the versionId of the version, this expects
+     *                             a fixed length versionId (without info part)
+     *                             to facilitate easy checking if a version is
+     *                             a PHD version; see PHD_VER_LENGTH above
+     * @return {string} - the serialized version
+     */
+    static generatePHDVersion() {
+        return `{ "isPHD": true, "versionId": "${VID.generateVersionId('')}" }`;
+    }
+
+    /**
+     * Put versionId into an object in the (cheap) way of string manipulation,
+     * instead of the more expensive alternative parsing and stringification.
+     *
+     * @param {string} value - stringification of the object to append versionId
+     * @param {string} versionId - the versionId to append
+     * @return {string} - the object with versionId appended
+     */
+    static appendVersionId(value, versionId) {
+        // assuming value has the format of '{...}'
+        let index = value.length - 2;
+        while (value.charAt(index--) === ' ');
+        const comma = value.charAt(index + 1) !== '{';
+        return `${value.slice(0, value.length - 1)}` + // eslint-disable-line
+            (comma ? ',' : '') + `"versionId":"${versionId}"}`;
     }
 
     /**

--- a/lib/versioning/Version.js
+++ b/lib/versioning/Version.js
@@ -41,6 +41,10 @@ class Version {
      * @return {boolean} - whether this is a PHD version
      */
     static isPHD(value) {
+        // check if the input is a valid version
+        if (!value) {
+            return false;
+        }
         // look for the keyword 'isPHD' in the value before parsing it;
         // all PHD versions must have this keyword
         if (value.indexOf('isPHD') < 0) {

--- a/lib/versioning/VersionID.js
+++ b/lib/versioning/VersionID.js
@@ -8,45 +8,52 @@
 
 // the lengths of the components in bytes
 const LENGTH_TS = 14; // timestamp: epoch in ms
-const LENGTH_SQ = 6; // position in ms slot
-const LENGTH_ST = 5; // site identifier
+const LENGTH_SEQ = 6; // position in ms slot
+const LENGTH_SITE = 5; // site identifier
 
 // empty string template for the variables in a versionId
 const TEMPLATE_TS = new Array(LENGTH_TS + 1).join('0');
-const TEMPLATE_SQ = new Array(LENGTH_SQ + 1).join('0');
-const TEMPLATE_ST = new Array(LENGTH_ST + 1).join(' ');
+const TEMPLATE_SEQ = new Array(LENGTH_SEQ + 1).join('0');
+const TEMPLATE_SITE = new Array(LENGTH_SITE + 1).join(' ');
 
 /**
- * Padding a string representation of a value with a given template.
- * For example: pad('foo', '00000') equals '00foo' for left padding
- * and 'foo00' for right padding.
+ * Left-pad a string representation of a value with a given template.
+ * For example: pad('foo', '00000') gives '00foo'.
  *
  * @param {any} value - value to pad
  * @param {string} template - padding template
- * @param {boolean} [right] - padding right (default is padding left)
  * @return {string} - padded string
  */
-function pad(value, template, right = false) {
-    if (right) {
-        return `${value}${template}`.slice(0, template.length);
-    }
+function padLeft(value, template) {
     return `${template}${value}`.slice(-template.length);
 }
 
+/**
+ * Right-pad a string representation of a value with a given template.
+ * For example: pad('foo', '00000') gives 'foo00'.
+ *
+ * @param {any} value - value to pad
+ * @param {string} template - padding template
+ * @return {string} - padded string
+ */
+function padRight(value, template) {
+    return `${value}${template}`.slice(0, template.length);
+}
+
 // site identifier, like PARIS, TOKYO; will be trimmed if exceeding max length
-const SITE_ID = pad(process.env.SITE_ID, TEMPLATE_ST, true);
-// const SITE_ID = `${process.env.SITE_ID}${TEMPLATE_ST}`.slice(0, LENGTH_ST);
+const SITE_ID = padRight(process.env.SITE_ID, TEMPLATE_SITE);
 
 // constants for max epoch and max sequential number in the same epoch
 const MAX_TS = Math.pow(10, LENGTH_TS) - 1; // good until 16 Nov 5138
-const MAX_SQ = Math.pow(10, LENGTH_SQ) - 1; // good for 1 billion ops
+const MAX_SEQ = Math.pow(10, LENGTH_SEQ) - 1; // good for 1 billion ops
 
 // the earliest versionId, used for versions before versioning
-const VID_INF = pad(MAX_TS, TEMPLATE_TS) + pad(MAX_SQ, TEMPLATE_SQ) + SITE_ID;
+const VID_INF = (padLeft(MAX_TS, TEMPLATE_TS) +
+                 padLeft(MAX_SEQ, TEMPLATE_SEQ) + SITE_ID);
 
 // internal state of the module
-let prvts = 0; // epoch of the last versionId
-let prvsq = 0; // sequential number of the last versionId
+let lastTimestamp = 0; // epoch of the last versionId
+let lastSeq = 0; // sequential number of the last versionId
 
 /**
  * This function ACTIVELY (wastes CPU cycles and) waits for an amount of time
@@ -80,7 +87,7 @@ function generateVersionId(info) {
     // Need to wait for the millisecond slot got "flushed". We wait for
     // only a single millisecond when the module is restarted, which is
     // necessary for the correctness of the system. This is therefore cheap.
-    if (prvts === 0) {
+    if (lastTimestamp === 0) {
         wait(1000000);
     }
     // get the present epoch (in millisecond)
@@ -93,15 +100,15 @@ function generateVersionId(info) {
     // in the queue for the same millisecond which is supposed to be unique.
 
     // increase the position if this request is in the same epoch
-    prvsq = (prvts === ts) ? prvsq + 1 : 0;
-    prvts = ts;
+    lastSeq = (lastTimestamp === ts) ? lastSeq + 1 : 0;
+    lastTimestamp = ts;
 
     // In the default cases, we reverse the chronological order of the
     // timestamps so that all versions of an object can be retrieved in the
     // reversed chronological order---newest versions first. This is because of
     // the limitation of leveldb for listing keys in the reverse order.
-    return pad(MAX_TS - prvts, TEMPLATE_TS) +
-           pad(MAX_SQ - prvsq, TEMPLATE_SQ) + SITE_ID + info;
+    return padLeft(MAX_TS - lastTimestamp, TEMPLATE_TS) +
+           padLeft(MAX_SEQ - lastSeq, TEMPLATE_SEQ) + SITE_ID + info;
 }
 
 /**

--- a/lib/versioning/VersioningRequestProcessor.js
+++ b/lib/versioning/VersioningRequestProcessor.js
@@ -1,0 +1,404 @@
+const errors = require('../errors');
+const Version = require('./Version').Version;
+
+const genVID = require('./VersionID').generateVersionId;
+
+// some predefined constants
+const VID_SEP = require('./constants').VersioningConstants.VersionId.Separator;
+
+/**
+ * Increment the charCode of the last character of a valid string.
+ *
+ * @param {string} prefix - the input string
+ * @return {string} - the incremented string, or the input if it is not valid
+ */
+function getPrefixUpperBoundary(prefix) {
+    if (prefix) {
+        return prefix.slice(0, prefix.length - 1) +
+            String.fromCharCode(prefix.charCodeAt(prefix.length - 1) + 1);
+    }
+    return prefix;
+}
+
+function formatVersionKey(key, versionId) {
+    return `${key}${VID_SEP}${versionId}`;
+}
+
+function formatCacheKey(db, key) {
+    // using double VID_SEP to make sure the cache key is unique
+    return `${db}${VID_SEP}${VID_SEP}${key}`;
+}
+
+const VID_SEPPLUS = getPrefixUpperBoundary(VID_SEP);
+
+class VersioningRequestProcessor {
+    /**
+     * This class takes a random string generator as additional input.
+     * @param {WriteCache} writeCache - the WriteCache to which this
+     *   will forward the cachable processed requests to
+     * @param {writeGatheringManager} writeGatheringManager - the
+     *   WriteGatheringManager to which this will forward the
+     *   non-cachable processed requests to
+     * @constructor
+     */
+    constructor(writeCache, writeGatheringManager) {
+        this.writeCache = writeCache;
+        this.wgm = writeGatheringManager;
+        // internal state
+        this.uidCounter = 0;
+        this.queue = {};
+        this.repairing = {};
+    }
+
+    generateVersionId() {
+        return genVID(this.uidCounter++);
+    }
+
+    /**
+     * Get a version of an object. If it is a place holder for
+     * deletion, search by listing for the latest version then repair
+     * it.
+     *
+     * @param {object} request - the request in original
+     *                           RepdConnection format { db, key
+     *                           [, value][, type], method, options }
+     * @param {object} logger - logger
+     * @param {function} callback - callback function
+     * @return {any} - to finish the call
+     */
+    get(request, logger, callback) {
+        const { db, key, options } = request;
+        if (options && options.versionId) {
+            const versionKey = formatVersionKey(key, options.versionId);
+            return this.wgm.get({ db, key: versionKey }, logger, callback);
+        }
+        return this.wgm.get(request, logger, (err, data) => {
+            if (err) {
+                return callback(err);
+            }
+            // answer if value is not a place holder for deletion
+            if (! Version.isPHD(data)) {
+                return callback(null, data);
+            }
+            logger.debug('master version is a PHD, getting the latest version',
+                         { db, key });
+            // otherwise, need to search for the latest version
+            return this.getByListing(request, logger, callback);
+        });
+    }
+
+    /**
+     * Get the latest version of an object when the master version is a place
+     * holder for deletion. For any given pair of db and key, only a
+     * single process is performed at any moment. Subsequent get-by-listing
+     * requests are queued up and these requests will have the same response.
+     *
+     * @param {object} request - the request in original
+     *                           RepdConnection format { db, key
+     *                           [, value][, type], method, options }
+     * @param {object} logger - logger
+     * @param {function} callback - callback function
+     * @return {any} - to finish the call
+     */
+    getByListing(request, logger, callback) {
+        // enqueue the get entry; do nothing if another is processing it
+        // this is to manage the number of expensive listings when there
+        // are multiple concurrent gets on the same key which is a PHD version
+        if (!this.enqueueGet(request, logger, callback)) {
+            return null;
+        }
+        logger.info('start listing latest versions', { request });
+        // otherwise, search for the latest version
+        const cacheKey = formatCacheKey(request.db, request.key);
+        clearTimeout(this.repairing[cacheKey]);
+        delete this.repairing[cacheKey];
+        const req = { db: request.db, params: {
+            gte: request.key, lt: `${request.key}${VID_SEPPLUS}`, limit: 2 } };
+        return this.wgm.list(req, logger, (err, list) => {
+            logger.info('listing latest versions done', { err, list });
+            if (err) {
+                return this.dequeueGet(request, err);
+            }
+            // the complete list of versions is always: mst, v1, v2, ...
+            if (list.length === 0) {
+                return this.dequeueGet(request, errors.ObjNotFound);
+            }
+            if (!Version.isPHD(list[0].value)) {
+                return this.dequeueGet(request, null, list[0].value);
+            }
+            if (list.length === 1) {
+                logger.info('no other versions', { request });
+                this.dequeueGet(request, errors.ObjNotFound);
+                return this.repairMaster(request, logger,
+                                         { type: 'del',
+                                           value: list[0].value });
+            }
+            // need repair
+            logger.info('update master by the latest version', { request });
+            const nextValue = list[1].value;
+            this.dequeueGet(request, null, nextValue);
+            return this.repairMaster(request, logger,
+                                     { type: 'put', value: list[0].value,
+                                       nextValue });
+        });
+    }
+
+    /**
+     * Enqueue a get-by-listing request.
+     *
+     * @param {object} request - the request in original
+     *                           RepdConnection format { db, key
+     *                           [, value][, type], method, options }
+     * @param {object} logger - logger
+     * @param {function} callback - callback function
+     * @return {boolean} - this request is the first in the queue or not
+     */
+    enqueueGet(request, logger, callback) {
+        const cacheKey = formatCacheKey(request.db, request.key);
+        // enqueue the get entry if another is processing it
+        if (this.queue[cacheKey]) {
+            this.queue[cacheKey].push({ request, logger, callback });
+            return false;
+        }
+        // otherwise, create a queue and enqueue itself
+        this.queue[cacheKey] = [{ request, logger, callback }];
+        return true;
+    }
+
+    /**
+     * Dequeue all pending get-by-listing requests by the result of the first
+     * request in the queue.
+     *
+     * @param {object} request - the request in original
+     *                           RepdConnection format { db, key
+     *                           [, value][, type], method, options }
+     * @param {object} err - resulting error of the first request
+     * @param {string} value - resulting value of the first request
+     * @return {undefined}
+     */
+    dequeueGet(request, err, value) {
+        const cacheKey = formatCacheKey(request.db, request.key);
+        if (this.queue[cacheKey]) {
+            this.queue[cacheKey].forEach(entry => {
+                if (err || value) {
+                    return entry.callback(err, value);
+                }
+                return this.wgm.get(entry.request, entry.logger,
+                                    entry.callback);
+            });
+            delete this.queue[cacheKey];
+        }
+    }
+
+    /**
+     * Search for the latest version of an object to update its master version
+     * in an atomic manner when the master version is a PHD.
+     *
+     * @param {object} request - the request in original
+     *                           RepdConnection format { db, key
+     *                           [, value][, type], method, options }
+     * @param {object} logger - logger
+     * @param {object} hints - storing reparing hints
+     * @param {string} hints.type - type of repair operation ('put' or 'del')
+     * @param {string} hints.value - existing value of the master version (PHD)
+     * @param {string} hints.nextValue - the suggested latest version
+         (for 'put')
+     * @return {any} - to finish the call
+     */
+    repairMaster(request, logger, hints) {
+        const { db, key } = request;
+        logger.info('start repair process', { request });
+        this.writeCache.get({ db, key }, logger, (err, value) => {
+            // error or the new version is not a place holder for deletion
+            if (err) {
+                return logger.info('error repairing', { request, error: err });
+            }
+            if (!Version.isPHD(value)) {
+                return logger.debug('master is updated already', { request });
+            }
+            // the latest version is the same place holder for deletion
+            if (hints.value === value) {
+                // update the latest version with the next version
+                const repairRequest = {
+                    db,
+                    array: [
+                        { type: hints.type, key, value: hints.nextValue },
+                    ] };
+                logger.info('replicate repair request', { repairRequest });
+                return this.writeCache.batch(repairRequest, logger, () => {});
+            }
+            // The latest version is an updated place holder for deletion,
+            // repeat the repair process from listing for latest versions.
+            // The queue will ensure single repair process at any moment.
+            return this.getByListing(request, logger, () => {});
+        });
+    }
+
+    /**
+     * Process the request if it is a versioning request, or send it to the
+     * next level replicator if it is not.
+     *
+     * @param {object} request - the request in original
+     *                           RepdConnection format { db, key
+     *                           [, value][, type], method, options }
+     * @param {object} logger - logger
+     * @param {function} callback - expect callback(err, data)
+     * @return {any} - to finish the call
+     */
+    put(request, logger, callback) {
+        const { db, key, value, options } = request;
+        // valid combinations of versioning options:
+        // - !versioning && !versionId: normal non-versioning put
+        // - versioning && !versionId: create a new version
+        // - !versioning && versionId: update (PUT/DELETE) an existing version
+        //                             if versionId === '' update master version
+        // other cases are invalid and metadata does nothing
+        const versioning = options &&
+            (options.versioning || options.versioning === '');
+        const versionId = options &&
+            (options.versionId || options.versionId === '');
+        if (versioning && versionId) {
+            return callback(errors.BadRequest.message);
+        }
+        // no versioning or versioning configuration off
+        if (!versioning && !versionId) {
+            return this.writeCache.batch(
+                    { db, array: [{ key, value }] }, logger, callback);
+        }
+
+        const versioningCb = (err, array, vid) => {
+            if (err) {
+                return callback(err);
+            }
+            return this.writeCache.batch({ db, array, options },
+                    logger, err => callback(err, `{"versionId":"${vid}"}`));
+        };
+        // creating new version PUT
+        if (versioning) {
+            return this.processNewVersionPut(request, logger, versioningCb);
+        }
+        // version specific PUT
+        return this.processVersionSpecificPut(request, logger, versioningCb);
+    }
+
+    /**
+     * Processes a versioning putObject request. This will create a batch of
+     * operations for updating the master version and creating the specific
+     * version.
+     *
+     * @param {object} request - the request in original
+     *                           RepdConnection format { db, key
+     *                           [, value][, type], method, options }
+     * @param {object} logger - logger
+     * @param {function} callback - expect callback(err, batch, versionId)
+     * @return {any} - to finish the call
+     */
+    processNewVersionPut(request, logger, callback) {
+        // making a new versionId and a new version key
+        const versionId = this.generateVersionId();
+        const versionKey = formatVersionKey(request.key, versionId);
+        const versionValue = Version.appendVersionId(request.value, versionId);
+        const ops = [
+            { key: request.key, value: versionValue },
+            { key: versionKey, value: versionValue },
+        ];
+        return callback(null, ops, versionId);
+    }
+
+    /**
+     * Processes a version specific putObject request. This will create a batch
+     * of operations for updating the target version, and the master version if
+     * the target version is the latest.
+     *
+     * @param {object} request - the request in original
+     *                           RepdConnection format { db, key
+     *                           [, value][, type], method, options }
+     * @param {object} logger - logger
+     * @param {function} callback - expect callback(err, batch, versionId)
+     * @return {any} - to finish the call
+     */
+    processVersionSpecificPut(request, logger, callback) {
+        const { db, key } = request;
+        // versionId is empty: update the master version
+        if (request.options.versionId === '') {
+            const versionId = this.generateVersionId();
+            const value = Version.appendVersionId(request.value, versionId);
+            return callback(null, [{ key, value }], versionId);
+        }
+        // need to get the master version to check if this is the master version
+        this.writeCache.get({ db, key }, logger, (err, data) => {
+            if (err && !err.ObjNotFound) {
+                return callback(err);
+            }
+            const versionId = request.options.versionId;
+            const versionKey = formatVersionKey(request.key, versionId);
+            const ops = [{ key: versionKey, value: request.value }];
+            if (Version.from(data).getVersionId() === versionId) {
+                // the version is also the master version: need to update both
+                ops.push({ key: request.key, value: request.value });
+            }
+            return callback(null, ops, versionId);
+        });
+        return null;
+    }
+
+
+    del(request, logger, callback) {
+        const { db, key, options } = request;
+        // no versioning or versioning configuration off
+        if (!(options && options.versionId)) {
+            return this.writeCache.batch({ db,
+                                           array: [{ key, type: 'del' }] },
+                                         logger, callback);
+        }
+        // version specific DELETE
+        return this.processVersionSpecificDelete(request, logger,
+            (err, array, vid) => {
+                if (err) {
+                    return callback(err);
+                }
+                return this.writeCache.batch({ db, array }, logger,
+                    err => callback(err, `{"versionId":"${vid}"}`));
+            });
+    }
+
+    /**
+     * Processes a version specific deleteObject request. This will create a
+     * batch of operations for deleting the specific version and marking the
+     * master version of the object as a place holder for deletion if the
+     * specific version is also the master version.
+     *
+     * @param {object} request - the request in original
+     *                           RepdConnection format { db, key
+     *                           [, value][, type], method, options }
+     * @param {object} logger - logger
+     * @param {function} callback - expect callback(err, batch, versionId)
+     * @return {any} - to finish the call
+     */
+    processVersionSpecificDelete(request, logger, callback) {
+        const { db, key, options } = request;
+        // deleting a specific version
+        this.writeCache.get({ db, key }, logger, (err, data) => {
+            if (err && !err.ObjNotFound) {
+                return callback(err);
+            }
+            // delete the specific version
+            const versionId = options.versionId;
+            const versionKey = formatVersionKey(key, versionId);
+            const ops = [{ key: versionKey, type: 'del' }];
+            // update the master version as PHD if it is the deleting version
+            if (Version.isPHD(data) ||
+                Version.from(data).getVersionId() === versionId) {
+                ops.push({ key, value: Version.generatePHDVersion() });
+                // start the repair process later
+                const cacheKey = formatCacheKey(db, key);
+                clearTimeout(this.repairing[cacheKey]);
+                this.repairing[cacheKey] = setTimeout(() =>
+                        this.getByListing(request, logger, () => {}), 15000);
+            }
+            return callback(null, ops, versionId);
+        });
+    }
+}
+
+module.exports = VersioningRequestProcessor;

--- a/lib/versioning/WriteCache.js
+++ b/lib/versioning/WriteCache.js
@@ -1,0 +1,193 @@
+'use strict'; // eslint-disable-line
+
+const errors = require('../errors');
+
+function formatCacheKey(db, key) {
+    return `${db}\0\0${key}`;
+}
+
+/**
+ * The WriteCache class provides an isolation" layer for versioning updates,
+ * which involve a read (GET), a computation based on the read value, and a
+ * subsequent write (PUT) of the computation result. This layer ensures that
+ * there are no other concurrent operations changing the value of the target
+ * object between these steps of a versioning update on the object.
+ * "Isolation: ensures the result of executing concurrent operations being as
+ * if we execute them sequentially.
+ * What it does to achieve the isolation is to put concurrent updates into a
+ * queue, get the target object from either the cache or the database, do the
+ * computation and store the result to the cache, then move on with the next
+ * request in the queue, finally write the batch of the generated updates to
+ * the database.
+ * WriteCache also caches the latest value of the object it's writing to ensure
+ * the next update (which comes while WriteCache is writing) to be able to see
+ * the latest value of that object, thus ensuring isolation. This cached entry
+ * remains only until the write is done and no other update is using it.
+ */
+class WriteCache {
+    constructor(wgm) {
+        this.wgm = wgm;
+        // internal state
+        this.cache = {};
+        this.queue = {};
+        this.counter = 0; // an increasing counter for unique signatures
+    }
+
+    /**
+     * Get the value of an entry either in temporary cache, cache, or database.
+     *
+     * @param {object} request - the request in original
+     *                           RepdConnection format { db, key
+     *                           [, value][, type], method, options }
+     * @param {object} logger - logger
+     * @param {function} callback - callback function: callback(error, value)
+     * @return {any} - to finish the call
+     */
+    get(request, logger, callback) {
+        const { db, key } = request;
+
+        const cacheKey = formatCacheKey(db, key);
+        if (this.cache[cacheKey]) {
+            if (this.cache[cacheKey].value) {
+                return callback(null, this.cache[cacheKey].value);
+            }
+            return callback(errors.ObjNotFound);
+        }
+        // not in cache, try to get it from the database
+        const signature = this._enqueue(cacheKey, callback);
+        if (signature === undefined) {
+            // another get is in progress, keep calm and queue up
+            return null;
+        }
+        // no other is in progress, get the key from the database
+        return this.wgm.get(request, logger, (err, value) => {
+            // answer all the queued requests
+            this._dequeue(cacheKey, signature, err, value);
+        });
+    }
+
+    /**
+     * Queue up a get request.
+     *
+     * @param {string} cacheKey - key of the cache entry
+     * @param {function} callback - callback
+     * @return {number} - the signature of the request if this is the first
+     *                    entry in the queue (which will do the get from the
+     *                    database), undefined otherwise
+     */
+    _enqueue(cacheKey, callback) {
+        if (this.queue[cacheKey]) {
+            this.queue[cacheKey].queue.push(callback);
+            return undefined;
+        }
+        this.queue[cacheKey] = { queue: [callback], signature: this.counter };
+        return this.counter;
+    }
+
+    /**
+     * Dequeue the concurrent get requests on the same object.
+     *
+     * @param {string} cacheKey - key of the cache entry
+     * @param {number} signature - signature of the first request of the queue
+     * @param {object} err - the error from the get
+     * @param {string} value - the value of the object to seed dequeueing
+     * @param {boolean} force - force dequeuing even on signature mismatch
+     * @return {undefined} - nothing
+     */
+    _dequeue(cacheKey, signature, err, value, force = false) {
+        if (this.queue[cacheKey] === undefined) {
+            return;
+        }
+        // the lock (dequeueing) here is to prevent the concurrency of
+        // dequeueing where a dequeued request can synchronously update
+        // the cache, which will trigger a new dequeue process
+        if (this.queue[cacheKey].dequeueing) {
+            return;
+        }
+        if (this.queue[cacheKey].signature === signature || force) {
+            this.queue[cacheKey].dequeueing = true;
+            // dequeueing will read, compute, and update the cache
+            const dequeueSignature = this.counter++;
+            this.cache[cacheKey] = { signature: dequeueSignature, value };
+            this.queue[cacheKey].queue.forEach(callback => {
+                // always return the value from cache, not the value that
+                // started dequeueing, because the cache might be updated
+                // synchronously by a dequeued request
+                if (err) {
+                    return callback(err);
+                }
+                if (this.cache[cacheKey].value === undefined) {
+                    return callback(errors.ObjNotFound);
+                }
+                return callback(null, this.cache[cacheKey].value);
+            });
+            // clear the queue when done dequeueing all entries
+            delete this.queue[cacheKey];
+            // also clear the cache if there is no new write
+            if (this.cache[cacheKey].signature === dequeueSignature) {
+                delete this.cache[cacheKey];
+            }
+        }
+    }
+
+    /**
+     * Replicate the latest value of an entry and cache it during replication.
+     *
+     * @param {object} request - the request in format { db,
+     *                           array, options }
+     * @param {object} logger - logger of the operation
+     * @param {function} callback - asynchronous callback of the call
+     * @return {undefined}
+     */
+    batch(request, logger, callback) {
+        const { db, array } = request;
+        const signature = this._cacheWrite(db, array);
+        this.wgm.batch(request, logger, (err, data) => {
+            this._cacheClear(db, array, signature);
+            callback(err, data);
+        });
+    }
+
+    /**
+     * Temporarily cache the writing value. Overwrite existing temporary value
+     * and dequeue all pending temporary gets if exist. This is here is to
+     * ensure the "isolation" property: an operation depends on the one before
+     * it. The newly put value is always the latest; we have to use it instead
+     * of using the potentially more stale value in the database.
+     *
+     * @param {string} db - name of the database
+     * @param {object} array - batch operation to apply on the database
+     * @return {string} - signature of the request
+     */
+    _cacheWrite(db, array) {
+        const signature = this.counter++;
+        array.forEach(entry => {
+            const cacheKey = formatCacheKey(db, entry.key);
+            this.cache[cacheKey] = { signature, value: entry.value };
+            this._dequeue(cacheKey, null, null, entry.value, true);
+        });
+        return signature;
+    }
+
+    /**
+     * Clear the cached entries after a successful write.
+     *
+     * @param {string} db - name of the database
+     * @param {object} array - batch operation to apply on the database
+     * @param {string} signature - signature if temporarily cached
+     * @return {undefined}
+     */
+    _cacheClear(db, array, signature) {
+        array.forEach(entry => {
+            const key = formatCacheKey(db, entry.key);
+            if (this.cache[key] && this.cache[key].signature === signature) {
+                // only clear cache when the temporarily cached entry
+                // is still available and the signatures match, which
+                // means it has not been updated by a subsequent update
+                delete this.cache[key];
+            }
+        });
+    }
+}
+
+module.exports = WriteCache;

--- a/lib/versioning/WriteGatheringManager.js
+++ b/lib/versioning/WriteGatheringManager.js
@@ -1,0 +1,136 @@
+const WG_TIMEOUT = 5; // batching period in milliseconds
+
+/**
+ * This write-gathering manager aggregates and send requests in batches.
+ * Because we are managing buckets in separate databases, we build a batch
+ * from operations targeting the same database.
+ */
+class WriteGatheringManager {
+    constructor(db) {
+        this.db = db;
+        this.dbState = {};
+    }
+
+    /**
+     * Get the value of an entry either in temporary cache, cache, or database.
+     *
+     * @param {object} request - the request in original
+     *                           RepdConnection format { db, key
+     *                           [, value][, type], method, options }
+     * @param {object} logger - logger
+     * @param {function} callback - callback function: callback(error, value)
+     * @return {any} - to finish the call
+     */
+    get(request, logger, callback) {
+        return this.db.get(request, logger, callback);
+    }
+
+    list(request, logger, callback) {
+        return this.db.list(request, logger, callback);
+    }
+
+    /**
+     * Append a request to the write gathering batch.
+     * Replicate and commit the batch on timeout or oversize.
+     *
+     * @param {object} request - the request in format { db,
+     *                           array, options }
+     * @param {object} logger - logger of the request
+     * @param {function} callback - callback(err)
+     * @return {WriteGatheringManager} - return this
+     */
+    batch(request, logger, callback) {
+        const { db, array } = request;
+        if (this.dbState[db] === undefined) {
+            this.dbState[db] = { db, isCommitting: false };
+        }
+        const dbState = this.dbState[db];
+        if (dbState.batchCache === undefined) {
+            dbState.batchCache = {
+                batch: [],
+                uids: [],
+                callback: [],
+                logger,
+                timer: setTimeout(() => this._commitBatch(db), WG_TIMEOUT),
+            };
+        }
+        const bCache = dbState.batchCache;
+        array.forEach((entry, index) => {
+            bCache.batch.push(entry);
+            bCache.uids.push(logger.getSerializedUids());
+            bCache.callback.push(index ? null : callback);
+        });
+        return this;
+    }
+
+    /**
+     * Commit a batch of operations on a database.
+     *
+     * @param {string} db - Name of the database
+     * @return {any} - to finish the call
+     */
+    _commitBatch(db) {
+        const dbState = this.dbState[db];
+        const bCache = dbState.batchCache;
+        // do nothing if no batch to replicate
+        if (bCache === undefined) {
+            return null;
+        }
+        // clear the existing timer of the batch here, this pending batch will
+        // be sent automatically when the previous batch finishes
+        clearTimeout(bCache.timer);
+        bCache.timer = undefined;
+        // do nothing if another batch on the same database is in progress
+        // WGM will retry after it has done committing the in-progress batch
+        if (dbState.isCommitting) {
+            return null;
+        }
+        // otherwise, clear the cache, lock the database, and commit batch
+        dbState.batchCache = undefined;
+        dbState.isCommitting = true; // lock batching on the database
+        const request = { db, array: bCache.batch };
+
+        return this.db.batch(request, bCache.logger, err => {
+            // release the lock and answer the requests in all cases
+            dbState.isCommitting = false;
+            this._batchCommitted(err, bCache);
+            // then check if there is any pending batch to commit
+            const _bCache = this.dbState[db].batchCache;
+            if (_bCache === undefined) {
+                // no more pending requests, do nothing
+                return null;
+            }
+            if (err) {
+                // in the case of commit error, it is better to clear the
+                // batch cache instead of rebuilding it because it is very
+                // likely that the rebuilt batch will fail as well
+                clearTimeout(_bCache.timer);
+                _bCache.timer = undefined;
+                dbState.batchCache = undefined;
+                return this._batchCommitted(err, _bCache);
+            }
+            if (_bCache.timer === undefined) {
+                // the next batch is waiting, go committing it
+                return this._commitBatch(db);
+            }
+            return null;
+        });
+    }
+
+    /**
+     * Respond to all requests of a batch after it has been committed.
+     *
+     * @param {object} error - error of committing the batch
+     * @param {object} batch - the committed batch
+     * @return {undefined} - nothing
+     */
+    _batchCommitted(error, batch) {
+        batch.callback.forEach(callback => {
+            if (callback) {
+                callback(error);
+            }
+        });
+    }
+}
+
+module.exports = WriteGatheringManager;

--- a/tests/unit/versioning/VersioningRequestProcessor.js
+++ b/tests/unit/versioning/VersioningRequestProcessor.js
@@ -90,7 +90,7 @@ function batch(callback) {
     }, callback);
 }
 
-describe.only('test VSP', () => {
+describe('test VSP', () => {
     afterEach(() => _cleanupKeyValueStore());
 
     it('should run a batch of operations correctly', done => {

--- a/tests/unit/versioning/VersioningRequestProcessor.js
+++ b/tests/unit/versioning/VersioningRequestProcessor.js
@@ -1,0 +1,153 @@
+const assert = require('assert');
+const async = require('async');
+
+const Version = require('../../../lib/versioning/Version').Version;
+
+const errors = require('../../../lib/errors');
+const WGM = require('../../../lib/versioning/WriteGatheringManager');
+const WriteCache = require('../../../lib/versioning/WriteCache');
+const VSP = require('../../../lib/versioning/VersioningRequestProcessor');
+
+const DELAY_MIN = 1;
+const DELAY_MAX = 5;
+const OP_COUNT = 1000;
+const THREADS = 5;
+
+function batchDelayGen() {
+    return Math.floor(Math.random() * (DELAY_MAX - DELAY_MIN) + DELAY_MIN);
+}
+
+const logger = {
+    info: () => {},
+    debug: () => {},
+    error: () => {},
+    getSerializedUids: () => 'foo',
+};
+
+let keyValueStore = {};
+
+function _cleanupKeyValueStore() {
+    keyValueStore = {};
+}
+
+const dbapi = {
+    get: (request, logger, callback) =>
+        setTimeout(() => {
+            const value = keyValueStore[request.key];
+            if (value !== undefined) {
+                callback(null, value);
+            } else {
+                callback(errors.ObjNotFound);
+            }
+        }),
+    list: (request, logger, callback) =>
+        setTimeout(() => {
+            const allKeys = Object.keys(keyValueStore).filter(k => {
+                if (request.gte !== undefined && request.gte > k) {
+                    return false;
+                }
+                if (request.gt !== undefined && request.gt >= k) {
+                    return false;
+                }
+                if (request.lte !== undefined && request.lte < k) {
+                    return false;
+                }
+                if (request.lt !== undefined && request.lt <= k) {
+                    return false;
+                }
+                return true;
+            }).sort();
+            const res = [];
+            allKeys.forEach(k => res.push({ key: k, value: keyValueStore[k] }));
+            callback(null, res);
+        }),
+    batch: (request, log, callback) =>
+        setTimeout(() => {
+            const { array } = request;
+            array.forEach(op => {
+                if (op.type && op.type === 'del') {
+                    delete keyValueStore[op.key];
+                } else {
+                    keyValueStore[op.key] = op.value;
+                }
+            });
+            callback(null);
+        }, batchDelayGen()),
+};
+const wgm = new WGM(dbapi);
+const writeCache = new WriteCache(wgm);
+const vsp = new VSP(writeCache, wgm);
+
+function batch(callback) {
+    async.times(OP_COUNT, (i, next) => {
+        const request = {
+            db: 'foo',
+            key: `bar${i}`,
+            value: '{"qux":"quz"}',
+            options: { versioning: true },
+        };
+        setTimeout(() => vsp.put(request, logger, next), i);
+    }, callback);
+}
+
+describe('test VSP', () => {
+    afterEach(() => _cleanupKeyValueStore());
+
+    it('should run a batch of operations correctly', done => {
+        async.times(THREADS,
+            (i, next) => setTimeout(() => batch(next), i), done);
+    });
+
+    it('should be able to repair a PHD master version', done => {
+        const putRequest = {
+            db: 'foo',
+            key: 'bar',
+            value: '{"qux":"quz"}',
+            options: { versioning: true },
+        };
+        const getRequest = { db: 'foo', key: 'bar' };
+        async.waterfall([
+            callback => async.times(OP_COUNT, (i, next) =>
+                vsp.put(putRequest, logger, next), (err, res) => {
+                    assert.strictEqual(err, null);
+                    const vidCount = res.sort().reverse().length;
+                    assert.strictEqual(vidCount, OP_COUNT);
+                    const latestVID = JSON.parse(res[vidCount - 1]).versionId;
+                    const nextVID = JSON.parse(res[vidCount - 2]).versionId;
+                    callback(null, latestVID, nextVID);
+                }),
+            (latestVID, nextVID, callback) => {
+                const deleteRequest = { db: 'foo', key: 'bar',
+                    options: { versionId: latestVID }, type: 'del' };
+                vsp.del(deleteRequest, logger, err => {
+                    assert.strictEqual(err, null);
+                    callback(null, nextVID);
+                });
+            },
+            (nextVID, callback) => wgm.list({}, logger, (err, list) => {
+                assert.strictEqual(err, null);
+                // listing result has the master version
+                assert(list.length, OP_COUNT);
+                assert(Version.isPHD(list[0].value),
+                        'latest version must be a PHD version');
+                // force repairing using a get request so that
+                // we do not need to wait the scheduled repair
+                callback(null, nextVID);
+            }),
+            (nextVID, callback) => vsp.get(getRequest, logger, (err, res) => {
+                assert.strictEqual(err, null);
+                assert.strictEqual(Version.from(res).getVersionId(), nextVID);
+                // repairing using a get still takes time so we
+                // just need to wait a bit
+                setTimeout(() => wgm.list({}, logger, (err, list) => {
+                    assert.strictEqual(err, null);
+                    // listing result has the master version
+                    assert(list.length, OP_COUNT);
+                    assert.strictEqual(list[0].value, res,
+                            'latest version is not repaired');
+                    callback();
+                }), 1000);
+            }),
+        ], done);
+    });
+});

--- a/tests/unit/versioning/VersioningRequestProcessor.js
+++ b/tests/unit/versioning/VersioningRequestProcessor.js
@@ -90,7 +90,7 @@ function batch(callback) {
     }, callback);
 }
 
-describe('test VSP', () => {
+describe.only('test VSP', () => {
     afterEach(() => _cleanupKeyValueStore());
 
     it('should run a batch of operations correctly', done => {
@@ -127,7 +127,7 @@ describe('test VSP', () => {
             (nextVID, callback) => wgm.list({}, logger, (err, list) => {
                 assert.strictEqual(err, null);
                 // listing result has the master version
-                assert(list.length, OP_COUNT);
+                assert.strictEqual(list.length, OP_COUNT);
                 assert(Version.isPHD(list[0].value),
                         'latest version must be a PHD version');
                 // force repairing using a get request so that
@@ -142,7 +142,7 @@ describe('test VSP', () => {
                 setTimeout(() => wgm.list({}, logger, (err, list) => {
                     assert.strictEqual(err, null);
                     // listing result has the master version
-                    assert(list.length, OP_COUNT);
+                    assert.strictEqual(list.length, OP_COUNT);
                     assert.strictEqual(list[0].value, res,
                             'latest version is not repaired');
                     callback();


### PR DESCRIPTION
What it does: provides different layers of processing requests
- VersioningRequestProcessor: to process versioning information
- WriteCache: to ensure the atomicity and isolation of requests
- WriteGatheringManager: bucketfile's operation batching layer

This versioning support is meant to be used eventually for MetaData as
well, it is a slightly modified port of the original versioning code
in MetaData.

Author: Vinh Tao <vinh.tao@scality.com>

Changes made by: Jonathan Gramain <jonathan.gramain@scality.com>