### PR TITLE
bf: S3C-1427 use expired interval to avg out throughput

### DIFF
--- a/lib/backbeat/Metrics.js
+++ b/lib/backbeat/Metrics.js
@@ -11,7 +11,10 @@ class Metrics {
         const { redisConfig, validSites, internalStart } = config;
         this._logger = logger;
         this._redisClient = new RedisClient(redisConfig, this._logger);
-        this._statsClient = new StatsModel(this._redisClient, INTERVAL, EXPIRY);
+        // Redis expiry increased by an additional interval so we can reference
+        // the immediate older data for average throughput calculation
+        this._statsClient = new StatsModel(this._redisClient, INTERVAL,
+            (EXPIRY + INTERVAL));
         this._validSites = validSites;
         this._internalStart = internalStart;
     }
@@ -105,7 +108,9 @@ class Metrics {
                 });
                 return cb(errors.InternalError);
             }
-            const d = res.map(r => r.requests);
+            const d = res.map(r => (
+                r.requests.slice(0, 3).reduce((acc, i) => acc + i)
+            ));
 
             let opsBacklog = d[0] - d[1];
             if (opsBacklog < 0) opsBacklog = 0;
@@ -150,9 +155,12 @@ class Metrics {
                 return cb(errors.InternalError);
             }
 
+            const d = res.map(r => (
+                r.requests.slice(0, 3).reduce((acc, i) => acc + i)
+            ));
+
             // Find if time since start is less than EXPIRY time
-            const timeSinceStart = Math.floor(
-                (Date.now() - this._internalStart) / 1000);
+            const timeSinceStart = (Date.now() - this._internalStart) / 1000;
             // if timeSinceStart, then round the number to nearest 10's
             const timeDisplay = timeSinceStart < EXPIRY ?
                 (Math.ceil(timeSinceStart / 10) * 10) : EXPIRY;
@@ -163,8 +171,8 @@ class Metrics {
                         '(count) and number of MB transferred (size) in the ' +
                         `last ${timeDisplay} seconds`,
                     results: {
-                        count: res[0].requests,
-                        size: (res[1].requests / 1000).toFixed(2),
+                        count: d[0],
+                        size: (d[1] / 1000).toFixed(2),
                     },
                 },
             };
@@ -197,14 +205,26 @@ class Metrics {
                 return cb(errors.InternalError);
             }
 
+            const now = new Date();
+            const timeSinceStart = Math.floor(
+                (now - this._internalStart) / 1000);
+
             const [opsThroughput, bytesThroughput] = res.map(r => {
-                // Find if time since start is less than r.sampleDuration
-                const timeSinceStart = Math.floor(
-                    (Date.now() - this._internalStart) / 1000);
-                if (timeSinceStart < r.sampleDuration) {
-                    return (r.requests / timeSinceStart).toFixed(2);
+                let total = r.requests.slice(0, 3).reduce((acc, i) => acc + i);
+
+                // last interval timestamp
+                const lastInterval =
+                    this._statsClient._normalizeTimestamp(new Date(now));
+                // in seconds
+                const diff = Math.floor((now - lastInterval) / 1000);
+
+                if (timeSinceStart >= EXPIRY) {
+                    // Get average for last interval depending on time surpassed
+                    // so far for newest interval
+                    total += ((INTERVAL - diff) / INTERVAL) * r.requests[3];
                 }
-                return (r.requests / r.sampleDuration).toFixed(2);
+                // Divide total by EXPIRY to determine data per second
+                return (total / EXPIRY).toFixed(2);
             });
 
             const response = {

--- a/lib/metrics/StatsModel.js
+++ b/lib/metrics/StatsModel.js
@@ -1,3 +1,5 @@
+const async = require('async');
+
 const StatsClient = require('./StatsClient');
 
 /**
@@ -9,6 +11,16 @@ const StatsClient = require('./StatsClient');
 class StatsModel extends StatsClient {
 
     /**
+    * Utility method to convert 2d array rows to columns, and vice versa
+    * See also: https://docs.ruby-lang.org/en/2.0.0/Array.html#method-i-zip
+    * @param {array} arrays - 2d array of integers
+    * @return {array} converted array
+    */
+    _zip(arrays) {
+        return arrays[0].map((_, i) => arrays.map(a => a[i]));
+    }
+
+    /**
     * normalize to the nearest interval
     * @param {object} d - Date instance
     * @return {number} timestamp - normalized to the nearest interval
@@ -16,6 +28,72 @@ class StatsModel extends StatsClient {
     _normalizeTimestamp(d) {
         const m = d.getMinutes();
         return d.setMinutes(m - m % (Math.floor(this._interval / 60)), 0, 0);
+    }
+
+    /**
+    * override the method to get the count as an array of integers separated
+    * by each interval
+    * typical input looks like [[null, '1'], [null, '2'], [null, null]...]
+    * @param {array} arr - each index contains the result of each batch command
+    *   where index 0 signifies the error and index 1 contains the result
+    * @return {array} array of integers, ordered from most recent interval to
+    *   oldest interval
+    */
+    _getCount(arr) {
+        return arr.reduce((store, i) => {
+            let num = parseInt(i[1], 10);
+            num = Number.isNaN(num) ? 0 : num;
+            store.push(num);
+            return store;
+        }, []);
+    }
+
+    /**
+    * wrapper on `getStats` that handles a list of keys
+    * override the method to reduce the returned 2d array from `_getCount`
+    * @param {object} log - Werelogs request logger
+    * @param {array} ids - service identifiers
+    * @param {callback} cb - callback to call with the err/result
+    * @return {undefined}
+    */
+    getAllStats(log, ids, cb) {
+        if (!this._redis) {
+            return cb(null, {});
+        }
+
+        const statsRes = {
+            'requests': [],
+            '500s': [],
+            'sampleDuration': this._expiry,
+        };
+        const requests = [];
+        const errors = [];
+
+        // for now set concurrency to default of 10
+        return async.eachLimit(ids, 10, (id, done) => {
+            this.getStats(log, id, (err, res) => {
+                if (err) {
+                    return done(err);
+                }
+                requests.push(res.requests);
+                errors.push(res['500s']);
+                return done();
+            });
+        }, error => {
+            if (error) {
+                log.error('error getting stats', {
+                    error,
+                    method: 'StatsModel.getAllStats',
+                });
+                return cb(null, statsRes);
+            }
+
+            statsRes.requests = this._zip(requests).map(arr =>
+                arr.reduce((acc, i) => acc + i));
+            statsRes['500s'] = this._zip(errors).map(arr =>
+                arr.reduce((acc, i) => acc + i));
+            return cb(null, statsRes);
+        });
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=6.9.5"
   },
-  "version": "1.0.0-zenko",
+  "version": "1.0.1-zenko",
   "description": "Common utilities for the S3 project components",
   "main": "index.js",
   "repository": {

--- a/tests/unit/metrics/StatsModel.js
+++ b/tests/unit/metrics/StatsModel.js
@@ -1,0 +1,158 @@
+'use strict'; // eslint-disable-line strict
+
+const assert = require('assert');
+const async = require('async');
+
+const RedisClient = require('../../../lib/metrics/RedisClient');
+const StatsModel = require('../../../lib/metrics/StatsModel');
+
+// setup redis client
+const config = {
+    host: '127.0.0.1',
+    port: 6379,
+    enableOfflineQueue: false,
+};
+const fakeLogger = {
+    trace: () => {},
+    error: () => {},
+};
+const redisClient = new RedisClient(config, fakeLogger);
+
+// setup stats model
+const STATS_INTERVAL = 300; // 5 minutes
+const STATS_EXPIRY = 900; // 15 minutes
+const statsModel = new StatsModel(redisClient, STATS_INTERVAL, STATS_EXPIRY);
+
+// Since many methods were overwritten, these tests should validate the changes
+// made to the original methods
+describe('StatsModel class', () => {
+    const id = 'arsenal-test';
+
+    afterEach(() => redisClient.clear(() => {}));
+
+    it('should convert a 2d array columns into rows and vice versa using _zip',
+    () => {
+        const arrays = [
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 9],
+        ];
+
+        const res = statsModel._zip(arrays);
+        const expected = [
+            [1, 4, 7],
+            [2, 5, 8],
+            [3, 6, 9],
+        ];
+
+        assert.deepStrictEqual(res, expected);
+    });
+
+    it('_getCount should return a an array of all valid integer values',
+    () => {
+        const res = statsModel._getCount([
+            [null, '1'],
+            [null, '2'],
+            [null, null],
+        ]);
+        assert.deepStrictEqual(res, [1, 2, 0]);
+    });
+
+    it('should correctly record a new request by default one increment',
+    done => {
+        async.series([
+            next => {
+                statsModel.reportNewRequest(id, (err, res) => {
+                    assert.ifError(err);
+
+                    const expected = [[null, 1], [null, 1]];
+                    assert.deepStrictEqual(res, expected);
+                    next();
+                });
+            },
+            next => {
+                statsModel.reportNewRequest(id, (err, res) => {
+                    assert.ifError(err);
+
+                    const expected = [[null, 2], [null, 1]];
+                    assert.deepStrictEqual(res, expected);
+                    next();
+                });
+            },
+        ], done);
+    });
+
+    it('should record new requests by defined amount increments', done => {
+        function noop() {}
+
+        async.series([
+            next => {
+                statsModel.reportNewRequest(id, 9);
+                statsModel.getStats(fakeLogger, id, (err, res) => {
+                    assert.ifError(err);
+
+                    assert.deepStrictEqual(res.requests, [9, 0, 0]);
+                    next();
+                });
+            },
+            next => {
+                statsModel.reportNewRequest(id);
+                statsModel.getStats(fakeLogger, id, (err, res) => {
+                    assert.ifError(err);
+
+                    assert.deepStrictEqual(res.requests, [10, 0, 0]);
+                    next();
+                });
+            },
+            next => {
+                statsModel.reportNewRequest(id, noop);
+                statsModel.getStats(fakeLogger, id, (err, res) => {
+                    assert.ifError(err);
+
+                    assert.deepStrictEqual(res.requests, [11, 0, 0]);
+                    next();
+                });
+            },
+        ], done);
+    });
+
+    it('should correctly record a 500 on the server', done => {
+        statsModel.report500(id, (err, res) => {
+            assert.ifError(err);
+
+            const expected = [[null, 1], [null, 1]];
+            assert.deepStrictEqual(res, expected);
+            done();
+        });
+    });
+
+    it('should respond back with total requests as an array', done => {
+        async.series([
+            next => {
+                statsModel.reportNewRequest(id, err => {
+                    assert.ifError(err);
+                    next();
+                });
+            },
+            next => {
+                statsModel.report500(id, err => {
+                    assert.ifError(err);
+                    next();
+                });
+            },
+            next => {
+                statsModel.getStats(fakeLogger, id, (err, res) => {
+                    assert.ifError(err);
+
+                    const expected = {
+                        'requests': [1, 0, 0],
+                        '500s': [1, 0, 0],
+                        'sampleDuration': STATS_EXPIRY,
+                    };
+                    assert.deepStrictEqual(res, expected);
+                    next();
+                });
+            },
+        ], done);
+    });
+});


### PR DESCRIPTION
When an interval of data in Redis expires, throughput will
abruptly reduce. Given the data we collect, we can only
calculate the average throughput. To ease the erratic
decrease on expiration of an interval, instead, get the
average of elapsed time for the newest interval and
remaining time of the interval multiplied against the
average of the just-expired interval.

In Redis, we need to save an extra interval to reference
the just-expired data.