### PR TITLE
Rf/unsupported check

### DIFF
--- a/lib/s3routes/routes.js
+++ b/lib/s3routes/routes.js
@@ -19,17 +19,11 @@ const routeMap = {
     OPTIONS: routeOPTIONS,
 };
 
-function checkUnsupportedRoutes(reqMethod, reqQuery, unsupportedQueries, log) {
+function checkUnsupportedRoutes(reqMethod) {
     const method = routeMap[reqMethod];
     if (!method) {
         return { error: errors.MethodNotAllowed };
     }
-
-    if (routesUtils.isUnsupportedQuery(reqQuery, unsupportedQueries)) {
-        log.debug('encountered unsupported query');
-        return { error: errors.NotImplemented };
-    }
-
     return { method };
 }
 
@@ -100,8 +94,6 @@ function checkTypes(req, res, params, logger) {
         assert.strictEqual(typeof pre, 'string',
         'bad routes param: each blacklisted object prefix must be a string');
     });
-    assert.strictEqual(typeof params.unsupportedQueries, 'object',
-        'bad routes param: unsupportedQueries must be an object');
     assert.strictEqual(typeof params.dataRetrievalFn, 'function',
         'bad routes param: dataRetrievalFn must be a defined function');
 }
@@ -136,7 +128,6 @@ function routes(req, res, params, logger) {
         allEndpoints,
         websiteEndpoints,
         blacklistedPrefixes,
-        unsupportedQueries,
         dataRetrievalFn,
     } = params;
 
@@ -188,10 +179,7 @@ function routes(req, res, params, logger) {
         bodyLength: parseInt(req.headers['content-length'], 10) || 0,
     });
 
-    const reqMethod = req.method.toUpperCase();
-
-    const { error, method } = checkUnsupportedRoutes(reqMethod, req.query,
-        unsupportedQueries, log);
+    const { error, method } = checkUnsupportedRoutes(req.method, req.query);
 
     if (error) {
         log.trace('error validating route or uri params', { error });
@@ -199,7 +187,7 @@ function routes(req, res, params, logger) {
     }
 
     const bucketOrKeyError = checkBucketAndKey(req.bucketName, req.objectKey,
-        reqMethod, req.query, blacklistedPrefixes, log);
+        req.method, req.query, blacklistedPrefixes, log);
 
     if (bucketOrKeyError) {
         log.trace('error with bucket or key value',

--- a/lib/s3routes/routes/routePUT.js
+++ b/lib/s3routes/routes/routePUT.js
@@ -1,15 +1,6 @@
 const errors = require('../../errors');
 const routesUtils = require('../routesUtils');
 
-const encryptionHeaders = [
-    'x-amz-server-side-encryption',
-    'x-amz-server-side-encryption-customer-algorithm',
-    'x-amz-server-side-encryption-aws-kms-key-id',
-    'x-amz-server-side-encryption-context',
-    'x-amz-server-side-encryption-customer-key',
-    'x-amz-server-side-encryption-customer-key-md5',
-];
-
 /* eslint-disable no-param-reassign */
 function routePUT(request, response, api, log, statsClient) {
     log.debug('routing request', { method: 'routePUT' });
@@ -103,11 +94,6 @@ function routePUT(request, response, api, log, statsClient) {
                     .responseNoBody(errors.InvalidDigest, null, response, 200,
                                     log);
             }
-        }
-        // object level encryption
-        if (encryptionHeaders.some(i => request.headers[i] !== undefined)) {
-            return routesUtils.responseXMLBody(errors.NotImplemented, null,
-                response, log);
         }
         if (request.query.partNumber) {
             if (request.headers['x-amz-copy-source']) {

--- a/lib/s3routes/routesUtils.js
+++ b/lib/s3routes/routesUtils.js
@@ -675,18 +675,6 @@ const routesUtils = {
     },
 
     /**
-     * Check if request query contains unsupported query
-     * @param {object} queryObj - parsed http request query
-     * @param {object} unsupportedQueries - true/false value for whether queries
-     *  are supported
-     * @return {boolean} true/false - whether query contains unsupported query
-     */
-    isUnsupportedQuery(queryObj, unsupportedQueries) {
-        return Object.keys(queryObj)
-            .some(key => unsupportedQueries[key]);
-    },
-
-    /**
      * Validate bucket name per naming rules and restrictions
      * @param {string} bucketname - name of the bucket to be created
      * @param {string[]} prefixBlacklist - prefixes reserved for internal use


### PR DESCRIPTION
Dependency of https://github.com/scality/S3/pull/788
Since S3-related projects may diverge on support and rely on different parameters, move check for unsupported queries and headers to api.