### PR TITLE
AUTH: Handle expect header stripping

### DIFF
--- a/lib/auth/v4/createCanonicalRequest.js
+++ b/lib/auth/v4/createCanonicalRequest.js
@@ -62,6 +62,11 @@ function createCanonicalRequest(params) {
                 .trim().replace(/\s+/g, ' ');
             return `${signedHeader}:${trimmedHeader}\n`;
         }
+        // nginx will strip the actual expect header so add value of
+        // header back here if it was included as a signed header
+        if (signedHeader === 'expect') {
+            return `${signedHeader}:100-continue\n`;
+        }
         // handle case where signed 'header' is actually query param
         return `${signedHeader}:${pQuery[signedHeader]}\n`;
     });

--- a/tests/unit/auth/v4/createCanonicalRequest.js
+++ b/tests/unit/auth/v4/createCanonicalRequest.js
@@ -186,6 +186,29 @@ describe('createCanonicalRequest function', () => {
         assert.strictEqual(actualOutput, expectedOutput);
     });
 
+    it('should construct a canonical request that contains a ' +
+        'signed expect header even if expect header value was ' +
+        'stripped by the load balancer', () => {
+        const params = {
+            pHttpVerb: 'PUT',
+            pResource: '/test.txt',
+            pQuery: {},
+            pHeaders: {
+                host: 'examplebucket.s3.amazonaws.com',
+            },
+            pSignedHeaders: 'expect;host',
+            payloadChecksum: 'UNSIGNED-PAYLOAD',
+        };
+        const expectedOutput = 'PUT\n' +
+            '/test.txt\n\n' +
+            'expect:100-continue\n' +
+            'host:examplebucket.s3.amazonaws.com\n\n' +
+            'expect;host\n' +
+            'UNSIGNED-PAYLOAD';
+        const actualOutput = createCanonicalRequest(params);
+        assert.strictEqual(actualOutput, expectedOutput);
+    });
+
     it('should trim white space in a canonical header value so that ' +
         'there is no white space before or after a value and any sequential ' +
         'white space becomes a single space', () => {


### PR DESCRIPTION
If load balancer strips off expect header but
expect header was included in signed headers for v4 auth,
authentication will fail. We add back the header value here since
there is only 1 specified expect header value.