### PR TITLE
test: increase timeout of stringHash test

### DIFF
--- a/tests/unit/stringHash.js
+++ b/tests/unit/stringHash.js
@@ -33,7 +33,7 @@ describe('StringHash', () => {
     });
     it(`Should distribute uniformly with a maximum of ${ERROR}% of deviation`,
         function f(done) {
-            this.timeout(10000);
+            this.timeout(20000);
             const strings = new Array(STRING_COUNT).fill('')
                                 .map(() => randomString(10));
             const arr = new Array(ARRAY_LENGTH).fill(0);


### PR DESCRIPTION
This as an attempt to reduce flakiness on this test, which I have seen
failing regularly due to the 10s timeout reached on the CI environment.