### PR TITLE
MD-7: fix resource account id

### DIFF
--- a/lib/policyEvaluator/RequestContext.js
+++ b/lib/policyEvaluator/RequestContext.js
@@ -132,11 +132,15 @@ function _buildArn(service, generalResource, specificResource, requesterInfo) {
     }
     if (service === 'iam' || service === 'sts') {
         // arn:aws:iam::<account-id>:<resource-type><resource>
+        let accountId = requesterInfo.accountid;
+        if (service === 'sts') {
+            accountId = requesterInfo.targetAccountId;
+        }
         if (specificResource) {
-            return `arn:aws:iam::${requesterInfo.accountid}:` +
+            return `arn:aws:iam::${accountId}:` +
                 `${generalResource}${specificResource}`;
         }
-        return `arn:aws:iam::${requesterInfo.accountid}:${generalResource}`;
+        return `arn:aws:iam::${accountId}:${generalResource}`;
     }
     if (service === 'ring') {
         // arn:aws:iam::<account-id>:<resource-type><resource>


### PR DESCRIPTION
Fixing resource account id by using the target account instead of
the requester one

See https://scality.atlassian.net/browse/MD-7