### PR TITLE
FX: constructing v4 query auth signature with proxyPath

### DIFF
--- a/lib/auth/v4/headerAuthCheck.js
+++ b/lib/auth/v4/headerAuthCheck.js
@@ -126,8 +126,17 @@ function check(request, log, data, awsService) {
     if (isTimeSkewed) {
         return { err: errors.RequestTimeTooSkewed };
     }
-    const proxyPath = request.headers.proxy_path ?
-    decodeURIComponent(request.headers.proxy_path) : null;
+
+    let proxyPath = null;
+    if (request.headers.proxy_path) {
+        try {
+            proxyPath = decodeURIComponent(request.headers.proxy_path);
+        } catch (err) {
+            log.debug('invalid proxy_path header', { proxyPath, err });
+            return { err: errors.InvalidArgument.customizeDescription(
+              'invalid proxy_path header') };
+        }
+    }
 
     const stringToSign = constructStringToSign({
         log,

--- a/lib/auth/v4/queryAuthCheck.js
+++ b/lib/auth/v4/queryAuthCheck.js
@@ -62,6 +62,17 @@ function check(request, log, data) {
         return { err: errors.RequestTimeTooSkewed };
     }
 
+    let proxyPath = null;
+    if (request.headers.proxy_path) {
+        try {
+            proxyPath = decodeURIComponent(request.headers.proxy_path);
+        } catch (err) {
+            log.debug('invalid proxy_path header', { proxyPath });
+            return { err: errors.InvalidArgument.customizeDescription(
+              'invalid proxy_path header') };
+        }
+    }
+
     // In query v4 auth, the canonical request needs
     // to include the query params OTHER THAN
     // the signature so create a
@@ -87,6 +98,7 @@ function check(request, log, data) {
         credentialScope:
             `${scopeDate}/${region}/${service}/${requestType}`,
         awsService: service,
+        proxyPath,
     });
     if (stringToSign instanceof Error) {
         return { err: stringToSign };

--- a/tests/unit/auth/v4/headerAuthCheck.js
+++ b/tests/unit/auth/v4/headerAuthCheck.js
@@ -282,4 +282,20 @@ describe('v4 headerAuthCheck', () => {
         assert.strictEqual(res.err, null);
         done();
     });
+
+    it('should return InvalidRequest error if proxy_path header is invalid',
+    done => {
+        // Freezes time so date created within function will be Feb 8, 2016
+        const clock = lolex.install(1454962445000);
+        /* eslint-disable camelcase */
+        const alteredRequest = createAlteredRequest({
+            proxy_path: 'absc%2proxy/1234' }, 'headers', request, headers);
+        /* eslint-enable camelcase */
+        const res = headerAuthCheck(alteredRequest, log);
+        clock.uninstall();
+        assert.deepStrictEqual(res.err,
+            errors.InvalidArgument.customizeDescription(
+            'invalid proxy_path header'));
+        done();
+    });
 });

--- a/tests/unit/auth/v4/queryAuthCheck.js
+++ b/tests/unit/auth/v4/queryAuthCheck.js
@@ -225,4 +225,34 @@ describe('v4 queryAuthCheck', () => {
         assert.strictEqual(res.params.version, 4);
         done();
     });
+
+    it('should successfully return no error if proxy_path header is added',
+    done => {
+        // Freezes time so date created within function will be Feb 8, 2016
+        const clock = lolex.install(1454974984001);
+        /* eslint-disable camelcase */
+        const alteredRequest = createAlteredRequest({ proxy_path:
+        'proxy/1234' }, 'headers', request, query);
+        /* eslint-enable camelcase */
+        const res = queryAuthCheck(alteredRequest, log, alteredRequest.query);
+        clock.uninstall();
+        assert.deepStrictEqual(res.err, null);
+        done();
+    });
+
+    it('should return InvalidRequest error if proxy_path header is invalid',
+    done => {
+        // Freezes time so date created within function will be Feb 8, 2016
+        const clock = lolex.install(1454974984001);
+        /* eslint-disable camelcase */
+        const alteredRequest = createAlteredRequest({ proxy_path:
+        'absc%2proxy/1234' }, 'headers', request, query);
+        /* eslint-enable camelcase */
+        const res = queryAuthCheck(alteredRequest, log, alteredRequest.query);
+        clock.uninstall();
+        assert.deepStrictEqual(res.err,
+            errors.InvalidArgument.customizeDescription(
+            'invalid proxy_path header'));
+        done();
+    });
 });


### PR DESCRIPTION
If `proxyPath` header is specified, we use it to construct our v4 query auth signature.