### PR TITLE
Add Bucket and ObjecTMD models in Arsenal

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,4 +78,12 @@ module.exports = {
         },
         utils: require('./lib/storage/utils'),
     },
+
+    models: {
+        BucketInfo: require('./lib/models/BucketInfo'),
+        ObjectMD: require('./lib/models/ObjectMD'),
+        WebsiteConfiguration: require('./lib/models/WebsiteConfiguration'),
+        ReplicationConfiguration:
+          require('./lib/models/ReplicationConfiguration'),
+    },
 };

--- a/lib/models/BucketInfo.js
+++ b/lib/models/BucketInfo.js
@@ -1,0 +1,502 @@
+const assert = require('assert');
+const { WebsiteConfiguration } = require('./WebsiteConfiguration');
+const ReplicationConfiguration = require('./ReplicationConfiguration');
+
+// WHEN UPDATING THIS NUMBER, UPDATE MODELVERSION.MD CHANGELOG
+const modelVersion = 5;
+
+class BucketInfo {
+    /**
+    * Represents all bucket information.
+    * @constructor
+    * @param {string} name - bucket name
+    * @param {string} owner - bucket owner's name
+    * @param {string} ownerDisplayName - owner's display name
+    * @param {object} creationDate - creation date of bucket
+    * @param {number} mdBucketModelVersion - bucket model version
+    * @param {object} [acl] - bucket ACLs (no need to copy
+    * ACL object since referenced object will not be used outside of
+    * BucketInfo instance)
+    * @param {boolean} transient - flag indicating whether bucket is transient
+    * @param {boolean} deleted - flag indicating whether attempt to delete
+    * @param {object} serverSideEncryption - sse information for this bucket
+    * @param {number} serverSideEncryption.cryptoScheme -
+    * cryptoScheme used
+    * @param {string} serverSideEncryption.algorithm -
+    * algorithm to use
+    * @param {string} serverSideEncryption.masterKeyId -
+    * key to get master key
+    * @param {boolean} serverSideEncryption.mandatory -
+    * true for mandatory encryption
+    * bucket has been made
+    * @param {object} versioningConfiguration - versioning configuration
+    * @param {string} versioningConfiguration.Status - versioning status
+    * @param {object} versioningConfiguration.MfaDelete - versioning mfa delete
+    * @param {string} locationConstraint - locationConstraint for bucket
+    * @param {WebsiteConfiguration} [websiteConfiguration] - website
+    * configuration
+    * @param {object[]} [cors] - collection of CORS rules to apply
+    * @param {string} [cors[].id] - optional ID to identify rule
+    * @param {string[]} cors[].allowedMethods - methods allowed for CORS request
+    * @param {string[]} cors[].allowedOrigins - origins allowed for CORS request
+    * @param {string[]} [cors[].allowedHeaders] - headers allowed in an OPTIONS
+    * request via the Access-Control-Request-Headers header
+    * @param {number} [cors[].maxAgeSeconds] - seconds browsers should cache
+    * OPTIONS response
+    * @param {string[]} [cors[].exposeHeaders] - headers expose to applications
+    * @param {object} [replicationConfiguration] - replication configuration
+    */
+    constructor(name, owner, ownerDisplayName, creationDate,
+                mdBucketModelVersion, acl, transient, deleted,
+                serverSideEncryption, versioningConfiguration,
+                locationConstraint, websiteConfiguration, cors,
+                replicationConfiguration) {
+        assert.strictEqual(typeof name, 'string');
+        assert.strictEqual(typeof owner, 'string');
+        assert.strictEqual(typeof ownerDisplayName, 'string');
+        assert.strictEqual(typeof creationDate, 'string');
+        if (mdBucketModelVersion) {
+            assert.strictEqual(typeof mdBucketModelVersion, 'number');
+        }
+        if (acl) {
+            assert.strictEqual(typeof acl, 'object');
+            assert(Array.isArray(acl.FULL_CONTROL));
+            assert(Array.isArray(acl.WRITE));
+            assert(Array.isArray(acl.WRITE_ACP));
+            assert(Array.isArray(acl.READ));
+            assert(Array.isArray(acl.READ_ACP));
+        }
+        if (serverSideEncryption) {
+            assert.strictEqual(typeof serverSideEncryption, 'object');
+            const { cryptoScheme, algorithm, masterKeyId, mandatory } =
+                serverSideEncryption;
+            assert.strictEqual(typeof cryptoScheme, 'number');
+            assert.strictEqual(typeof algorithm, 'string');
+            assert.strictEqual(typeof masterKeyId, 'string');
+            assert.strictEqual(typeof mandatory, 'boolean');
+        }
+        if (versioningConfiguration) {
+            assert.strictEqual(typeof versioningConfiguration, 'object');
+            const { Status, MfaDelete } = versioningConfiguration;
+            assert(Status === undefined ||
+                Status === 'Enabled' ||
+                Status === 'Suspended');
+            assert(MfaDelete === undefined ||
+                MfaDelete === 'Enabled' ||
+                MfaDelete === 'Disabled');
+        }
+        if (locationConstraint) {
+            assert.strictEqual(typeof locationConstraint, 'string');
+        }
+        if (websiteConfiguration) {
+            assert(websiteConfiguration instanceof WebsiteConfiguration);
+            const { indexDocument, errorDocument, redirectAllRequestsTo,
+                routingRules } = websiteConfiguration;
+            assert(indexDocument === undefined ||
+                typeof indexDocument === 'string');
+            assert(errorDocument === undefined ||
+                typeof errorDocument === 'string');
+            assert(redirectAllRequestsTo === undefined ||
+                typeof redirectAllRequestsTo === 'object');
+            assert(routingRules === undefined ||
+                Array.isArray(routingRules));
+        }
+        if (cors) {
+            assert(Array.isArray(cors));
+        }
+        if (replicationConfiguration) {
+            ReplicationConfiguration.validateConfig(replicationConfiguration);
+        }
+        const aclInstance = acl || {
+            Canned: 'private',
+            FULL_CONTROL: [],
+            WRITE: [],
+            WRITE_ACP: [],
+            READ: [],
+            READ_ACP: [],
+        };
+
+        // IF UPDATING PROPERTIES, INCREMENT MODELVERSION NUMBER ABOVE
+        this._acl = aclInstance;
+        this._name = name;
+        this._owner = owner;
+        this._ownerDisplayName = ownerDisplayName;
+        this._creationDate = creationDate;
+        this._mdBucketModelVersion = mdBucketModelVersion || 0;
+        this._transient = transient || false;
+        this._deleted = deleted || false;
+        this._serverSideEncryption = serverSideEncryption || null;
+        this._versioningConfiguration = versioningConfiguration || null;
+        this._locationConstraint = locationConstraint || null;
+        this._websiteConfiguration = websiteConfiguration || null;
+        this._replicationConfiguration = replicationConfiguration || null;
+        this._cors = cors || null;
+        return this;
+    }
+    /**
+    * Serialize the object
+    * @return {string} - stringified object
+    */
+    serialize() {
+        const bucketInfos = {
+            acl: this._acl,
+            name: this._name,
+            owner: this._owner,
+            ownerDisplayName: this._ownerDisplayName,
+            creationDate: this._creationDate,
+            mdBucketModelVersion: this._mdBucketModelVersion,
+            transient: this._transient,
+            deleted: this._deleted,
+            serverSideEncryption: this._serverSideEncryption,
+            versioningConfiguration: this._versioningConfiguration,
+            locationConstraint: this._locationConstraint,
+            websiteConfiguration: undefined,
+            cors: this._cors,
+            replicationConfiguration: this._replicationConfiguration,
+        };
+        if (this._websiteConfiguration) {
+            bucketInfos.websiteConfiguration =
+                this._websiteConfiguration.getConfig();
+        }
+        return JSON.stringify(bucketInfos);
+    }
+    /**
+     * deSerialize the JSON string
+     * @param {string} stringBucket - the stringified bucket
+     * @return {object} - parsed string
+     */
+    static deSerialize(stringBucket) {
+        const obj = JSON.parse(stringBucket);
+        const websiteConfig = obj.websiteConfiguration ?
+            new WebsiteConfiguration(obj.websiteConfiguration) : null;
+        return new BucketInfo(obj.name, obj.owner, obj.ownerDisplayName,
+            obj.creationDate, obj.mdBucketModelVersion, obj.acl,
+            obj.transient, obj.deleted, obj.serverSideEncryption,
+            obj.versioningConfiguration, obj.locationConstraint, websiteConfig,
+            obj.cors, obj.replicationConfiguration);
+    }
+
+    /**
+     * Returns the current model version for the data structure
+     * @return {number} - the current model version set above in the file
+     */
+    static currentModelVersion() {
+        return modelVersion;
+    }
+
+    /**
+     * Create a BucketInfo from an object
+     *
+     * @param {object} data - object containing data
+     * @return {BucketInfo} Return an BucketInfo
+     */
+    static fromObj(data) {
+        return new BucketInfo(data._name, data._owner, data._ownerDisplayName,
+            data._creationDate, data._mdBucketModelVersion, data._acl,
+            data._transient, data._deleted, data._serverSideEncryption,
+            data._versioningConfiguration, data._locationConstraint,
+            data._websiteConfiguration, data._cors,
+            data._replicationConfiguration);
+    }
+
+    /**
+    * Get the ACLs.
+    * @return {object} acl
+    */
+    getAcl() {
+        return this._acl;
+    }
+    /**
+    * Set the canned acl's.
+    * @param {string} cannedACL - canned ACL being set
+    * @return {BucketInfo} - bucket info instance
+    */
+    setCannedAcl(cannedACL) {
+        this._acl.Canned = cannedACL;
+        return this;
+    }
+    /**
+    * Set a specific ACL.
+    * @param {string} canonicalID - id for account being given access
+    * @param {string} typeOfGrant - type of grant being granted
+    * @return {BucketInfo} - bucket info instance
+    */
+    setSpecificAcl(canonicalID, typeOfGrant) {
+        this._acl[typeOfGrant].push(canonicalID);
+        return this;
+    }
+    /**
+    * Set all ACLs.
+    * @param {object} acl - new set of ACLs
+    * @return {BucketInfo} - bucket info instance
+    */
+    setFullAcl(acl) {
+        this._acl = acl;
+        return this;
+    }
+    /**
+     * Get the server side encryption information
+     * @return {object} serverSideEncryption
+     */
+    getServerSideEncryption() {
+        return this._serverSideEncryption;
+    }
+    /**
+     * Set server side encryption information
+     * @param {object} serverSideEncryption - server side encryption information
+     * @return {BucketInfo} - bucket info instance
+     */
+    setServerSideEncryption(serverSideEncryption) {
+        this._serverSideEncryption = serverSideEncryption;
+        return this;
+    }
+    /**
+     * Get the versioning configuration information
+     * @return {object} versioningConfiguration
+     */
+    getVersioningConfiguration() {
+        return this._versioningConfiguration;
+    }
+    /**
+     * Set versioning configuration information
+     * @param {object} versioningConfiguration - versioning information
+     * @return {BucketInfo} - bucket info instance
+     */
+    setVersioningConfiguration(versioningConfiguration) {
+        this._versioningConfiguration = versioningConfiguration;
+        return this;
+    }
+    /**
+     * Check that versioning is 'Enabled' on the given bucket.
+     * @return {boolean} - `true` if versioning is 'Enabled', otherwise `false`
+     */
+    isVersioningEnabled() {
+        const versioningConfig = this.getVersioningConfiguration();
+        return versioningConfig ? versioningConfig.Status === 'Enabled' : false;
+    }
+    /**
+     * Get the website configuration information
+     * @return {object} websiteConfiguration
+     */
+    getWebsiteConfiguration() {
+        return this._websiteConfiguration;
+    }
+    /**
+     * Set website configuration information
+     * @param {object} websiteConfiguration - configuration for bucket website
+     * @return {BucketInfo} - bucket info instance
+     */
+    setWebsiteConfiguration(websiteConfiguration) {
+        this._websiteConfiguration = websiteConfiguration;
+        return this;
+    }
+    /**
+     * Set replication configuration information
+     * @param {object} replicationConfiguration - replication information
+     * @return {BucketInfo} - bucket info instance
+     */
+    setReplicationConfiguration(replicationConfiguration) {
+        this._replicationConfiguration = replicationConfiguration;
+        return this;
+    }
+    /**
+     * Get replication configuration information
+     * @return {object|null} replication configuration information or `null` if
+     * the bucket does not have a replication configuration
+     */
+    getReplicationConfiguration() {
+        return this._replicationConfiguration;
+    }
+    /**
+     * Get cors resource
+     * @return {object[]} cors
+     */
+    getCors() {
+        return this._cors;
+    }
+    /**
+     * Set cors resource
+     * @param {object[]} rules - collection of CORS rules
+     * @param {string} [rules.id] - optional id to identify rule
+     * @param {string[]} rules[].allowedMethods - methods allowed for CORS
+     * @param {string[]} rules[].allowedOrigins - origins allowed for CORS
+     * @param {string[]} [rules[].allowedHeaders] - headers allowed in an
+     * OPTIONS request via the Access-Control-Request-Headers header
+     * @param {number} [rules[].maxAgeSeconds] - seconds browsers should cache
+     * OPTIONS response
+     * @param {string[]} [rules[].exposeHeaders] - headers to expose to external
+     * applications
+     * @return {BucketInfo} - bucket info instance
+     */
+    setCors(rules) {
+        this._cors = rules;
+        return this;
+    }
+    /**
+     * get the serverside encryption algorithm
+     * @return {string} - sse algorithm used by this bucket
+     */
+    getSseAlgorithm() {
+        if (!this._serverSideEncryption) {
+            return null;
+        }
+        return this._serverSideEncryption.algorithm;
+    }
+    /**
+     * get the server side encryption master key Id
+     * @return {string} -  sse master key Id used by this bucket
+     */
+    getSseMasterKeyId() {
+        if (!this._serverSideEncryption) {
+            return null;
+        }
+        return this._serverSideEncryption.masterKeyId;
+    }
+    /**
+    * Get bucket name.
+    * @return {string} - bucket name
+    */
+    getName() {
+        return this._name;
+    }
+    /**
+    * Set bucket name.
+    * @param {string} bucketName - new bucket name
+    * @return {BucketInfo} - bucket info instance
+    */
+    setName(bucketName) {
+        this._name = bucketName;
+        return this;
+    }
+    /**
+    * Get bucket owner.
+    * @return {string} - bucket owner's canonicalID
+    */
+    getOwner() {
+        return this._owner;
+    }
+    /**
+    * Set bucket owner.
+    * @param {string} ownerCanonicalID - bucket owner canonicalID
+    * @return {BucketInfo} - bucket info instance
+    */
+    setOwner(ownerCanonicalID) {
+        this._owner = ownerCanonicalID;
+        return this;
+    }
+    /**
+    * Get bucket owner display name.
+    * @return {string} - bucket owner dispaly name
+    */
+    getOwnerDisplayName() {
+        return this._ownerDisplayName;
+    }
+    /**
+    * Set bucket owner display name.
+    * @param {string} ownerDisplayName - bucket owner display name
+    * @return {BucketInfo} - bucket info instance
+    */
+    setOwnerDisplayName(ownerDisplayName) {
+        this._ownerDisplayName = ownerDisplayName;
+        return this;
+    }
+    /**
+    * Get bucket creation date.
+    * @return {object} - bucket creation date
+    */
+    getCreationDate() {
+        return this._creationDate;
+    }
+    /**
+    * Set location constraint.
+    * @param {string} location - bucket location constraint
+    * @return {BucketInfo} - bucket info instance
+    */
+    setLocationConstraint(location) {
+        this._locationConstraint = location;
+        return this;
+    }
+
+    /**
+    * Get location constraint.
+    * @return {string} - bucket location constraint
+    */
+    getLocationConstraint() {
+        return this._locationConstraint;
+    }
+
+    /**
+     * Set Bucket model version
+     *
+     * @param {number} version - Model version
+     * @return {BucketInfo} - bucket info instance
+     */
+    setMdBucketModelVersion(version) {
+        this._mdBucketModelVersion = version;
+        return this;
+    }
+    /**
+     * Get Bucket model version
+     *
+     * @return {number} Bucket model version
+     */
+    getMdBucketModelVersion() {
+        return this._mdBucketModelVersion;
+    }
+    /**
+    * Add transient flag.
+    * @return {BucketInfo} - bucket info instance
+    */
+    addTransientFlag() {
+        this._transient = true;
+        return this;
+    }
+    /**
+    * Remove transient flag.
+    * @return {BucketInfo} - bucket info instance
+    */
+    removeTransientFlag() {
+        this._transient = false;
+        return this;
+    }
+    /**
+    * Check transient flag.
+    * @return {boolean} - depending on whether transient flag in place
+    */
+    hasTransientFlag() {
+        return !!this._transient;
+    }
+    /**
+    * Add deleted flag.
+    * @return {BucketInfo} - bucket info instance
+    */
+    addDeletedFlag() {
+        this._deleted = true;
+        return this;
+    }
+    /**
+    * Remove deleted flag.
+    * @return {BucketInfo} - bucket info instance
+    */
+    removeDeletedFlag() {
+        this._deleted = false;
+        return this;
+    }
+    /**
+    * Check deleted flag.
+    * @return {boolean} - depending on whether deleted flag in place
+    */
+    hasDeletedFlag() {
+        return !!this._deleted;
+    }
+    /**
+     * Check if the versioning mode is on.
+     * @return {boolean} - versioning mode status
+     */
+    isVersioningOn() {
+        return this._versioningConfiguration &&
+            this._versioningConfiguration.Status === 'Enabled';
+    }
+}
+
+module.exports = BucketInfo;

--- a/lib/models/ObjectMD.js
+++ b/lib/models/ObjectMD.js
@@ -1,0 +1,643 @@
+
+// Version 2 changes the format of the data location property
+const modelVersion = 2;
+
+/**
+ * Class to manage metadata object for regular s3 objects (instead of
+ * mpuPart metadata for example)
+ */
+module.exports = class ObjectMD {
+
+    /**
+     * @constructor
+     *
+     * @param {number} version - Version of the metadata model
+     */
+    constructor(version) {
+        const now = new Date().toJSON();
+        this._data = {
+            'md-model-version': version || modelVersion,
+            'owner-display-name': '',
+            'owner-id': '',
+            'cache-control': '',
+            'content-disposition': '',
+            'content-encoding': '',
+            'expires': '',
+            'content-length': 0,
+            'content-type': '',
+            'last-modified': now,
+            'content-md5': '',
+            // simple/no version. will expand once object versioning is
+            // introduced
+            'x-amz-version-id': 'null',
+            'x-amz-server-version-id': '',
+            // TODO: Handle this as a utility function for all object puts
+            // similar to normalizing request but after checkAuth so
+            // string to sign is not impacted.  This is GH Issue#89.
+            'x-amz-storage-class': 'STANDARD',
+            'x-amz-server-side-encryption': '',
+            'x-amz-server-side-encryption-aws-kms-key-id': '',
+            'x-amz-server-side-encryption-customer-algorithm': '',
+            'x-amz-website-redirect-location': '',
+            'acl': {
+                Canned: 'private',
+                FULL_CONTROL: [],
+                WRITE_ACP: [],
+                READ: [],
+                READ_ACP: [],
+            },
+            'key': '',
+            'location': [],
+            'isNull': '',
+            'nullVersionId': '',
+            'isDeleteMarker': '',
+            'versionId': undefined, // If no versionId, it should be undefined
+            'tags': {},
+            'replicationInfo': {
+                status: '',
+                content: [],
+                destination: '',
+                storageClass: '',
+            },
+        };
+    }
+
+    /**
+     * Returns metadata model version
+     *
+     * @return {number} Metadata model version
+     */
+    getModelVersion() {
+        return this._data['md-model-version'];
+    }
+
+    /**
+     * Set owner display name
+     *
+     * @param {string} displayName - Owner display name
+     * @return {ObjectMD} itself
+     */
+    setOwnerDisplayName(displayName) {
+        this._data['owner-display-name'] = displayName;
+        return this;
+    }
+
+    /**
+     * Returns owner display name
+     *
+     * @return {string} Onwer display name
+     */
+    getOwnerDisplayName() {
+        return this._data['owner-display-name'];
+    }
+
+    /**
+     * Set owner id
+     *
+     * @param {string} id - Owner id
+     * @return {ObjectMD} itself
+     */
+    setOwnerId(id) {
+        this._data['owner-id'] = id;
+        return this;
+    }
+
+    /**
+     * Returns owner id
+     *
+     * @return {string} owner id
+     */
+    getOwnerId() {
+        return this._data['owner-id'];
+    }
+
+    /**
+     * Set cache control
+     *
+     * @param {string} cacheControl - Cache control
+     * @return {ObjectMD} itself
+     */
+    setCacheControl(cacheControl) {
+        this._data['cache-control'] = cacheControl;
+        return this;
+    }
+
+    /**
+     * Returns cache control
+     *
+     * @return {string} Cache control
+     */
+    getCacheControl() {
+        return this._data['cache-control'];
+    }
+
+    /**
+     * Set content disposition
+     *
+     * @param {string} contentDisposition - Content disposition
+     * @return {ObjectMD} itself
+     */
+    setContentDisposition(contentDisposition) {
+        this._data['content-disposition'] = contentDisposition;
+        return this;
+    }
+
+    /**
+     * Returns content disposition
+     *
+     * @return {string} Content disposition
+     */
+    getContentDisposition() {
+        return this._data['content-disposition'];
+    }
+
+    /**
+     * Set content encoding
+     *
+     * @param {string} contentEncoding - Content encoding
+     * @return {ObjectMD} itself
+     */
+    setContentEncoding(contentEncoding) {
+        this._data['content-encoding'] = contentEncoding;
+        return this;
+    }
+
+    /**
+     * Returns content encoding
+     *
+     * @return {string} Content encoding
+     */
+    getContentEncoding() {
+        return this._data['content-encoding'];
+    }
+
+    /**
+     * Set expiration date
+     *
+     * @param {string} expires - Expiration date
+     * @return {ObjectMD} itself
+     */
+    setExpires(expires) {
+        this._data.expires = expires;
+        return this;
+    }
+
+    /**
+     * Returns expiration date
+     *
+     * @return {string} Expiration date
+     */
+    getExpires() {
+        return this._data.expires;
+    }
+
+    /**
+     * Set content length
+     *
+     * @param {number} contentLength - Content length
+     * @return {ObjectMD} itself
+     */
+    setContentLength(contentLength) {
+        this._data['content-length'] = contentLength;
+        return this;
+    }
+
+    /**
+     * Returns content length
+     *
+     * @return {number} Content length
+     */
+    getContentLength() {
+        return this._data['content-length'];
+    }
+
+    /**
+     * Set content type
+     *
+     * @param {string} contentType - Content type
+     * @return {ObjectMD} itself
+     */
+    setContentType(contentType) {
+        this._data['content-type'] = contentType;
+        return this;
+    }
+
+    /**
+     * Returns content type
+     *
+     * @return {string} Content type
+     */
+    getContentType() {
+        return this._data['content-type'];
+    }
+
+    /**
+     * Set last modified date
+     *
+     * @param {string} lastModified - Last modified date
+     * @return {ObjectMD} itself
+     */
+    setLastModified(lastModified) {
+        this._data['last-modified'] = lastModified;
+        return this;
+    }
+
+    /**
+     * Returns last modified date
+     *
+     * @return {string} Last modified date
+     */
+    getLastModified() {
+        return this._data['last-modified'];
+    }
+
+    /**
+     * Set content md5 hash
+     *
+     * @param {string} contentMd5 - Content md5 hash
+     * @return {ObjectMD} itself
+     */
+    setContentMd5(contentMd5) {
+        this._data['content-md5'] = contentMd5;
+        return this;
+    }
+
+    /**
+     * Returns content md5 hash
+     *
+     * @return {string} content md5 hash
+     */
+    getContentMd5() {
+        return this._data['content-md5'];
+    }
+
+    /**
+     * Set version id
+     *
+     * @param {string} versionId - Version id
+     * @return {ObjectMD} itself
+     */
+    setAmzVersionId(versionId) {
+        this._data['x-amz-version-id'] = versionId;
+        return this;
+    }
+
+    /**
+     * Returns version id
+     *
+     * @return {string} Version id
+     */
+    getAmzVersionId() {
+        return this._data['x-amz-version-id'];
+    }
+
+    /**
+     * Set server version id
+     *
+     * @param {string} versionId - server version id
+     * @return {ObjectMD} itself
+     */
+    setAmzServerVersionId(versionId) {
+        this._data['x-amz-server-version-id'] = versionId;
+        return this;
+    }
+
+    /**
+     * Returns server version id
+     *
+     * @return {string} server version id
+     */
+    getAmzServerVersionId() {
+        return this._data['x-amz-server-version-id'];
+    }
+
+    /**
+     * Set storage class
+     *
+     * @param {string} storageClass - Storage class
+     * @return {ObjectMD} itself
+     */
+    setAmzStorageClass(storageClass) {
+        this._data['x-amz-storage-class'] = storageClass;
+        return this;
+    }
+
+    /**
+     * Returns storage class
+     *
+     * @return {string} Storage class
+     */
+    getAmzStorageClass() {
+        return this._data['x-amz-storage-class'];
+    }
+
+    /**
+     * Set server side encryption
+     *
+     * @param {string} serverSideEncryption - Server side encryption
+     * @return {ObjectMD} itself
+     */
+    setAmzServerSideEncryption(serverSideEncryption) {
+        this._data['x-amz-server-side-encryption'] = serverSideEncryption;
+        return this;
+    }
+
+    /**
+     * Returns server side encryption
+     *
+     * @return {string} server side encryption
+     */
+    getAmzServerSideEncryption() {
+        return this._data['x-amz-server-side-encryption'];
+    }
+
+    /**
+     * Set encryption key id
+     *
+     * @param {string} keyId - Encryption key id
+     * @return {ObjectMD} itself
+     */
+    setAmzEncryptionKeyId(keyId) {
+        this._data['x-amz-server-side-encryption-aws-kms-key-id'] = keyId;
+        return this;
+    }
+
+    /**
+     * Returns encryption key id
+     *
+     * @return {string} Encryption key id
+     */
+    getAmzEncryptionKeyId() {
+        return this._data['x-amz-server-side-encryption-aws-kms-key-id'];
+    }
+
+    /**
+     * Set encryption customer algorithm
+     *
+     * @param {string} algo - Encryption customer algorithm
+     * @return {ObjectMD} itself
+     */
+    setAmzEncryptionCustomerAlgorithm(algo) {
+        this._data['x-amz-server-side-encryption-customer-algorithm'] = algo;
+        return this;
+    }
+
+    /**
+     * Returns Encryption customer algorithm
+     *
+     * @return {string} Encryption customer algorithm
+     */
+    getAmzEncryptionCustomerAlgorithm() {
+        return this._data['x-amz-server-side-encryption-customer-algorithm'];
+    }
+
+    /**
+     * Set metadata redirectLocation value
+     *
+     * @param {string} redirectLocation - The website redirect location
+     * @return {ObjectMD} itself
+     */
+    setRedirectLocation(redirectLocation) {
+        this._data['x-amz-website-redirect-location'] = redirectLocation;
+        return this;
+    }
+
+    /**
+     * Get metadata redirectLocation value
+     *
+     * @return {string} Website redirect location
+     */
+    getRedirectLocation() {
+        return this._data['x-amz-website-redirect-location'];
+    }
+
+    /**
+     * Set access control list
+     *
+     * @param {object} acl - Access control list
+     * @param {string} acl.Canned -
+     * @param {string[]} acl.FULL_CONTROL -
+     * @param {string[]} acl.WRITE_ACP -
+     * @param {string[]} acl.READ -
+     * @param {string[]} acl.READ_ACP -
+     * @return {ObjectMD} itself
+     */
+    setAcl(acl) {
+        this._data.acl = acl;
+        return this;
+    }
+
+    /**
+     * Returns access control list
+     *
+     * @return {object} Access control list
+     */
+    getAcl() {
+        return this._data.acl;
+    }
+
+    /**
+     * Set object key
+     *
+     * @param {string} key - Object key
+     * @return {ObjectMD} itself
+     */
+    setKey(key) {
+        this._data.key = key;
+        return this;
+    }
+
+    /**
+     * Returns object key
+     *
+     * @return {string} object key
+     */
+    getKey() {
+        return this._data.key;
+    }
+
+    /**
+     * Set location
+     *
+     * @param {string[]} location - location
+     * @return {ObjectMD} itself
+     */
+    setLocation(location) {
+        this._data.location = location;
+        return this;
+    }
+
+    /**
+     * Returns location
+     *
+     * @return {string[]} location
+     */
+    getLocation() {
+        return this._data.location;
+    }
+
+    /**
+     * Set metadata isNull value
+     *
+     * @param {boolean} isNull - Whether new version is null or not
+     * @return {ObjectMD} itself
+     */
+    setIsNull(isNull) {
+        this._data.isNull = isNull;
+        return this;
+    }
+
+    /**
+     * Get metadata isNull value
+     *
+     * @return {boolean} Whether new version is null or not
+     */
+    getIsNull() {
+        return this._data.isNull;
+    }
+
+    /**
+     * Set metadata nullVersionId value
+     *
+     * @param {string} nullVersionId - The version id of the null version
+     * @return {ObjectMD} itself
+     */
+    setNullVersionId(nullVersionId) {
+        this._data.nullVersionId = nullVersionId;
+        return this;
+    }
+
+    /**
+     * Get metadata nullVersionId value
+     *
+     * @return {string} The version id of the null version
+     */
+    getNullVersionId() {
+        return this._data.nullVersionId;
+    }
+
+    /**
+     * Set metadata isDeleteMarker value
+     *
+     * @param {boolean} isDeleteMarker - Whether object is a delete marker
+     * @return {ObjectMD} itself
+     */
+    setIsDeleteMarker(isDeleteMarker) {
+        this._data.isDeleteMarker = isDeleteMarker;
+        return this;
+    }
+
+    /**
+     * Get metadata isDeleteMarker value
+     *
+     * @return {boolean} Whether object is a delete marker
+     */
+    getIsDeleteMarker() {
+        return this._data.isDeleteMarker;
+    }
+
+    /**
+     * Set metadata versionId value
+     *
+     * @param {string} versionId - The object versionId
+     * @return {ObjectMD} itself
+     */
+    setVersionId(versionId) {
+        this._data.versionId = versionId;
+        return this;
+    }
+
+    /**
+     * Get metadata versionId value
+     *
+     * @return {string} The object versionId
+     */
+    getVersionId() {
+        return this._data.versionId;
+    }
+
+    /**
+     * Set tags
+     *
+     * @param {object} tags - tags object
+     * @return {ObjectMD} itself
+     */
+    setTags(tags) {
+        this._data.tags = tags;
+        return this;
+    }
+
+    /**
+     * Returns tags
+     *
+     * @return {object} tags object
+     */
+    getTags() {
+        return this._data.tags;
+    }
+
+    /**
+     * Set replication information
+     *
+     * @param {object} replicationInfo - replication information object
+     * @return {ObjectMD} itself
+     */
+    setReplicationInfo(replicationInfo) {
+        const { status, content, destination, storageClass } = replicationInfo;
+        this._data.replicationInfo = {
+            status,
+            content,
+            destination,
+            storageClass: storageClass || '',
+        };
+        return this;
+    }
+
+    /**
+     * Get replication information
+     *
+     * @return {object} replication object
+     */
+    getReplicationInfo() {
+        return this._data.replicationInfo;
+    }
+
+    /**
+     * Set custom meta headers
+     *
+     * @param {object} metaHeaders - Meta headers
+     * @return {ObjectMD} itself
+     */
+    setUserMetadata(metaHeaders) {
+        Object.keys(metaHeaders).forEach(key => {
+            if (key.startsWith('x-amz-meta-')) {
+                this._data[key] = metaHeaders[key];
+            }
+        });
+        // If a multipart object and the acl is already parsed, we update it
+        if (metaHeaders.acl) {
+            this.setAcl(metaHeaders.acl);
+        }
+        return this;
+    }
+
+    /**
+     * overrideMetadataValues (used for complete MPU and object copy)
+     *
+     * @param {object} headers - Headers
+     * @return {ObjectMD} itself
+     */
+    overrideMetadataValues(headers) {
+        Object.assign(this._data, headers);
+        return this;
+    }
+
+    /**
+     * Returns metadata object
+     *
+     * @return {object} metadata object
+     */
+    getValue() {
+        return this._data;
+    }
+};

--- a/lib/models/ReplicationConfiguration.js
+++ b/lib/models/ReplicationConfiguration.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const UUID = require('node-uuid');
+const UUID = require('uuid');
 
 const escapeForXml = require('../s3middleware/escapeForXml');
 const errors = require('../errors');

--- a/lib/models/ReplicationConfiguration.js
+++ b/lib/models/ReplicationConfiguration.js
@@ -1,0 +1,404 @@
+const assert = require('assert');
+const UUID = require('node-uuid');
+
+const escapeForXml = require('../s3middleware/escapeForXml');
+const errors = require('../errors');
+const { isValidBucketName } = require('../s3routes/routesUtils');
+
+const MAX_RULES = 1000;
+const RULE_ID_LIMIT = 255;
+const validStorageClasses = [
+    undefined,
+    'STANDARD',
+    'STANDARD_IA',
+    'REDUCED_REDUNDANCY',
+];
+
+/**
+    Example XML request:
+
+    <ReplicationConfiguration>
+        <Role>IAM-role-ARN</Role>
+        <Rule>
+            <ID>Rule-1</ID>
+            <Status>rule-status</Status>
+            <Prefix>key-prefix</Prefix>
+            <Destination>
+                <Bucket>arn:aws:s3:::bucket-name</Bucket>
+                <StorageClass>
+                    optional-destination-storage-class-override
+                </StorageClass>
+            </Destination>
+        </Rule>
+        <Rule>
+            <ID>Rule-2</ID>
+            ...
+        </Rule>
+        ...
+    </ReplicationConfiguration>
+*/
+
+class ReplicationConfiguration {
+    /**
+     * Create a ReplicationConfiguration instance
+     * @param {string} xml - The parsed XML
+     * @param {object} log - Werelogs logger
+     * @return {object} - ReplicationConfiguration instance
+     */
+    constructor(xml, log) {
+        this._parsedXML = xml;
+        this._log = log;
+        this._configPrefixes = [];
+        this._configIDs = [];
+        // The bucket metadata model of replication config. Note there is a
+        // single `destination` property because we can replicate to only one
+        // other bucket. Thus each rule is simplified to these properties.
+        this._role = null;
+        this._destination = null;
+        this._rules = null;
+    }
+
+    /**
+     * Get the role of the bucket replication configuration
+     * @return {string|null} - The role if defined, otherwise `null`
+     */
+    getRole() {
+        return this._role;
+    }
+
+    /**
+     * The bucket to replicate data to
+     * @return {string|null} - The bucket if defined, otherwise `null`
+     */
+    getDestination() {
+        return this._destination;
+    }
+
+    /**
+     * The rules for replication configuration
+     * @return {string|null} - The rules if defined, otherwise `null`
+     */
+    getRules() {
+        return this._rules;
+    }
+
+    /**
+     * Get the replication configuration
+     * @return {object} - The replication configuration
+     */
+    getReplicationConfiguration() {
+        return {
+            role: this.getRole(),
+            destination: this.getDestination(),
+            rules: this.getRules(),
+        };
+    }
+
+    /**
+     * Build the rule object from the parsed XML of the given rule
+     * @param {object} rule - The rule object from this._parsedXML
+     * @return {object} - The rule object to push into the `Rules` array
+     */
+    _buildRuleObject(rule) {
+        const obj = {
+            prefix: rule.Prefix[0],
+            enabled: rule.Status[0] === 'Enabled',
+        };
+        // ID is an optional property, but create one if not provided or is ''.
+        // We generate a 48-character alphanumeric, unique ID for the rule.
+        obj.id = rule.ID && rule.ID[0] !== '' ? rule.ID[0] :
+            Buffer.from(UUID.v4()).toString('base64');
+        // StorageClass is an optional property.
+        if (rule.Destination[0].StorageClass) {
+            obj.storageClass = rule.Destination[0].StorageClass[0];
+        }
+        return obj;
+    }
+
+    /**
+     * Check if the Role field of the replication configuration is valid
+     * @param {string} ARN - The Role field value provided in the configuration
+     * @return {boolean} `true` if a valid role ARN, `false` otherwise
+     */
+    _isValidRoleARN(ARN) {
+        // AWS accepts a range of values for the Role field. Though this does
+        // not encompass all constraints imposed by AWS, we have opted to
+        // enforce the following.
+        const arr = ARN.split(':');
+        const isValidRoleARN =
+            arr[0] === 'arn' &&
+            arr[1] === 'aws' &&
+            arr[2] === 'iam' &&
+            arr[3] === '' &&
+            (arr[4] === '*' || arr[4].length > 1) &&
+            arr[5].startsWith('role');
+        return isValidRoleARN;
+    }
+
+    /**
+     * Check that the `Role` property of the configuration is valid
+     * @return {undefined}
+     */
+    _parseRole() {
+        const parsedRole = this._parsedXML.ReplicationConfiguration.Role;
+        if (!parsedRole) {
+            return errors.MalformedXML;
+        }
+        const role = parsedRole[0];
+        if (!this._isValidRoleARN(role)) {
+            return errors.InvalidArgument.customizeDescription(
+                'Invalid Role specified in replication configuration');
+        }
+        this._role = role;
+        return undefined;
+    }
+
+    /**
+     * Check that the `Rules` property array is valid
+     * @return {undefined}
+     */
+    _parseRules() {
+        // Note that the XML uses 'Rule' while the config object uses 'Rules'.
+        const { Rule } = this._parsedXML.ReplicationConfiguration;
+        if (!Rule || Rule.length < 1) {
+            return errors.MalformedXML;
+        }
+        if (Rule.length > MAX_RULES) {
+            return errors.InvalidRequest.customizeDescription(
+                'Number of defined replication rules cannot exceed 1000');
+        }
+        const err = this._parseEachRule(Rule);
+        if (err) {
+            return err;
+        }
+        return undefined;
+    }
+
+    /**
+     * Check that each rule in the `Rules` property array is valid
+     * @param {array} rules - The rule array from this._parsedXML
+     * @return {undefined}
+     */
+    _parseEachRule(rules) {
+        const rulesArr = [];
+        for (let i = 0; i < rules.length; i++) {
+            const err =
+                this._parseStatus(rules[i]) || this._parsePrefix(rules[i]) ||
+                this._parseID(rules[i]) || this._parseDestination(rules[i]);
+            if (err) {
+                return err;
+            }
+            rulesArr.push(this._buildRuleObject(rules[i]));
+        }
+        this._rules = rulesArr;
+        return undefined;
+    }
+
+    /**
+     * Check that the `Status` property is valid
+     * @param {object} rule - The rule object from this._parsedXML
+     * @return {undefined}
+     */
+    _parseStatus(rule) {
+        const status = rule.Status && rule.Status[0];
+        if (!status || !['Enabled', 'Disabled'].includes(status)) {
+            return errors.MalformedXML;
+        }
+        return undefined;
+    }
+
+    /**
+     * Check that the `Prefix` property is valid
+     * @param {object} rule - The rule object from this._parsedXML
+     * @return {undefined}
+     */
+    _parsePrefix(rule) {
+        const prefix = rule.Prefix && rule.Prefix[0];
+        // An empty string prefix should be allowed.
+        if (!prefix && prefix !== '') {
+            return errors.MalformedXML;
+        }
+        if (prefix.length > 1024) {
+            return errors.InvalidArgument.customizeDescription('Rule prefix ' +
+                'cannot be longer than maximum allowed key length of 1024');
+        }
+        // Each Prefix in a list of rules must not overlap. For example, two
+        // prefixes 'TaxDocs' and 'TaxDocs/2015' are overlapping. An empty
+        // string prefix is expected to overlap with any other prefix.
+        for (let i = 0; i < this._configPrefixes.length; i++) {
+            const used = this._configPrefixes[i];
+            if (prefix.startsWith(used) || used.startsWith(prefix)) {
+                return errors.InvalidRequest.customizeDescription('Found ' +
+                    `overlapping prefixes '${used}' and '${prefix}'`);
+            }
+        }
+        this._configPrefixes.push(prefix);
+        return undefined;
+    }
+
+    /**
+     * Check that the `ID` property is valid
+     * @param {object} rule - The rule object from this._parsedXML
+     * @return {undefined}
+     */
+    _parseID(rule) {
+        const id = rule.ID && rule.ID[0];
+        if (id && id.length > RULE_ID_LIMIT) {
+            return errors.InvalidArgument
+                .customizeDescription('Rule Id cannot be greater than 255');
+        }
+        // Each ID in a list of rules must be unique.
+        if (this._configIDs.includes(id)) {
+            return errors.InvalidRequest.customizeDescription(
+                'Rule Id must be unique');
+        }
+        this._configIDs.push(id);
+        return undefined;
+    }
+
+    /**
+     * Check that the `StorageClass` is a valid class
+     * @param {string} storageClass - The storage class to validate
+     * @return {boolean} `true` if valid, otherwise `false`
+     */
+    static _isValidStorageClass(storageClass) {
+        return validStorageClasses.includes(storageClass);
+    }
+
+    /**
+     * Check that the `StorageClass` property is valid
+     * @param {object} destination - The destination object from this._parsedXML
+     * @return {undefined}
+     */
+    _parseStorageClass(destination) {
+        const storageClass = destination.StorageClass &&
+            destination.StorageClass[0];
+        if (!ReplicationConfiguration._isValidStorageClass(storageClass)) {
+            return errors.MalformedXML;
+        }
+        return undefined;
+    }
+
+    /**
+     * Check that the `Bucket` property is valid
+     * @param {object} destination - The destination object from this._parsedXML
+     * @return {undefined}
+     */
+    _parseBucket(destination) {
+        const parsedBucketARN = destination.Bucket;
+        if (!parsedBucketARN) {
+            return errors.MalformedXML;
+        }
+        const bucketARN = parsedBucketARN[0];
+        if (!bucketARN) {
+            return errors.InvalidArgument.customizeDescription(
+                'Destination bucket cannot be null or empty');
+        }
+        const arr = bucketARN.split(':');
+        const isValidARN =
+            arr[0] === 'arn' &&
+            arr[1] === 'aws' &&
+            arr[2] === 's3' &&
+            arr[3] === '' &&
+            arr[4] === '';
+        if (!isValidARN) {
+            return errors.InvalidArgument
+                .customizeDescription('Invalid bucket ARN');
+        }
+        if (!isValidBucketName(arr[5], [])) {
+            return errors.InvalidArgument
+                .customizeDescription('The specified bucket is not valid');
+        }
+        // We can replicate objects only to one destination bucket.
+        if (this._destination && this._destination !== bucketARN) {
+            return errors.InvalidRequest.customizeDescription(
+                'The destination bucket must be same for all rules');
+        }
+        this._destination = bucketARN;
+        return undefined;
+    }
+
+    /**
+     * Check that the `destination` property is valid
+     * @param {object} rule - The rule object from this._parsedXML
+     * @return {undefined}
+     */
+    _parseDestination(rule) {
+        const dest = rule.Destination && rule.Destination[0];
+        if (!dest) {
+            return errors.MalformedXML;
+        }
+        const err = this._parseBucket(dest) || this._parseStorageClass(dest);
+        if (err) {
+            return err;
+        }
+        return undefined;
+    }
+
+    /**
+     * Check that the request configuration is valid
+     * @return {undefined}
+     */
+    parseConfiguration() {
+        const err = this._parseRole() || this._parseRules();
+        if (err) {
+            return err;
+        }
+        return undefined;
+    }
+
+    /**
+     * Get the XML representation of the configuration object
+     * @param {object} config - The bucket replication configuration
+     * @return {string} - The XML representation of the configuration
+     */
+    static getConfigXML(config) {
+        const { role, destination, rules } = config;
+        const Role = `<Role>${escapeForXml(role)}</Role>`;
+        const Bucket = `<Bucket>${escapeForXml(destination)}</Bucket>`;
+        const rulesXML = rules.map(rule => {
+            const { prefix, enabled, storageClass, id } = rule;
+            const Prefix = prefix === '' ? '<Prefix/>' :
+                `<Prefix>${escapeForXml(prefix)}</Prefix>`;
+            const Status =
+                `<Status>${enabled ? 'Enabled' : 'Disabled'}</Status>`;
+            const StorageClass = storageClass ?
+                `<StorageClass>${storageClass}</StorageClass>` : '';
+            const Destination =
+                `<Destination>${Bucket}${StorageClass}</Destination>`;
+            // If the ID property was omitted in the configuration object, we
+            // create an ID for the rule. Hence it is always defined.
+            const ID = `<ID>${escapeForXml(id)}</ID>`;
+            return `<Rule>${ID}${Prefix}${Status}${Destination}</Rule>`;
+        }).join('');
+        return '<?xml version="1.0" encoding="UTF-8"?>' +
+            '<ReplicationConfiguration ' +
+                'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+                `${rulesXML}${Role}` +
+            '</ReplicationConfiguration>';
+    }
+
+    /**
+     * Validate the bucket metadata replication configuration structure and
+     * value types
+     * @param {object} config - The replication configuration to validate
+     * @return {undefined}
+     */
+    static validateConfig(config) {
+        assert.strictEqual(typeof config, 'object');
+        const { role, rules, destination } = config;
+        assert.strictEqual(typeof role, 'string');
+        assert.strictEqual(typeof destination, 'string');
+        assert.strictEqual(Array.isArray(rules), true);
+        rules.forEach(rule => {
+            assert.strictEqual(typeof rule, 'object');
+            const { prefix, enabled, id, storageClass } = rule;
+            assert.strictEqual(typeof prefix, 'string');
+            assert.strictEqual(typeof enabled, 'boolean');
+            assert(id === undefined || typeof id === 'string');
+            assert(this._isValidStorageClass(storageClass) === true);
+        });
+    }
+}
+
+module.exports = ReplicationConfiguration;

--- a/lib/models/WebsiteConfiguration.js
+++ b/lib/models/WebsiteConfiguration.js
@@ -1,0 +1,195 @@
+class RoutingRule {
+    /**
+    * Represents a routing rule in a website configuration.
+    * @constructor
+    * @param {object} params - object containing redirect and condition objects
+    * @param {object} params.redirect - specifies how to redirect requests
+    * @param {string} [params.redirect.protocol] - protocol to use for redirect
+    * @param {string} [params.redirect.hostName] - hostname to use for redirect
+    * @param {string} [params.redirect.replaceKeyPrefixWith] - string to replace
+    *   keyPrefixEquals specified in condition
+    * @param {string} [params.redirect.replaceKeyWith] - string to replace key
+    * @param {string} [params.redirect.httpRedirectCode] - http redirect code
+    * @param {object} [params.condition] - specifies conditions for a redirect
+    * @param {string} [params.condition.keyPrefixEquals] - key prefix that
+    *   triggers a redirect
+    * @param {string} [params.condition.httpErrorCodeReturnedEquals] - http code
+    *   that triggers a redirect
+    */
+    constructor(params) {
+        if (params) {
+            this._redirect = params.redirect;
+            this._condition = params.condition;
+        }
+    }
+
+    /**
+    * Return copy of rule as plain object
+    * @return {object} rule;
+    */
+    getRuleObject() {
+        const rule = {
+            redirect: this._redirect,
+            condition: this._condition,
+        };
+        return rule;
+    }
+
+    /**
+    * Return the condition object
+    * @return {object} condition;
+    */
+    getCondition() {
+        return this._condition;
+    }
+
+    /**
+    * Return the redirect object
+    * @return {object} redirect;
+    */
+    getRedirect() {
+        return this._redirect;
+    }
+}
+
+class WebsiteConfiguration {
+    /**
+    * Object that represents website configuration
+    * @constructor
+    * @param {object} params - object containing params to construct Object
+    * @param {string} params.indexDocument - key for index document object
+    *   required when redirectAllRequestsTo is undefined
+    * @param {string} [params.errorDocument] - key for error document object
+    * @param {object} params.redirectAllRequestsTo - object containing info
+    *   about how to redirect all requests
+    * @param {string} params.redirectAllRequestsTo.hostName - hostName to use
+    *   when redirecting all requests
+    * @param {string} [params.redirectAllRequestsTo.protocol] - protocol to use
+    *   when redirecting all requests ('http' or 'https')
+    * @param {(RoutingRule[]|object[])} params.routingRules - array of Routing
+    *   Rule instances or plain routing rule objects to cast as RoutingRule's
+    */
+    constructor(params) {
+        if (params) {
+            this._indexDocument = params.indexDocument;
+            this._errorDocument = params.errorDocument;
+            this._redirectAllRequestsTo = params.redirectAllRequestsTo;
+            this.setRoutingRules(params.routingRules);
+        }
+    }
+
+    /**
+    * Return plain object with configuration info
+    * @return {object} - Object copy of class instance
+    */
+    getConfig() {
+        const websiteConfig = {
+            indexDocument: this._indexDocument,
+            errorDocument: this._errorDocument,
+            redirectAllRequestsTo: this._redirectAllRequestsTo,
+        };
+        if (this._routingRules) {
+            websiteConfig.routingRules =
+            this._routingRules.map(rule => rule.getRuleObject());
+        }
+        return websiteConfig;
+    }
+
+    /**
+    * Set the redirectAllRequestsTo
+    * @param {object} obj - object to set as redirectAllRequestsTo
+    * @param {string} obj.hostName - hostname for redirecting all requests
+    * @param {object} [obj.protocol] - protocol for redirecting all requests
+    * @return {undefined};
+    */
+    setRedirectAllRequestsTo(obj) {
+        this._redirectAllRequestsTo = obj;
+    }
+
+    /**
+    * Return the redirectAllRequestsTo object
+    * @return {object} redirectAllRequestsTo;
+    */
+    getRedirectAllRequestsTo() {
+        return this._redirectAllRequestsTo;
+    }
+
+    /**
+    * Set the index document object name
+    * @param {string} suffix - index document object key
+    * @return {undefined};
+    */
+    setIndexDocument(suffix) {
+        this._indexDocument = suffix;
+    }
+
+    /**
+     * Get the index document object name
+     * @return {string} indexDocument
+     */
+    getIndexDocument() {
+        return this._indexDocument;
+    }
+
+    /**
+     * Set the error document object name
+     * @param {string} key - error document object key
+     * @return {undefined};
+     */
+    setErrorDocument(key) {
+        this._errorDocument = key;
+    }
+
+    /**
+     * Get the error document object name
+     * @return {string} errorDocument
+     */
+    getErrorDocument() {
+        return this._errorDocument;
+    }
+
+    /**
+    * Set the whole RoutingRules array
+    * @param {array} array - array to set as instance's RoutingRules
+    * @return {undefined};
+    */
+    setRoutingRules(array) {
+        if (array) {
+            this._routingRules = array.map(rule => {
+                if (rule instanceof RoutingRule) {
+                    return rule;
+                }
+                return new RoutingRule(rule);
+            });
+        }
+    }
+
+    /**
+     * Add a RoutingRule instance to routingRules array
+     * @param {object} obj - rule to add to array
+     * @return {undefined};
+     */
+    addRoutingRule(obj) {
+        if (!this._routingRules) {
+            this._routingRules = [];
+        }
+        if (obj && obj instanceof RoutingRule) {
+            this._routingRules.push(obj);
+        } else if (obj) {
+            this._routingRules.push(new RoutingRule(obj));
+        }
+    }
+
+    /**
+     * Get routing rules
+     * @return {RoutingRule[]} - array of RoutingRule instances
+     */
+    getRoutingRules() {
+        return this._routingRules;
+    }
+}
+
+module.exports = {
+    RoutingRule,
+    WebsiteConfiguration,
+};

--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
     "socket.io": "~1.7.3",
     "socket.io-client": "~1.7.3",
     "utf8": "2.1.2",
-    "uuid": "~3.0.1",
+    "uuid": "^3.0.1",
     "werelogs": "scality/werelogs",
     "xml2js": "~0.4.16"
   },
   "optionalDependencies": {
-      "ioctl": "2.0.0"
+    "ioctl": "2.0.0"
   },
   "devDependencies": {
     "eslint": "2.13.1",

--- a/tests/unit/models/BucketInfo.js
+++ b/tests/unit/models/BucketInfo.js
@@ -1,0 +1,324 @@
+const assert = require('assert');
+const BucketInfo = require('../../../lib/models/BucketInfo');
+const { WebsiteConfiguration } =
+    require('../../../lib/models/WebsiteConfiguration.js');
+
+// create variables to populate dummyBucket
+const bucketName = 'nameOfBucket';
+const owner = 'canonicalID';
+const ownerDisplayName = 'bucketOwner';
+const emptyAcl = {
+    Canned: 'private',
+    FULL_CONTROL: [],
+    WRITE: [],
+    WRITE_ACP: [],
+    READ: [],
+    READ_ACP: [],
+};
+
+const filledAcl = {
+    Canned: '',
+    FULL_CONTROL: ['someOtherAccount'],
+    WRITE: [],
+    WRITE_ACP: ['yetAnotherAccount'],
+    READ: [],
+    READ_ACP: ['thisaccount'],
+};
+
+const acl = { undefined, emptyAcl, filledAcl };
+
+const testDate = new Date().toJSON();
+
+const testVersioningConfiguration = { Status: 'Enabled' };
+
+const testWebsiteConfiguration = new WebsiteConfiguration({
+    indexDocument: 'index.html',
+    errorDocument: 'error.html',
+    routingRules: [
+        {
+            redirect: {
+                httpRedirectCode: '301',
+                hostName: 'www.example.com',
+                replaceKeyPrefixWith: '/documents',
+            },
+            condition: {
+                httpErrorCodeReturnedEquals: 400,
+                keyPrefixEquals: '/docs',
+            },
+        },
+        {
+            redirect: {
+                protocol: 'http',
+                replaceKeyWith: 'error.html',
+            },
+            condition: {
+                keyPrefixEquals: 'ExamplePage.html',
+            },
+        },
+    ],
+});
+
+const testLocationConstraint = 'us-west-1';
+
+const testCorsConfiguration = [
+    { id: 'test',
+        allowedMethods: ['PUT', 'POST', 'DELETE'],
+        allowedOrigins: ['http://www.example.com'],
+        allowedHeaders: ['*'],
+        maxAgeSeconds: 3000,
+        exposeHeaders: ['x-amz-server-side-encryption'] },
+    { allowedMethods: ['GET'],
+        allowedOrigins: ['*'],
+        allowedHeaders: ['*'],
+        maxAgeSeconds: 3000 },
+];
+
+const testReplicationConfiguration = {
+    role: 'STRING_VALUE',
+    destination: 'STRING_VALUE',
+    rules: [
+        {
+            storageClass: 'STANDARD',
+            prefix: 'STRING_VALUE',
+            enabled: true,
+            id: 'STRING_VALUE',
+        },
+    ],
+};
+// create a dummy bucket to test getters and setters
+
+Object.keys(acl).forEach(
+    aclObj => describe(`different acl configurations : ${aclObj}`, () => {
+        const dummyBucket = new BucketInfo(
+            bucketName, owner, ownerDisplayName, testDate,
+            BucketInfo.currentModelVersion(), acl[aclObj],
+            false, false, {
+                cryptoScheme: 1,
+                algorithm: 'sha1',
+                masterKeyId: 'somekey',
+                mandatory: true,
+            }, testVersioningConfiguration,
+            testLocationConstraint,
+            testWebsiteConfiguration,
+            testCorsConfiguration,
+            testReplicationConfiguration);
+
+        describe('serialize/deSerialize on BucketInfo class', () => {
+            const serialized = dummyBucket.serialize();
+            it('should serialize', done => {
+                assert.strictEqual(typeof serialized, 'string');
+                const bucketInfos = {
+                    acl: dummyBucket._acl,
+                    name: dummyBucket._name,
+                    owner: dummyBucket._owner,
+                    ownerDisplayName: dummyBucket._ownerDisplayName,
+                    creationDate: dummyBucket._creationDate,
+                    mdBucketModelVersion: dummyBucket._mdBucketModelVersion,
+                    transient: dummyBucket._transient,
+                    deleted: dummyBucket._deleted,
+                    serverSideEncryption: dummyBucket._serverSideEncryption,
+                    versioningConfiguration:
+                        dummyBucket._versioningConfiguration,
+                    locationConstraint: dummyBucket._locationConstraint,
+                    websiteConfiguration: dummyBucket._websiteConfiguration
+                        .getConfig(),
+                    cors: dummyBucket._cors,
+                    replicationConfiguration:
+                        dummyBucket._replicationConfiguration,
+                };
+                assert.strictEqual(serialized, JSON.stringify(bucketInfos));
+                done();
+            });
+
+            it('should deSerialize into an instance of BucketInfo', done => {
+                const serialized = dummyBucket.serialize();
+                const deSerialized = BucketInfo.deSerialize(serialized);
+                assert.strictEqual(typeof deSerialized, 'object');
+                assert(deSerialized instanceof BucketInfo);
+                assert.deepStrictEqual(deSerialized, dummyBucket);
+                done();
+            });
+        });
+
+        describe('constructor', () => {
+            it('this should have the right BucketInfo types',
+               () => {
+                   assert.strictEqual(typeof dummyBucket.getName(), 'string');
+                   assert.strictEqual(typeof dummyBucket.getOwner(), 'string');
+                   assert.strictEqual(typeof dummyBucket.getOwnerDisplayName(),
+                                      'string');
+                   assert.strictEqual(typeof dummyBucket.getCreationDate(),
+                                      'string');
+               });
+            it('this should have the right acl\'s types', () => {
+                assert.strictEqual(typeof dummyBucket.getAcl(), 'object');
+                assert.strictEqual(
+                    typeof dummyBucket.getAcl().Canned, 'string');
+                assert(Array.isArray(dummyBucket.getAcl().FULL_CONTROL));
+                assert(Array.isArray(dummyBucket.getAcl().WRITE));
+                assert(Array.isArray(dummyBucket.getAcl().WRITE_ACP));
+                assert(Array.isArray(dummyBucket.getAcl().READ));
+                assert(Array.isArray(dummyBucket.getAcl().READ_ACP));
+            });
+            it('this should have the right acls', () => {
+                assert.deepStrictEqual(dummyBucket.getAcl(),
+                                       acl[aclObj] || emptyAcl);
+            });
+            it('this should have the right website config types', () => {
+                const websiteConfig = dummyBucket.getWebsiteConfiguration();
+                assert.strictEqual(typeof websiteConfig, 'object');
+                assert.strictEqual(typeof websiteConfig._indexDocument,
+                    'string');
+                assert.strictEqual(typeof websiteConfig._errorDocument,
+                    'string');
+                assert(Array.isArray(websiteConfig._routingRules));
+            });
+            it('this should have the right cors config types', () => {
+                const cors = dummyBucket.getCors();
+                assert(Array.isArray(cors));
+                assert(Array.isArray(cors[0].allowedMethods));
+                assert(Array.isArray(cors[0].allowedOrigins));
+                assert(Array.isArray(cors[0].allowedHeaders));
+                assert(Array.isArray(cors[0].allowedMethods));
+                assert(Array.isArray(cors[0].exposeHeaders));
+                assert.strictEqual(typeof cors[0].maxAgeSeconds, 'number');
+                assert.strictEqual(typeof cors[0].id, 'string');
+            });
+        });
+
+        describe('getters on BucketInfo class', () => {
+            it('getACl should return the acl', () => {
+                assert.deepStrictEqual(dummyBucket.getAcl(),
+                                       acl[aclObj] || emptyAcl);
+            });
+            it('getName should return name', () => {
+                assert.deepStrictEqual(dummyBucket.getName(), bucketName);
+            });
+            it('getOwner should return owner', () => {
+                assert.deepStrictEqual(dummyBucket.getOwner(), owner);
+            });
+            it('getOwnerDisplayName should return ownerDisplayName', () => {
+                assert.deepStrictEqual(dummyBucket.getOwnerDisplayName(),
+                                       ownerDisplayName);
+            });
+            it('getCreationDate should return creationDate', () => {
+                assert.deepStrictEqual(dummyBucket.getCreationDate(), testDate);
+            });
+            it('getVersioningConfiguration should return configuration', () => {
+                assert.deepStrictEqual(dummyBucket.getVersioningConfiguration(),
+                        testVersioningConfiguration);
+            });
+            it('getWebsiteConfiguration should return configuration', () => {
+                assert.deepStrictEqual(dummyBucket.getWebsiteConfiguration(),
+                        testWebsiteConfiguration);
+            });
+            it('getLocationConstraint should return locationConstraint', () => {
+                assert.deepStrictEqual(dummyBucket.getLocationConstraint(),
+                testLocationConstraint);
+            });
+            it('getCors should return CORS configuration', () => {
+                assert.deepStrictEqual(dummyBucket.getCors(),
+                        testCorsConfiguration);
+            });
+        });
+
+        describe('setters on BucketInfo class', () => {
+            it('setCannedAcl should set acl.Canned', () => {
+                const testAclCanned = 'public-read';
+                dummyBucket.setCannedAcl(testAclCanned);
+                assert.deepStrictEqual(
+                    dummyBucket.getAcl().Canned, testAclCanned);
+            });
+            it('setSpecificAcl should set the acl of a specified bucket',
+               () => {
+                   const typeOfGrant = 'WRITE';
+                   dummyBucket.setSpecificAcl(owner, typeOfGrant);
+                   const lastIndex =
+                             dummyBucket.getAcl()[typeOfGrant].length - 1;
+                   assert.deepStrictEqual(
+                       dummyBucket.getAcl()[typeOfGrant][lastIndex], owner);
+               });
+            it('setFullAcl should set full set of ACLs', () => {
+                const newACLs = {
+                    Canned: '',
+                    FULL_CONTROL: ['someOtherAccount'],
+                    WRITE: [],
+                    WRITE_ACP: ['yetAnotherAccount'],
+                    READ: [],
+                    READ_ACP: [],
+                };
+                dummyBucket.setFullAcl(newACLs);
+                assert.deepStrictEqual(dummyBucket.getAcl().FULL_CONTROL,
+                                       ['someOtherAccount']);
+                assert.deepStrictEqual(dummyBucket.getAcl().WRITE_ACP,
+                                       ['yetAnotherAccount']);
+            });
+            it('setName should set the bucket name', () => {
+                const newName = 'newName';
+                dummyBucket.setName(newName);
+                assert.deepStrictEqual(dummyBucket.getName(), newName);
+            });
+            it('setOwner should set the owner', () => {
+                const newOwner = 'newOwner';
+                dummyBucket.setOwner(newOwner);
+                assert.deepStrictEqual(dummyBucket.getOwner(), newOwner);
+            });
+            it('getOwnerDisplayName should return ownerDisplayName', () => {
+                const newOwnerDisplayName = 'newOwnerDisplayName';
+                dummyBucket.setOwnerDisplayName(newOwnerDisplayName);
+                assert.deepStrictEqual(dummyBucket.getOwnerDisplayName(),
+                                       newOwnerDisplayName);
+            });
+            it('setLocationConstraint should set the locationConstraint',
+               () => {
+                   const newLocation = 'newLocation';
+                   dummyBucket.setLocationConstraint(newLocation);
+                   assert.deepStrictEqual(
+                       dummyBucket.getLocationConstraint(), newLocation);
+               });
+            it('setVersioningConfiguration should set configuration', () => {
+                const newVersioningConfiguration =
+                    { Status: 'Enabled', MfaDelete: 'Enabled' };
+                dummyBucket
+                    .setVersioningConfiguration(newVersioningConfiguration);
+                assert.deepStrictEqual(dummyBucket.getVersioningConfiguration(),
+                    newVersioningConfiguration);
+            });
+            it('setWebsiteConfiguration should set configuration', () => {
+                const newWebsiteConfiguration = {
+                    redirectAllRequestsTo: {
+                        hostName: 'www.example.com',
+                        protocol: 'https',
+                    },
+                };
+                dummyBucket
+                    .setWebsiteConfiguration(newWebsiteConfiguration);
+                assert.deepStrictEqual(dummyBucket.getWebsiteConfiguration(),
+                    newWebsiteConfiguration);
+            });
+            it('setCors should set CORS configuration', () => {
+                const newCorsConfiguration =
+                    [{ allowedMethods: ['PUT'], allowedOrigins: ['*'] }];
+                dummyBucket.setCors(newCorsConfiguration);
+                assert.deepStrictEqual(dummyBucket.getCors(),
+                    newCorsConfiguration);
+            });
+            it('setReplicationConfiguration should set replication ' +
+                'configuration', () => {
+                const newReplicationConfig = {
+                    Role: 'arn:aws:iam::account-id:role/resource',
+                    Rules: [
+                        {
+                            Destination: {
+                                Bucket: 'arn:aws:s3:::destination-bucket',
+                            },
+                            Prefix: 'test-prefix',
+                            Status: 'Enabled',
+                        },
+                    ],
+                };
+                dummyBucket.setReplicationConfiguration(newReplicationConfig);
+            });
+        });
+    })
+);

--- a/tests/unit/models/WebsiteConfiguration.js
+++ b/tests/unit/models/WebsiteConfiguration.js
@@ -1,0 +1,183 @@
+const assert = require('assert');
+const {
+    WebsiteConfiguration,
+    RoutingRule,
+} = require('../../../lib/models/WebsiteConfiguration.js');
+
+const testRoutingRuleParams = {
+    redirect: {
+        protocol: 'http',
+        hostName: 'test',
+        replaceKeyPrefixWith: '/docs',
+        replaceKeyWith: 'cat',
+        httpRedirectCode: '303',
+    },
+    condition: {
+        keyPrefixEquals: '/documents',
+        httpErrorCodeReturnedEquals: '404',
+    },
+};
+
+describe('RoutingRule class', () => {
+    it('should initialize even if no parameters are provided', done => {
+        const routingRule = new RoutingRule();
+        assert.strictEqual(routingRule._redirect, undefined);
+        assert.strictEqual(routingRule._condition, undefined);
+        done();
+    });
+
+    it('should return a new routing rule', done => {
+        const routingRule = new RoutingRule(testRoutingRuleParams);
+        assert.deepStrictEqual(routingRule._redirect,
+            testRoutingRuleParams.redirect);
+        assert.deepStrictEqual(routingRule._condition,
+            testRoutingRuleParams.condition);
+        done();
+    });
+
+    it('getRedirect should fetch the instance\'s redirect', done => {
+        const routingRule = new RoutingRule(testRoutingRuleParams);
+        assert.deepStrictEqual(routingRule.getRedirect(),
+            testRoutingRuleParams.redirect);
+        done();
+    });
+
+    it('getCondition should fetch the instance\'s condition', done => {
+        const routingRule = new RoutingRule(testRoutingRuleParams);
+        assert.deepStrictEqual(routingRule.getCondition(),
+            testRoutingRuleParams.condition);
+        done();
+    });
+});
+
+describe('WebsiteConfiguration class', () => {
+    it('should initialize even if no parameters are provided', done => {
+        const websiteConfig = new WebsiteConfiguration();
+        assert.strictEqual(websiteConfig._indexDocument, undefined);
+        assert.strictEqual(websiteConfig._errorDocument, undefined);
+        assert.strictEqual(websiteConfig._redirectAllRequestsTo, undefined);
+        assert.strictEqual(websiteConfig._routingRules, undefined);
+        done();
+    });
+
+    it('should initialize indexDocument, errorDocument during construction ' +
+    'if provided in params', done => {
+        const testWebsiteConfigParams = {
+            indexDocument: 'index.html',
+            errorDocument: 'error.html',
+        };
+        const websiteConfig = new WebsiteConfiguration(testWebsiteConfigParams);
+        assert.strictEqual(websiteConfig._indexDocument, 'index.html');
+        assert.strictEqual(websiteConfig._errorDocument, 'error.html');
+        done();
+    });
+
+    it('should initialize redirectAllRequestsTo during construction if ' +
+    'provided in params', done => {
+        const testWebsiteConfigParams = {
+            redirectAllRequestsTo: {
+                hostName: 'test',
+                protocol: 'https',
+            },
+        };
+        const websiteConfig = new WebsiteConfiguration(testWebsiteConfigParams);
+        assert.strictEqual(websiteConfig._redirectAllRequestsTo.hostName,
+            'test');
+        assert.strictEqual(websiteConfig._redirectAllRequestsTo.protocol,
+            'https');
+        done();
+    });
+
+    it('should initialize routingRules properly during construction from ' +
+    'array of RoutingRule class instances', done => {
+        const testWebsiteConfigParams = {
+            routingRules: [],
+        };
+        const testRoutingRule = new RoutingRule(testRoutingRuleParams);
+        testWebsiteConfigParams.routingRules.push(testRoutingRule);
+        testWebsiteConfigParams.routingRules.push(testRoutingRule);
+        testWebsiteConfigParams.routingRules.push(testRoutingRule);
+        const websiteConfig = new WebsiteConfiguration(testWebsiteConfigParams);
+        assert.deepStrictEqual(websiteConfig._routingRules,
+            testWebsiteConfigParams.routingRules);
+        done();
+    });
+
+    it('should initialize routingRules properly during construction from ' +
+    'array of plain objects', done => {
+        const testWebsiteConfigParams = {
+            routingRules: [],
+        };
+        testWebsiteConfigParams.routingRules.push(testRoutingRuleParams);
+        testWebsiteConfigParams.routingRules.push(testRoutingRuleParams);
+        testWebsiteConfigParams.routingRules.push(testRoutingRuleParams);
+        const websiteConfig = new WebsiteConfiguration(testWebsiteConfigParams);
+        assert.deepEqual(websiteConfig._routingRules[0]._condition,
+            testRoutingRuleParams.condition);
+        assert.deepEqual(websiteConfig._routingRules[1]._condition,
+            testRoutingRuleParams.condition);
+        assert.deepEqual(websiteConfig._routingRules[2]._condition,
+            testRoutingRuleParams.condition);
+        assert.deepEqual(websiteConfig._routingRules[0]._redirect,
+            testRoutingRuleParams.redirect);
+        assert.deepEqual(websiteConfig._routingRules[1]._redirect,
+            testRoutingRuleParams.redirect);
+        assert.deepEqual(websiteConfig._routingRules[2]._redirect,
+            testRoutingRuleParams.redirect);
+        assert(websiteConfig._routingRules[0] instanceof RoutingRule);
+        done();
+    });
+
+    describe('Getter/setter methods', () => {
+        it('for indexDocument should get/set indexDocument property', done => {
+            const websiteConfig = new WebsiteConfiguration();
+            websiteConfig.setIndexDocument('index.html');
+            assert.strictEqual(websiteConfig.getIndexDocument(), 'index.html');
+            done();
+        });
+
+        it('for errorDocument should get/set errorDocument property', done => {
+            const websiteConfig = new WebsiteConfiguration();
+            websiteConfig.setErrorDocument('error.html');
+            assert.strictEqual(websiteConfig.getErrorDocument(), 'error.html');
+            done();
+        });
+
+        it('for redirectAllRequestsTo should get/set redirectAllRequestsTo ' +
+        'object', done => {
+            const websiteConfig = new WebsiteConfiguration();
+            const redirectAllRequestsTo = {
+                hostName: 'test',
+                protocol: 'http',
+            };
+            websiteConfig.setRedirectAllRequestsTo(redirectAllRequestsTo);
+            assert.deepStrictEqual(websiteConfig.getRedirectAllRequestsTo(),
+                redirectAllRequestsTo);
+            done();
+        });
+
+        it('for routingRules should get/set routingRules', done => {
+            const websiteConfig = new WebsiteConfiguration();
+            const routingRules = [testRoutingRuleParams];
+            websiteConfig.setRoutingRules(routingRules);
+            assert.strictEqual(websiteConfig.getRoutingRules()[0]._condition,
+                routingRules[0].condition);
+            assert.strictEqual(websiteConfig.getRoutingRules()[0]._redirect,
+                routingRules[0].redirect);
+            assert(websiteConfig._routingRules[0] instanceof RoutingRule);
+            done();
+        });
+    });
+
+    it('addRoutingRule should add a RoutingRule to routingRules', done => {
+        const websiteConfig = new WebsiteConfiguration();
+        websiteConfig.addRoutingRule(testRoutingRuleParams);
+        assert(Array.isArray(websiteConfig._routingRules));
+        assert.strictEqual(websiteConfig._routingRules.length, 1);
+        assert.strictEqual(websiteConfig._routingRules[0].getCondition(),
+            testRoutingRuleParams.condition);
+        assert.strictEqual(websiteConfig._routingRules[0].getRedirect(),
+            testRoutingRuleParams.redirect);
+        done();
+    });
+});

--- a/tests/unit/models/object.js
+++ b/tests/unit/models/object.js
@@ -1,0 +1,108 @@
+const assert = require('assert');
+const ObjectMD = require('../../../lib/models/ObjectMD');
+
+describe('ObjectMD class setters/getters', () => {
+    let md = null;
+
+    beforeEach(() => {
+        md = new ObjectMD();
+    });
+
+    [
+        // In order: data property, value to set/get, default value
+        ['ModelVersion', null, 2],
+        ['OwnerDisplayName', null, ''],
+        ['OwnerDisplayName', 'owner-display-name'],
+        ['OwnerId', null, ''],
+        ['OwnerId', 'owner-id'],
+        ['CacheControl', null, ''],
+        ['CacheControl', 'cache-control'],
+        ['ContentDisposition', null, ''],
+        ['ContentDisposition', 'content-disposition'],
+        ['ContentEncoding', null, ''],
+        ['ContentEncoding', 'content-encoding'],
+        ['Expires', null, ''],
+        ['Expires', 'expire-date'],
+        ['ContentLength', null, 0],
+        ['ContentLength', 15000],
+        ['ContentType', null, ''],
+        ['ContentType', 'content-type'],
+        ['LastModified', new Date().toJSON()],
+        ['ContentMd5', null, ''],
+        ['ContentMd5', 'content-md5'],
+        ['AmzVersionId', null, 'null'],
+        ['AmzVersionId', 'version-id'],
+        ['AmzServerVersionId', null, ''],
+        ['AmzServerVersionId', 'server-version-id'],
+        ['AmzStorageClass', null, 'STANDARD'],
+        ['AmzStorageClass', 'storage-class'],
+        ['AmzServerSideEncryption', null, ''],
+        ['AmzServerSideEncryption', 'server-side-encryption'],
+        ['AmzEncryptionKeyId', null, ''],
+        ['AmzEncryptionKeyId', 'encryption-key-id'],
+        ['AmzEncryptionCustomerAlgorithm', null, ''],
+        ['AmzEncryptionCustomerAlgorithm', 'customer-algorithm'],
+        ['Acl', null, {
+            Canned: 'private',
+            FULL_CONTROL: [],
+            WRITE_ACP: [],
+            READ: [],
+            READ_ACP: [],
+        }],
+        ['Acl', {
+            Canned: 'public',
+            FULL_CONTROL: ['id'],
+            WRITE_ACP: ['id'],
+            READ: ['id'],
+            READ_ACP: ['id'],
+        }],
+        ['Key', null, ''],
+        ['Key', 'key'],
+        ['Location', null, []],
+        ['Location', ['location1']],
+        ['IsNull', null, ''],
+        ['IsNull', true],
+        ['NullVersionId', null, ''],
+        ['NullVersionId', '111111'],
+        ['IsDeleteMarker', null, ''],
+        ['IsDeleteMarker', true],
+        ['VersionId', null, undefined],
+        ['VersionId', '111111'],
+        ['Tags', null, {}],
+        ['Tags', {
+            key: 'value',
+        }],
+        ['Tags', null, {}],
+        ['ReplicationInfo', null, {
+            status: '',
+            content: [],
+            destination: '',
+            storageClass: '',
+        }],
+        ['ReplicationInfo', {
+            status: 'PENDING',
+            content: ['DATA', 'METADATA'],
+            destination: 'destination-bucket',
+            storageClass: 'STANDARD',
+        }],
+    ].forEach(test => {
+        const property = test[0];
+        const testValue = test[1];
+        const defaultValue = test[2];
+        const testName = testValue === null ? 'get default' : 'get/set';
+        it(`${testName}: ${property}`, () => {
+            if (testValue !== null) {
+                md[`set${property}`](testValue);
+            }
+            const value = md[`get${property}`]();
+            if ((testValue !== null && typeof testValue === 'object') ||
+                typeof defaultValue === 'object') {
+                assert.deepStrictEqual(value, testValue || defaultValue);
+            } else if (testValue !== null) {
+                assert.strictEqual(value, testValue);
+            } else {
+                assert.strictEqual(value, defaultValue);
+            }
+        });
+    });
+});


### PR DESCRIPTION
This two models are needed for the S3SOFS feature into the cdmiclient
repository. The S3 one does not export modules and shared ones are in
Arsenal so move these two model modules to it.