### PR TITLE
Ft/rpc service rest api

### DIFF
--- a/lib/network/rpc/rpc.js
+++ b/lib/network/rpc/rpc.js
@@ -543,18 +543,16 @@ function objectStreamToJSON(rstream, wstream, cb) {
  * port (you must call listen(port) on the returned object)
  */
 function RESTServer(params) {
+    assert(params);
     assert(params.logger);
     const httpServer = http.createServer((req, res) => {
         if (req.method !== 'POST') {
-            res.writeHead(405);
-            return res.end();
+            return sendHTTPError(
+                res, errors.MethodNotAllowed.customizeDescription(
+                    'only POST requests are supported for RPC calls'));
         }
-        let matchingService;
-        httpServer.serviceList.forEach(service => {
-            if (req.url === service.namespace) {
-                matchingService = service;
-            }
-        });
+        const matchingService = httpServer.serviceList.find(
+            service => req.url === service.namespace);
         if (!matchingService) {
             return sendHTTPError(
                 res, errors.InvalidArgument.customizeDescription(
@@ -587,10 +585,9 @@ function RESTServer(params) {
                         res.write('{"result":');
                         return objectStreamToJSON(data, res, err => {
                             if (err) {
-                                res.emit('error', err);
-                            } else {
-                                res.end('}\n');
+                                return res.end(JSON.stringify(err));
                             }
+                            return res.end('}\n');
                         });
                     }
                     return res.end(`{"result":${JSON.stringify(data)}}\n`);

--- a/lib/network/rpc/rpc.js
+++ b/lib/network/rpc/rpc.js
@@ -10,6 +10,8 @@ const EventEmitter = require('events').EventEmitter;
 
 const flattenError = require('./utils').flattenError;
 const reconstructError = require('./utils').reconstructError;
+const errors = require('../../errors');
+const jsutil = require('../../jsutil');
 
 const DEFAULT_CALL_TIMEOUT_MS = 30000;
 
@@ -35,7 +37,7 @@ class BaseClient extends EventEmitter {
 
     /**
      * @constructor
-
+     *
      * @param {Object} params - constructor params
      * @param {String} params.url - URL of the socket.io namespace,
      *   e.g. 'http://localhost:9990/metadata'
@@ -274,7 +276,9 @@ class BaseService {
 
         // initialize with a single hard-coded API call, the user will
         // register its own calls later
-        this.syncAPI = {
+        this.syncAPI = {};
+        this.asyncAPI = {};
+        this.registerSyncAPI({
             getManifest: () => {
                 const exposedAPI = [];
                 Object.keys(this.syncAPI).forEach(callName => {
@@ -288,8 +292,7 @@ class BaseService {
                 return { apiVersion: this.apiVersion,
                          api: exposedAPI };
             },
-        };
-        this.asyncAPI = {};
+        });
 
         this.addRequestInfoConsumer((dbService, params) => {
             const env = {};
@@ -367,13 +370,11 @@ class BaseService {
         this.requestInfoConsumers.push(f);
     }
 
-    _onCall(streamsSocket, remoteCall, args, cb) {
-        const decodedArgs = streamsSocket.decodeStreams(args);
+    _onCall(remoteCall, args, cb) {
         if (remoteCall in this.asyncAPI) {
             try {
-                this.onAsyncCall(remoteCall, decodedArgs, (err, data) => {
-                    cb(flattenError(err),
-                       streamsSocket.encodeStreams(data));
+                this.onAsyncCall(remoteCall, args, (err, data) => {
+                    cb(flattenError(err), data);
                 });
             } catch (err) {
                 return cb(flattenError(err));
@@ -382,16 +383,15 @@ class BaseService {
             let result;
 
             try {
-                result = this.onSyncCall(remoteCall, decodedArgs);
-                result = streamsSocket.encodeStreams(result);
+                result = this.onSyncCall(remoteCall, args);
                 return cb(null, result);
             } catch (err) {
                 return cb(flattenError(err));
             }
         } else {
-            return cb(flattenError(
-                new Error(`Unknown remote call ${remoteCall} ` +
-                          `in namespace ${this.namespace}`)));
+            return cb(errors.InvalidArgument.customizeDescription(
+                `Unknown remote call ${remoteCall} ` +
+                    `in namespace ${this.namespace}`));
         }
         return undefined;
     }
@@ -470,7 +470,16 @@ function RPCServer(params) {
                     log.error('error on socket.io connection',
                               { namespace: service.namespace, error: err });
                 });
-                conn.on('call', service._onCall.bind(service, streamsSocket));
+                conn.on('call', (remoteCall, args, cb) => {
+                    const decodedArgs = streamsSocket.decodeStreams(args);
+                    service._onCall(remoteCall, decodedArgs, (err, res) => {
+                        if (err) {
+                            return cb(err);
+                        }
+                        const encodedRes = streamsSocket.encodeStreams(res);
+                        return cb(err, encodedRes);
+                    });
+                });
             });
         });
     };
@@ -482,8 +491,139 @@ function RPCServer(params) {
     return server;
 }
 
+
+function sendHTTPError(res, err) {
+    res.writeHead(err.code || 500);
+    return res.end(`${JSON.stringify({ error: err.message,
+                                       message: err.description })}\n`);
+}
+
+
+/**
+ * convert an input object stream to a JSON array streamed in output
+ *
+ * @param {stream.Readable} rstream - object input stream to serialize
+ *   as a JSON array
+ * @param {stream.Writable} wstream - bytes output stream to write the
+ *   serialized array to
+ * @param {function} cb - callback when done writing data
+ * @return {undefined}
+ */
+function objectStreamToJSON(rstream, wstream, cb) {
+    wstream.write('[');
+    let begin = true;
+    const cbOnce = jsutil.once(cb);
+    rstream.on('data', item => {
+        if (begin) {
+            begin = false;
+        } else {
+            wstream.write(',');
+        }
+        wstream.write(JSON.stringify(item));
+    });
+    rstream.on('end', () => {
+        wstream.write(']');
+        cbOnce(null);
+    });
+    rstream.on('error', err => {
+        cbOnce(err);
+    });
+}
+/**
+ * @brief create a server object that serves RPC requests through POST
+ * HTTP requests. This is intended to help functional testing, the
+ * RPCServer class is meant to be used on real traffic.
+ *
+ * Services associated to namespaces (aka. URL base path) must be
+ * registered thereafter on this server.
+ *
+ * @param {Object} params - params object
+ * @param {Object} params.logger - logger object
+ * @return {Object} a HTTP server object, not yet listening on a TCP
+ * port (you must call listen(port) on the returned object)
+ */
+function RESTServer(params) {
+    assert(params.logger);
+    const httpServer = http.createServer((req, res) => {
+        if (req.method !== 'POST') {
+            res.writeHead(405);
+            return res.end();
+        }
+        let matchingService;
+        httpServer.serviceList.forEach(service => {
+            if (req.url === service.namespace) {
+                matchingService = service;
+            }
+        });
+        if (!matchingService) {
+            return sendHTTPError(
+                res, errors.InvalidArgument.customizeDescription(
+                    `unknown service in URL ${req.url}`));
+        }
+        const reqBody = [];
+        req.on('data', data => {
+            reqBody.push(data);
+        });
+        return req.on('end', () => {
+            if (reqBody.length === 0) {
+                return sendHTTPError(res, errors.MissingRequestBodyError);
+            }
+            try {
+                const jsonReq = JSON.parse(reqBody);
+                if (!jsonReq.call) {
+                    throw errors.InvalidArgument.customizeDescription(
+                        'missing "call" JSON attribute');
+                }
+                const args = jsonReq.args || {};
+                matchingService._onCall(jsonReq.call, args, (err, data) => {
+                    if (err) {
+                        return sendHTTPError(res, err);
+                    }
+                    res.writeHead(200);
+                    if (data === undefined) {
+                        return res.end();
+                    }
+                    if (data.pipe !== undefined) {
+                        res.write('{"result":');
+                        return objectStreamToJSON(data, res, err => {
+                            if (err) {
+                                res.emit('error', err);
+                            } else {
+                                res.end('}\n');
+                            }
+                        });
+                    }
+                    return res.end(`{"result":${JSON.stringify(data)}}\n`);
+                });
+                return undefined;
+            } catch (err) {
+                return sendHTTPError(res, err);
+            }
+        });
+    });
+
+    httpServer.serviceList = [];
+
+    /**
+     * register a list of service objects on this server
+     *
+     * It's not necessary to call this function if you provided a
+     * "server" parameter to the service constructor.
+     *
+     * @param {BaseService} serviceList - list of services to register
+     * @return {undefined}
+     */
+    httpServer.registerServices = function registerServices(...serviceList) {
+        this.serviceList.push.apply(this.serviceList, serviceList);
+    };
+
+    return httpServer;
+}
+
+
 module.exports = {
     BaseClient,
-    RPCServer,
     BaseService,
+    RPCServer,
+    RESTServer,
 };

--- a/lib/storage/metadata/file/MetadataFileServer.js
+++ b/lib/storage/metadata/file/MetadataFileServer.js
@@ -40,6 +40,12 @@ class MetadataFileServer {
      * @param {Number} [params.streamAckTimeoutMs] - timeout for
      *   receiving an ack after an output stream packet is sent to the
      *   client
+     * @param {Boolean} [params.restEnabled=false] - set to
+     *   <tt>true</tt> to enable a debug HTTP interface for accessing
+     *   raw metadata info (based on JSON-enabled POST
+     *   requests/responses mapping socket.io transfers)
+     * @param {Number} [params.restPort] - if <tt>restEnabled</tt> is
+     *   <tt>true</tt>, set the port to which the interface listens to
      * @param {Object} [params.log] - logging configuration
      */
     constructor(params) {
@@ -52,6 +58,8 @@ class MetadataFileServer {
         this.streamMaxPendingAck = params.streamMaxPendingAck;
         this.streamAckTimeoutMs = params.streamAckTimeoutMs;
         this.versioning = params.versioning;
+        this.restEnabled = params.restEnabled;
+        this.restPort = params.restPort;
         this.setupLogging(params.log);
     }
 
@@ -98,6 +106,11 @@ class MetadataFileServer {
         fs.accessSync(this.path, fs.F_OK | fs.R_OK | fs.W_OK);
         storageUtils.setDirSyncFlag(this.path, this.logger);
 
+        this.servers = [];
+        this.services = [];
+
+        this.initMetadataService();
+
         this.logger.info('starting metadata file backend server');
         /* We start a server that will serve the sublevel capable
            db to clients */
@@ -105,9 +118,19 @@ class MetadataFileServer {
             { logger: this.logger,
               streamMaxPendingAck: this.streamMaxPendingAck,
               streamAckTimeoutMs: this.streamAckTimeoutMs });
-
-        this.initMetadataService();
         this.server.listen(this.port, this.bindAddress);
+        this.servers.push(this.server);
+
+        if (this.restEnabled) {
+            this.logger.info(`starting REST server on port ${this.restPort}`);
+            this.restServer = new rpc.RESTServer({ logger: this.logger });
+            this.restServer.listen(this.restPort, this.bindAddress);
+            this.servers.push(this.restServer);
+        }
+
+        this.servers.forEach(server => {
+            server.registerServices.apply(server, this.services);
+        });
 
         this.genUUIDIfNotExists();
         this.printUUID();
@@ -119,11 +142,11 @@ class MetadataFileServer {
         const namespace = `${constants.metadataFileNamespace}/metadata`;
         this.logger.info(`creating RPC service at ${namespace}`);
         const dbService = new levelNet.LevelDbService({
-            server: this.server,
             rootDb: sublevel(level(`${this.path}/${ROOT_DB}`)),
             namespace,
             logger: this.logger,
         });
+        this.services.push(dbService);
 
         /* provide an API compatible with MetaData API */
         const metadataAPI = {

--- a/lib/storage/metadata/file/MetadataFileServer.js
+++ b/lib/storage/metadata/file/MetadataFileServer.js
@@ -61,6 +61,8 @@ class MetadataFileServer {
         this.restEnabled = params.restEnabled;
         this.restPort = params.restPort;
         this.setupLogging(params.log);
+        this.servers = [];
+        this.services = [];
     }
 
     setupLogging(config) {
@@ -105,9 +107,6 @@ class MetadataFileServer {
     startServer() {
         fs.accessSync(this.path, fs.F_OK | fs.R_OK | fs.W_OK);
         storageUtils.setDirSyncFlag(this.path, this.logger);
-
-        this.servers = [];
-        this.services = [];
 
         this.initMetadataService();
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": "6.9.5"
   },
-  "version": "7.0.0",
+  "version": "7.0.0-rpc",
   "description": "Common utilities for the S3 project components",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Add a REST server for metadata RPC calls
    
This is meant to be an ease for scripting/debugging, using traditional HTTP tools (curl etc.) rather than a socket.io client. The actual client implementations should still use the socket.io client.
