### PR TITLE
ft: add new action type 'objectReplicate'

### DIFF
--- a/lib/policyEvaluator/RequestContext.js
+++ b/lib/policyEvaluator/RequestContext.js
@@ -50,6 +50,7 @@ const _actionMap = {
     objectPutTagging: 's3:PutObjectTagging',
     objectPutTaggingVersion: 's3:PutObjectVersionTagging',
     serviceGet: 's3:ListAllMyBuckets',
+    objectReplicate: 's3:ReplicateObject',
 };
 
 const _actionMapIAM = {


### PR DESCRIPTION
This action maps to a standard policy action 's3:ReplicateObject', that will be
granted to backbeat on the destination.