### PR TITLE
bf: zero-fill response for getAllStats

### DIFF
--- a/lib/metrics/StatsModel.js
+++ b/lib/metrics/StatsModel.js
@@ -61,13 +61,18 @@ class StatsModel extends StatsClient {
             return cb(null, {});
         }
 
+        const size = Math.floor(this._expiry / this._interval);
         const statsRes = {
-            'requests': [],
-            '500s': [],
+            'requests': Array(size).fill(0),
+            '500s': Array(size).fill(0),
             'sampleDuration': this._expiry,
         };
-        const requests = [];
-        const errors = [];
+        let requests = [];
+        let errors = [];
+
+        if (ids.length === 0) {
+            return cb(null, statsRes);
+        }
 
         // for now set concurrency to default of 10
         return async.eachLimit(ids, 10, (id, done) => {
@@ -88,10 +93,22 @@ class StatsModel extends StatsClient {
                 return cb(null, statsRes);
             }
 
-            statsRes.requests = this._zip(requests).map(arr =>
+            requests = this._zip(requests).map(arr =>
                 arr.reduce((acc, i) => acc + i));
-            statsRes['500s'] = this._zip(errors).map(arr =>
+            errors = this._zip(errors).map(arr =>
                 arr.reduce((acc, i) => acc + i));
+
+            // replace any existing values in arrays "requests" and "errors"
+            // in statsRes.requests and statsRes['500s']
+            // i.e. statsRes.requests = [0,0,0,0]
+            //      requests = [1, 2]
+            //    The splice should change:
+            //      statsRes.requests = [1,2,0,0]
+            Array.prototype.splice.apply(statsRes.requests,
+                [0, requests.length].concat(requests));
+            Array.prototype.splice.apply(statsRes['500s'],
+                [0, errors.length].concat(errors));
+
             return cb(null, statsRes);
         });
     }


### PR DESCRIPTION
For `StatsModel.getAllStats`, the `ids` argument can be an empty array. If empty, return a zero filled array instead