### PR TITLE
bf: fix get lifecycle xml

### DIFF
--- a/lib/models/LifecycleConfiguration.js
+++ b/lib/models/LifecycleConfiguration.js
@@ -672,9 +672,15 @@ class LifecycleConfiguration {
                     return Tag;
                 }).join('');
             }
-            const Filter = ((rulePrefix && tags) || (tags && tags.length > 1)) ?
-                `<Filter><And>${Prefix}${tagXML}</And></Filter>` :
-                `<Filter>${Prefix}${tagXML}</Filter>`;
+            let Filter;
+            if (rulePrefix && !tags) {
+                Filter = Prefix;
+            } else if (tags && (rulePrefix || tags.length > 1)) {
+                Filter = `<Filter><And>${Prefix}${tagXML}</And></Filter>`;
+            } else {
+                // remaining condition is if only one or no tag
+                Filter = `<Filter>${tagXML}</Filter>`;
+            }
 
             const Actions = actions.map(action => {
                 const { actionName, days, date, deleteMarker } = action;


### PR DESCRIPTION
There was an issue using AWS cli's in getting a bucket's lifecycle due to xml formatting.