### PR TITLE
rf: edit monitoring route details

### DIFF
--- a/lib/backbeat/routes.js
+++ b/lib/backbeat/routes.js
@@ -73,7 +73,7 @@ function routes(redisKeys, allSites) {
         {
             httpMethod: 'GET',
             category: 'monitoring',
-            type: 'monitoring',
+            type: 'metrics',
             extensions: {},
             method: 'monitoringHandler',
         },


### PR DESCRIPTION
Previously, we weren't using the `type` field for the monitoring route. Making this change for easier route parsing and if we were to add other monitoring routes, we can specify using the `type` field