### PR TITLE
ft: add getters to storageClass/storageType

### DIFF
--- a/lib/models/ObjectMD.js
+++ b/lib/models/ObjectMD.js
@@ -727,6 +727,14 @@ class ObjectMD {
         return this._data.replicationInfo.role;
     }
 
+    getReplicationStorageType() {
+        return this._data.replicationInfo.storageType;
+    }
+
+    getReplicationStorageClass() {
+        return this._data.replicationInfo.storageClass;
+    }
+
     getReplicationTargetBucket() {
         const destBucketArn = this._data.replicationInfo.destination;
         return destBucketArn.split(':').slice(-1)[0];


### PR DESCRIPTION
These getters were originally in backbeat QueueEntry class, move them
to the ObjectMD model.