### PR TITLE
Ft/s3 c 301 record log api

### DIFF
--- a/lib/network/rpc/rpc.js
+++ b/lib/network/rpc/rpc.js
@@ -15,6 +15,9 @@ const jsutil = require('../../jsutil');
 
 const DEFAULT_CALL_TIMEOUT_MS = 30000;
 
+// to handle recursion without no-use-before-define warning
+// eslint-disable-next-line prefer-const
+let streamRPCJSONObj;
 
 /**
  * @brief get a client object that proxies RPC calls to a remote
@@ -323,6 +326,16 @@ class BaseService {
      */
     registerSyncAPI(apiExtension) {
         Object.assign(this.syncAPI, apiExtension);
+        Object.keys(apiExtension).forEach(callName => {
+            this[callName] = function localCall(...args) {
+                const params = { rpcArgs: args };
+                if (this.requestParams) {
+                    Object.assign(params, this.requestParams);
+                    this.requestParams = undefined;
+                }
+                return this.onSyncCall(callName, params);
+            };
+        });
     }
 
     /**
@@ -340,6 +353,22 @@ class BaseService {
      */
     registerAsyncAPI(apiExtension) {
         Object.assign(this.asyncAPI, apiExtension);
+        Object.keys(apiExtension).forEach(callName => {
+            this[callName] = function localCall(...args) {
+                const cb = args.pop();
+                const params = { rpcArgs: args };
+                if (this.requestParams) {
+                    Object.assign(params, this.requestParams);
+                    this.requestParams = undefined;
+                }
+                return this.onAsyncCall(callName, params, cb);
+            };
+        });
+    }
+
+    withRequestParams(params) {
+        this.requestParams = params;
+        return this;
     }
 
     /**
@@ -408,13 +437,13 @@ class BaseService {
     onSyncCall(remoteCall, params) {
         const env = this._createCallEnv(params);
         return this.syncAPI[remoteCall].apply(
-            null, [env].concat(params.rpcArgs));
+            this, [env].concat(params.rpcArgs));
     }
 
     onAsyncCall(remoteCall, params, cb) {
         const env = this._createCallEnv(params);
         this.asyncAPI[remoteCall].apply(
-            null, [env].concat(params.rpcArgs).concat(cb));
+            this, [env].concat(params.rpcArgs).concat(cb));
     }
 }
 
@@ -498,7 +527,6 @@ function sendHTTPError(res, err) {
                                        message: err.description })}\n`);
 }
 
-
 /**
  * convert an input object stream to a JSON array streamed in output
  *
@@ -513,22 +541,120 @@ function objectStreamToJSON(rstream, wstream, cb) {
     wstream.write('[');
     let begin = true;
     const cbOnce = jsutil.once(cb);
+    let writeInProgress = false;
+    let readEnd = false;
     rstream.on('data', item => {
         if (begin) {
             begin = false;
         } else {
             wstream.write(',');
         }
-        wstream.write(JSON.stringify(item));
+        rstream.pause();
+        writeInProgress = true;
+        streamRPCJSONObj(item, wstream, err => {
+            writeInProgress = false;
+            if (err) {
+                return cbOnce(err);
+            }
+            if (readEnd) {
+                wstream.write(']');
+                return cbOnce(null);
+            }
+            return rstream.resume();
+        });
     });
     rstream.on('end', () => {
-        wstream.write(']');
-        cbOnce(null);
+        readEnd = true;
+        if (!writeInProgress) {
+            wstream.write(']');
+            cbOnce(null);
+        }
     });
     rstream.on('error', err => {
         cbOnce(err);
     });
 }
+
+/**
+ * stream the result as returned by the RPC call to a connected client
+ *
+ * It's similar to sending the raw contents of JSON.stringify() to the
+ * client, except that any embedded object with pipe() method is
+ * considered as an object stream and will be sent as a JSON array of
+ * objects.
+ *
+ * Keep in mind that this function is only meant to be used in debug
+ * tools, it would require strenghtening to be used in production
+ * mode.
+ *
+ * @param {Object} obj - js object to stream JSON-serialized
+ * @param {stream.Writable} wstream - output stream
+ * @param {function} cb - callback when all JSON data has been output
+ *   or if there was an error
+ * @return {undefined}
+ */
+streamRPCJSONObj = function _streamRPCJSONObj(obj, wstream, cb) {
+    const cbOnce = jsutil.once(cb);
+
+    if (typeof(obj) === 'object') {
+        if (obj && obj.pipe !== undefined) {
+            // stream object streams as JSON arrays
+            return objectStreamToJSON(obj, wstream, cbOnce);
+        }
+        if (Array.isArray(obj)) {
+            let first = true;
+            wstream.write('[');
+            return async.eachSeries(obj, (child, done) => {
+                if (first) {
+                    first = false;
+                } else {
+                    wstream.write(',');
+                }
+                streamRPCJSONObj(child, wstream, done);
+            },
+            err => {
+                if (err) {
+                    return cbOnce(err);
+                }
+                wstream.write(']');
+                return cbOnce(null);
+            });
+        }
+        if (obj) {
+            let first = true;
+            wstream.write('{');
+            return async.eachSeries(Object.keys(obj), (k, done) => {
+                if (obj[k] === undefined) {
+                    return done();
+                }
+                if (first) {
+                    first = false;
+                } else {
+                    wstream.write(',');
+                }
+                wstream.write(`${JSON.stringify(k)}:`);
+                return streamRPCJSONObj(obj[k], wstream, done);
+            },
+            err => {
+                if (err) {
+                    return cbOnce(err);
+                }
+                wstream.write('}');
+                return cbOnce(null);
+            });
+        }
+    }
+    // primitive types
+    if (obj === undefined) {
+        wstream.write('null'); // if undefined elements are present in
+                               // arrays, convert them to JSON null
+                               // objects
+    } else {
+        wstream.write(JSON.stringify(obj));
+    }
+    return setImmediate(() => cbOnce(null));
+};
+
 /**
  * @brief create a server object that serves RPC requests through POST
  * HTTP requests. This is intended to help functional testing, the
@@ -581,16 +707,13 @@ function RESTServer(params) {
                     if (data === undefined) {
                         return res.end();
                     }
-                    if (data.pipe !== undefined) {
-                        res.write('{"result":');
-                        return objectStreamToJSON(data, res, err => {
-                            if (err) {
-                                return res.end(JSON.stringify(err));
-                            }
-                            return res.end('}\n');
-                        });
-                    }
-                    return res.end(`{"result":${JSON.stringify(data)}}\n`);
+                    res.write('{"result":');
+                    return streamRPCJSONObj(data, res, err => {
+                        if (err) {
+                            return res.end(JSON.stringify(err));
+                        }
+                        return res.end('}\n');
+                    });
                 });
                 return undefined;
             } catch (err) {

--- a/lib/network/rpc/sio-stream.js
+++ b/lib/network/rpc/sio-stream.js
@@ -262,11 +262,15 @@ class SIOStreamSocket {
         const log = this.logger;
         const isReadStream = (typeof(arg.pipe) === 'function'
                               && typeof (arg.read) === 'function');
-        const isWriteStream = (typeof(arg.write) === 'function');
+        let isWriteStream = (typeof(arg.write) === 'function');
 
         if (isReadStream || isWriteStream) {
             if (isReadStream && isWriteStream) {
-                throw new Error('duplex streams not supported');
+                // For now, consider that duplex streams are input
+                // streams for the purpose of supporting Transform
+                // streams in server -> client direction. If the need
+                // arises, we can implement full duplex streams later.
+                isWriteStream = false;
             }
             const streamId = uuid();
             const encodedStream = {

--- a/lib/storage/metadata/file/MetadataFileClient.js
+++ b/lib/storage/metadata/file/MetadataFileClient.js
@@ -5,18 +5,20 @@ const Logger = require('werelogs').Logger;
 const constants = require('../../../constants');
 
 const levelNet = require('../../../network/rpc/level-net');
+const { RecordLogProxy } = require('./RecordLog.js');
 
 class MetadataFileClient {
 
     /**
      * Construct a metadata client
      *
-     * @param {Object} params the following parameters are used:
-     * @param {String} params.host name or IP address of metadata
+     * @param {Object} params - constructor params
+     * @param {String} params.host - name or IP address of metadata
      *   server host
-     * @param {Number} params.port TCP port to connect to the metadata
+     * @param {Number} params.port - TCP port to connect to the metadata
      *   server
-     * @param {Object} [params.log] logging configuration
+     * @param {Object} [params.log] - logging configuration
+     * @param {Number} [params.callTimeoutMs] - timeout for remote calls
      */
     constructor(params) {
         assert.notStrictEqual(params.host, undefined);
@@ -47,14 +49,48 @@ class MetadataFileClient {
     openDB(done) {
         const url = `http://${this.host}:${this.port}` +
                   `${constants.metadataFileNamespace}/metadata`;
-        this.logger.info(`connecting to RPC server at ${url}`);
-        this.client = new levelNet.LevelDbClient({
+        this.logger.info(`connecting to metadata service at ${url}`);
+        const dbClient = new levelNet.LevelDbClient({
             url,
             logger: this.logger,
             callTimeoutMs: this.callTimeoutMs,
         });
-        this.client.connect(done);
-        return this.client;
+        dbClient.connect(done);
+        return dbClient;
+    }
+
+    /**
+     * Open a new or existing record log and access its API through
+     * RPC calls.
+     *
+     * @param {String} [params] - open params
+     * @param {String} [params.logName] - name of log to open (default
+     *   "main")
+     * @param {Function} done - callback expecting an error argument,
+     *   or null and the opened log proxy object on success
+     * @return {undefined}
+     */
+    openRecordLog(params, done) {
+        const _params = params || {};
+        const url = `http://${this.host}:${this.port}` +
+                  `${constants.metadataFileNamespace}/recordLog`;
+        this.logger.info('connecting to record log service', { url });
+        const logProxy = new RecordLogProxy({
+            url,
+            name: _params.logName,
+            logger: this.logger,
+            callTimeoutMs: this.callTimeoutMs,
+        });
+        logProxy.connect(err => {
+            if (err) {
+                this.logger.error('error connecting to record log service',
+                                  { url, error: err.stack });
+                return done(err);
+            }
+            this.logger.info('connected to record log service', { url });
+            return done();
+        });
+        return logProxy;
     }
 }
 

--- a/lib/storage/metadata/file/MetadataFileServer.js
+++ b/lib/storage/metadata/file/MetadataFileServer.js
@@ -5,6 +5,7 @@ const assert = require('assert');
 const uuid = require('uuid');
 const level = require('level');
 const sublevel = require('level-sublevel');
+const debug = require('debug')('MetadataFileServer');
 
 const Logger = require('werelogs').Logger;
 
@@ -13,6 +14,7 @@ const errors = require('../../../errors');
 const storageUtils = require('../../utils');
 const rpc = require('../../../network/rpc/rpc');
 const levelNet = require('../../../network/rpc/level-net');
+const { RecordLogService } = require('./RecordLog.js');
 
 const WGM = require('../../../versioning/WriteGatheringManager');
 const WriteCache = require('../../../versioning/WriteCache');
@@ -55,11 +57,16 @@ class MetadataFileServer {
         this.path = params.path;
         this.port = params.port;
         this.bindAddress = params.bindAddress || 'localhost';
+        this.restEnabled = params.restEnabled || false;
+        this.restPort = params.restPort;
         this.streamMaxPendingAck = params.streamMaxPendingAck;
         this.streamAckTimeoutMs = params.streamAckTimeoutMs;
         this.versioning = params.versioning;
-        this.restEnabled = params.restEnabled;
-        this.restPort = params.restPort;
+        if (params.recordLog) {
+            this.recordLog = Object.assign({}, params.recordLog);
+        } else {
+            this.recordLog = { enabled: false };
+        }
         this.setupLogging(params.log);
         this.servers = [];
         this.services = [];
@@ -115,6 +122,9 @@ class MetadataFileServer {
         storageUtils.setDirSyncFlag(this.path, this.logger);
 
         this.initMetadataService();
+        if (this.recordLog.enabled) {
+            this.initRecordLogService();
+        }
 
         this.logger.info('starting metadata file backend server');
         /* We start a server that will serve the sublevel capable
@@ -145,9 +155,10 @@ class MetadataFileServer {
         // all metadata operations executed by leveldb go through the
         // /metadata namespace
         const namespace = `${constants.metadataFileNamespace}/metadata`;
-        this.logger.info(`creating RPC service at ${namespace}`);
+        this.logger.info(`creating metadata service at ${namespace}`);
+        this.rootDb = sublevel(level(`${this.path}/${ROOT_DB}`));
         const dbService = new levelNet.LevelDbService({
-            rootDb: sublevel(level(`${this.path}/${ROOT_DB}`)),
+            rootDb: this.rootDb,
             namespace,
             logger: this.logger,
         });
@@ -187,9 +198,24 @@ class MetadataFileServer {
             },
             batch: (request, logger, callback) => {
                 const dbPath = request.db.split(SUBLEVEL_SEP);
-                const subDb = dbService.lookupSubLevel(dbPath);
-                subDb.batch(request.array, SYNC_OPTIONS,
-                            err => callback(err));
+                const ops = request.array.map(
+                    op => Object.assign({}, op, { prefix: dbPath }));
+                if (this.recordLog.enabled) {
+                    this.recordLogService
+                        .withRequestParams(
+                            { logName: this.recordLog.recordLogName })
+                        .createLogRecordOps(
+                            ops, (err, logEntries) => {
+                                debug('ops to batch:', ops);
+                                debug('log entries:', logEntries);
+                                return this.rootDb.batch(
+                                    ops.concat(logEntries), SYNC_OPTIONS,
+                                    err => callback(err));
+                            });
+                } else {
+                    this.rootDb.batch(ops, SYNC_OPTIONS,
+                                      err => callback(err));
+                }
             },
         };
 
@@ -223,6 +249,17 @@ class MetadataFileServer {
             (env, options) => env.subDb.createReadStream(options),
             getUUID: () => this.readUUID(),
         });
+    }
+
+    initRecordLogService() {
+        const namespace = `${constants.metadataFileNamespace}/recordLog`;
+        this.logger.info(`creating record log service at ${namespace}`);
+        this.recordLogService = new RecordLogService({
+            namespace,
+            rootDb: this.rootDb,
+            logger: this.logger,
+        });
+        this.services.push(this.recordLogService);
     }
 }
 

--- a/lib/storage/metadata/file/RecordLog.js
+++ b/lib/storage/metadata/file/RecordLog.js
@@ -1,0 +1,333 @@
+'use strict'; // eslint-disable-line
+
+const stream = require('stream');
+const debug = require('debug')('record-log');
+
+const errors = require('../../../errors');
+const rpc = require('../../../network/rpc/rpc');
+
+const RECORD_LOG_PREFIX = '..recordLogs';
+const DEFAULT_RECORD_LOG_NAME = 's3-recordlog';
+
+/**
+ * @class
+ * @classdesc Object used to access a new or existing record log on a
+ * metadata daemon
+ *
+ * The provided RPC API is the one exposed by the {@link RecordLogService}
+ * object.
+ */
+class RecordLogProxy extends rpc.BaseClient {
+
+    constructor(params) {
+        super(params);
+
+        this.name = params.name || DEFAULT_RECORD_LOG_NAME;
+        this.addRequestInfoProducer(
+            logProxy => ({ logName: logProxy.name }));
+    }
+}
+
+
+function formatSeq(seq) {
+    if (seq === undefined) {
+        return undefined;
+    }
+    return `0000000000000000${seq.toString()}`.slice(-16);
+}
+
+function formatLogRecord(dbOp) {
+    const timestamp = new Date().toJSON();
+    return JSON.stringify({
+        type: dbOp.type || 'put',
+        db: dbOp.prefix[0],
+        key: dbOp.key,
+        value: dbOp.value,
+        timestamp,
+    });
+}
+
+class ListRecordStream extends stream.Transform {
+    constructor(endSeq, limit) {
+        super({ objectMode: true });
+        this.endSeq = endSeq;
+        this.limit = limit;
+        this.hasStarted = false;
+    }
+
+    _transform(dbRecord, encoding, callback) {
+        debug('transforming db record:', dbRecord);
+        if (!this.hasStarted) {
+            this.hasStarted = true;
+            const startSeq = Number.parseInt(dbRecord.key, 10);
+            if (this.limit !== undefined &&
+                startSeq + this.limit <= this.endSeq) {
+                this.endSeq = startSeq + this.limit - 1;
+            }
+            this.emit('info', {
+                start: startSeq,
+                end: this.endSeq,
+            });
+        }
+        const logRecord = JSON.parse(dbRecord.value);
+        const streamObject = {
+            timestamp: logRecord.timestamp,
+            db: logRecord.db,
+            // only one entry, but keep format compatible with MetaData
+            entries: [
+                {
+                    type: logRecord.type,
+                    key: logRecord.key,
+                    value: logRecord.value,
+                },
+            ],
+        };
+        callback(null, streamObject);
+    }
+
+    _flush(callback) {
+        if (!this.hasStarted) {
+            this.emit('info', { start: null, end: null });
+        }
+        callback();
+    }
+}
+
+/**
+ * @class
+ * @classdesc Expose an RPC API to access a record log
+ *
+ * The record log is stored as part of the metadata LevelDB database,
+ * in a separate sub-level prefix, so that metadata and record log
+ * updates can be transactional with each other.
+ */
+class RecordLogService extends rpc.BaseService {
+
+    /**
+     * @constructor
+     *
+     * @param {Object} params - constructor params
+     * @param {String} params.namespace - socket.io namespace, a free
+     *   string name that must start with '/'. The client will have to
+     *   provide the same namespace in the URL
+     *   (http://host:port/namespace)
+     * @param {level-sublevel} params.rootDb - root LevelDB metadata
+     *   database object (as returned by "level-sublevel" module)
+     * @param {Object} params.logger - logger object
+     * @param {RPCServer} [params.server] - convenience parameter,
+     * calls server.registerServices() automatically
+     *
+     * The stored records, when read back by <tt>readRecords</tt>
+     * contain the original batch update fields, plus the following
+     * fields:
+     *
+     * - <tt>prefix</tt>: prefix in the database, aka. sub-level,
+     *   as an Array (for bucketfile S3, it's a one-element array
+     *   containing the bucket name)
+     * - <tt>timestamp</tt>: timestamp of the operation when logged,
+     *   for information purpose (e.g. '2017-05-03T00:00:34.808Z')
+     * - <tt>seq</tt>: sequence number, starting from 1 and
+     *   monotonically increasing for each logged update, as a Number
+     */
+    constructor(params) {
+        super(params);
+
+        this.openedRecordLogs = {};
+        this.rootLog = params.rootDb.sublevel(RECORD_LOG_PREFIX);
+        this.addRequestInfoConsumer((logService, reqParams) => {
+            const env = {};
+            if (reqParams.logName) {
+                let openLog = this.openedRecordLogs[reqParams.logName];
+                if (!openLog) {
+                    openLog = {
+                        logName: reqParams.logName,
+                        logDb: this.rootLog.sublevel(reqParams.logName),
+                        // next seq will be set to the highest seq in
+                        // the DB + 1 in API commands
+                        seq: undefined,
+                    };
+                    this.openedRecordLogs[reqParams.logName] = openLog;
+                }
+                env.openLog = openLog;
+            }
+            return env;
+        });
+
+        this.registerAsyncAPI({
+            /**
+             * Generate a series of record log operations as a batch
+             * array to append to a LevelDB batch, from the array of
+             * original batch LevelDB operations in
+             * <tt>recordList</tt>.
+             *
+             * @note This call is asynchronous because
+             * it may fetch the latest sequence number from the db
+             * when first called (the subsequent calls will use the
+             * cached value).
+             *
+             * @param {Object} env - Request environment passed by the
+             *   RPC service
+             * @param {Object} env.openLog - Info about the target
+             *   record log
+             * @param {Array} dbOps - Array of LevelDB batch
+             *   operations to log
+             * @param {Function} cb - callback when done, called with
+             *   an error argument on error, or <tt>null</tt> on success
+             *   and the array of log updates to add to the global batch
+             *   as second argument.
+             * @return {undefined}
+             *
+             * Note that this function generates the next sequence
+             * numbers for the log batch, so the batches should be
+             * committed to the DB in the same order than the calls to
+             * <tt>createLogRecordOps</tt> are made to keep sequence
+             * numbers consistent and in sync with the logged
+             * operations.
+             *
+             * In case the later batch fails during commit, this series
+             * of sequence numbers will never make it to the log, so there
+             * will be a gap in the logged sequence numbers.
+             *
+             * @example
+             * <tt>createLogRecordOps({ openLog },
+             *         [{ type: 'put', key: 'foo', value: 'bar' },
+             *          { type: 'del', key: 'baz' }],
+             *         (err, logOps) => { })</tt>
+             */
+            createLogRecordOps(env, dbOps, cb) {
+                const { openLog } = env;
+                this._findNextSeq(openLog, err => {
+                    if (err) {
+                        return cb(err);
+                    }
+                    return cb(null, dbOps.map(op => {
+                        const seqKey = formatSeq(openLog.nextSeq);
+                        openLog.nextSeq += 1;
+                        const value = formatLogRecord(op);
+                        return {
+                            type: 'put',
+                            prefix: [RECORD_LOG_PREFIX, openLog.logName],
+                            key: seqKey, value,
+                        };
+                    }));
+                });
+            },
+
+            /**
+             * Prune the oldest records in the record log
+             *
+             * Note: not implemented yet
+             *
+             * @param {Object} env - Request environment passed by the
+             *   RPC service, skipped in the client call
+             * @param {Object} env.openLog - Info about the target
+             *   record log
+             * @param {Object} params - params object
+             * @param {Function} cb - callback when done
+             * @return {undefined}
+             */
+            pruneRecords: (env, params, cb) => {
+                cb(errors.NotImplemented);
+            },
+
+            /**
+             * Read a range of records from the log
+             *
+             * @param {Object} env - Request environment passed by the
+             *   RPC service, skipped in the client call
+             * @param {Object} env.openLog - Info about the target
+             *   record log
+             * @param {Object} [params] - params object
+             * @param {Number} [params.startSeq] - read from this
+             *   sequence number
+             * @param {Number} [params.endSeq] - read up to this
+             *   sequence number
+             * @param {Number} [params.limit] - limit the number of
+             *   records returned by the stream
+             * @param {function} cb - callback function, on success
+             *   2nd parameter is an object containing the following
+             *   attributes:
+             *   - {Object} info - info about the stream
+             *   - {Number} info.start - start sequence number
+             *   - {Number} info.end - end sequence number
+             *   - {stream.Readable} log - stream of log record objects
+             * @return {undefined}
+             */
+            readRecords: (env, params, cb) => {
+                const { openLog } = env;
+                this._findNextSeq(openLog, err => {
+                    if (err) {
+                        return cb(err);
+                    }
+                    const _params = params || {};
+                    let endSeq = openLog.nextSeq - 1;
+                    if (_params.endSeq !== undefined) {
+                        if (_params.endSeq <= 0) {
+                            endSeq = 0;
+                        } else if (_params.endSeq < openLog.nextSeq) {
+                            endSeq = _params.endSeq;
+                        }
+                    }
+                    const queryParams = {
+                        gte: formatSeq(_params.startSeq),
+                        lte: formatSeq(endSeq),
+                        limit: _params.limit,
+                    };
+                    const userStream = new ListRecordStream(endSeq,
+                                                            _params.limit);
+                    const dbStream =
+                              openLog.logDb.createReadStream(queryParams);
+                    dbStream.pipe(userStream);
+                    dbStream.once('error',
+                                  err => userStream.emit('error', err));
+                    userStream.once('error', err => {
+                        userStream.removeAllListeners('info');
+                        cb(err);
+                    });
+                    userStream.once('info', info => {
+                        userStream.removeAllListeners('error');
+                        cb(null, { info, log: userStream });
+                    });
+                    return undefined;
+                });
+            },
+        });
+    }
+
+    _findNextSeq(openLog, cb) {
+        if (openLog.nextSeq !== undefined) {
+            return setImmediate(() => cb(null));
+        }
+        if (this.findNextSeqWaiters) {
+            this.findNextSeqWaiters.push(cb);
+            return undefined;
+        }
+        const callWaiters = err => {
+            const waiterList = this.findNextSeqWaiters;
+            delete this.findNextSeqWaiters;
+            waiterList.forEach(cb => cb(err));
+        };
+        this.findNextSeqWaiters = [cb];
+        let lastSeq;
+        return openLog.logDb.createKeyStream({ reverse: true, limit: 1 })
+            .on('data', key => {
+                lastSeq = Number.parseInt(key, 10);
+            })
+            .on('end', () => {
+                if (lastSeq !== undefined) {
+                    // eslint-disable-next-line no-param-reassign
+                    openLog.nextSeq = lastSeq + 1;
+                } else {
+                    // eslint-disable-next-line no-param-reassign
+                    openLog.nextSeq = 1;
+                }
+                callWaiters(null);
+            })
+            .on('error', callWaiters);
+    }
+}
+
+module.exports = {
+    RecordLogProxy,
+    RecordLogService,
+};

--- a/tests/unit/storage/metadata/file/RecordLog.js
+++ b/tests/unit/storage/metadata/file/RecordLog.js
@@ -1,0 +1,281 @@
+'use strict'; //eslint-disable-line
+
+const assert = require('assert');
+const temp = require('temp');
+const debug = require('debug')('record-log:test');
+const level = require('level');
+const sublevel = require('level-sublevel');
+
+const Logger = require('werelogs').Logger;
+
+const rpc = require('../../../../../lib/network/rpc/rpc');
+const { RecordLogService, RecordLogProxy } =
+          require('../../../../../lib/storage/metadata/file/RecordLog.js');
+
+function randomName() {
+    let text = '';
+    const possible = ('ABCDEFGHIJKLMNOPQRSTUVWXYZ' +
+                      'abcdefghijklmnopqrstuvwxyz0123456789');
+
+    for (let i = 0; i < 5; i++) {
+        text += possible.charAt(Math.floor(Math.random()
+                                           * possible.length));
+    }
+    return text;
+}
+
+function createScratchRecordLog(logger, done) {
+    const name = randomName();
+    debug(`creating scratch log ${name}`);
+    const logProxy = new RecordLogProxy({
+        url: 'http://localhost:6677/test/recordLog',
+        logger,
+        name,
+    });
+    logProxy.connect(err => {
+        assert.ifError(err);
+        done();
+    });
+    return logProxy;
+}
+
+function closeRecordLog(logProxy, done) {
+    debug(`closing scratch log ${logProxy.name}`);
+    logProxy.on('disconnect', done);
+    logProxy.disconnect();
+}
+
+describe('record log - persistent log of metadata operations', () => {
+    let server;
+    const srvLogger = new Logger('recordLog:test-server',
+                                 { level: 'info', dump: 'error' });
+    const cliLogger = new Logger('recordLog:test-client',
+                                 { level: 'info', dump: 'error' });
+    let db;
+
+    function setup(done) {
+        server = new rpc.RPCServer({ logger: srvLogger });
+        server.listen(6677);
+
+        new RecordLogService({ // eslint-disable-line no-new
+            server,
+            namespace: '/test/recordLog',
+            logger: srvLogger,
+            rootDb: db,
+        });
+        done();
+    }
+
+    before(done => {
+        temp.mkdir('record-log-testdir-', (err, dbDir) => {
+            const rootDb = level(dbDir);
+            db = sublevel(rootDb);
+            setup(done);
+        });
+    });
+
+    after(done => {
+        server.close();
+        done();
+    });
+
+    describe('simple tests', () => {
+        // reinitialized for each test
+        let logProxy;
+
+        beforeEach(done => {
+            logProxy = createScratchRecordLog(cliLogger, done);
+        });
+        afterEach(done => {
+            if (logProxy) {
+                closeRecordLog(logProxy, () => {
+                    logProxy = undefined;
+                    done();
+                });
+            } else {
+                done();
+            }
+        });
+
+        it('should list an empty record log', done => {
+            logProxy.readRecords({}, (err, res) => {
+                assert.ifError(err);
+                const info = res.info;
+                const recordStream = res.log;
+
+                assert(info);
+                assert.strictEqual(info.start, null);
+                assert.strictEqual(info.end, null);
+                assert(recordStream);
+                recordStream.on('data', () => {
+                    assert.fail('unexpected data event');
+                });
+                recordStream.on('end', done);
+            });
+        });
+        it('should be able to add records and list them thereafter', done => {
+            debug('going to append records');
+            const ops = [{ type: 'put', key: 'foo', value: 'bar',
+                           prefix: ['foobucket'] },
+                         { type: 'del', key: 'baz',
+                           prefix: ['foobucket'] },
+                         { type: 'put',
+                           key: 'Pâtisserie=中文-español-English',
+                           value: 'yummy',
+                           prefix: ['foobucket'] },
+                        ];
+            logProxy.createLogRecordOps(ops, (err, logEntries) => {
+                assert.ifError(err);
+                db.batch(ops.concat(logEntries), err => {
+                    assert.ifError(err);
+                    logProxy.readRecords({}, (err, res) => {
+                        assert.ifError(err);
+                        const info = res.info;
+                        const recordStream = res.log;
+                        assert(info);
+                        assert.strictEqual(info.start, 1);
+                        assert.strictEqual(info.end, 3);
+                        assert(recordStream);
+                        debug('readRecords: received new recordStream');
+                        let nbRecords = 0;
+                        recordStream.on('data', record => {
+                            debug('readRecords: next record:', record);
+                            if (nbRecords === 0) {
+                                assert.deepStrictEqual(record.db,
+                                                       'foobucket');
+                                assert.strictEqual(typeof record.timestamp,
+                                                   'string');
+                                assert.strictEqual(record.entries.length, 1);
+                                const entry = record.entries[0];
+                                assert.strictEqual(entry.type, 'put');
+                                assert.strictEqual(entry.key, 'foo');
+                                assert.strictEqual(entry.value, 'bar');
+                            } else if (nbRecords === 1) {
+                                assert.deepStrictEqual(record.db,
+                                                       'foobucket');
+                                assert.strictEqual(typeof record.timestamp,
+                                                   'string');
+                                assert.strictEqual(record.entries.length, 1);
+                                const entry = record.entries[0];
+                                assert.strictEqual(entry.type, 'del');
+                                assert.strictEqual(entry.key, 'baz');
+                                assert.strictEqual(entry.value, undefined);
+                            } else if (nbRecords === 2) {
+                                assert.deepStrictEqual(record.db,
+                                                       'foobucket');
+                                assert.strictEqual(typeof record.timestamp,
+                                                   'string');
+                                assert.strictEqual(record.entries.length, 1);
+                                const entry = record.entries[0];
+                                assert.strictEqual(entry.type, 'put');
+                                assert.strictEqual(
+                                    entry.key,
+                                    'Pâtisserie=中文-español-English');
+                                assert.strictEqual(entry.value, 'yummy');
+                            }
+                            nbRecords += 1;
+                        });
+                        recordStream.on('end', () => {
+                            debug('readRecords: stream end');
+                            assert.strictEqual(nbRecords, 3);
+                            done();
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    describe('readRecords', () => {
+        let logProxy;
+
+        before(done => {
+            logProxy = createScratchRecordLog(cliLogger, err => {
+                assert.ifError(err);
+                // fill the log with 1000 entries
+                debug('going to append records');
+                const recordsToAdd = [];
+                for (let i = 1; i <= 1000; ++i) {
+                    recordsToAdd.push(
+                        { type: 'put', key: `foo${i}`, value: `bar${i}`,
+                          prefix: ['foobucket'] });
+                }
+                logProxy.createLogRecordOps(recordsToAdd, (err, logRecs) => {
+                    assert.ifError(err);
+                    db.batch(recordsToAdd.concat(logRecs), err => {
+                        assert.ifError(err);
+                        done();
+                    });
+                });
+            });
+        });
+
+        function checkRecord(record, seq) {
+            assert.strictEqual(record.entries.length, 1);
+            assert.deepStrictEqual(record.db, 'foobucket');
+            assert.strictEqual(typeof record.timestamp, 'string');
+            const entry = record.entries[0];
+            assert.strictEqual(entry.type, 'put');
+            assert.strictEqual(entry.key, `foo${seq}`);
+            assert.strictEqual(entry.value, `bar${seq}`);
+        }
+        function checkReadRecords(res, params, done) {
+            assert(res);
+            const info = res.info;
+            const recordStream = res.log;
+            assert(info.start === params.startSeq);
+            assert(info.end === params.endSeq);
+            debug('readRecords: received new recordStream');
+            let seq = params.startSeq;
+            recordStream.on('data', record => {
+                debug('readRecords: next record:', record);
+                checkRecord(record, seq);
+                seq += 1;
+            });
+            recordStream.on('end', () => {
+                debug('readRecords: stream end');
+                assert.strictEqual(seq, params.endSeq + 1);
+                done();
+            });
+        }
+        it('should list all entries', done => {
+            logProxy.readRecords({}, (err, res) => {
+                assert.ifError(err);
+                checkReadRecords(res, { startSeq: 1, endSeq: 1000 }, done);
+            });
+        });
+
+        it('should list all entries from a given startSeq', done => {
+            logProxy.readRecords({ startSeq: 500 }, (err, res) => {
+                assert.ifError(err);
+                checkReadRecords(res, { startSeq: 500, endSeq: 1000 }, done);
+            });
+        });
+
+        it('should list all entries up to a given endSeq', done => {
+            logProxy.readRecords({ endSeq: 500 }, (err, res) => {
+                assert.ifError(err);
+                checkReadRecords(res, { startSeq: 1, endSeq: 500 }, done);
+            });
+        });
+
+        it('should list all entries in a seq range', done => {
+            logProxy.readRecords(
+                { startSeq: 100, endSeq: 500 }, (err, res) => {
+                    assert.ifError(err);
+                    checkReadRecords(res, { startSeq: 100, endSeq: 500 },
+                                     done);
+                });
+        });
+
+        it('should list all entries from a given startSeq up to a limit',
+        done => {
+            logProxy.readRecords(
+                { startSeq: 100, limit: 100 }, (err, res) => {
+                    assert.ifError(err);
+                    checkReadRecords(res, { startSeq: 100, endSeq: 199 },
+                                     done);
+                });
+        });
+    });
+});


### PR DESCRIPTION
This is basically implementing the record log functionality in the dmd necessary to enable async replication with backbeat.

A compatible API is being implemented also for MetaData, fetching the updates from the existing transaction log.

The current PR is based on top of https://github.com/scality/Arsenal/pull/252, for conflict management.
