### PR TITLE
forward-port to master of bf: sanity check on returned content-length

### DIFF
--- a/lib/s3routes/routesUtils.js
+++ b/lib/s3routes/routesUtils.js
@@ -1,5 +1,6 @@
 const url = require('url');
 const ipCheck = require('../ipCheck');
+const errors = require('../errors');
 
 /**
  * setCommonResponseHeaders - Set HTTP response headers
@@ -304,6 +305,14 @@ function _responseBody(responseBackend, errCode, payload, response, log,
     return undefined;
 }
 
+function _contentLengthMatchesLocations(contentLength, dataLocations) {
+    const sumSizes = dataLocations.reduce(
+        (sum, location) => (sum !== undefined && location.size ?
+                            sum + Number.parseInt(location.size, 10) :
+                            undefined), 0);
+    return sumSizes === undefined || sumSizes === contentLength;
+}
+
 const routesUtils = {
     /**
      * @param {string} errCode - S3 error Code
@@ -401,6 +410,21 @@ const routesUtils = {
         if (errCode && !response.headersSent) {
             return XMLResponseBackend.errorResponse(errCode, response, log,
                                                     resHeaders);
+        }
+        if (dataLocations !== null && !response.headersSent) {
+            // sanity check of content length against individual data
+            // locations to fetch
+            const contentLength = resHeaders && resHeaders['Content-Length'];
+            if (contentLength !== undefined &&
+                !_contentLengthMatchesLocations(contentLength,
+                                                dataLocations)) {
+                log.error('logic error: total length of fetched data ' +
+                          'locations does not match returned content-length',
+                          { contentLength, dataLocations });
+                return XMLResponseBackend.errorResponse(errors.InternalError,
+                                                        response, log,
+                                                        resHeaders);
+            }
         }
         if (!response.headersSent) {
             okContentHeadersResponse(overrideParams, resHeaders, response,


### PR DESCRIPTION
In responseStreamData() helper, ensure the content-length is correct
with respect to data locations aggregated size. Log an error and
return internal error to the client if not.

This should catch off-by-one errors when computing ranges of data
locations to fetch and return.

Forward-port of https://github.com/scality/Arsenal/pull/365