### PR TITLE
ft: add a new mode in versioning put request for backbeat replication

### DIFF
--- a/lib/versioning/VersioningRequestProcessor.js
+++ b/lib/versioning/VersioningRequestProcessor.js
@@ -253,21 +253,14 @@ class VersioningRequestProcessor {
         // valid combinations of versioning options:
         // - !versioning && !versionId: normal non-versioning put
         // - versioning && !versionId: create a new version
-        // - !versioning && versionId: update (PUT/DELETE) an existing version
-        //                             if versionId === '' update master version
-        // other cases are invalid and metadata does nothing
+        // - versionId: update (PUT/DELETE) an existing version, and
+        //              also update master version in case the put
+        //              version is newer or same version than master.
+        //              if versionId === '' update master version
         const versioning = options &&
             (options.versioning || options.versioning === '');
         const versionId = options &&
             (options.versionId || options.versionId === '');
-        if (versioning && versionId) {
-            return callback(errors.BadRequest.message);
-        }
-        // no versioning or versioning configuration off
-        if (!versioning && !versionId) {
-            return this.writeCache.batch(
-                    { db, array: [{ key, value }] }, logger, callback);
-        }
 
         const versioningCb = (err, array, vid) => {
             if (err) {
@@ -276,12 +269,17 @@ class VersioningRequestProcessor {
             return this.writeCache.batch({ db, array, options },
                     logger, err => callback(err, `{"versionId":"${vid}"}`));
         };
-        // creating new version PUT
+
+        if (versionId) {
+            return this.processVersionSpecificPut(request, logger,
+                                                  versioningCb);
+        }
         if (versioning) {
             return this.processNewVersionPut(request, logger, versioningCb);
         }
-        // version specific PUT
-        return this.processVersionSpecificPut(request, logger, versioningCb);
+        // no versioning or versioning configuration off
+        return this.writeCache.batch({ db, array: [{ key, value }] },
+                                     logger, callback);
     }
 
     /**
@@ -336,8 +334,11 @@ class VersioningRequestProcessor {
             const versionId = request.options.versionId;
             const versionKey = formatVersionKey(request.key, versionId);
             const ops = [{ key: versionKey, value: request.value }];
-            if (Version.from(data).getVersionId() === versionId) {
-                // the version is also the master version: need to update both
+            if (data === undefined ||
+                Version.from(data).getVersionId() >= versionId) {
+                // master does not exist or is not newer than put
+                // version and needs to be updated as well.
+                // Note that older versions have a greater version ID.
                 ops.push({ key: request.key, value: request.value });
             }
             return callback(null, ops, versionId);

--- a/tests/unit/versioning/VersioningRequestProcessor.js
+++ b/tests/unit/versioning/VersioningRequestProcessor.js
@@ -150,4 +150,73 @@ describe('test VSP', () => {
             }),
         ], done);
     });
+    it('should allow to write a specific version + update master', done => {
+        let v1;
+        let v2;
+
+        async.waterfall([next => {
+            const request = {
+                db: 'foo',
+                key: 'bar',
+                value: '{"qux":"quz"}',
+                options: { versioning: true },
+            };
+            vsp.put(request, logger, next);
+        },
+        (res, next) => {
+            v1 = Version.from(res).getVersionId();
+            const request = {
+                db: 'foo',
+                key: 'bar',
+                value: '{"qux":"quz2"}',
+                options: { versioning: true },
+            };
+            vsp.put(request, logger, next);
+        },
+        (res, next) => {
+            v2 = Version.from(res).getVersionId();
+
+            // overwriting v1: master should not be updated
+            const request = {
+                db: 'foo',
+                key: 'bar',
+                value: '{"qux":"quz1.1"}',
+                options: { versioning: true,
+                           versionId: v1 },
+            };
+            vsp.put(request, logger, next);
+        },
+        (res, next) => {
+            const request = {
+                db: 'foo',
+                key: 'bar',
+            };
+            vsp.get(request, logger, next);
+        },
+        (res, next) => {
+            assert.strictEqual(JSON.parse(res).qux, 'quz2');
+
+            // overwriting v2: master should be updated
+            const request = {
+                db: 'foo',
+                key: 'bar',
+                value: '{"qux":"quz2.1"}',
+                options: { versioning: true,
+                           versionId: v2 },
+            };
+            vsp.put(request, logger, next);
+        },
+        (res, next) => {
+            const request = {
+                db: 'foo',
+                key: 'bar',
+            };
+            vsp.get(request, logger, next);
+        },
+        (res, next) => {
+            assert.strictEqual(JSON.parse(res).qux, 'quz2.1');
+            next();
+        }],
+                     done);
+    });
 });


### PR DESCRIPTION
When both 'versioning' and 'versionId' options are provided, write a
new version with the specified versionId, and also create or update
the master version like done for new versioned puts.

This is for backbeat to write new specific versions to the destination, while updating master as well

@ttvi Is it a reasonable implementation for you, or do you think it should be made another way?
