### PR TITLE
bf: ZENKO-336 zero fill interval stats if none present

### DIFF
--- a/lib/metrics/StatsModel.js
+++ b/lib/metrics/StatsModel.js
@@ -17,7 +17,10 @@ class StatsModel extends StatsClient {
     * @return {array} converted array
     */
     _zip(arrays) {
-        return arrays[0].map((_, i) => arrays.map(a => a[i]));
+        if (arrays.length > 0 && arrays.every(a => Array.isArray(a))) {
+            return arrays[0].map((_, i) => arrays.map(a => a[i]));
+        }
+        return [];
     }
 
     /**
@@ -37,15 +40,21 @@ class StatsModel extends StatsClient {
     * @param {array} arr - each index contains the result of each batch command
     *   where index 0 signifies the error and index 1 contains the result
     * @return {array} array of integers, ordered from most recent interval to
-    *   oldest interval
+    *   oldest interval with length of (expiry / interval)
     */
     _getCount(arr) {
-        return arr.reduce((store, i) => {
+        const size = Math.floor(this._expiry / this._interval);
+        const array = arr.reduce((store, i) => {
             let num = parseInt(i[1], 10);
             num = Number.isNaN(num) ? 0 : num;
             store.push(num);
             return store;
         }, []);
+
+        if (array.length < size) {
+            array.push(...Array(size - array.length).fill(0));
+        }
+        return array;
     }
 
     /**
@@ -61,13 +70,18 @@ class StatsModel extends StatsClient {
             return cb(null, {});
         }
 
+        const size = Math.floor(this._expiry / this._interval);
         const statsRes = {
-            'requests': [],
-            '500s': [],
+            'requests': Array(size).fill(0),
+            '500s': Array(size).fill(0),
             'sampleDuration': this._expiry,
         };
         const requests = [];
         const errors = [];
+
+        if (ids.length === 0) {
+            return cb(null, statsRes);
+        }
 
         // for now set concurrency to default of 10
         return async.eachLimit(ids, 10, (id, done) => {
@@ -88,14 +102,11 @@ class StatsModel extends StatsClient {
                 return cb(null, statsRes);
             }
 
-            if (requests.length) {
-                statsRes.requests = this._zip(requests).map(arr =>
-                    arr.reduce((acc, i) => acc + i, 0));
-            }
-            if (errors.length) {
-                statsRes['500s'] = this._zip(errors).map(arr =>
-                    arr.reduce((acc, i) => acc + i, 0));
-            }
+            statsRes.requests = this._zip(requests).map(arr =>
+                arr.reduce((acc, i) => acc + i), 0);
+            statsRes['500s'] = this._zip(errors).map(arr =>
+                arr.reduce((acc, i) => acc + i), 0);
+
             return cb(null, statsRes);
         });
     }

--- a/tests/unit/backbeat/Metrics.js
+++ b/tests/unit/backbeat/Metrics.js
@@ -68,8 +68,8 @@ describe('Metrics class', () => {
                         ' operations in ops/sec (count) and bytes/sec (size) ' +
                         'in the last 900 seconds',
                     results: {
-                        count: 'NaN',
-                        size: 'NaN',
+                        count: '0.00',
+                        size: '0.00',
                     },
                 },
             };

--- a/tests/unit/metrics/StatsModel.js
+++ b/tests/unit/metrics/StatsModel.js
@@ -27,6 +27,8 @@ const statsModel = new StatsModel(redisClient, STATS_INTERVAL, STATS_EXPIRY);
 // made to the original methods
 describe('StatsModel class', () => {
     const id = 'arsenal-test';
+    const id2 = 'test-2';
+    const id3 = 'test-3';
 
     afterEach(() => redisClient.clear(() => {}));
 
@@ -46,6 +48,14 @@ describe('StatsModel class', () => {
         ];
 
         assert.deepStrictEqual(res, expected);
+    });
+
+    it('_zip should return an empty array if given an invalid array', () => {
+        const arrays = [];
+
+        const res = statsModel._zip(arrays);
+
+        assert.deepStrictEqual(res, []);
     });
 
     it('_getCount should return a an array of all valid integer values',
@@ -159,6 +169,18 @@ describe('StatsModel class', () => {
     it('should not crash on empty results', done => {
         async.series([
             next => {
+                statsModel.getStats(fakeLogger, id, (err, res) => {
+                    assert.ifError(err);
+                    const expected = {
+                        'requests': [0, 0, 0],
+                        '500s': [0, 0, 0],
+                        'sampleDuration': STATS_EXPIRY,
+                    };
+                    assert.deepStrictEqual(res, expected);
+                    next();
+                });
+            },
+            next => {
                 statsModel.getAllStats(fakeLogger, id, (err, res) => {
                     assert.ifError(err);
                     const expected = {
@@ -167,6 +189,49 @@ describe('StatsModel class', () => {
                         'sampleDuration': STATS_EXPIRY,
                     };
                     assert.deepStrictEqual(res, expected);
+                    next();
+                });
+            },
+        ], done);
+    });
+
+    it('should return a zero-filled array if no ids are passed to getAllStats',
+    done => {
+        statsModel.getAllStats(fakeLogger, [], (err, res) => {
+            assert.ifError(err);
+
+            const expected = Array(STATS_EXPIRY / STATS_INTERVAL).fill(0);
+
+            assert.deepStrictEqual(res.requests, expected);
+            assert.deepStrictEqual(res['500s'], expected);
+            done();
+        });
+    });
+
+    it('should get accurately reported data for given id from getAllStats',
+    done => {
+        statsModel.reportNewRequest(id, 9);
+        statsModel.reportNewRequest(id2, 2);
+        statsModel.reportNewRequest(id3, 3);
+        statsModel.report500(id);
+
+        async.series([
+            next => {
+                statsModel.getAllStats(fakeLogger, [id], (err, res) => {
+                    assert.ifError(err);
+
+                    assert.equal(res.requests[0], 9);
+                    assert.equal(res['500s'][0], 1);
+                    next();
+                });
+            },
+            next => {
+                statsModel.getAllStats(fakeLogger, [id, id2, id3],
+                (err, res) => {
+                    assert.ifError(err);
+
+                    assert.equal(res.requests[0], 14);
+                    assert.deepStrictEqual(res.requests, [14, 0, 0]);
                     next();
                 });
             },


### PR DESCRIPTION
Re-opened for bert-e. Original PR https://github.com/scality/Arsenal/pull/488

Fixes:
- check if `_zip` receives an empty array
- check if there are data intervals is less than total number of intervals. If so, zero fill empty intervals