### PR TITLE
Fixes flakiness in S3 functional tests with mongo backend

### DIFF
--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -393,7 +393,7 @@ class MongoClientInterface {
                 return cb(errors.InternalError);
             }
             const objUpsert = !checkObj;
-            return c.bulkWrite([{
+            c.bulkWrite([{
                 updateOne: {
                     filter: {
                         _id: vObjName,
@@ -440,6 +440,7 @@ class MongoClientInterface {
                 }
                 return cb(null, `{"versionId": "${objVal.versionId}"}`);
             });
+            return null;
         });
     }
 


### PR DESCRIPTION
Commit b3103e1 that fixes versioning introduced some flakiness into the S3 functional tests with mongo backend. This reduces the flakiness on the tests.