### PR TITLE
fix: continue handling req after writeContinue

### DIFF
--- a/lib/network/http/server.js
+++ b/lib/network/http/server.js
@@ -20,7 +20,10 @@ class Server {
         this._noDelay = true;
         this._cbOnListening = () => {};
         this._cbOnRequest = (req, res) => this._noHandlerCb(req, res);
-        this._cbOnCheckContinue = (req, res) => res.writeContinue();
+        this._cbOnCheckContinue = (req, res) => {
+            res.writeContinue();
+            this._cbOnRequest(req, res);
+        };
         // AWS S3 does not respond with 417 Expectation Failed or any error
         // when Expect header is received and the value is not 100-continue
         this._cbOnCheckExpectation = (req, res) => this._cbOnRequest(req, res);


### PR DESCRIPTION
After we send the write continue response to the client, we should handle the request normally.