### PR TITLE
cleanup: generalize internal routes handling

### DIFF
--- a/lib/s3routes/routes.js
+++ b/lib/s3routes/routes.js
@@ -66,8 +66,8 @@ function checkTypes(req, res, params, logger) {
         'bad routes param: api must be an object');
     assert.strictEqual(typeof params.api.callApiMethod, 'function',
         'bad routes param: api.callApiMethod must be a defined function');
-    assert.strictEqual(typeof params.healthcheckHandler, 'function',
-        'bad routes param: healthcheckHandler must be a function');
+    assert.strictEqual(typeof params.internalHandlers, 'object',
+        'bad routes param: internalHandlers must be an object');
     if (params.statsClient) {
         assert.strictEqual(typeof params.statsClient, 'object',
         'bad routes param: statsClient must be an object');
@@ -112,8 +112,8 @@ function checkTypes(req, res, params, logger) {
  * @param {object} params - additional routing parameters
  * @param {object} params.api - all api methods and method to call an api method
  *  i.e. api.callApiMethod(methodName, request, response, log, callback)
- * @param {function} params.healthcheckHandler - healthcheck function
- *  parameters: (clientIP, deep, req, res, log, statsClient)
+ * @param {function} params.internalHandlers - internal handlers API object
+ *  for queries beginning with '/_/'
  * @param {StatsClient} [params.statsClient] - client to report stats to Redis
  * @param {string[]} params.allEndpoints - all accepted REST endpoints
  * @param {string[]} params.websiteEndpoints - all accepted website endpoints
@@ -131,7 +131,7 @@ function routes(req, res, params, logger) {
 
     const {
         api,
-        healthcheckHandler,
+        internalHandlers,
         statsClient,
         allEndpoints,
         websiteEndpoints,
@@ -153,12 +153,20 @@ function routes(req, res, params, logger) {
 
     log.end().addDefaultFields(clientInfo);
 
-    if (req.url === '/_/healthcheck') {
-        return healthcheckHandler(clientInfo.clientIP, false, req, res, log,
-            statsClient);
-    } else if (req.url === '/_/healthcheck/deep') {
-        return healthcheckHandler(clientInfo.clientIP, true, req, res, log);
+    if (req.url.startsWith('/_/')) {
+        let internalServiceName = req.url.slice(3);
+        const serviceDelim = internalServiceName.indexOf('/');
+        if (serviceDelim !== -1) {
+            internalServiceName = internalServiceName.slice(0, serviceDelim);
+        }
+        if (internalHandlers[internalServiceName] === undefined) {
+            return routesUtils.responseXMLBody(
+                errors.InvalidURI, undefined, res, log);
+        }
+        return internalHandlers[internalServiceName](
+            clientInfo.clientIP, req, res, log, statsClient);
     }
+
     if (statsClient) {
         // report new request for stats
         statsClient.reportNewRequest();

--- a/lib/s3routes/routes/routePUT.js
+++ b/lib/s3routes/routes/routePUT.js
@@ -62,7 +62,7 @@ function routePUT(request, response, api, log, statsClient) {
                     routesUtils.responseNoBody(err, corsHeaders, response, 200,
                         log);
                 });
-        } else if (request.query.acl === undefined) {
+        } else {
             // PUT bucket
             return api.callApiMethod('bucketPut', request, response, log,
                 (err, corsHeaders) => {


### PR DESCRIPTION
Every url starting with '/_/' is now routed through a registered internal service handler in the routing code, instead of being specifically checked for a particular service. This will be useful to integrate backbeat routes properly in the next step.
