### PR TITLE
bf: pull response content headers from query

### DIFF
--- a/lib/auth/v2/constructStringToSign.js
+++ b/lib/auth/v2/constructStringToSign.js
@@ -36,7 +36,7 @@ function constructStringToSign(request, data, log) {
     than here in stringToSign so we have replicated that.
     */
     const date = query.Expires ? query.Expires : headers.date;
-    const combinedQueryHeaders = Object.assign(headers, query);
+    const combinedQueryHeaders = Object.assign({}, headers, query);
     stringToSign += (date ? `${date}\n` : '\n')
         + getCanonicalizedAmzHeaders(combinedQueryHeaders)
         + getCanonicalizedResource(request);

--- a/lib/s3routes/routes/routeGET.js
+++ b/lib/s3routes/routes/routeGET.js
@@ -108,7 +108,7 @@ function routerGET(request, response, api, log, statsClient, dataRetrievalFn) {
                     }
                     log.end().addDefaultFields({ contentLength });
                     routesUtils.statsReport500(err, statsClient);
-                    return routesUtils.responseStreamData(err, request.headers,
+                    return routesUtils.responseStreamData(err, request.query,
                         resMetaHeaders, dataGetInfo, dataRetrievalFn, response,
                         range, log);
                 });

--- a/lib/s3routes/routes/routeWebsite.js
+++ b/lib/s3routes/routes/routeWebsite.js
@@ -36,7 +36,7 @@ function routerWebsite(request, response, api, log, statsClient,
                         response, resMetaHeaders, log);
                 }
                 // no error, stream data
-                return routesUtils.responseStreamData(null, request.headers,
+                return routesUtils.responseStreamData(null, request.query,
                     resMetaHeaders, dataGetInfo, dataRetrievalFn, response,
                     null, log);
             });

--- a/lib/s3routes/routesUtils.js
+++ b/lib/s3routes/routesUtils.js
@@ -181,8 +181,8 @@ const JSONResponseBackend = {
 
 /**
  * Modify response headers for an objectGet or objectHead request
- * @param {object} overrideHeaders - headers in this object override common
- * headers. These are extracted from the request object
+ * @param {object} overrideParams - parameters in this object override common
+ * headers. These are extracted from the request's query object
  * @param {object} resHeaders - object with common response headers
  * @param {object} response - router's response object
  * @param {array | undefined} range  - range in form of [start, end]
@@ -190,7 +190,7 @@ const JSONResponseBackend = {
  * @param {object} log - Werelogs logger
  * @return {object} response - modified response object
  */
-function okContentHeadersResponse(overrideHeaders, resHeaders,
+function okContentHeadersResponse(overrideParams, resHeaders,
     response, range, log) {
     const addHeaders = {};
     if (process.env.ALLOW_INVALID_META_HEADERS) {
@@ -213,26 +213,26 @@ function okContentHeadersResponse(overrideHeaders, resHeaders,
 
     Object.assign(addHeaders, resHeaders);
 
-    if (overrideHeaders['response-content-type']) {
-        addHeaders['Content-Type'] = overrideHeaders['response-content-type'];
+    if (overrideParams['response-content-type']) {
+        addHeaders['Content-Type'] = overrideParams['response-content-type'];
     }
-    if (overrideHeaders['response-content-language']) {
+    if (overrideParams['response-content-language']) {
         addHeaders['Content-Language'] =
-            overrideHeaders['response-content-language'];
+            overrideParams['response-content-language'];
     }
-    if (overrideHeaders['response-expires']) {
-        addHeaders.Expires = overrideHeaders['response-expires'];
+    if (overrideParams['response-expires']) {
+        addHeaders.Expires = overrideParams['response-expires'];
     }
-    if (overrideHeaders['response-cache-control']) {
-        addHeaders['Cache-Control'] = overrideHeaders['response-cache-control'];
+    if (overrideParams['response-cache-control']) {
+        addHeaders['Cache-Control'] = overrideParams['response-cache-control'];
     }
-    if (overrideHeaders['response-content-disposition']) {
+    if (overrideParams['response-content-disposition']) {
         addHeaders['Content-Disposition'] =
-        overrideHeaders['response-content-disposition'];
+        overrideParams['response-content-disposition'];
     }
-    if (overrideHeaders['response-content-encoding']) {
+    if (overrideParams['response-content-encoding']) {
         addHeaders['Content-Encoding'] =
-            overrideHeaders['response-content-encoding'];
+            overrideParams['response-content-encoding'];
     }
     setCommonResponseHeaders(addHeaders, response, log);
     const httpCode = range ? 206 : 200;
@@ -337,14 +337,14 @@ const routesUtils = {
 
     /**
      * @param {string} errCode - S3 error Code
-     * @param {object} overrideHeaders - headers in this object override common
-     * headers. These are extracted from the request object
+     * @param {object} overrideParams - parameters in this object override
+     * common headers. These are extracted from the request's query object
      * @param {string} resHeaders - headers to be set for the response
      * @param {object} response - router's response object
      * @param {object} log - Werelogs logger
      * @return {object} - router's response object
      */
-    responseContentHeaders(errCode, overrideHeaders, resHeaders, response,
+    responseContentHeaders(errCode, overrideParams, resHeaders, response,
                            log) {
         if (errCode && !response.headersSent) {
             return XMLResponseBackend.errorResponse(errCode, response, log,
@@ -353,7 +353,7 @@ const routesUtils = {
         if (!response.headersSent) {
             // Undefined added as an argument since need to send range to
             // okContentHeadersResponse in responseStreamData
-            okContentHeadersResponse(overrideHeaders, resHeaders, response,
+            okContentHeadersResponse(overrideParams, resHeaders, response,
                 undefined, log);
         }
         return response.end(() => {
@@ -365,8 +365,8 @@ const routesUtils = {
 
     /**
      * @param {string} errCode - S3 error Code
-     * @param {object} overrideHeaders - headers in this object override common
-     * headers. These are extracted from the request object
+     * @param {object} overrideParams - parameters in this object override
+     * common headers. These are extracted from the request's query object
      * @param {string} resHeaders - headers to be set for the response
      * @param {array | null} dataLocations --
      *   - array of locations to get streams from sproxyd
@@ -378,14 +378,14 @@ const routesUtils = {
      * @param {object} log - Werelogs logger
      * @return {undefined}
      */
-    responseStreamData(errCode, overrideHeaders, resHeaders, dataLocations,
+    responseStreamData(errCode, overrideParams, resHeaders, dataLocations,
         dataRetrievalFn, response, range, log) {
         if (errCode && !response.headersSent) {
             return XMLResponseBackend.errorResponse(errCode, response, log,
                                                     resHeaders);
         }
         if (!response.headersSent) {
-            okContentHeadersResponse(overrideHeaders, resHeaders, response,
+            okContentHeadersResponse(overrideParams, resHeaders, response,
                 range, log);
         }
         if (dataLocations === null) {


### PR DESCRIPTION
Dependency of https://github.com/scality/Mystique/pull/18

We used to pull them from the headers object, but they are supposed to be specified as query parameters.

It worked because of an accidental side effect with V2 auth where we assigned query parameters to request.headers. But this meant that getting the response content headers was failing with v4 auth.