### PR TITLE
fix: send accurate content-length for error xml

### DIFF
--- a/lib/s3routes/routesUtils.js
+++ b/lib/s3routes/routesUtils.js
@@ -108,7 +108,7 @@ const XMLResponseBackend = {
         setCommonResponseHeaders(corsHeaders, response, log);
         response.writeHead(errCode.code,
                            { 'Content-Type': 'application/xml',
-                             'Content-Length': xmlStr.length });
+                             'Content-Length': bytesSent });
         return response.end(xmlStr, 'utf8', () => {
             log.end().info('responded with error XML', {
                 httpCode: response.statusCode,
@@ -169,7 +169,7 @@ const JSONResponseBackend = {
         setCommonResponseHeaders(corsHeaders, response, log);
         response.writeHead(errCode.code,
                            { 'Content-Type': 'application/json',
-                             'Content-Length': jsonStr.length });
+                             'Content-Length': bytesSent });
         return response.end(jsonStr, 'utf8', () => {
             log.end().info('responded with error JSON', {
                 httpCode: response.statusCode,


### PR DESCRIPTION
Before we were sending the length of the xml string before it was converted to utf-8 encoding; we should send the accurate byte length of the string when it has been utf-8 encoded in case a character conversion results in different lengths.

This issue is causing an existing functional test in Mystique to fail: we were sending a weird character by accident in an error response, and the inaccurate content-length post-encoding caused the xml to be trimmed, resulting in an XmlParserError from the sdk cilent.

If tests are desired, I might be able to add one to the s3 repo where I can make a functional test or use the node-mocks-http dependency for a unit test, or follow other suggestions.