### PR TITLE
restore mongo op log filtering per db

### DIFF
--- a/lib/storage/metadata/mongoclient/LogConsumer.js
+++ b/lib/storage/metadata/mongoclient/LogConsumer.js
@@ -103,11 +103,13 @@ class LogConsumer {
      * @param {string} logger - logger
      */
     constructor(mongoConfig, logger) {
-        const { replicaSetHosts } = mongoConfig;
+        const { replicaSetHosts, database } = mongoConfig;
         // 'local' is the database where MongoDB has oplogs.rs capped collection
         this.database = 'local';
         this.mongoUrl = `mongodb://${replicaSetHosts}/local`;
         this.logger = logger;
+        this.metadataDatabase = database;
+        this.oplogNsRegExp = new RegExp(`^${database}\\.`);
     }
 
     /**
@@ -156,6 +158,7 @@ class LogConsumer {
 
         this.coll = this.db.collection('oplog.rs');
         return this.coll.find({
+            ns: this.oplogNsRegExp,
             ts: { $gte: Timestamp.fromNumber(startSeq) },
         }, {
             limit,


### PR DESCRIPTION
For Orbit that has multiple instances per mongo database. This change
restores the filtering per db, but keeps publishing the internal DBs
that have '__' in their name.

Also attempt to fix the original regexp which was matching the '$DB.'
pattern at any place, not at the beginning of the 'ns' field.
