### PR TITLE
ft: add JSON error response support

### DIFF
--- a/lib/s3routes/routesUtils.js
+++ b/lib/s3routes/routesUtils.js
@@ -49,71 +49,135 @@ function okHeaderResponse(headers, response, httpCode, log) {
     });
 }
 
-/**
- * okXMLResponse - Response with XML body
- * @param {string} xml - XML body as string
- * @param {object} response - http response object
- * @param {object} log - Werelogs logger
- * @param {object} additionalHeaders -- additional headers to add to response
- * @return {object} response - response object with additional headers
- */
-function okXMLResponse(xml, response, log, additionalHeaders) {
-    const bytesSent = Buffer.byteLength(xml);
-    log.trace('sending success xml response');
-    log.addDefaultFields({
-        bytesSent,
-    });
-    setCommonResponseHeaders(additionalHeaders, response, log);
-    response.writeHead(200, { 'Content-type': 'application/xml' });
-    log.debug('response http code', { httpCode: 200 });
-    log.trace('xml response', { xml });
-    return response.end(xml, 'utf8', () => {
-        log.end().info('responded with XML', {
-            httpCode: response.statusCode,
-        });
-    });
-}
+const XMLResponseBackend = {
 
-function errorXMLResponse(errCode, response, log, corsHeaders) {
-    log.trace('sending error xml response', { errCode });
-    /*
-    <?xml version="1.0" encoding="UTF-8"?>
-     <Error>
-     <Code>NoSuchKey</Code>
-     <Message>The resource you requested does not exist</Message>
-     <Resource>/mybucket/myfoto.jpg</Resource>
-     <RequestId>4442587FB7D0A2F9</RequestId>
-     </Error>
+    /**
+     * okXMLResponse - Response with XML body
+     * @param {string} xml - XML body as string
+     * @param {object} response - http response object
+     * @param {object} log - Werelogs logger
+     * @param {object} additionalHeaders -- additional headers to add
+     *   to response
+     * @return {object} response - response object with additional headers
      */
-    const xml = [];
-    xml.push(
-        '<?xml version="1.0" encoding="UTF-8"?>',
-        '<Error>',
-        `<Code>${errCode.message}</Code>`,
-        `<Message>${errCode.description}</Message>`,
-        '<Resource></Resource>',
-        `<RequestId>${log.getSerializedUids()}</RequestId>`,
-        '</Error>'
-    );
-    const xmlStr = xml.join('');
-    const bytesSent = Buffer.byteLength(xmlStr);
-    log.addDefaultFields({
-        bytesSent,
-    });
-    if (corsHeaders) {
-        // eslint-disable-next-line no-param-reassign
-        corsHeaders['Content-Type'] = 'application/xml';
-        // eslint-disable-next-line no-param-reassign
-        corsHeaders['Content-Length'] = xmlStr.length;
-    }
-    setCommonResponseHeaders(corsHeaders, response, log);
-    response.writeHead(errCode.code, { 'Content-type': 'application/xml' });
-    return response.end(xmlStr, 'utf8', () => {
-        log.end().info('responded with error XML', {
-            httpCode: response.statusCode,
+    okResponse: function okXMLResponse(xml, response, log,
+                                       additionalHeaders) {
+        const bytesSent = Buffer.byteLength(xml);
+        log.trace('sending success xml response');
+        log.addDefaultFields({
+            bytesSent,
         });
-    });
-}
+        setCommonResponseHeaders(additionalHeaders, response, log);
+        response.writeHead(200, { 'Content-type': 'application/xml' });
+        log.debug('response http code', { httpCode: 200 });
+        log.trace('xml response', { xml });
+        return response.end(xml, 'utf8', () => {
+            log.end().info('responded with XML', {
+                httpCode: response.statusCode,
+            });
+        });
+    },
+
+    errorResponse: function errorXMLResponse(errCode, response, log,
+                                             corsHeaders) {
+        log.trace('sending error xml response', { errCode });
+        /*
+         <?xml version="1.0" encoding="UTF-8"?>
+         <Error>
+         <Code>NoSuchKey</Code>
+         <Message>The resource you requested does not exist</Message>
+         <Resource>/mybucket/myfoto.jpg</Resource>
+         <RequestId>4442587FB7D0A2F9</RequestId>
+         </Error>
+         */
+        const xml = [];
+        xml.push(
+            '<?xml version="1.0" encoding="UTF-8"?>',
+            '<Error>',
+            `<Code>${errCode.message}</Code>`,
+            `<Message>${errCode.description}</Message>`,
+            '<Resource></Resource>',
+            `<RequestId>${log.getSerializedUids()}</RequestId>`,
+            '</Error>'
+        );
+        const xmlStr = xml.join('');
+        const bytesSent = Buffer.byteLength(xmlStr);
+        log.addDefaultFields({
+            bytesSent,
+        });
+        setCommonResponseHeaders(corsHeaders, response, log);
+        response.writeHead(errCode.code,
+                           { 'Content-Type': 'application/xml',
+                             'Content-Length': xmlStr.length });
+        return response.end(xmlStr, 'utf8', () => {
+            log.end().info('responded with error XML', {
+                httpCode: response.statusCode,
+            });
+        });
+    },
+};
+
+const JSONResponseBackend = {
+
+    /**
+     * okJSONResponse - Response with JSON body
+     * @param {string} json - JSON body as string
+     * @param {object} response - http response object
+     * @param {object} log - Werelogs logger
+     * @param {object} additionalHeaders -- additional headers to add
+     *   to response
+     * @return {object} response - response object with additional headers
+     */
+    okResponse: function okJSONResponse(json, response, log,
+                                        additionalHeaders) {
+        const bytesSent = Buffer.byteLength(json);
+        log.trace('sending success json response');
+        log.addDefaultFields({
+            bytesSent,
+        });
+        setCommonResponseHeaders(additionalHeaders, response, log);
+        response.writeHead(200, { 'Content-type': 'application/json' });
+        log.debug('response http code', { httpCode: 200 });
+        log.trace('json response', { json });
+        return response.end(json, 'utf8', () => {
+            log.end().info('responded with JSON', {
+                httpCode: response.statusCode,
+            });
+        });
+    },
+
+    errorResponse: function errorJSONResponse(errCode, response, log,
+                                              corsHeaders) {
+        log.trace('sending error json response', { errCode });
+        /*
+         {
+             "code": "NoSuchKey",
+             "message": "The resource you requested does not exist",
+             "resource": "/mybucket/myfoto.jpg",
+             "requestId": "4442587FB7D0A2F9"
+         }
+         */
+        const jsonStr =
+                  `{"code":"${errCode.message}",` +
+                  `"message":"${errCode.description}",` +
+                  '"resource":null,' +
+                  `"requestId":"${log.getSerializedUids()}"}`;
+        const bytesSent = Buffer.byteLength(jsonStr);
+        log.addDefaultFields({
+            bytesSent,
+        });
+        setCommonResponseHeaders(corsHeaders, response, log);
+        response.writeHead(errCode.code,
+                           { 'Content-Type': 'application/json',
+                             'Content-Length': jsonStr.length });
+        return response.end(jsonStr, 'utf8', () => {
+            log.end().info('responded with error JSON', {
+                httpCode: response.statusCode,
+            });
+        });
+    },
+};
+
 
 /**
  * Modify response headers for an objectGet or objectHead request
@@ -209,6 +273,19 @@ function retrieveData(locations, dataRetrievalFn,
         });
 }
 
+function _responseBody(responseBackend, errCode, payload, response, log,
+                       additionalHeaders) {
+    if (errCode && !response.headersSent) {
+        return responseBackend.errorResponse(errCode, response, log,
+                                             additionalHeaders);
+    }
+    if (!response.headersSent) {
+        return responseBackend.okResponse(payload, response, log,
+                                          additionalHeaders);
+    }
+    return undefined;
+}
+
 const routesUtils = {
     /**
      * @param {string} errCode - S3 error Code
@@ -220,13 +297,22 @@ const routesUtils = {
      * @return {function} - error or success response utility
      */
     responseXMLBody(errCode, xml, response, log, additionalHeaders) {
-        if (errCode && !response.headersSent) {
-            return errorXMLResponse(errCode, response, log, additionalHeaders);
-        }
-        if (!response.headersSent) {
-            return okXMLResponse(xml, response, log, additionalHeaders);
-        }
-        return undefined;
+        return _responseBody(XMLResponseBackend, errCode, xml, response,
+                             log, additionalHeaders);
+    },
+
+    /**
+     * @param {string} errCode - S3 error Code
+     * @param {string} json - JSON body as string conforming to S3's spec.
+     * @param {object} response - router's response object
+     * @param {object} log - Werelogs logger
+     * @param {object} [additionalHeaders] - additionalHeaders to add
+     * to response
+     * @return {function} - error or success response utility
+     */
+    responseJSONBody(errCode, json, response, log, additionalHeaders) {
+        return _responseBody(JSONResponseBackend, errCode, json, response,
+                             log, additionalHeaders);
     },
 
     /**
@@ -240,7 +326,8 @@ const routesUtils = {
      */
     responseNoBody(errCode, resHeaders, response, httpCode = 200, log) {
         if (errCode && !response.headersSent) {
-            return errorXMLResponse(errCode, response, log, resHeaders);
+            return XMLResponseBackend.errorResponse(errCode, response, log,
+                                                    resHeaders);
         }
         if (!response.headersSent) {
             return okHeaderResponse(resHeaders, response, httpCode, log);
@@ -260,7 +347,8 @@ const routesUtils = {
     responseContentHeaders(errCode, overrideHeaders, resHeaders, response,
                            log) {
         if (errCode && !response.headersSent) {
-            return errorXMLResponse(errCode, response, log, resHeaders);
+            return XMLResponseBackend.errorResponse(errCode, response, log,
+                                                    resHeaders);
         }
         if (!response.headersSent) {
             // Undefined added as an argument since need to send range to
@@ -293,7 +381,8 @@ const routesUtils = {
     responseStreamData(errCode, overrideHeaders, resHeaders, dataLocations,
         dataRetrievalFn, response, range, log) {
         if (errCode && !response.headersSent) {
-            return errorXMLResponse(errCode, response, log, resHeaders);
+            return XMLResponseBackend.errorResponse(errCode, response, log,
+                                                    resHeaders);
         }
         if (!response.headersSent) {
             okContentHeadersResponse(overrideHeaders, resHeaders, response,


### PR DESCRIPTION
In addition to XML error response, JSON response will be used by
backbeat routes, because their success responses is in JSON
format. Having JSON as success and XML as error format confuses the
AWS client going to be used as the client for backbeat routes, as it
expects and can be configured for one or the other, not both.