### PR TITLE
bf: ZENKO-343 remove regexp-based 'ns' filtering

### DIFF
--- a/lib/storage/metadata/mongoclient/LogConsumer.js
+++ b/lib/storage/metadata/mongoclient/LogConsumer.js
@@ -103,12 +103,11 @@ class LogConsumer {
      * @param {string} logger - logger
      */
     constructor(mongoConfig, logger) {
-        const { replicaSetHosts, database } = mongoConfig;
+        const { replicaSetHosts } = mongoConfig;
         // 'local' is the database where MongoDB has oplogs.rs capped collection
         this.database = 'local';
         this.mongoUrl = `mongodb://${replicaSetHosts}/local`;
         this.logger = logger;
-        this.metadataDatabase = database;
     }
 
     /**
@@ -155,12 +154,8 @@ class LogConsumer {
         const lastEndID = startIDandSeq[1];
         const recordStream = new ListRecordStream(this.logger, lastEndID);
 
-        const db = this.metadataDatabase;
-        const ns = new RegExp(`^(?!.*${db}.*(?:__)).*${db}\\.\\w+.*`);
-
         this.coll = this.db.collection('oplog.rs');
         return this.coll.find({
-            ns,
             ts: { $gte: Timestamp.fromNumber(startSeq) },
         }, {
             limit,


### PR DESCRIPTION
Don't filter internal namespace entries from mongo log, as backbeat
need the metastore entries exposed to process lifecycle entries.