### PR TITLE
bf: stream response from getRaftLog()

### DIFF
--- a/lib/storage/metadata/bucketclient/LogConsumer.js
+++ b/lib/storage/metadata/bucketclient/LogConsumer.js
@@ -1,6 +1,7 @@
 'use strict'; // eslint-disable-line
 
 const stream = require('stream');
+const jsonStream = require('JSONStream');
 
 const werelogs = require('werelogs');
 
@@ -89,7 +90,7 @@ class LogConsumer {
 
         this.bucketClient.getRaftLog(
             this.raftSession, _params.startSeq, _params.limit,
-            false, null, (err, data) => {
+            false, null, (err, stream) => {
                 if (err) {
                     if (err.code === 404) {
                         // no such raft session, log and ignore
@@ -109,18 +110,25 @@ class LogConsumer {
                         'Error handling record log request', { error: err });
                     return cb(err);
                 }
-                let logResponse;
-                try {
-                    logResponse = JSON.parse(data);
-                } catch (err) {
-                    this.logger.error('received malformed JSON',
-                                      { params });
+                // setup a temporary listener until the 'header' event
+                // is emitted
+                recordStream.on('error', err => {
+                    this.logger.error('error receiving raft log',
+                                      { error: err.message });
                     return cb(errors.InternalError);
-                }
-                logResponse.log.forEach(entry => recordStream.write(entry));
-                recordStream.end();
-                return cb(null, { info: logResponse.info,
-                    log: recordStream });
+                });
+                const jsonResponse = stream.pipe(jsonStream.parse('log.*'));
+                jsonResponse.pipe(recordStream);
+                stream.on('error', err => recordStream.emit('error', err));
+                jsonResponse
+                    .on('header', header => {
+                        // remove temporary listener
+                        recordStream.removeAllListeners('error');
+                        return cb(null, { info: header.info,
+                                          log: recordStream });
+                    })
+                    .on('error', err => recordStream.emit('error', err));
+                return undefined;
             }, this.logger.newRequestLogger());
     }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "ioredis": "2.4.0",
     "ipaddr.js": "1.2.0",
     "joi": "^10.6",
+    "JSONStream": "^1.0.0",
     "level": "~1.6.0",
     "level-sublevel": "~6.6.1",
     "simple-glob": "^0.1",


### PR DESCRIPTION
Adapt LogConsumer.readRecords() to use the stream returned by the modified
BucketClient.getRaftLog() function. That allows end-to-end streaming, hence
supporting arbitrary-sized responses, which should avoid toString() exceptions
or consume excessive amounts of memory.

Goes with https://github.com/scality/bucketclient/pull/126
