### PR TITLE
FT: Export constructStringToSignV2 module

### DIFF
--- a/lib/auth/auth.js
+++ b/lib/auth/auth.js
@@ -7,6 +7,7 @@ const AuthInfo = require('./AuthInfo');
 const v2 = require('./v2/authV2');
 const v4 = require('./v4/authV4');
 const constants = require('../constants');
+const constructStringToSignV2 = require('./v2/constructStringToSign');
 const constructStringToSignV4 = require('./v4/constructStringToSign');
 const convertUTCtoISO8601 = require('./v4/timeUtils').convertUTCtoISO8601;
 const vaultUtilities = require('./in_memory/vaultUtilities');
@@ -143,7 +144,6 @@ function doAuth(request, log, cb, awsService, requestContexts) {
     return cb(errors.InternalError);
 }
 
-
 /**
  * This function will generate a version 4 header
  *
@@ -212,6 +212,7 @@ module.exports = {
     },
     client: {
         generateV4Headers,
+        constructStringToSignV2,
     },
     inMemory: {
         backend,


### PR DESCRIPTION
Exports v2 version of constructStringtoSign for use with the coming GCP
backend.