### PR TITLE
ft: round-robin helper class in network/utils/RoundRobin

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ module.exports = {
             RESTServer: require('./lib/network/rest/RESTServer'),
             RESTClient: require('./lib/network/rest/RESTClient'),
         },
+        RoundRobin: require('./lib/network/RoundRobin'),
     },
     s3routes: {
         routes: require('./lib/s3routes/routes'),

--- a/lib/network/RoundRobin.js
+++ b/lib/network/RoundRobin.js
@@ -1,0 +1,163 @@
+const DEFAULT_STICKY_COUNT = 100;
+
+/**
+ * Shuffle an array in-place
+ *
+ * @param {Array} array - The array to shuffle
+ * @return {undefined}
+ */
+function shuffle(array) {
+    for (let i = array.length - 1; i > 0; i--) {
+        const randIndex = Math.floor(Math.random() * (i + 1));
+        /* eslint-disable no-param-reassign */
+        const randIndexVal = array[randIndex];
+        array[randIndex] = array[i];
+        array[i] = randIndexVal;
+        /* eslint-enable no-param-reassign */
+    }
+}
+
+class RoundRobin {
+    /**
+     * @constructor
+     * @param {object[]|string[]} hostsList - list of hosts to query
+     *   in round-robin fashion.
+     * @param {string} hostsList[].host - host name or IP address
+     * @param {number} [hostsList[].port] - port number to contact
+     * @param {object} [options] - options object
+     * @param {number} [options.stickyCount=100] - number of requests
+     *   to send to the same host before switching to the next one
+     * @param {Logger} [options.logger] - logger object
+     */
+    constructor(hostsList, options) {
+        if (hostsList.length === 0) {
+            throw new Error(
+                'at least one host must be provided for round robin');
+        }
+        this.hostsList = hostsList.map(item => this._validateHostObj(item));
+
+        if (options && options.logger) {
+            this.logger = options.logger;
+        }
+        if (options && options.stickyCount) {
+            this.stickyCount = options.stickyCount;
+        } else {
+            this.stickyCount = DEFAULT_STICKY_COUNT;
+        }
+
+        // TODO: add blacklisting capability
+
+        shuffle(this.hostsList);
+        this.hostIndex = 0;
+        this.pickCount = 0;
+    }
+
+    _validateHostObj(hostItem) {
+        const hostItemObj = {};
+
+        if (typeof hostItem === 'string') {
+            const hostParts = hostItem.split(':');
+            if (hostParts.length > 2) {
+                throw new Error(`${hostItem}: ` +
+                                'bad round robin item: expect "host[:port]"');
+            }
+            hostItemObj.host = hostParts[0];
+            hostItemObj.port = hostParts[1];
+        } else {
+            if (typeof hostItem !== 'object') {
+                throw new Error(`${hostItem}: bad round robin item: ` +
+                                'must be a string or object');
+            }
+            hostItemObj.host = hostItem.host;
+            hostItemObj.port = hostItem.port;
+        }
+        if (typeof hostItemObj.host !== 'string') {
+            throw new Error(`${hostItemObj.host}: ` +
+                            'bad round robin host name: not a string');
+        }
+        if (hostItemObj.port !== undefined) {
+            if (/^[0-9]+$/.exec(hostItemObj.port) === null) {
+                throw new Error(`'${hostItemObj.port}': ` +
+                                'bad round robin host port: not a number');
+            }
+            const parsedPort = Number.parseInt(hostItemObj.port, 10);
+            if (parsedPort <= 0 || parsedPort > 65535) {
+                throw new Error(`'${hostItemObj.port}': bad round robin ` +
+                                'host port: not a valid port number');
+            }
+            return {
+                host: hostItemObj.host,
+                port: parsedPort,
+            };
+        }
+        return { host: hostItemObj.host };
+    }
+
+    /**
+     * return the next host within round-robin cycle
+     *
+     * The same host is returned up to {@link this.stickyCount} times,
+     * then the next host in the round-robin list is returned.
+     *
+     * Once all hosts have been returned once, the list is shuffled
+     * and a new round-robin cycle starts.
+     *
+     * @return {object} a host object with { host, port } attributes
+     */
+    pickHost() {
+        if (this.logger) {
+            this.logger.debug('pick host',
+                              { host: this.getCurrentHost() });
+        }
+        const curHost = this.getCurrentHost();
+        ++this.pickCount;
+        if (this.pickCount === this.stickyCount) {
+            this._roundRobinCurrentHost();
+            this.pickCount = 0;
+        }
+        return curHost;
+    }
+
+    /**
+     * return the next host within round-robin cycle
+     *
+     * stickyCount is ignored, the next host in the round-robin list
+     * is returned.
+     *
+     * Once all hosts have been returned once, the list is shuffled
+     * and a new round-robin cycle starts.
+     *
+     * @return {object} a host object with { host, port } attributes
+     */
+    pickNextHost() {
+        const curHost = this.getCurrentHost();
+        this._roundRobinCurrentHost();
+        this.pickCount = 0;
+        return curHost;
+    }
+
+    /**
+     * return the current host in round-robin, without changing the
+     * round-robin state
+     *
+     * @return {object} a host object with { host, port } attributes
+     */
+    getCurrentHost() {
+        return this.hostsList[this.hostIndex];
+    }
+
+    _roundRobinCurrentHost() {
+        this.hostIndex += 1;
+        // re-shuffle the array when all entries have been returned once
+        if (this.hostIndex === this.hostsList.length) {
+            this.hostIndex = 0;
+            shuffle(this.hostsList);
+        }
+        if (this.logger) {
+            this.logger.debug('round robin host',
+                              { newHost: this.getCurrentHost() });
+        }
+    }
+}
+
+module.exports = RoundRobin;

--- a/tests/unit/network/RoundRobin.spec.js
+++ b/tests/unit/network/RoundRobin.spec.js
@@ -1,0 +1,105 @@
+const assert = require('assert');
+
+const RoundRobin = require('../../../lib/network/RoundRobin');
+
+describe('round robin hosts', () => {
+    let roundRobin;
+
+    [{
+        caption: 'with { host, port } objects in list',
+        hostsList: [{ host: '1.2.3.0', port: 1000 },
+                    { host: '1.2.3.1', port: 1001 },
+                    { host: '1.2.3.2', port: 1002 }],
+    }, {
+        caption: 'with "host:port" strings in list',
+        hostsList: ['1.2.3.0:1000',
+                    '1.2.3.1:1001',
+                    '1.2.3.2'],
+    }].forEach(testCase => describe(testCase.caption, () => {
+        beforeEach(() => {
+            roundRobin = new RoundRobin(testCase.hostsList,
+                                        { stickyCount: 10 });
+        });
+
+        it('should pick all hosts in turn', () => {
+            const hostsPickCount = {
+                '1.2.3.0': 0,
+                '1.2.3.1': 0,
+                '1.2.3.2': 0,
+            };
+
+            // expect 3 loops of 10 times each of the 3 hosts
+            for (let i = 0; i < 90; ++i) {
+                const hostItem = roundRobin.pickHost();
+                hostsPickCount[hostItem.host] =
+                    hostsPickCount[hostItem.host] + 1;
+            }
+            assert.strictEqual(hostsPickCount['1.2.3.0'], 30);
+            assert.strictEqual(hostsPickCount['1.2.3.1'], 30);
+            assert.strictEqual(hostsPickCount['1.2.3.2'], 30);
+        });
+
+        it('should pick the same current host up to stickyCount ' +
+        'with pickHost()', () => {
+            const hostsPickCount = {
+                '1.2.3.0': 0,
+                '1.2.3.1': 0,
+                '1.2.3.2': 0,
+            };
+
+            // the current host should be picked 10 times in a row
+            const curHost = roundRobin.getCurrentHost();
+            for (let i = 0; i < 10; ++i) {
+                const hostItem = roundRobin.pickHost();
+                hostsPickCount[hostItem.host] =
+                    hostsPickCount[hostItem.host] + 1;
+            }
+            assert.strictEqual(hostsPickCount[curHost.host], 10);
+        });
+
+        it('should pick each host in turn with pickNextHost()', () => {
+            const hostsPickCount = {
+                '1.2.3.0': 0,
+                '1.2.3.1': 0,
+                '1.2.3.2': 0,
+            };
+
+            // expect each host to be picked up 3 times
+            for (let i = 0; i < 9; ++i) {
+                const hostItem = roundRobin.pickNextHost();
+                hostsPickCount[hostItem.host] =
+                    hostsPickCount[hostItem.host] + 1;
+            }
+            assert.strictEqual(hostsPickCount['1.2.3.0'], 3);
+            assert.strictEqual(hostsPickCount['1.2.3.1'], 3);
+            assert.strictEqual(hostsPickCount['1.2.3.2'], 3);
+        });
+
+        it('should refuse if no valid host/port is given', () => {
+            assert.throws(() => new RoundRobin([]), Error);
+            assert.throws(() => new RoundRobin([{}]), Error);
+            assert.throws(() => new RoundRobin([
+                { host: '', port: '' },
+            ]), Error);
+            assert.throws(() => new RoundRobin([
+                { host: 'zenko.io', port: '' },
+            ]), Error);
+            assert.throws(() => new RoundRobin([
+                { host: 'zenko.io', port: 'abcde' },
+            ]), Error);
+            assert.throws(() => new RoundRobin([
+                { host: 'zenko.io', port: '10abcde' },
+            ]), Error);
+            assert.throws(() => new RoundRobin(['zenko.io:1000:bad']),
+                          Error);
+
+            // this is valid
+            // eslint-disable-next-line no-new
+            new RoundRobin([{ host: 'zenko.io', port: '42' }]);
+            // eslint-disable-next-line no-new
+            new RoundRobin(['zenko.io:42']);
+            // eslint-disable-next-line no-new
+            new RoundRobin(['zenko.io', 'zenka.ia']);
+        });
+    }));
+});


### PR DESCRIPTION
This is meant to be a generic round-robin manager (aka. bootstrap
list) to contact hosts in turn.

Blacklisting should be implemented in a next iteration.