### PR TITLE
ft: S3C-1065: Null part generator

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,7 @@ module.exports = {
             require('./lib/s3middleware/validateConditionalHeaders')
             .validateConditionalHeaders,
         MD5Sum: require('./lib/s3middleware/MD5Sum'),
+        NullStream: require('./lib/s3middleware/nullStream'),
         objectUtils: require('./lib/s3middleware/objectUtils'),
         azureHelper: {
             mpuUtils:

--- a/lib/s3middleware/nullStream.js
+++ b/lib/s3middleware/nullStream.js
@@ -1,0 +1,42 @@
+const Readable = require('stream').Readable;
+
+
+/**
+ * This class is used to produce zeros filled buffers for a reader consumption
+ */
+class NullStream extends Readable {
+
+    /**
+     * Construct a new zeros filled buffers producer that will
+     * produce as much bytes as specified by the range parameter, or the size
+     * parameter if range is null or not constituted of 2 elements
+     * @constructor
+     * @param {integer} size - the number of null bytes to produce
+     * @param {array} range - a range specification to override to size
+     */
+    constructor(size, range) {
+        super({});
+        if (Array.isArray(range) && range.length === 2) {
+            this.bytesToRead = range[1] - range[0] + 1;
+        } else {
+            this.bytesToRead = size;
+        }
+    }
+
+    /**
+     * This function generates the stream of null bytes
+     *
+     * @param {integer} size - advisory amount of data to produce
+     * @returns {undefined}
+     */
+    _read(size) {
+        const toRead = Math.min(size, this.bytesToRead);
+        const buffer = toRead > 0
+                  ? Buffer.alloc(toRead, 0)
+                  : null;
+        this.bytesToRead -= toRead;
+        this.push(buffer);
+    }
+}
+
+module.exports = NullStream;

--- a/tests/unit/s3middleware/nullStream.js
+++ b/tests/unit/s3middleware/nullStream.js
@@ -1,0 +1,34 @@
+const assert = require('assert');
+const NullStream = require('../../../lib/s3middleware/nullStream');
+const MD5Sum = require('../../../lib/s3middleware/MD5Sum');
+
+const nullChunks = [
+    { size: 1, md5sum: '93b885adfe0da089cdf634904fd59f71' },
+    { size: 15000000, md5sum: 'e05ffc4ac83a1a4f4d545a3a4852383f' },
+];
+
+function testNullChunk(size, range, expectedMD5, done) {
+    const nullChunk = new NullStream(size, range);
+    const digestStream = new MD5Sum();
+    digestStream.on('hashed', () => {
+        assert.strictEqual(digestStream.completedHash, expectedMD5);
+        done();
+    });
+    nullChunk.pipe(digestStream);
+    digestStream.on('data', () => {});
+}
+
+describe('s3middleware.NullStream', () => {
+    for (let i = 0; i < nullChunks.length; ++i) {
+        const size = nullChunks[i].size;
+        const md5sum = nullChunks[i].md5sum;
+        it(`should generate ${size} null bytes by size`, done => {
+            testNullChunk(size, null, md5sum, done);
+        });
+        it(`should generate ${size} null bytes by range`, done => {
+            const dummyOffset = 9320954;
+            testNullChunk(0, [dummyOffset, dummyOffset + size - 1],
+                          md5sum, done);
+        });
+    }
+});


### PR DESCRIPTION
This provides a new class, NullStream, that will be used to read null parts.
(null parts are parts with null keys which are generated by the NFS server when
growing a file with truncate)