### PR TITLE
bf: sanity check on returned content-length

### DIFF
--- a/lib/s3routes/routesUtils.js
+++ b/lib/s3routes/routesUtils.js
@@ -310,7 +310,8 @@ function _contentLengthMatchesLocations(contentLength, dataLocations) {
         (sum, location) => (sum !== undefined && location.size ?
                             sum + Number.parseInt(location.size, 10) :
                             undefined), 0);
-    return sumSizes === undefined || sumSizes === contentLength;
+    return sumSizes === undefined ||
+        sumSizes === Number.parseInt(contentLength, 10);
 }
 
 const routesUtils = {


### PR DESCRIPTION
In responseStreamData() helper, ensure the content-length is correct
with respect to data locations aggregated size. Log an error and
return internal error to the client if not.

This should catch off-by-one errors when computing ranges of data
locations to fetch and return.