### PR TITLE
ft: Add uid property to BucketInfo

### DIFF
--- a/lib/models/BucketInfo.js
+++ b/lib/models/BucketInfo.js
@@ -1,10 +1,13 @@
 const assert = require('assert');
+const uuid = require('uuid/v4');
+
 const { WebsiteConfiguration } = require('./WebsiteConfiguration');
 const ReplicationConfiguration = require('./ReplicationConfiguration');
 const LifecycleConfiguration = require('./LifecycleConfiguration');
 
 // WHEN UPDATING THIS NUMBER, UPDATE MODELVERSION.MD CHANGELOG
-const modelVersion = 6;
+// MODELVERSION.MD can be found in S3 repo: lib/metadata/ModelVersion.md
+const modelVersion = 7;
 
 class BucketInfo {
     /**
@@ -47,12 +50,14 @@ class BucketInfo {
     * @param {string[]} [cors[].exposeHeaders] - headers expose to applications
     * @param {object} [replicationConfiguration] - replication configuration
     * @param {object} [lifecycleConfiguration] - lifecycle configuration
+    * @param {string} [uid] - unique identifier for the bucket, necessary
+    * addition for use with lifecycle operations
     */
     constructor(name, owner, ownerDisplayName, creationDate,
                 mdBucketModelVersion, acl, transient, deleted,
                 serverSideEncryption, versioningConfiguration,
                 locationConstraint, websiteConfiguration, cors,
-                replicationConfiguration, lifecycleConfiguration) {
+                replicationConfiguration, lifecycleConfiguration, uid) {
         assert.strictEqual(typeof name, 'string');
         assert.strictEqual(typeof owner, 'string');
         assert.strictEqual(typeof ownerDisplayName, 'string');
@@ -112,6 +117,10 @@ class BucketInfo {
         if (lifecycleConfiguration) {
             LifecycleConfiguration.validateConfig(lifecycleConfiguration);
         }
+        if (uid) {
+            assert.strictEqual(typeof uid, 'string');
+            assert.strictEqual(uid.length, 36);
+        }
         const aclInstance = acl || {
             Canned: 'private',
             FULL_CONTROL: [],
@@ -137,6 +146,8 @@ class BucketInfo {
         this._replicationConfiguration = replicationConfiguration || null;
         this._cors = cors || null;
         this._lifecycleConfiguration = lifecycleConfiguration || null;
+        // Using undefined because limited to certain features at the moment
+        this._uid = uid || undefined;
         return this;
     }
     /**
@@ -160,6 +171,7 @@ class BucketInfo {
             cors: this._cors,
             replicationConfiguration: this._replicationConfiguration,
             lifecycleConfiguration: this._lifecycleConfiguration,
+            uid: this._uid,
         };
         if (this._websiteConfiguration) {
             bucketInfos.websiteConfiguration =
@@ -180,7 +192,8 @@ class BucketInfo {
             obj.creationDate, obj.mdBucketModelVersion, obj.acl,
             obj.transient, obj.deleted, obj.serverSideEncryption,
             obj.versioningConfiguration, obj.locationConstraint, websiteConfig,
-            obj.cors, obj.replicationConfiguration, obj.lifecycleConfiguration);
+            obj.cors, obj.replicationConfiguration, obj.lifecycleConfiguration,
+            obj.uid);
     }
 
     /**
@@ -203,7 +216,8 @@ class BucketInfo {
             data._transient, data._deleted, data._serverSideEncryption,
             data._versioningConfiguration, data._locationConstraint,
             data._websiteConfiguration, data._cors,
-            data._replicationConfiguration, data._lifecycleConfiguration);
+            data._replicationConfiguration, data._lifecycleConfiguration,
+            data._uid);
     }
 
     /**
@@ -520,6 +534,20 @@ class BucketInfo {
     isVersioningOn() {
         return this._versioningConfiguration &&
             this._versioningConfiguration.Status === 'Enabled';
+    }
+    /**
+     * Get unique id of bucket.
+     * @return {string} - unique id
+     */
+    getUid() {
+        return this._uid;
+    }
+    /**
+     * Generate unique id and set uid for bucket
+     * @return {BucketInfo} - bucket info instance
+     */
+    generateUid() {
+        this._uid = uuid();
     }
 }
 

--- a/tests/unit/models/BucketInfo.js
+++ b/tests/unit/models/BucketInfo.js
@@ -115,6 +115,8 @@ const testLifecycleConfiguration = {
         },
     ],
 };
+
+const testUid = '0e951060-6647-49cb-9852-42f9808b89c5';
 // create a dummy bucket to test getters and setters
 
 Object.keys(acl).forEach(
@@ -132,7 +134,8 @@ Object.keys(acl).forEach(
             testWebsiteConfiguration,
             testCorsConfiguration,
             testReplicationConfiguration,
-            testLifecycleConfiguration);
+            testLifecycleConfiguration,
+            testUid);
 
         describe('serialize/deSerialize on BucketInfo class', () => {
             const serialized = dummyBucket.serialize();
@@ -158,6 +161,7 @@ Object.keys(acl).forEach(
                         dummyBucket._replicationConfiguration,
                     lifecycleConfiguration:
                         dummyBucket._lifecycleConfiguration,
+                    uid: dummyBucket._uid,
                 };
                 assert.strictEqual(serialized, JSON.stringify(bucketInfos));
                 done();
@@ -182,6 +186,7 @@ Object.keys(acl).forEach(
                                       'string');
                    assert.strictEqual(typeof dummyBucket.getCreationDate(),
                                       'string');
+                   assert.strictEqual(typeof dummyBucket.getUid(), 'string');
                });
             it('this should have the right acl\'s types', () => {
                 assert.strictEqual(typeof dummyBucket.getAcl(), 'object');
@@ -256,6 +261,9 @@ Object.keys(acl).forEach(
             it('getLifeCycleConfiguration should return configuration', () => {
                 assert.deepStrictEqual(dummyBucket.getLifecycleConfiguration(),
                     testLifecycleConfiguration);
+            });
+            it('getUid should return the correct uid', () => {
+                assert.deepStrictEqual(dummyBucket.getUid(), testUid);
             });
         });
 
@@ -381,3 +389,25 @@ Object.keys(acl).forEach(
         });
     })
 );
+
+describe('uid default', () => {
+    it('should not set uid if none is specified by constructor params', () => {
+        const dummyBucket = new BucketInfo(
+            bucketName, owner, ownerDisplayName, testDate,
+            BucketInfo.currentModelVersion(), acl[emptyAcl],
+            false, false, {
+                cryptoScheme: 1,
+                algorithm: 'sha1',
+                masterKeyId: 'somekey',
+                mandatory: true,
+            }, testVersioningConfiguration,
+            testLocationConstraint,
+            testWebsiteConfiguration,
+            testCorsConfiguration,
+            testReplicationConfiguration,
+            testLifecycleConfiguration);
+
+        const defaultUid = dummyBucket.getUid();
+        assert.strictEqual(defaultUid, undefined);
+    });
+});


### PR DESCRIPTION
Currently only setting `uid` when using `putBucketLifecycle`