### PR TITLE
fix: update replication configuration format

### DIFF
--- a/lib/models/ReplicationConfiguration.js
+++ b/lib/models/ReplicationConfiguration.js
@@ -277,7 +277,7 @@ class ReplicationConfiguration {
         }
 
         const replicationEndpoints = this._config.replicationEndpoints
-            .map(endpoint => endpoint.name);
+            .map(endpoint => endpoint.site);
         return replicationEndpoints.includes(storageClass) ||
             validStorageClasses.includes(storageClass);
     }


### PR DESCRIPTION
This commit updates the format of the expected replication config
from S3 from name/endpoint to site/servers to support the new
bootstrap list changes.