### PR TITLE
service accounts

### DIFF
--- a/lib/auth/AuthInfo.js
+++ b/lib/auth/AuthInfo.js
@@ -49,6 +49,14 @@ class AuthInfo {
     isRequesterPublicUser() {
         return this.canonicalID === constants.publicId;
     }
+    isRequesterAServiceAccount() {
+        return this.canonicalID.startsWith(
+            `${constants.zenkoServiceAccount}/`);
+    }
+    isRequesterThisServiceAccount(serviceName) {
+        return this.canonicalID ===
+            `${constants.zenkoServiceAccount}/${serviceName}`;
+    }
 }
 
 module.exports = AuthInfo;

--- a/lib/auth/in_memory/Backend.js
+++ b/lib/auth/in_memory/Backend.js
@@ -171,11 +171,11 @@ class Backend {
     * @param {object} requestContextParams.constantParams -
     * params that have the
     * same value for each requestContext to be constructed in Vault
-    * @param {object} requestContextParams.paramaterize - params that have
+    * @param {object} requestContextParams.parameterize - params that have
     * arrays as values since a requestContext needs to be constructed with
     * each option in Vault
-    * @param {object[]} requestContextParams.paramaterize.specificResource -
-    * specific resources paramaterized as an array of objects containing
+    * @param {object[]} requestContextParams.parameterize.specificResource -
+    * specific resources parameterized as an array of objects containing
     * properties `key` and optional `versionId`
     * @param {string} userArn - arn of requesting user
     * @param {object} log - log object

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -20,6 +20,7 @@ module.exports = {
     // no authentication information.  Requestor can access
     // only public resources
     publicId: 'http://acs.amazonaws.com/groups/global/AllUsers',
+    zenkoServiceAccount: 'http://acs.zenko.io/accounts/service',
     metadataFileNamespace: '/MDFile',
     dataFileURL: '/DataFile',
     // AWS states max size for user-defined metadata

--- a/tests/unit/auth/AuthInfo.js
+++ b/tests/unit/auth/AuthInfo.js
@@ -72,4 +72,20 @@ describe('AuthInfo class constructor', () => {
         const publicUser = new AuthInfo({ canonicalID: constants.publicId });
         assert.strictEqual(publicUser.isRequesterPublicUser(), true);
     });
+
+    it('should have a working isRequesterAServiceAccount() method', () => {
+        assert.strictEqual(authInfo.isRequesterAServiceAccount(), false);
+        const serviceAccount = new AuthInfo({
+            canonicalID: `${constants.zenkoServiceAccount}/clueso` });
+        assert.strictEqual(serviceAccount.isRequesterAServiceAccount(), true);
+    });
+
+    it('should have a working isRequesterThisServiceAccount() method', () => {
+        const serviceAccount = new AuthInfo({
+            canonicalID: `${constants.zenkoServiceAccount}/clueso` });
+        assert.strictEqual(
+            serviceAccount.isRequesterThisServiceAccount('backbeat'), false);
+        assert.strictEqual(
+            serviceAccount.isRequesterThisServiceAccount('clueso'), true);
+    });
 });


### PR DESCRIPTION
 ft: service account identification support

Add support in AuthInfo for service accounts, designated by a
canonical ID starting with the service accounts namespace URL (newly
defined). We can ask if the authenticated account is a service account
or a particular one by its name.
