### PR TITLE
DelimiterTools export path

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,8 +19,10 @@ module.exports = {
                 .DelimiterVersions,
             DelimiterMaster: require('./lib/algos/list/delimiterMaster')
                 .DelimiterMaster,
-            DelimiterTools: require('./lib/algos/list/tools'),
             MPU: require('./lib/algos/list/MPU').MultipartUploads,
+        },
+        listTools: {
+            DelimiterTools: require('./lib/algos/list/tools'),
         },
     },
     policies: {


### PR DESCRIPTION
Export DelimiterTools outside the "algorithms.list" one which contains
only delimiter classes.

Furthermore, a S3 unit test expects all the class exported in this path
to be delimiter classes and iterate on them. Instead of adding
conditional in test, give to this tool class a specific export path.