### PR TITLE
fix(net): http server remove listeners before to rebind events

### DIFF
--- a/lib/network/http/server.js
+++ b/lib/network/http/server.js
@@ -325,15 +325,17 @@ class Server {
                 this._server = http.createServer(
                     (req, res) => this._onRequest(req, res));
             }
+
+            this._server.on('error', err => this._onError(err));
+            this._server.on('secureConnection',
+                sock => this._onSecureConnection(sock));
+            this._server.on('tlsClientError', (err, sock) =>
+                    this._onClientError(err, sock));
+            this._server.on('clientError', (err, sock) =>
+                    this._onClientError(err, sock));
+            this._server.on('listening', () => this._onListening());
         }
-        this._server.on('error', err => this._onError(err));
-        this._server.on('secureConnection',
-            sock => this._onSecureConnection(sock));
-        this._server.on('tlsClientError', (err, sock) =>
-            this._onClientError(err, sock));
-        this._server.on('clientError', (err, sock) =>
-            this._onClientError(err, sock));
-        this._server.listen(this._port, () => this._onListening());
+        this._server.listen(this._port);
         return this;
     }
 


### PR DESCRIPTION
In case of error the old listeners was not removed before to restart the
server leading to some leaks and useless calls