### PR TITLE
ft: log uid from sent X-Scal-Request-Uids header

### DIFF
--- a/lib/s3routes/routes.js
+++ b/lib/s3routes/routes.js
@@ -19,6 +19,12 @@ const routeMap = {
     OPTIONS: routeOPTIONS,
 };
 
+function isValidReqUids(reqUids) {
+    // baseline check, to avoid the risk of running into issues if
+    // users craft a large x-scal-request-uids header
+    return reqUids.length < 128;
+}
+
 function checkUnsupportedRoutes(reqMethod) {
     const method = routeMap[reqMethod];
     if (!method) {
@@ -139,7 +145,15 @@ function routes(req, res, params, logger) {
         endpoint: req.endpoint,
     };
 
-    const log = logger.newRequestLogger();
+    let reqUids = req.headers['x-scal-request-uids'];
+    if (reqUids !== undefined && !isValidReqUids(reqUids)) {
+        // simply ignore invalid id (any user can provide an
+        // invalid request ID through a crafted header)
+        reqUids = undefined;
+    }
+    const log = (reqUids !== undefined ?
+                 logger.newRequestLoggerFromSerializedUids(reqUids) :
+                 logger.newRequestLogger());
     log.info('received request', clientInfo);
 
     log.end().addDefaultFields(clientInfo);


### PR DESCRIPTION
backbeat will send this header to provide the request uid set while
processing an entry to S3 routes.