### PR TITLE
Zenko-21: FT: New Route for Prometheus Client

### DIFF
--- a/lib/backbeat/routes.js
+++ b/lib/backbeat/routes.js
@@ -70,6 +70,13 @@ function routes(redisKeys, allSites) {
             extensions: { crr: ['failed'] },
             method: 'retryFailedCRR',
         },
+        {
+            httpMethod: 'GET',
+            category: 'monitoring',
+            type: 'monitoring',
+            extensions: {},
+            method: 'monitoringHandler',
+        },
     ];
 }
 


### PR DESCRIPTION
Added new route for Prometheus client: /_/monitoring/metrics
Signed-off-by: anurag4DSB <anurag.213@gmail.com>