### PR TITLE
FT: Modifies V2 auth functions to handle GCP

### DIFF
--- a/lib/auth/v2/constructStringToSign.js
+++ b/lib/auth/v2/constructStringToSign.js
@@ -5,7 +5,7 @@ const utf8 = require('utf8');
 const getCanonicalizedAmzHeaders = require('./getCanonicalizedAmzHeaders');
 const getCanonicalizedResource = require('./getCanonicalizedResource');
 
-function constructStringToSign(request, data, log) {
+function constructStringToSign(request, data, log, clientType) {
     /*
     Build signature per AWS requirements:
     StringToSign = HTTP-Verb + '\n' +
@@ -38,8 +38,8 @@ function constructStringToSign(request, data, log) {
     const date = query.Expires ? query.Expires : headers.date;
     const combinedQueryHeaders = Object.assign({}, headers, query);
     stringToSign += (date ? `${date}\n` : '\n')
-        + getCanonicalizedAmzHeaders(combinedQueryHeaders)
-        + getCanonicalizedResource(request);
+        + getCanonicalizedAmzHeaders(combinedQueryHeaders, clientType)
+        + getCanonicalizedResource(request, clientType);
     return utf8.encode(stringToSign);
 }
 

--- a/lib/auth/v2/getCanonicalizedAmzHeaders.js
+++ b/lib/auth/v2/getCanonicalizedAmzHeaders.js
@@ -1,13 +1,16 @@
 'use strict'; // eslint-disable-line strict
 
-function getCanonicalizedAmzHeaders(headers) {
+function getCanonicalizedAmzHeaders(headers, clientType) {
     /*
     Iterate through headers and pull any headers that are x-amz headers.
     Need to include 'x-amz-date' here even though AWS docs
     ambiguous on this.
     */
+    const filterFn = clientType === 'GCP' ?
+        val => val.substr(0, 7) === 'x-goog-' :
+        val => val.substr(0, 6) === 'x-amz-';
     const amzHeaders = Object.keys(headers)
-        .filter(val => val.substr(0, 6) === 'x-amz-')
+        .filter(filterFn)
         .map(val => [val.trim(), headers[val].trim()]);
     /*
     AWS docs state that duplicate headers should be combined

--- a/lib/auth/v2/getCanonicalizedResource.js
+++ b/lib/auth/v2/getCanonicalizedResource.js
@@ -2,7 +2,46 @@
 
 const url = require('url');
 
-function getCanonicalizedResource(request) {
+const gcpSubresources = [
+    'acl',
+    'billing',
+    'compose',
+    'cors',
+    'encryption',
+    'lifecycle',
+    'location',
+    'logging',
+    'storageClass',
+    'tagging',
+    'upload_id',
+    'versioning',
+    'versions',
+    'websiteConfig',
+];
+
+const awsSubresources = [
+    'acl',
+    'cors',
+    'delete',
+    'lifecycle',
+    'location',
+    'logging',
+    'notification',
+    'partNumber',
+    'policy',
+    'requestPayment',
+    'tagging',
+    'torrent',
+    'uploadId',
+    'uploads',
+    'versionId',
+    'versioning',
+    'replication',
+    'versions',
+    'website',
+];
+
+function getCanonicalizedResource(request, clientType) {
     /*
     This variable is used to determine whether to insert
     a '?' or '&'.  Once a query parameter is added to the resourceString,
@@ -24,27 +63,8 @@ function getCanonicalizedResource(request) {
     */
 
     // Specified subresources:
-    const subresources = [
-        'acl',
-        'cors',
-        'delete',
-        'lifecycle',
-        'location',
-        'logging',
-        'notification',
-        'partNumber',
-        'policy',
-        'requestPayment',
-        'tagging',
-        'torrent',
-        'uploadId',
-        'uploads',
-        'versionId',
-        'versioning',
-        'replication',
-        'versions',
-        'website',
-    ];
+    const subresources =
+        clientType === 'GCP' ? gcpSubresources : awsSubresources;
 
     /*
     If the request includes parameters in the query string,

--- a/tests/unit/auth/v2/canonicalization.js
+++ b/tests/unit/auth/v2/canonicalization.js
@@ -7,8 +7,14 @@ const getCanonicalizedAmzHeaders =
 const getCanonicalizedResource =
     require('../../../../lib/auth/v2/getCanonicalizedResource');
 
+const getCanonicalizedGcpHeaders = headers =>
+    getCanonicalizedAmzHeaders(headers, 'GCP');
+const gcpCanonicalizedResource = request =>
+    getCanonicalizedResource(request, 'GCP');
+
 describe('canonicalization', () => {
-    it('should construct a canonicalized header in the correct order', () => {
+    it('should construct a canonicalized header in the correct order for AWS',
+    () => {
         const headers = {
             'date': 'Mon, 21 Sep 2015 22:29:27 GMT',
             'x-amz-request-payer': 'requester',
@@ -43,7 +49,7 @@ describe('canonicalization', () => {
         assert.strictEqual(canonicalizedHeader, '');
     });
 
-    it('should construct a canonicalized resource', () => {
+    it('should construct a canonicalized resource for AWS', () => {
         const request = {
             headers: { host: 'bucket.s3.amazonaws.com:80' },
             url: '/obj',
@@ -60,7 +66,7 @@ describe('canonicalization', () => {
     });
 
     it('should return the path as the canonicalized resource ' +
-       'if no bucket name, overriding headers or delete query', () => {
+       'if no bucket name, overriding headers or delete query for AWS', () => {
         const request = {
             headers: { host: 's3.amazonaws.com:80' },
             url: '/',
@@ -71,7 +77,7 @@ describe('canonicalization', () => {
     });
 
     it('should sort the subresources (included query params) in ' +
-        'lexicographical order', () => {
+        'lexicographical order for AWS', () => {
         const request = {
             headers: { host: 's3.amazonaws.com:80' },
             url: '/',
@@ -83,5 +89,84 @@ describe('canonicalization', () => {
         const canonicalizedResource = getCanonicalizedResource(request);
         assert.strictEqual(canonicalizedResource,
             '/?partNumber=5&uploadId=iamanuploadid');
+    });
+
+    it('should construct a canonicalized header in the correct order for GCP',
+    () => {
+        const headers = {
+            'date': 'Mon, 21 Sep 2015 22:29:27 GMT',
+            'x-goog-request-payer': 'requester',
+            'x-goog-meta-meta': 'something very meta',
+            'x-goog-meta-bits': '0',
+            'x-goog-meta-blksize': '2097152',
+            'x-goog-meta-compress': '0',
+            'authorization': 'GOOG1 accessKey1:V8g5UJUFmMzruMqUHVT6ZwvUw+M=',
+            'host': 's3.amazonaws.com:80',
+            'connection': 'Keep-Alive',
+            'user-agent': 'Cyberduck/4.7.2.18004 (Mac OS X/10.10.5) (x86_64)',
+        };
+        const canonicalizedHeader = getCanonicalizedGcpHeaders(headers);
+        assert.strictEqual(canonicalizedHeader,
+            'x-goog-meta-bits:0\n' +
+            'x-goog-meta-blksize:2097152\n' +
+            'x-goog-meta-compress:0\n' +
+            'x-goog-meta-meta:something very meta\n' +
+            'x-goog-request-payer:requester\n');
+    });
+
+    it('should return an empty string as the canonicalized ' +
+       'header if no goog headers', () => {
+        const headers = {
+            'date': 'Mon, 21 Sep 2015 22:29:27 GMT',
+            'authorization': 'GOOG1 accessKey1:V8g5UJUFmMzruMqUHVT6ZwvUw+M=',
+            'host': 'storage.googleapis.com:80',
+            'connection': 'Keep-Alive',
+            'user-agent': 'Cyberduck/4.7.2.18004 (Mac OS X/10.10.5) (x86_64)',
+        };
+        const canonicalizedHeader = getCanonicalizedGcpHeaders(headers);
+        assert.strictEqual(canonicalizedHeader, '');
+    });
+
+    it('should construct a canonicalized resource for GCP', () => {
+        const request = {
+            headers: { host: 'bucket.storage.googapis.com:80' },
+            url: '/obj',
+            query: {
+                billing: 'yes,please',
+                ignore: 'me',
+            },
+            gotBucketNameFromHost: true,
+            bucketName: 'bucket',
+        };
+        const canonicalizedResource = gcpCanonicalizedResource(request);
+        assert.strictEqual(canonicalizedResource,
+                           '/bucket/obj?billing=yes,please');
+    });
+
+    it('should return the path as the canonicalized resource ' +
+       'if no bucket name, overriding headers or delete query for GCP', () => {
+        const request = {
+            headers: { host: 'storage.googleapis.com:80' },
+            url: '/',
+            query: { ignore: 'me' },
+        };
+        const canonicalizedResource = gcpCanonicalizedResource(request);
+        assert.strictEqual(canonicalizedResource, '/');
+    });
+
+
+    it('should sort the subresources (included query params) in ' +
+        'lexicographical order for GCP', () => {
+        const request = {
+            headers: { host: 'storage.googleapis.com:80' },
+            url: '/',
+            query: {
+                versioning: 'yes,please',
+                compose: 'yes,please',
+            },
+        };
+        const canonicalizedResource = gcpCanonicalizedResource(request);
+        assert.strictEqual(canonicalizedResource,
+            '/?compose=yes,please&versioning=yes,please');
     });
 });

--- a/tests/unit/auth/v2/constructStringToSign.js
+++ b/tests/unit/auth/v2/constructStringToSign.js
@@ -10,7 +10,7 @@ const log = new DummyRequestLogger();
 
 describe('v2 constructStringToSign function', () => {
     it('should construct a stringToSign with query params treated ' +
-        'like headers (e.g. x-amz-acl', () => {
+        'like headers (e.g. x-amz-acl) for AWS', () => {
         const request = {
             url: '/noderocks/cuteotter.jpeg?AWSAccessKeyId' +
             '=accessKey1&Content-Type=image%2Fjpeg&Expires=147266' +
@@ -42,6 +42,42 @@ describe('v2 constructStringToSign function', () => {
             'x-amz-acl:public-read\n' +
             '/noderocks/cuteotter.jpeg';
         const actualOutput = constructStringToSign(request, data, log);
+        assert.strictEqual(actualOutput, expectedOutput);
+    });
+
+    it('should construct a stringToSign with query params treated ' +
+        'like headers (e.g. x-goog-acl) for GCP', () => {
+        const request = {
+            url: '/noderocks/cuteotter.jpeg?AWSAccessKeyId' +
+            '=accessKey1&Content-Type=image%2Fjpeg&Expires=147266' +
+            '9382&Signature=WAkITY3f1igNJf68weCmffkUzDM%3D&x-' +
+            'amz-acl=public-read',
+            method: 'PUT',
+            headers: {
+                'host': 'localhost:8000',
+                'content-length': '5414',
+            },
+            query: {
+                'AWSAccessKeyId': 'accessKey1',
+                'Content-Type': 'image/jpeg',
+                'Expires': '1472669382',
+                'Signature': 'WAkITY3f1igNJf68weCmffkUzDM=',
+                'x-goog-acl': 'public-read',
+            },
+        };
+        const data = {
+            'AWSAccessKeyId': 'accessKey1',
+            'Content-Type': 'image/jpeg',
+            'Expires': '1472669382',
+            'Signature': 'WAkITY3f1igNJf68weCmffkUzDM=',
+            'x-goog-acl': 'public-read',
+        };
+        const expectedOutput = 'PUT\n\n' +
+            'image/jpeg\n' +
+            '1472669382\n' +
+            'x-goog-acl:public-read\n' +
+            '/noderocks/cuteotter.jpeg';
+        const actualOutput = constructStringToSign(request, data, log, 'GCP');
         assert.strictEqual(actualOutput, expectedOutput);
     });
 });

--- a/tests/unit/auth/v2/signature.js
+++ b/tests/unit/auth/v2/signature.js
@@ -10,9 +10,12 @@ const DummyRequestLogger = require('../../helpers').DummyRequestLogger;
 
 const log = new DummyRequestLogger();
 
+const gcpConstructStringToSign = (request, query, log) =>
+    constructStringToSign(request, query, log, 'GCP');
+
 describe('checkAuth reconstruction of signature', () => {
     it('should reconstruct the signature for a ' +
-       'GET request from s3-curl', () => {
+       'GET request from s3-curl for AWS', () => {
         // Based on s3-curl run
         const request = {
             method: 'GET',
@@ -32,8 +35,8 @@ describe('checkAuth reconstruction of signature', () => {
         assert.strictEqual(reconstructedSig, 'MJNF7AqNapSu32TlBOVkcAxj58c=');
     });
 
-    it('should reconstruct the signature for a GET request from '
-        + 'CyberDuck', () => {
+    it('should reconstruct the signature for a GET request from ' +
+       'CyberDuck for AWS', () => {
         // Based on CyberDuck request
         const request = {
             method: 'GET',
@@ -55,7 +58,8 @@ describe('checkAuth reconstruction of signature', () => {
         assert.strictEqual(reconstructedSig, 'V8g5UJUFmMzruMqUHVT6ZwvUw+M=');
     });
 
-    it('should reconstruct the signature for a PUT request from s3cmd', () => {
+    it('should reconstruct the signature for a PUT request from ' +
+       's3cmd for AWS', () => {
         // Based on s3cmd run
         const request = {
             method: 'PUT',
@@ -80,5 +84,83 @@ describe('checkAuth reconstruction of signature', () => {
         const stringToSign = constructStringToSign(request, request.query, log);
         const reconstructedSig = hashSignature(stringToSign, secretKey, 'sha1');
         assert.strictEqual(reconstructedSig, 'fWPcicKn7Fhzfje/0pRTifCxL44=');
+    });
+
+    it('should reconstruct the signature for a ' +
+       'GET request from s3-curl for GCP', () => {
+        // Based on s3-curl run
+        const request = {
+            method: 'GET',
+            headers: {
+                'host': 'storage.google.com:80',
+                'user-agent': 'curl/7.43.0',
+                'accept': '*/*',
+                'date': 'Fri, 18 Sep 2015 22:57:23 +0000',
+                'authorization':
+                    'GOOG1 accessKey1:MJNF7AqNapSu32TlBOVkcAxj58c=',
+            },
+            url: '/bucket',
+            query: {},
+        };
+        const secretKey = 'verySecretKey1';
+        const stringToSign =
+            gcpConstructStringToSign(request, request.query, log);
+        const reconstructedSig = hashSignature(stringToSign, secretKey, 'sha1');
+        assert.strictEqual(reconstructedSig, 'MJNF7AqNapSu32TlBOVkcAxj58c=');
+    });
+
+    it('should reconstruct the signature for a GET request from ' +
+       'CyberDuck for GCP', () => {
+        // Based on CyberDuck request
+        const request = {
+            method: 'GET',
+            headers: {
+                'date': 'Mon, 21 Sep 2015 22:29:27 GMT',
+                'x-goog-request-payer': 'requester',
+                'authorization':
+                    'GOOG1 accessKey1:V8g5UJUFmMzruMqUHVT6ZwvUw+M=',
+                'host': 'storage.google.com:80',
+                'connection': 'Keep-Alive',
+                'user-agent':
+                    'Cyberduck/4.7.2.18004 (Mac OS X/10.10.5) (x86_64)',
+            },
+            url: '/mb/?max-keys=1000&prefix&delimiter=%2F',
+            query: { 'max-keys': '1000', 'prefix': '', 'delimiter': '/' },
+        };
+        const secretKey = 'verySecretKey1';
+        const stringToSign =
+            gcpConstructStringToSign(request, request.query, log);
+        const reconstructedSig = hashSignature(stringToSign, secretKey, 'sha1');
+        assert.strictEqual(reconstructedSig, 'bdcnXSDhpN0lR2NBUlayg4vmMDU=');
+    });
+
+    it('should reconstruct the signature for a PUT request from ' +
+       's3cmd for GCP', () => {
+        // Based on s3cmd run
+        const request = {
+            method: 'PUT',
+            headers: {
+                'host': '127.0.0.1:8000',
+                'accept-encoding': 'identity',
+                'authorization':
+                    'GOOG1 accessKey1:fWPcicKn7Fhzfje/0pRTifCxL44=',
+                'content-length': '3941',
+                'content-type': 'binary/octet-stream',
+                'x-goog-date': 'Fri, 18 Sep 2015 23:32:34 +0000',
+                'x-goog-meta-s3cmd-attrs':
+                    'uid:501/gname:staff/uname:lhs/gid:20/mode:33060/' +
+                    'mtime:1319136702/atime:1442619138/' +
+                    'md5:5e714348185ffe355a76b754f79176d6/ctime:1441840220',
+                'x-goog-now': 'susdr',
+                'x-goog-y': 'what',
+            },
+            url: '/test/obj',
+            query: {},
+        };
+        const secretKey = 'verySecretKey1';
+        const stringToSign =
+            gcpConstructStringToSign(request, request.query, log);
+        const reconstructedSig = hashSignature(stringToSign, secretKey, 'sha1');
+        assert.strictEqual(reconstructedSig, 'F1f5Gpj+nYEShVawmOlH2P4JbjI=');
     });
 });


### PR DESCRIPTION
This feature modifies the V2 functions to handle signing Google Cloud Storage requests.
- Adds a conditional argument, clientType, to specify the headers/querystring handling method. Uses 'GCP' only when clientType === 'GCP'; the default is 'AWS'.
- Adds additional tests to accompany these changes.