### PR TITLE
Ft: extend StatsClient to increase by given amount

### DIFF
--- a/lib/metrics/RedisClient.js
+++ b/lib/metrics/RedisClient.js
@@ -35,6 +35,19 @@ class RedisClient {
             .exec(cb);
     }
 
+    /**
+     * increment value of a key by a given amount and set a ttl
+     * @param {string} key - key holding the value
+     * @param {number} amount - amount to increase by
+     * @param {number} expiry - expiry in seconds
+     * @param {callback} cb - callback
+     * @return {undefined}
+     */
+    incrbyEx(key, amount, expiry, cb) {
+        return this._client
+            .multi([['incrby', key, amount], ['expire', key, expiry]])
+            .exec(cb);
+    }
 
     /**
     * execute a batch of commands

--- a/lib/metrics/StatsClient.js
+++ b/lib/metrics/StatsClient.js
@@ -65,16 +65,29 @@ class StatsClient {
     /**
     * report/record a new request received on the server
     * @param {string} id - service identifier
-    * @param {callback} cb - callback
+    * @param {number} incr - optional param increment
+    * @param {function} cb - callback
     * @return {undefined}
     */
-    reportNewRequest(id, cb) {
+    reportNewRequest(id, incr, cb) {
         if (!this._redis) {
             return undefined;
         }
-        const callback = cb || this._noop;
+
+        let callback;
+        let amount;
+        if (typeof incr === 'function') {
+            // In case where optional `incr` is not passed, but `cb` is passed
+            callback = incr;
+            amount = 1;
+        } else {
+            callback = (cb && typeof cb === 'function') ? cb : this._noop;
+            amount = (incr && typeof incr === 'number') ? incr : 1;
+        }
+
         const key = this._buildKey(`${id}:requests`, new Date());
-        return this._redis.incrEx(key, this._expiry, callback);
+
+        return this._redis.incrbyEx(key, amount, this._expiry, callback);
     }
 
     /**


### PR DESCRIPTION
Allow StatsClient to increment a key by a given amount, needed for https://github.com/scality/backbeat/pull/126 (to increment by byte size)

Support random order optional args case with `callback` and `amount` arg. 
I am not checking to see if the optional args passed are valid types. Instead, building on top of what exists, if a callback and/or integer are passed, they are assigned to appropriate variables for use