### PR TITLE
chore: bump package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": "6.9.5"
   },
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Common utilities for the S3 project components",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
To force ci builds to install new node_modules for previous release.