### PR TITLE
tentative fix for the maxKeys==0 bug + unit test

### DIFF
--- a/lib/algos/list/delimiter.js
+++ b/lib/algos/list/delimiter.js
@@ -55,7 +55,8 @@ class Delimiter extends Extension {
         this.delimiter = parameters.delimiter;
         this.prefix = parameters.prefix;
         this.marker = parameters.marker;
-        this.maxKeys = parameters.maxKeys || 1000;
+        this.maxKeys = (parameters.maxKeys !== undefined ?
+                        parameters.maxKeys : 1000);
         // results
         this.CommonPrefixes = [];
         this.Contents = [];
@@ -99,8 +100,8 @@ class Delimiter extends Extension {
      */
     _reachedMaxKeys() {
         if (this.keys >= this.maxKeys) {
-            // In cases of maxKeys <= 0 -> IsTruncated = false
-            this.IsTruncated = this.maxKeys > 0;
+            // In cases of maxKeys < 0 -> IsTruncated = false
+            this.IsTruncated = this.maxKeys >= 0;
             return true;
         }
         return false;

--- a/tests/unit/algos/list/delimiter.js
+++ b/tests/unit/algos/list/delimiter.js
@@ -123,6 +123,15 @@ const tests = [
         IsTruncated: false,
         NextMarker: undefined,
     }),
+    new Test('with zero makKeys', {
+        maxKeys: 0,
+    }, {
+        Contents: [],
+        CommonPrefixes: [],
+        Delimiter: undefined,
+        IsTruncated: true,
+        NextMarker: undefined,
+    }),
     new Test('with delimiter', {
         delimiter: '/',
     }, {


### PR DESCRIPTION
Issue #250 

This fix seems to be ok for bucketfile backend, but is likely to introduce regressions for bucketclient/MetaData because `maxKeys==0` seems to have a special treatment (could be a special case to allow 10000 keys in listing for multi-part?)

Anyway, let's start here and see what we can do to fix the big picture from there.
