### PR TITLE
bf: ZENKO-323 relax mongo count error

### DIFF
--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -1074,9 +1074,13 @@ class MongoClientInterface {
         return async.series({
             master: done => {
                 // query for getting only master version entries
+                const mstFilter = [];
                 /* eslint-disable quote-props */
-                const mstFilter = mstVerIds.map(id =>
-                    ({ 'value.versionId': { '$eq': id } }));
+                mstVerIds.forEach(id => {
+                    if (id) {
+                        mstFilter.push({ 'value.versionId': { '$eq': id } });
+                    }
+                });
                 const query = {
                     '$and': [
                         queryFilter,
@@ -1088,9 +1092,13 @@ class MongoClientInterface {
             },
             archived: done => {
                 // query for getting only versioned entries
+                const mstFilter = [];
                 /* eslint-disable quote-props */
-                const mstFilter = mstVerIds.map(id =>
-                    ({ 'value.versionId': { '$ne': id } }));
+                mstVerIds.forEach(id => {
+                    if (id) {
+                        mstFilter.push({ 'value.versionId': { '$ne': id } });
+                    }
+                });
                 const query = {
                     '$and': [
                         queryFilter,
@@ -1158,6 +1166,13 @@ class MongoClientInterface {
                 return async.map(uniqKeys, (key, done) => {
                     this.getLatestVersion(c, key, log, (err, mst) => {
                         if (err) {
+                            if (err.NoSuchKey) {
+                                log.debug('NoSuchKey master info', {
+                                    method: 'getObjectMDStats',
+                                    error: err,
+                                });
+                                return done();
+                            }
                             log.error('unable to retrieve master info', {
                                 method: 'getObjectMDStats',
                                 error: err,


### PR DESCRIPTION
In collecting metrics for `data managed`, a `NoSuchKey` may happen, and it prevents a collection request to be skipped. This fix relaxes the error handling in the metric collection by ignoring `NoSuchKey` errors instead of returning them.