### PR TITLE
FIX: Check only defined replication rule IDs

### DIFF
--- a/lib/models/ReplicationConfiguration.js
+++ b/lib/models/ReplicationConfiguration.js
@@ -262,7 +262,9 @@ class ReplicationConfiguration {
             return errors.InvalidRequest.customizeDescription(
                 'Rule Id must be unique');
         }
-        this._configIDs.push(id);
+        if (id !== undefined) {
+            this._configIDs.push(id);
+        }
         return undefined;
     }
 


### PR DESCRIPTION
Adding changes in Arsenal made in S3's `rel/7.0` branch by https://github.com/scality/S3/pull/924.