### PR TITLE
Ft/replication group token

### DIFF
--- a/lib/storage/metadata/file/server.js
+++ b/lib/storage/metadata/file/server.js
@@ -44,10 +44,12 @@ class MetadataFileServer {
     constructor(params) {
         assert.notStrictEqual(params.metadataPath, undefined);
         assert.notStrictEqual(params.metadataPort, undefined);
+        assert(params.versioning && params.versioning.replicationGroupId);
         this.metadataPath = params.metadataPath;
         this.metadataPort = params.metadataPort;
         this.streamMaxPendingAck = params.streamMaxPendingAck;
         this.streamAckTimeoutMs = params.streamAckTimeoutMs;
+        this.versioning = params.versioning;
         this.setupLogging(params.log);
     }
 
@@ -182,7 +184,7 @@ class MetadataFileServer {
 
         const wgm = new WGM(metadataAPI);
         const writeCache = new WriteCache(wgm);
-        const vrp = new VRP(writeCache, wgm);
+        const vrp = new VRP(writeCache, wgm, this.versioning);
 
         dbService.registerAsyncAPI({
             put: (env, key, value, options, cb) => {

--- a/lib/versioning/Version.js
+++ b/lib/versioning/Version.js
@@ -1,7 +1,5 @@
 'use strict'; // eslint-disable-line strict
 
-const VID = require('./VersionID');
-
 /**
  * Class for manipulating an object version.
  * The format of a version: { isNull, isDeleteMarker, versionId, otherInfo }
@@ -64,14 +62,11 @@ class Version {
      * to indicate that the master version of an object has been deleted and it
      * needs to be updated by the latest version if any.
      *
-     * @param {string} versionId - the versionId of the version, this expects
-     *                             a fixed length versionId (without info part)
-     *                             to facilitate easy checking if a version is
-     *                             a PHD version; see PHD_VER_LENGTH above
+     * @param {string} versionId - versionId of the PHD version
      * @return {string} - the serialized version
      */
-    static generatePHDVersion() {
-        return `{ "isPHD": true, "versionId": "${VID.generateVersionId('')}" }`;
+    static generatePHDVersion(versionId) {
+        return `{ "isPHD": true, "versionId": "${versionId}" }`;
     }
 
     /**

--- a/lib/versioning/VersionID.js
+++ b/lib/versioning/VersionID.js
@@ -1,20 +1,20 @@
 // VersionID format:
-//         timestamp  sequential_position  site_id  other_information
+//         timestamp  sequential_position  rep_group_id  other_information
 // where:
 // - timestamp              14 bytes        epoch in ms (good untill 5138)
 // - sequential_position    06 bytes        position in the ms slot (1B ops)
-// - site_id                05 bytes        site identifier (like PARIS)
+// - rep_group_id           07 bytes        replication group identifier
 // - other_information      arbitrary       user input, such as a unique string
 
 // the lengths of the components in bytes
 const LENGTH_TS = 14; // timestamp: epoch in ms
 const LENGTH_SEQ = 6; // position in ms slot
-const LENGTH_SITE = 5; // site identifier
+const LENGTH_RG = 7; // replication group id
 
 // empty string template for the variables in a versionId
 const TEMPLATE_TS = new Array(LENGTH_TS + 1).join('0');
 const TEMPLATE_SEQ = new Array(LENGTH_SEQ + 1).join('0');
-const TEMPLATE_SITE = new Array(LENGTH_SITE + 1).join(' ');
+const TEMPLATE_RG = new Array(LENGTH_RG + 1).join(' ');
 
 /**
  * Left-pad a string representation of a value with a given template.
@@ -40,16 +40,21 @@ function padRight(value, template) {
     return `${value}${template}`.slice(0, template.length);
 }
 
-// site identifier, like PARIS, TOKYO; will be trimmed if exceeding max length
-const SITE_ID = padRight(process.env.SITE_ID, TEMPLATE_SITE);
-
 // constants for max epoch and max sequential number in the same epoch
 const MAX_TS = Math.pow(10, LENGTH_TS) - 1; // good until 16 Nov 5138
 const MAX_SEQ = Math.pow(10, LENGTH_SEQ) - 1; // good for 1 billion ops
 
-// the earliest versionId, used for versions before versioning
-const VID_INF = (padLeft(MAX_TS, TEMPLATE_TS) +
-                 padLeft(MAX_SEQ, TEMPLATE_SEQ) + SITE_ID);
+/**
+ * Generates the earliest versionId, used for versions before versioning
+ *
+ * @param {string} replicationGroupId - replication group id
+ * @return {string} version ID for versions before versionig
+ */
+function getInfVid(replicationGroupId) {
+    const repGroupId = padRight(replicationGroupId, TEMPLATE_RG);
+    return (padLeft(MAX_TS, TEMPLATE_TS) +
+        padLeft(MAX_SEQ, TEMPLATE_SEQ) + repGroupId);
+}
 
 // internal state of the module
 let lastTimestamp = 0; // epoch of the last versionId
@@ -75,15 +80,19 @@ function wait(span) {
 /**
  * This function returns a "versionId" string indicating the current time as a
  * combination of the current time in millisecond, the position of the request
- * in that millisecond, and the identifier of the local site (which could be
+ * in that millisecond, and the replication group identifier (could be a
  * datacenter, region, or server depending on the notion of geographics). This
  * function is stateful which means it keeps some values in the memory and the
  * next call depends on the previous call.
  *
  * @param {string} info - the additional info to ensure uniqueness if desired
+ * @param {string} replicationGroupId - replication group id
  * @return {string} - the formated versionId string
  */
-function generateVersionId(info) {
+function generateVersionId(info, replicationGroupId) {
+    // replication group ID, like PARIS; will be trimmed if exceed LENGTH_RG
+    const repGroupId = padRight(replicationGroupId, TEMPLATE_RG);
+
     // Need to wait for the millisecond slot got "flushed". We wait for
     // only a single millisecond when the module is restarted, which is
     // necessary for the correctness of the system. This is therefore cheap.
@@ -108,7 +117,7 @@ function generateVersionId(info) {
     // reversed chronological order---newest versions first. This is because of
     // the limitation of leveldb for listing keys in the reverse order.
     return padLeft(MAX_TS - lastTimestamp, TEMPLATE_TS) +
-           padLeft(MAX_SEQ - lastSeq, TEMPLATE_SEQ) + SITE_ID + info;
+           padLeft(MAX_SEQ - lastSeq, TEMPLATE_SEQ) + repGroupId + info;
 }
 
 /**
@@ -143,4 +152,4 @@ function decode(str) {
     }
 }
 
-module.exports = { generateVersionId, VID_INF, encode, decode };
+module.exports = { generateVersionId, getInfVid, encode, decode };

--- a/lib/versioning/VersioningRequestProcessor.js
+++ b/lib/versioning/VersioningRequestProcessor.js
@@ -39,11 +39,14 @@ class VersioningRequestProcessor {
      * @param {writeGatheringManager} writeGatheringManager - the
      *   WriteGatheringManager to which this will forward the
      *   non-cachable processed requests
+     * @param {object} versioning - versioning configurations
+     * @param {string} versioning.replicationGroupId - replication group id
      * @constructor
      */
-    constructor(writeCache, writeGatheringManager) {
+    constructor(writeCache, writeGatheringManager, versioning) {
         this.writeCache = writeCache;
         this.wgm = writeGatheringManager;
+        this.replicationGroupId = versioning.replicationGroupId;
         // internal state
         this.uidCounter = 0;
         this.queue = {};
@@ -51,7 +54,7 @@ class VersioningRequestProcessor {
     }
 
     generateVersionId() {
-        return genVID(this.uidCounter++);
+        return genVID(this.uidCounter++, this.replicationGroupId);
     }
 
     /**
@@ -389,7 +392,8 @@ class VersioningRequestProcessor {
             // update the master version as PHD if it is the deleting version
             if (Version.isPHD(data) ||
                 Version.from(data).getVersionId() === versionId) {
-                ops.push({ key, value: Version.generatePHDVersion() });
+                const _vid = this.generateVersionId();
+                ops.push({ key, value: Version.generatePHDVersion(_vid) });
                 // start the repair process later
                 const cacheKey = formatCacheKey(db, key);
                 clearTimeout(this.repairing[cacheKey]);

--- a/tests/unit/versioning/VersionID.js
+++ b/tests/unit/versioning/VersionID.js
@@ -13,7 +13,7 @@ describe('test generating versionIds', () => {
     const count = 1000;
     const vids = Array(count).fill(null);
     for (let i = 0; i < count; i++) {
-        vids[i] = VID.generateVersionId(randkey(15));
+        vids[i] = VID.generateVersionId(randkey(15), 'PARIS');
     }
     process.env.VID_CRYPTO_PASSWORD = randkey(64);
 

--- a/tests/unit/versioning/VersioningRequestProcessor.js
+++ b/tests/unit/versioning/VersioningRequestProcessor.js
@@ -76,7 +76,7 @@ const dbapi = {
 };
 const wgm = new WGM(dbapi);
 const writeCache = new WriteCache(wgm);
-const vsp = new VSP(writeCache, wgm);
+const vsp = new VSP(writeCache, wgm, { replicationGroupId: 'PARIS' });
 
 function batch(callback) {
     async.times(OP_COUNT, (i, next) => {


### PR DESCRIPTION
Dependency of https://github.com/scality/S3/pull/708 and https://github.com/scality/MetaData/pull/1075

Provide a way to specify the replication group token (formerly 'site id') for versioning and replication without depending on environmental variables.

The replication group token identifies a group or unit of deployment sites relevant for versioning and replication; for example, it is used to generate version IDs that can be sorted by the identified groups after being replicated in another deployment. We use the term 'replication group' to avoid confusion with regions and location constraints.

The value should be set in the configuration of S3 if using in-memory or bucketfile backends, or the configuration of Metadata if using real metadata backend, so the appropriate backend can pass the token as an argument when generating version IDs.