### PR TITLE
bf: use arsenal errors in data store API

### DIFF
--- a/lib/auth/auth.js
+++ b/lib/auth/auth.js
@@ -65,7 +65,7 @@ function extractParams(request, log, awsService, data) {
         } else if (authHeader.startsWith('AWS4')) {
             version = 'v4';
         } else {
-            log.trace('missing authorization security header',
+            log.trace('invalid authorization security header',
                       { header: authHeader });
             return { err: errors.AccessDenied };
         }

--- a/lib/storage/data/file/DataFileStore.js
+++ b/lib/storage/data/file/DataFileStore.js
@@ -130,7 +130,8 @@ class DataFileStore {
             if (err) {
                 log.error('error opening filePath',
                           { method: 'put', key, filePath, error: err });
-                return callback(err);
+                return callback(errors.InternalError.customizeDescription(
+                    `filesystem error: open() returned ${err.code}`));
             }
             const cbOnce = jsutil.once(callback);
             // disable autoClose so that we can close(fd) only after
@@ -155,7 +156,10 @@ class DataFileStore {
                         log.error('fsync error',
                                   { method: 'put', key, filePath,
                                     error: err });
-                        return cbOnce(err);
+                        return cbOnce(
+                            errors.InternalError.customizeDescription(
+                                'filesystem error: fsync() returned ' +
+                                    `${err.code}`));
                     }
                     return ok();
                 });
@@ -165,7 +169,8 @@ class DataFileStore {
                           { method: 'put', key, filePath, error: err });
                 // destroying the write stream forces a close(fd)
                 fileStream.destroy();
-                return cbOnce(err);
+                return cbOnce(errors.InternalError.customizeDescription(
+                    `write stream error: ${err.code}`));
             });
             dataStream.resume();
             dataStream.pipe(fileStream);
@@ -174,7 +179,8 @@ class DataFileStore {
                     { method: 'put', key, filePath, error: err });
                 // destroying the write stream forces a close(fd)
                 fileStream.destroy();
-                return cbOnce(err);
+                return cbOnce(errors.InternalError.customizeDescription(
+                    `read stream error: ${err.code}`));
             });
             return undefined;
         });
@@ -199,7 +205,8 @@ class DataFileStore {
                 }
                 log.error('error on \'stat\' of file',
                           { key, filePath, error: err });
-                return callback(err);
+                return callback(errors.InternalError.customizeDescription(
+                    `filesystem error: stat() returned ${err.code}`));
             }
             const info = { objectSize: stat.size };
             return callback(null, info);
@@ -240,7 +247,9 @@ class DataFileStore {
                       log.error('error retrieving file',
                                 { method: 'get', key, filePath,
                                   error: err });
-                      return cbOnce(err);
+                      return cbOnce(
+                          errors.InternalError.customizeDescription(
+                              `filesystem read error: ${err.code}`));
                   })
                   .on('open', () => { cbOnce(null, rs); });
     }
@@ -264,7 +273,8 @@ class DataFileStore {
                 log.error('error deleting file', { method: 'delete',
                                                    key, filePath,
                                                    error: err });
-                return callback(err);
+                return callback(errors.InternalError.customizeDescription(
+                    `filesystem error: unlink() returned ${err.code}`));
             }
             return callback();
         });


### PR DESCRIPTION
While adding consistency on error management, the goal is also to be able to transmit
these errors properly to the upper layers (above wrapper.js) which expect proper
arsenal errors, so that specific error types can be checked (e.g. ObjNotFound).

+ unrelated: minor fix in trace message in auth module (not worth
doing a separate PR for this one)

Linked to backbeat routes handling on S3 connector, so that data fetching routes can handle proper "not found" error types.

sproxydclient does seem to already provide Arsenal errors, so there should be nothing to do on it.
