### PR TITLE
FIX: Wrong parameter encode url

### DIFF
--- a/lib/auth/v4/createCanonicalRequest.js
+++ b/lib/auth/v4/createCanonicalRequest.js
@@ -35,7 +35,7 @@ function createCanonicalRequest(params) {
                 notEncodeStar = true;
             }
             let payload = queryString.stringify(pQuery, null, null, {
-                encodeURIComponent: input => awsURIencode(input, false,
+                encodeURIComponent: input => awsURIencode(input, true,
                     notEncodeStar),
             });
             payload = payload.replace(/%20/g, '+');


### PR DESCRIPTION
Fix a wrong argument, encoding the '/' instead of not encoding it

(cherry picked from commit a72af2b7d1fc2b484759d6100f3bd743050b8f37)