### PR TITLE
FT: No need action mapping

### DIFF
--- a/lib/policyEvaluator/RequestContext.js
+++ b/lib/policyEvaluator/RequestContext.js
@@ -196,7 +196,8 @@ class RequestContext {
     constructor(headers, query, generalResource, specificResource,
         requesterIp, sslEnabled, apiMethod,
         awsService, locationConstraint, requesterInfo,
-        signatureVersion, authType, signatureAge, securityToken, policyArn) {
+        signatureVersion, authType, signatureAge, securityToken, policyArn,
+        action) {
         this._headers = headers;
         this._query = query;
         this._requesterIp = requesterIp;
@@ -223,7 +224,7 @@ class RequestContext {
         this._signatureAge = signatureAge;
         this._securityToken = securityToken;
         this._policyArn = policyArn;
-
+        this._action = action;
         return this;
     }
 
@@ -251,6 +252,7 @@ class RequestContext {
             tokenIssueTime: this._tokenIssueTime,
             securityToken: this._securityToken,
             policyArn: this._policyArn,
+            action: this._action,
         };
         return JSON.stringify(requestInfo);
     }
@@ -271,7 +273,8 @@ class RequestContext {
             obj.specificResource, obj.requesterIp, obj.sslEnabled,
             obj.apiMethod, obj.awsService, obj.locationConstraint,
             obj.requesterInfo, obj.signatureVersion,
-            obj.authType, obj.signatureAge, obj.securityToken, obj.policyArn);
+            obj.authType, obj.signatureAge, obj.securityToken, obj.policyArn,
+            obj.action);
     }
 
     /**
@@ -279,6 +282,9 @@ class RequestContext {
     * @return {string} action
     */
     getAction() {
+        if (this._action) {
+            return this._action;
+        }
         if (this._foundAction) {
             return this._foundAction;
         }


### PR DESCRIPTION
We currently use an action mapping with api methods, allowing the option
to send directly the action to not have to modify arsenal each new
action managed.

Need for https://scality.atlassian.net/browse/MD-292