### PR TITLE
bf: ZENKO-344 don't shunt 'info' event production

### DIFF
--- a/lib/storage/metadata/mongoclient/LogConsumer.js
+++ b/lib/storage/metadata/mongoclient/LogConsumer.js
@@ -42,16 +42,6 @@ class ListRecordStream extends stream.Transform {
             this.end = itemObj.ts.toNumber();
         }
 
-        // only push to stream unpublished objects
-        if (!this.unpublishedListing) {
-            // When an oplog with a unique ID that is stored in the
-            // log offset is found, all oplogs AFTER this is unpublished.
-            if (this.lastEndID === itemObj.h.toString()) {
-                this.unpublishedListing = true;
-            }
-            return callback();
-        }
-
         if (!this.hasStarted) {
             this.hasStarted = true;
             this.start = itemObj.ts.toNumber();
@@ -60,6 +50,16 @@ class ListRecordStream extends stream.Transform {
                 end: this.end,
                 uniqId: this.lastUniqID,
             });
+        }
+
+        // only push to stream unpublished objects
+        if (!this.unpublishedListing) {
+            // When an oplog with a unique ID that is stored in the
+            // log offset is found, all oplogs AFTER this is unpublished.
+            if (this.lastEndID === itemObj.h.toString()) {
+                this.unpublishedListing = true;
+            }
+            return callback();
         }
 
         const dbName = itemObj.ns.split('.');


### PR DESCRIPTION
Make sure the mongo consumer produces the 'info' event from the LogConsumer
when the lastEndID has not been reached yet.