### PR TITLE
ft: policy arn condition

### DIFF
--- a/lib/policyEvaluator/RequestContext.js
+++ b/lib/policyEvaluator/RequestContext.js
@@ -188,6 +188,7 @@ function _buildArn(service, generalResource, specificResource, requesterInfo) {
  * @param {string} authType - type of authentication used
  * @param {number} signatureAge - age of signature in milliseconds
  * @param {string} securityToken - auth security token (temporary credentials)
+ * @param {string} policyArn - policy arn
  * @return {RequestContext} a RequestContext instance
  */
 
@@ -195,7 +196,7 @@ class RequestContext {
     constructor(headers, query, generalResource, specificResource,
         requesterIp, sslEnabled, apiMethod,
         awsService, locationConstraint, requesterInfo,
-        signatureVersion, authType, signatureAge, securityToken) {
+        signatureVersion, authType, signatureAge, securityToken, policyArn) {
         this._headers = headers;
         this._query = query;
         this._requesterIp = requesterIp;
@@ -221,6 +222,7 @@ class RequestContext {
         this._authType = authType;
         this._signatureAge = signatureAge;
         this._securityToken = securityToken;
+        this._policyArn = policyArn;
 
         return this;
     }
@@ -248,6 +250,7 @@ class RequestContext {
             locationConstraint: this._locationConstraint,
             tokenIssueTime: this._tokenIssueTime,
             securityToken: this._securityToken,
+            policyArn: this._policyArn,
         };
         return JSON.stringify(requestInfo);
     }
@@ -268,7 +271,7 @@ class RequestContext {
             obj.specificResource, obj.requesterIp, obj.sslEnabled,
             obj.apiMethod, obj.awsService, obj.locationConstraint,
             obj.requesterInfo, obj.signatureVersion,
-            obj.authType, obj.signatureAge, obj.securityToken);
+            obj.authType, obj.signatureAge, obj.securityToken, obj.policyArn);
     }
 
     /**
@@ -577,6 +580,26 @@ class RequestContext {
      */
     setSecurityToken(token) {
         this._securityToken = token;
+        return this;
+    }
+
+    /**
+     * Get the policy arn
+     *
+     * @return {string} policyArn - Policy arn
+     */
+    getPolicyArn() {
+        return this._policyArn;
+    }
+
+    /**
+     * Set the policy arn
+     *
+     * @param {string} policyArn - Policy arn
+     * @return {RequestContext} itself
+     */
+    setPolicyArn(policyArn) {
+        this._policyArn = policyArn;
         return this;
     }
 }

--- a/lib/policyEvaluator/utils/checkArnMatch.js
+++ b/lib/policyEvaluator/utils/checkArnMatch.js
@@ -14,8 +14,7 @@ const handleWildcardInResource =
  */
 function checkArnMatch(policyArn, requestRelativeId, requestArnArr,
     caseSensitive) {
-    let regExofArn = handleWildcardInResource(policyArn);
-    regExofArn = caseSensitive ? regExofArn : regExofArn.toLowerCase();
+    const regExofArn = handleWildcardInResource(policyArn);
     // The relativeId is the last part of the ARN (for instance, a bucket and
     // object name in S3)
     // Join on ":" in case there were ":" in the relativeID at the end

--- a/lib/policyEvaluator/utils/conditions.js
+++ b/lib/policyEvaluator/utils/conditions.js
@@ -145,6 +145,7 @@ conditions.findConditionKey = (key, requestContext) => {
     map.set('s3:ObjLocationConstraint',
         headers['x-amz-meta-scal-location-constraint']);
     map.set('sts:ExternalId', requestContext.getRequesterExternalId());
+    map.set('iam:PolicyArn', requestContext.getPolicyArn());
     return map.get(key);
 };
 

--- a/tests/unit/policyEvaluator.js
+++ b/tests/unit/policyEvaluator.js
@@ -1078,6 +1078,36 @@ describe('policyEvaluator', () => {
                     check(requestContext, {}, policy, 'Allow');
                 });
 
+            it('should allow policy arn if meet condition',
+                () => {
+                    policy.Statement.Condition = {
+                        ArnLike: { 'iam:PolicyArn':
+                           ['arn:aws:iam::012345678901:policy/dev/*'] },
+                    };
+                    requestContext.setRequesterInfo(
+                        { accountid: '012345678901' });
+                    const rcModifiers = {
+                        _policyArn:
+                            'arn:aws:iam::012345678901:policy/dev/devMachine1',
+                    };
+                    check(requestContext, rcModifiers, policy, 'Allow');
+                });
+
+            it('should not allow policy arn if do not meet condition',
+                () => {
+                    policy.Statement.Condition = {
+                        ArnLike: { 'iam:PolicyArn':
+                            ['arn:aws:iam::012345678901:policy/dev/*'] },
+                    };
+                    requestContext.setRequesterInfo(
+                        { accountid: '012345678901' });
+                    const rcModifiers = {
+                        _policyArn:
+                            'arn:aws:iam::012345678901:policy/admin/deleteUser',
+                    };
+                    check(requestContext, rcModifiers, policy, 'Neutral');
+                });
+
             it('should allow access with multiple operator conditions ' +
             'and multiple conditions under an operator',
                 () => {


### PR DESCRIPTION
MD-286
There was a bug in `checkArnMatch`: it was making a ternary that is not necessary (`toLowerCase()` is done when the elements are joined).
Furthermore, it was calling this last method on an array.