### PR TITLE
fix: destroy connection if errorHandler is null

### DIFF
--- a/lib/s3routes/routesUtils.js
+++ b/lib/s3routes/routesUtils.js
@@ -246,7 +246,7 @@ function retrieveData(locations, dataRetrievalFn,
     if (locations.length === 0) {
         return response.end();
     }
-    if (errorHandlerFn === undefined) {
+    if (!errorHandlerFn) {
         // eslint-disable-next-line
         errorHandlerFn = () => { response.connection.destroy(); };
     }


### PR DESCRIPTION
~~Optional parameter is null if not sent, we setting the response streaming `errorHandler` only if it was `undefined`.~~
Actually it should be undefined, need to figure out why connection is still not getting destroyed.