### PR TITLE
Fix/mongologreader contract

### DIFF
--- a/lib/storage/metadata/mongoclient/LogConsumer.js
+++ b/lib/storage/metadata/mongoclient/LogConsumer.js
@@ -4,7 +4,7 @@ const stream = require('stream');
 const MongoClient = require('mongodb').MongoClient;
 const { Timestamp } = require('bson');
 
-let lastEndID = undefined;
+let lastEndID = null;
 
 const ops = {
     i: 'put',
@@ -17,12 +17,12 @@ class ListRecordStream extends stream.Transform {
         super({ objectMode: true });
         this.logger = logger;
         this.hasStarted = false;
-        this.start = undefined;
-        this.end = undefined;
-        this.lastUniqID = undefined;
+        this.start = null;
+        this.end = null;
+        this.lastUniqID = null;
         // this.unpublishedListing is true once we pass the oplog that has the
         // start seq timestamp and uniqID 'h'
-        this.unpublishedListing = undefined;
+        this.unpublishedListing = null;
     }
 
     _transform(itemObj, encoding, callback) {
@@ -39,7 +39,7 @@ class ListRecordStream extends stream.Transform {
         // always update to most recent uniqID
         this.lastUniqID = itemObj.h.toString();
 
-        if (this.end === undefined || itemObj.ts.toNumber() > this.end) {
+        if (this.end === null || itemObj.ts.toNumber() > this.end) {
             this.end = itemObj.ts.toNumber();
         }
 


### PR DESCRIPTION
Pre-existing LogConsumer contract uses `null` for initial values,
`undefined` breaks client code assumptions, backbeat crashing with
this exception:
```
`${logRes.info.end.toString()}|${logRes.info.uniqID.toString()}`;
^
TypeError: Cannot read property 'toString' of undefined
at MongoLogReader._processPublishEntries 
```