### PR TITLE
FT: Add storageType to replicationInfo

### DIFF
--- a/lib/models/ObjectMD.js
+++ b/lib/models/ObjectMD.js
@@ -60,6 +60,7 @@ module.exports = class ObjectMD {
                 destination: '',
                 storageClass: '',
                 role: '',
+                storageType: '',
             },
             'dataStoreName': '',
         };
@@ -586,14 +587,15 @@ module.exports = class ObjectMD {
      * @return {ObjectMD} itself
      */
     setReplicationInfo(replicationInfo) {
-        const { status, content, destination, storageClass, role } =
-            replicationInfo;
+        const { status, content, destination, storageClass, role,
+            storageType } = replicationInfo;
         this._data.replicationInfo = {
             status,
             content,
             destination,
             storageClass: storageClass || '',
             role,
+            storageType: storageType || '',
         };
         return this;
     }

--- a/lib/models/ReplicationConfiguration.js
+++ b/lib/models/ReplicationConfiguration.js
@@ -58,6 +58,8 @@ class ReplicationConfiguration {
         this._role = null;
         this._destination = null;
         this._rules = null;
+        this._prevStorageClass = null;
+        this._isExternalLocation = null;
     }
 
     /**
@@ -148,10 +150,15 @@ class ReplicationConfiguration {
         }
         const role = parsedRole[0];
         const rolesArr = role.split(',');
-        if (rolesArr.length !== 2) {
+        if (!this._isExternalLocation && rolesArr.length !== 2) {
             return errors.InvalidArgument.customizeDescription(
                 'Invalid Role specified in replication configuration: ' +
                 'Role must be a comma-separated list of two IAM roles');
+        }
+        if (this._isExternalLocation && rolesArr.length > 1) {
+            return errors.InvalidArgument.customizeDescription(
+                'Invalid Role specified in replication configuration: ' +
+                'Role may not contain a comma separator');
         }
         const invalidRole = rolesArr.find(r => !this._isValidRoleARN(r));
         if (invalidRole !== undefined) {
@@ -267,22 +274,6 @@ class ReplicationConfiguration {
     }
 
     /**
-     * Check that the `StorageClass` is a valid class
-     * @param {string} storageClass - The storage class to validate
-     * @return {boolean} `true` if valid, otherwise `false`
-     */
-    _isValidStorageClass(storageClass) {
-        if (!this._config) {
-            return validStorageClasses.includes(storageClass);
-        }
-
-        const replicationEndpoints = this._config.replicationEndpoints
-            .map(endpoint => endpoint.site);
-        return replicationEndpoints.includes(storageClass) ||
-            validStorageClasses.includes(storageClass);
-    }
-
-    /**
      * Check that the `StorageClass` property is valid
      * @param {object} destination - The destination object from this._parsedXML
      * @return {undefined}
@@ -290,9 +281,28 @@ class ReplicationConfiguration {
     _parseStorageClass(destination) {
         const storageClass = destination.StorageClass &&
             destination.StorageClass[0];
-        if (!this._isValidStorageClass(storageClass)) {
+        if (!this._config) {
+            return validStorageClasses.includes(storageClass);
+        }
+        const replicationEndpoints = this._config.replicationEndpoints
+            .map(endpoint => endpoint.site);
+        const locationConstraints =
+            Object.keys(this._config.locationConstraints);
+        if (locationConstraints.includes(storageClass)) {
+            if (this._prevStorageClass !== null &&
+                this._prevStorageClass !== storageClass) {
+                return errors.InvalidRequest.customizeDescription(
+                    'The storage class must be same for all rules when ' +
+                    'replicating objects to an external location');
+            }
+            this._isExternalLocation = true;
+        }
+        if (!replicationEndpoints.includes(storageClass) &&
+            !locationConstraints.includes(storageClass) &&
+            !validStorageClasses.includes(storageClass)) {
             return errors.MalformedXML;
         }
+        this._prevStorageClass = storageClass;
         return undefined;
     }
 
@@ -357,11 +367,11 @@ class ReplicationConfiguration {
      * @return {undefined}
      */
     parseConfiguration() {
-        const err = this._parseRole() || this._parseRules();
+        const err = this._parseRules();
         if (err) {
             return err;
         }
-        return undefined;
+        return this._parseRole();
     }
 
     /**

--- a/tests/unit/models/object.js
+++ b/tests/unit/models/object.js
@@ -79,6 +79,7 @@ describe('ObjectMD class setters/getters', () => {
             destination: '',
             storageClass: '',
             role: '',
+            storageType: '',
         }],
         ['ReplicationInfo', {
             status: 'PENDING',
@@ -87,6 +88,7 @@ describe('ObjectMD class setters/getters', () => {
             storageClass: 'STANDARD',
             role: 'arn:aws:iam::account-id:role/src-resource,' +
                 'arn:aws:iam::account-id:role/dest-resource',
+            storageType: 'aws_s3',
         }],
         ['DataStoreName', null, ''],
     ].forEach(test => {


### PR DESCRIPTION
Depends on https://github.com/scality/S3/pull/922.

* Add the `storageType` field to the `replicationInfo` field of an object's metadata.
* The definition of a valid `storageClass` is expanded to include values that exist in the locationConfig.json of CloudServer.