### PR TITLE
Fix/stuck replication

### DIFF
--- a/lib/storage/metadata/mongoclient/LogConsumer.js
+++ b/lib/storage/metadata/mongoclient/LogConsumer.js
@@ -48,7 +48,6 @@ class ListRecordStream extends stream.Transform {
             if (lastEndID === itemObj.h.toString()) {
                 this.unpublishedListing = true;
             }
-            return callback();
         }
 
         if (!this.hasStarted) {

--- a/lib/storage/metadata/mongoclient/LogConsumer.js
+++ b/lib/storage/metadata/mongoclient/LogConsumer.js
@@ -4,8 +4,6 @@ const stream = require('stream');
 const MongoClient = require('mongodb').MongoClient;
 const { Timestamp } = require('bson');
 
-let lastEndID = null;
-
 const ops = {
     i: 'put',
     u: 'put',
@@ -13,9 +11,10 @@ const ops = {
 };
 
 class ListRecordStream extends stream.Transform {
-    constructor(logger) {
+    constructor(logger, lastEndID) {
         super({ objectMode: true });
         this.logger = logger;
+        this.lastEndID = lastEndID;
         this.hasStarted = false;
         this.start = null;
         this.end = null;
@@ -45,7 +44,7 @@ class ListRecordStream extends stream.Transform {
 
         // only push to stream unpublished objects
         if (!this.unpublishedListing) {
-            if (lastEndID === itemObj.h.toString()) {
+            if (this.lastEndID === itemObj.h.toString()) {
                 this.unpublishedListing = true;
             }
         }
@@ -150,11 +149,11 @@ class LogConsumer {
      * @return {undefined}
      */
     readRecords(params, cb) {
-        const recordStream = new ListRecordStream(this.logger);
         const limit = params.limit || 10000;
         const startIDandSeq = params.startSeq.toString().split('|');
         const startSeq = parseInt(startIDandSeq[0], 10) || 0;
-        lastEndID = startIDandSeq[1];
+        const lastEndID = startIDandSeq[1];
+        const recordStream = new ListRecordStream(this.logger, lastEndID);
 
         const db = this.metadataDatabase;
         const ns = new RegExp(`^(?!.*${db}.*(?:__)).*${db}\\.\\w+.*`);

--- a/lib/storage/metadata/mongoclient/LogConsumer.js
+++ b/lib/storage/metadata/mongoclient/LogConsumer.js
@@ -105,11 +105,12 @@ class LogConsumer {
      * @param {string} logger - logger
      */
     constructor(mongoConfig, logger) {
-        const { replicaSetHosts } = mongoConfig;
+        const { replicaSetHosts, database } = mongoConfig;
         // 'local' is the database where MongoDB has oplogs.rs capped collection
         this.database = 'local';
         this.mongoUrl = `mongodb://${replicaSetHosts}/local`;
         this.logger = logger;
+        this.metadataDatabase = database;
     }
 
     /**
@@ -156,9 +157,12 @@ class LogConsumer {
         const startSeq = parseInt(startIDandSeq[0], 10) || 0;
         lastEndID = startIDandSeq[1];
 
+        const db = this.metadataDatabase;
+        const ns = new RegExp(`^(?!.*${db}.*(?:__)).*${db}\\.\\w+.*`);
+
         this.coll = this.db.collection('oplog.rs');
         return this.coll.find({
-            ns: /^(?!.*metadata.*(?:__)).*metadata\.\w+.*/,
+            ns,
             ts: { $gte: Timestamp.fromNumber(startSeq) },
         }, {
             limit,


### PR DESCRIPTION
Fixes mongdb oplog consumer:

* Un-hardcode mongodb database name
* The mongodb transform stream would never actually emit any objects to the extensions
* Remove use of global variable