### PR TITLE
Add MetadataFileServer.rawListKeys()

### DIFF
--- a/lib/storage/metadata/file/MetadataFileServer.js
+++ b/lib/storage/metadata/file/MetadataFileServer.js
@@ -159,7 +159,8 @@ class MetadataFileServer {
         // /metadata namespace
         const namespace = `${constants.metadataFileNamespace}/metadata`;
         this.logger.info(`creating metadata service at ${namespace}`);
-        this.rootDb = sublevel(level(`${this.path}/${ROOT_DB}`));
+        this.baseDb = level(`${this.path}/${ROOT_DB}`);
+        this.rootDb = sublevel(this.baseDb);
         const dbService = new levelNet.LevelDbService({
             rootDb: this.rootDb,
             namespace,
@@ -251,6 +252,8 @@ class MetadataFileServer {
         dbService.registerSyncAPI({
             createReadStream:
             (env, options) => env.subDb.createReadStream(options),
+            rawListKeys:
+            (env, options) => this.baseDb.createKeyStream(options),
             getUUID: () => this.readUUID(),
         });
     }


### PR DESCRIPTION
This new DB method lists the keys for the root DB, which makes inspecting all databases at once more convenient.