### PR TITLE
fix: do not crash on empty backbeat stats

### DIFF
--- a/lib/backbeat/Metrics.js
+++ b/lib/backbeat/Metrics.js
@@ -109,7 +109,7 @@ class Metrics {
                 return cb(errors.InternalError);
             }
             const d = res.map(r => (
-                r.requests.slice(0, 3).reduce((acc, i) => acc + i)
+                r.requests.slice(0, 3).reduce((acc, i) => acc + i, 0)
             ));
 
             let opsBacklog = d[0] - d[1];
@@ -156,7 +156,7 @@ class Metrics {
             }
 
             const d = res.map(r => (
-                r.requests.slice(0, 3).reduce((acc, i) => acc + i)
+                r.requests.slice(0, 3).reduce((acc, i) => acc + i, 0)
             ));
 
             // Find if time since start is less than EXPIRY time
@@ -210,7 +210,8 @@ class Metrics {
                 (now - this._internalStart) / 1000);
 
             const [opsThroughput, bytesThroughput] = res.map(r => {
-                let total = r.requests.slice(0, 3).reduce((acc, i) => acc + i);
+                let total = r.requests.slice(0, 3).reduce(
+                    (acc, i) => acc + i, 0);
 
                 // last interval timestamp
                 const lastInterval =

--- a/lib/metrics/StatsModel.js
+++ b/lib/metrics/StatsModel.js
@@ -88,10 +88,14 @@ class StatsModel extends StatsClient {
                 return cb(null, statsRes);
             }
 
-            statsRes.requests = this._zip(requests).map(arr =>
-                arr.reduce((acc, i) => acc + i));
-            statsRes['500s'] = this._zip(errors).map(arr =>
-                arr.reduce((acc, i) => acc + i));
+            if (requests.length) {
+                statsRes.requests = this._zip(requests).map(arr =>
+                    arr.reduce((acc, i) => acc + i, 0));
+            }
+            if (errors.length) {
+                statsRes['500s'] = this._zip(errors).map(arr =>
+                    arr.reduce((acc, i) => acc + i, 0));
+            }
             return cb(null, statsRes);
         });
     }

--- a/tests/unit/backbeat/Metrics.js
+++ b/tests/unit/backbeat/Metrics.js
@@ -1,0 +1,79 @@
+'use strict'; // eslint-disable-line strict
+
+const assert = require('assert');
+
+const RedisClient = require('../../../lib/metrics/RedisClient');
+const { backbeat } = require('../../../');
+
+// setup redis client
+const config = {
+    host: '127.0.0.1',
+    port: 6379,
+    enableOfflineQueue: false,
+};
+const fakeLogger = {
+    trace: () => {},
+    error: () => {},
+};
+const redisClient = new RedisClient(config, fakeLogger);
+
+// setup stats model
+const sites = ['site1', 'site2'];
+const metrics = new backbeat.Metrics({
+    redisConfig: config,
+    validSites: ['site1', 'site2', 'all'],
+    internalStart: Date.now() - 900000, // 15 minutes ago.
+}, fakeLogger);
+
+// Since many methods were overwritten, these tests should validate the changes
+// made to the original methods
+describe('Metrics class', () => {
+    afterEach(() => redisClient.clear(() => {}));
+
+    it('should not crash on empty results', done => {
+        const redisKeys = {
+            ops: 'bb:crr:ops',
+            bytes: 'bb:crr:bytes',
+            opsDone: 'bb:crr:opsdone',
+            bytesDone: 'bb:crr:bytesdone',
+            failedCRR: 'bb:crr:failed',
+        };
+        const routes = backbeat.routes(redisKeys, sites);
+        const details = routes.find(route =>
+            route.category === 'metrics' && route.type === 'all');
+        details.site = 'all';
+        metrics.getAllMetrics(details, (err, res) => {
+            assert.ifError(err);
+            const expected = {
+                backlog: {
+                    description: 'Number of incomplete replication operations' +
+                        ' (count) and number of incomplete MB transferred' +
+                        ' (size)',
+                    results: {
+                        count: 0,
+                        size: '0.00',
+                    },
+                },
+                completions: {
+                    description: 'Number of completed replication operations' +
+                        ' (count) and number of MB transferred (size) in the ' +
+                        'last 900 seconds',
+                    results: {
+                        count: 0,
+                        size: '0.00',
+                    },
+                },
+                throughput: {
+                    description: 'Current throughput for replication' +
+                        ' operations in ops/sec (count) and MB/sec (size)',
+                    results: {
+                        count: 'NaN',
+                        size: 'NaN',
+                    },
+                },
+            };
+            assert.deepStrictEqual(res, expected);
+            done();
+        });
+    });
+});

--- a/tests/unit/metrics/StatsModel.js
+++ b/tests/unit/metrics/StatsModel.js
@@ -155,4 +155,21 @@ describe('StatsModel class', () => {
             },
         ], done);
     });
+
+    it('should not crash on empty results', done => {
+        async.series([
+            next => {
+                statsModel.getAllStats(fakeLogger, id, (err, res) => {
+                    assert.ifError(err);
+                    const expected = {
+                        'requests': [0, 0, 0],
+                        '500s': [0, 0, 0],
+                        'sampleDuration': STATS_EXPIRY,
+                    };
+                    assert.deepStrictEqual(res, expected);
+                    next();
+                });
+            },
+        ], done);
+    });
 });


### PR DESCRIPTION
on a freshly started system where backbeat hasn't pushed stats yet, S3 crashes in a loop:

```"error":"Cannot read property 'map' of undefined","stack":"TypeError: Cannot read property 'map' of undefined\n at StatsModel._zip```