### PR TITLE
Ft/S3C-1148 statsclient multiple ids

### DIFF
--- a/lib/metrics/RedisClient.js
+++ b/lib/metrics/RedisClient.js
@@ -23,6 +23,28 @@ class RedisClient {
     }
 
     /**
+    * scan a pattern and return matching keys
+    * @param {string} pattern - string pattern to match with all existing keys
+    * @param {number} [count=10] - scan count
+    * @param {callback} cb - callback (error, result)
+    * @return {undefined}
+    */
+    scan(pattern, count = 10, cb) {
+        const params = { match: pattern, count };
+        const keys = [];
+
+        const stream = this._client.scanStream(params);
+        stream.on('data', resultKeys => {
+            for (let i = 0; i < resultKeys.length; i++) {
+                keys.push(resultKeys[i]);
+            }
+        });
+        stream.on('end', () => {
+            cb(null, keys);
+        });
+    }
+
+    /**
     * increment value of a key by 1 and set a ttl
     * @param {string} key - key holding the value
     * @param {number} expiry - expiry in seconds

--- a/lib/metrics/StatsClient.js
+++ b/lib/metrics/StatsClient.js
@@ -106,6 +106,50 @@ class StatsClient {
     }
 
     /**
+    * wrapper on `getStats` that handles a list of keys
+    * @param {object} log - Werelogs request logger
+    * @param {array} ids - service identifiers
+    * @param {callback} cb - callback to call with the err/result
+    * @return {undefined}
+    */
+    getAllStats(log, ids, cb) {
+        if (!this._redis) {
+            return cb(null, {});
+        }
+
+        const statsRes = {
+            'requests': 0,
+            '500s': 0,
+            'sampleDuration': this._expiry,
+        };
+        let requests = 0;
+        let errors = 0;
+
+        // for now set concurrency to default of 10
+        return async.eachLimit(ids, 10, (id, done) => {
+            this.getStats(log, id, (err, res) => {
+                if (err) {
+                    return done(err);
+                }
+                requests += res.requests;
+                errors += res['500s'];
+                return done();
+            });
+        }, error => {
+            if (error) {
+                log.error('error getting stats', {
+                    error,
+                    method: 'StatsClient.getAllStats',
+                });
+                return cb(null, statsRes);
+            }
+            statsRes.requests = requests;
+            statsRes['500s'] = errors;
+            return cb(null, statsRes);
+        });
+    }
+
+    /**
     * get stats for the last x seconds, x being the sampling duration
     * @param {object} log - Werelogs request logger
     * @param {string} id - service identifier


### PR DESCRIPTION
Extend support for querying a list of ids and
returning a total sum of results for that list.
(Plan is to query all keys using wildcard, and pass
the list of keys to `getAllStats`)

Also add wrapper for redis method `keys`