### PR TITLE
S3C-1101 FT: add read only backend error

### DIFF
--- a/errors/arsenalErrors.json
+++ b/errors/arsenalErrors.json
@@ -711,5 +711,10 @@
   "NotEnoughMapsInConfig:": {
     "description": "NotEnoughMapsInConfig",
     "code": 400
+  },
+  "_comment": "----------------------- cdmiclient -----------------------",
+  "ReadOnly": {
+    "description": "trying to write to read only back-end",
+    "code": 403
   }
 }


### PR DESCRIPTION
The feature to make the CDMI backend read only requires a dedicated
arsenal error. This new error will be thrown by all the data and
metadata callbacks which make write access.