### PR TITLE
ft: metadata import capability in ObjectMD

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,6 +98,7 @@ module.exports = {
     models: {
         BucketInfo: require('./lib/models/BucketInfo'),
         ObjectMD: require('./lib/models/ObjectMD'),
+        ObjectMDLocation: require('./lib/models/ObjectMDLocation'),
         ARN: require('./lib/models/ARN'),
         WebsiteConfiguration: require('./lib/models/WebsiteConfiguration'),
         ReplicationConfiguration:

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -30,4 +30,7 @@ module.exports = {
     // so we do the same.
     maximumMetaHeadersSize: 2136,
     emptyFileMd5: 'd41d8cd98f00b204e9800998ecf8427e',
+    // Version 2 changes the format of the data location property
+    // Version 3 adds the dataStoreName attribute
+    mdModelVersion: 3,
 };

--- a/lib/models/ObjectMD.js
+++ b/lib/models/ObjectMD.js
@@ -1,23 +1,66 @@
+const constants = require('../constants');
+const VersionIDUtils = require('../versioning/VersionID');
 
-// Version 2 changes the format of the data location property
-// Version 3 adds the dataStoreName attribute
-const modelVersion = 3;
+const ObjectMDLocation = require('./ObjectMDLocation');
 
 /**
  * Class to manage metadata object for regular s3 objects (instead of
  * mpuPart metadata for example)
  */
-module.exports = class ObjectMD {
+class ObjectMD {
 
     /**
-     * @constructor
+     * Create a new instance of ObjectMD. Parameter <tt>objMd</tt> is
+     * reserved for internal use, users should call
+     * {@link ObjectMD.createFromBlob()} to load from a stored
+     * metadata blob and check the returned value for errors.
      *
-     * @param {number} version - Version of the metadata model
+     * @constructor
+     * @param {ObjectMD|object} [objMd] - object metadata source,
+     *   either an ObjectMD instance or a native JS object parsed from
+     *   JSON
      */
-    constructor(version) {
-        const now = new Date().toJSON();
+    constructor(objMd = undefined) {
+        this._initMd();
+        if (objMd !== undefined) {
+            if (objMd instanceof ObjectMD) {
+                this._updateFromObjectMD(objMd);
+            } else {
+                this._updateFromParsedJSON(objMd);
+            }
+        } else {
+            // set newly-created object md modified time to current time
+            this._data['last-modified'] = new Date().toJSON();
+        }
+        // set latest md model version now that we ensured
+        // backward-compat conversion
+        this._data['md-model-version'] = constants.mdModelVersion;
+    }
+
+    /**
+     * create an ObjectMD instance from stored metadata
+     *
+     * @param {String|Buffer} storedBlob - serialized metadata blob
+     * @return {object} a result object containing either a 'result'
+     *   property which value is a new ObjectMD instance on success, or
+     *   an 'error' property on error
+     */
+    static createFromBlob(storedBlob) {
+        try {
+            const objMd = JSON.parse(storedBlob);
+            return { result: new ObjectMD(objMd) };
+        } catch (err) {
+            return { error: err };
+        }
+    }
+
+    getSerialized() {
+        return JSON.stringify(this.getValue());
+    }
+
+    _initMd() {
+        // initialize md with default values
         this._data = {
-            'md-model-version': version || modelVersion,
             'owner-display-name': '',
             'owner-id': '',
             'cache-control': '',
@@ -26,7 +69,6 @@ module.exports = class ObjectMD {
             'expires': '',
             'content-length': 0,
             'content-type': '',
-            'last-modified': now,
             'content-md5': '',
             // simple/no version. will expand once object versioning is
             // introduced
@@ -48,7 +90,7 @@ module.exports = class ObjectMD {
                 READ_ACP: [],
             },
             'key': '',
-            'location': [],
+            'location': null,
             'isNull': '',
             'nullVersionId': '',
             'isDeleteMarker': '',
@@ -66,13 +108,30 @@ module.exports = class ObjectMD {
         };
     }
 
-    /**
-     * Returns metadata model version
-     *
-     * @return {number} Metadata model version
-     */
-    getModelVersion() {
-        return this._data['md-model-version'];
+    _updateFromObjectMD(objMd) {
+        // We only duplicate selected attributes here, where setters
+        // allow to change inner values, and let the others as shallow
+        // copies. Since performance is a concern, we want to avoid
+        // the JSON.parse(JSON.stringify()) method.
+
+        Object.assign(this._data, objMd._data);
+        Object.assign(this._data.replicationInfo,
+                      objMd._data.replicationInfo);
+    }
+
+    _updateFromParsedJSON(objMd) {
+        // objMd is a new JS object created for the purpose, it's safe
+        // to just assign its top-level properties.
+
+        Object.assign(this._data, objMd);
+        this._convertToLatestModel();
+    }
+
+    _convertToLatestModel() {
+        // handle backward-compat stuff
+        if (typeof(this._data.location) === 'string') {
+            this.setLocation([{ key: this._data.location }]);
+        }
     }
 
     /**
@@ -463,21 +522,53 @@ module.exports = class ObjectMD {
     /**
      * Set location
      *
-     * @param {string[]} location - location
+     * @param {object[]} location - array of data locations (see
+     *   constructor of {@link ObjectMDLocation} for a description of
+     *   fields for each array object)
      * @return {ObjectMD} itself
      */
     setLocation(location) {
-        this._data.location = location;
+        if (!Array.isArray(location) || location.length === 0) {
+            this._data.location = null;
+        } else {
+            this._data.location = location;
+        }
         return this;
     }
 
     /**
      * Returns location
      *
-     * @return {string[]} location
+     * @return {object[]} location
      */
     getLocation() {
-        return this._data.location;
+        const { location } = this._data;
+        return Array.isArray(location) ? location : [];
+    }
+
+    // Object metadata may contain multiple elements for a single part if
+    // the part was originally copied from another MPU. Here we reduce the
+    // locations array to a single element for each part.
+    getReducedLocations() {
+        const locations = this.getLocation();
+        const reducedLocations = [];
+        let partTotal = 0;
+        for (let i = 0; i < locations.length; i++) {
+            const currPart = new ObjectMDLocation(locations[i]);
+            const currPartNum = currPart.getPartNumber();
+            let nextPartNum = undefined;
+            if (i < locations.length - 1) {
+                const nextPart = new ObjectMDLocation(locations[i + 1]);
+                nextPartNum = nextPart.getPartNumber();
+            }
+            partTotal += currPart.getPartSize();
+            if (currPartNum !== nextPartNum) {
+                currPart.setPartSize(partTotal);
+                reducedLocations.push(currPart.getValue());
+                partTotal = 0;
+            }
+        }
+        return reducedLocations;
     }
 
     /**
@@ -561,6 +652,16 @@ module.exports = class ObjectMD {
     }
 
     /**
+     * Get metadata versionId value in encoded form (the one visible
+     * to the S3 API user)
+     *
+     * @return {string} The encoded object versionId
+     */
+    getEncodedVersionId() {
+        return VersionIDUtils.encode(this.getVersionId());
+    }
+
+    /**
      * Set tags
      *
      * @param {object} tags - tags object
@@ -607,6 +708,28 @@ module.exports = class ObjectMD {
      */
     getReplicationInfo() {
         return this._data.replicationInfo;
+    }
+
+    setReplicationStatus(status) {
+        this._data.replicationInfo.status = status;
+        return this;
+    }
+
+    getReplicationStatus() {
+        return this._data.replicationInfo.status;
+    }
+
+    getReplicationContent() {
+        return this._data.replicationInfo.content;
+    }
+
+    getReplicationRoles() {
+        return this._data.replicationInfo.role;
+    }
+
+    getReplicationTargetBucket() {
+        const destBucketArn = this._data.replicationInfo.destination;
+        return destBucketArn.split(':').slice(-1)[0];
     }
 
     /**
@@ -667,4 +790,6 @@ module.exports = class ObjectMD {
     getValue() {
         return this._data;
     }
-};
+}
+
+module.exports = ObjectMD;

--- a/lib/models/ObjectMDLocation.js
+++ b/lib/models/ObjectMDLocation.js
@@ -1,0 +1,72 @@
+/**
+ * Helper class to ease access to a single data location in metadata
+ * 'location' array
+ */
+class ObjectMDLocation {
+
+    /**
+     * @constructor
+     * @param {object} locationObj - single data location info
+     * @param {string} locationObj.key - data backend key
+     * @param {number} locationObj.start - index of first data byte of
+     *   this part in the full object
+     * @param {number} locationObj.size - byte length of data part
+     * @param {string} locationObj.dataStoreName - type of data store
+     * @param {string} locationObj.dataStoreETag - internal ETag of
+     *   data part
+     */
+    constructor(locationObj) {
+        this._data = {
+            key: locationObj.key,
+            start: locationObj.start,
+            size: locationObj.size,
+            dataStoreName: locationObj.dataStoreName,
+            dataStoreETag: locationObj.dataStoreETag,
+        };
+    }
+
+    getKey() {
+        return this._data.key;
+    }
+
+    getDataStoreName() {
+        return this._data.dataStoreName;
+    }
+
+    setDataLocation(location) {
+        this._data.key = location.key;
+        this._data.dataStoreName = location.dataStoreName;
+        return this;
+    }
+
+    getDataStoreETag() {
+        return this._data.dataStoreETag;
+    }
+
+    getPartNumber() {
+        return Number.parseInt(this._data.dataStoreETag.split(':')[0], 10);
+    }
+
+    getPartETag() {
+        return this._data.dataStoreETag.split(':')[1];
+    }
+
+    getPartStart() {
+        return this._data.start;
+    }
+
+    getPartSize() {
+        return this._data.size;
+    }
+
+    setPartSize(size) {
+        this._data.size = size;
+        return this;
+    }
+
+    getValue() {
+        return this._data;
+    }
+}
+
+module.exports = ObjectMDLocation;


### PR DESCRIPTION
ObjectMD model class is now able to import metadata from stored blob
and convert it to the latest version internally.

The first use case will be for backbeat to handle metadata checks and
updates, but it should also give a cleaner way to import and
manipulate object metadata in S3.

Note: removed 'version' parameter from ObjectMD constructor since it's
handled internally by the class and should not be exposed anymore.