### PR TITLE
fix: StatsClient zero byte increment

### DIFF
--- a/lib/metrics/StatsClient.js
+++ b/lib/metrics/StatsClient.js
@@ -82,7 +82,7 @@ class StatsClient {
             amount = 1;
         } else {
             callback = (cb && typeof cb === 'function') ? cb : this._noop;
-            amount = (incr && typeof incr === 'number') ? incr : 1;
+            amount = (typeof incr === 'number') ? incr : 1;
         }
 
         const key = this._buildKey(`${id}:requests`, new Date());


### PR DESCRIPTION
For metrics, there might be a chance byte size might be 0