### PR TITLE
update models

### DIFF
--- a/lib/models/ObjectMD.js
+++ b/lib/models/ObjectMD.js
@@ -58,6 +58,7 @@ module.exports = class ObjectMD {
                 content: [],
                 destination: '',
                 storageClass: '',
+                role: '',
             },
         };
     }
@@ -583,12 +584,14 @@ module.exports = class ObjectMD {
      * @return {ObjectMD} itself
      */
     setReplicationInfo(replicationInfo) {
-        const { status, content, destination, storageClass } = replicationInfo;
+        const { status, content, destination, storageClass, role } =
+            replicationInfo;
         this._data.replicationInfo = {
             status,
             content,
             destination,
             storageClass: storageClass || '',
+            role,
         };
         return this;
     }

--- a/lib/models/ReplicationConfiguration.js
+++ b/lib/models/ReplicationConfiguration.js
@@ -43,11 +43,13 @@ class ReplicationConfiguration {
      * Create a ReplicationConfiguration instance
      * @param {string} xml - The parsed XML
      * @param {object} log - Werelogs logger
+     * @param {object} config - S3 server configuration
      * @return {object} - ReplicationConfiguration instance
      */
-    constructor(xml, log) {
+    constructor(xml, log, config) {
         this._parsedXML = xml;
         this._log = log;
+        this._config = config;
         this._configPrefixes = [];
         this._configIDs = [];
         // The bucket metadata model of replication config. Note there is a
@@ -145,9 +147,17 @@ class ReplicationConfiguration {
             return errors.MalformedXML;
         }
         const role = parsedRole[0];
-        if (!this._isValidRoleARN(role)) {
+        const rolesArr = role.split(',');
+        if (rolesArr.length !== 2) {
             return errors.InvalidArgument.customizeDescription(
-                'Invalid Role specified in replication configuration');
+                'Invalid Role specified in replication configuration: ' +
+                'Role must be a comma-separated list of two IAM roles');
+        }
+        const invalidRole = rolesArr.find(r => !this._isValidRoleARN(r));
+        if (invalidRole !== undefined) {
+            return errors.InvalidArgument.customizeDescription(
+                'Invalid Role specified in replication configuration: ' +
+                `'${invalidRole}'`);
         }
         this._role = role;
         return undefined;
@@ -262,7 +272,14 @@ class ReplicationConfiguration {
      * @return {boolean} `true` if valid, otherwise `false`
      */
     static _isValidStorageClass(storageClass) {
-        return validStorageClasses.includes(storageClass);
+        if (!this._config) {
+            return validStorageClasses.includes(storageClass);
+        }
+
+        const replicationEndpoints = this._config.replicationEndpoints
+            .map(endpoint => endpoint.name);
+        return replicationEndpoints.includes(storageClass) ||
+            validStorageClasses.includes(storageClass);
     }
 
     /**

--- a/tests/unit/models/BucketInfo.js
+++ b/tests/unit/models/BucketInfo.js
@@ -306,7 +306,8 @@ Object.keys(acl).forEach(
             it('setReplicationConfiguration should set replication ' +
                 'configuration', () => {
                 const newReplicationConfig = {
-                    Role: 'arn:aws:iam::account-id:role/resource',
+                    Role: 'arn:aws:iam::123456789012:role/src-resource,' +
+                        'arn:aws:iam::123456789012:role/dest-resource',
                     Rules: [
                         {
                             Destination: {

--- a/tests/unit/models/object.js
+++ b/tests/unit/models/object.js
@@ -78,12 +78,15 @@ describe('ObjectMD class setters/getters', () => {
             content: [],
             destination: '',
             storageClass: '',
+            role: '',
         }],
         ['ReplicationInfo', {
             status: 'PENDING',
             content: ['DATA', 'METADATA'],
             destination: 'destination-bucket',
             storageClass: 'STANDARD',
+            role: 'arn:aws:iam::account-id:role/src-resource,' +
+                'arn:aws:iam::account-id:role/dest-resource',
         }],
     ].forEach(test => {
         const property = test[0];


### PR DESCRIPTION
Because I did not know the merge process in the Arsenal repository I
merged too early a PR moving code from S3 to Arsenal. The problem is
that the PR in S3 removing this models is not yet merged and some
modification have been made on this code in S3, leading the previous S3
PR to fail.

This commit updates the models code and test in Arsenal, accordingly to
what has been done in S3.
In the S3 repository, the ReplicationConfiguration source file required
the S3 config. Because it is not possible to do that in the Arsenal
repository, the config is now a constructor parameter.