### PR TITLE
bf: force pickNextHost() to pick all hosts in turn

### DIFF
--- a/lib/network/RoundRobin.js
+++ b/lib/network/RoundRobin.js
@@ -112,7 +112,7 @@ class RoundRobin {
         const curHost = this.getCurrentHost();
         ++this.pickCount;
         if (this.pickCount === this.stickyCount) {
-            this._roundRobinCurrentHost();
+            this._roundRobinCurrentHost({ shuffle: true });
             this.pickCount = 0;
         }
         return curHost;
@@ -130,10 +130,11 @@ class RoundRobin {
      * @return {object} a host object with { host, port } attributes
      */
     pickNextHost() {
-        const curHost = this.getCurrentHost();
-        this._roundRobinCurrentHost();
+        // don't shuffle in this case because we want to force picking
+        // a different host, shuffling may return the same host again
+        this._roundRobinCurrentHost({ shuffle: false });
         this.pickCount = 0;
-        return curHost;
+        return this.getCurrentHost();
     }
 
     /**
@@ -146,12 +147,15 @@ class RoundRobin {
         return this.hostsList[this.hostIndex];
     }
 
-    _roundRobinCurrentHost() {
+    _roundRobinCurrentHost(params) {
         this.hostIndex += 1;
-        // re-shuffle the array when all entries have been returned once
         if (this.hostIndex === this.hostsList.length) {
             this.hostIndex = 0;
-            shuffle(this.hostsList);
+            // re-shuffle the array when all entries have been
+            // returned once, if shuffle param is true
+            if (params.shuffle) {
+                shuffle(this.hostsList);
+            }
         }
         if (this.logger) {
             this.logger.debug('round robin host',


### PR DESCRIPTION
Previously the shuffling may have returned the same host or at least
not go through all hosts once in turn. Fix this by not shuffling the
hosts array and by doing round-robin prior to returning the next host.