### PR TITLE
bf: fix mongo counter

### DIFF
--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -42,7 +42,7 @@ const INFOSTORE = '__infostore';
 const __UUID = 'uuid';
 const PENSIEVE = 'PENSIEVE';
 const ASYNC_REPAIR_TIMEOUT = 15000;
-const itemScanRefreshDelay = 1000 * 30 * 60; // 30 minutes
+const itemScanRefreshDelay = 1000 * 60 * 60; // 1 hour
 
 const initialInstanceID = process.env.INITIAL_INSTANCE_ID;
 
@@ -559,7 +559,7 @@ class MongoClientInterface {
                 return cb(err);
             }
             const { prevMD, putObjectRes } = result;
-            if (typeof prevMD === Object) {
+            if (typeof prevMD === 'object') {
                 if (isUpdate) {
                     switch (prevMD.length) {
                     case 2:

--- a/tests/unit/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/tests/unit/storage/metadata/mongoclient/MongoClientInterface.js
@@ -1,0 +1,330 @@
+const assert = require('assert');
+
+const MongoClientInterface = require(
+    '../../../../../lib/storage/metadata/mongoclient/MongoClientInterface');
+const DummyMongoDB = require('./utils/DummyMongoDB');
+const DummyRequestLogger = require('./utils/DummyRequestLogger');
+const { generateMD } = require('./utils/helper');
+
+const log = new DummyRequestLogger();
+const mongoTestClient = new MongoClientInterface({});
+mongoTestClient.db = new DummyMongoDB();
+
+const bucketName = 'mongoTestBucket';
+const objectName = 'mongoTestObject';
+
+const zeroRef = {
+    objects: 0,
+    versions: 0,
+    buckets: 0,
+    bucketList: [],
+    dataManaged: {
+        total: { curr: 0, prev: 0 },
+        byLocation: {},
+    },
+};
+
+const startRef = {
+    objects: 10,
+    versions: 10,
+    buckets: 0,
+    bucketList: [],
+    dataManaged: {
+        total: { curr: 1000, prev: 1000 },
+        byLocation: {
+            mongotest: { curr: 1000, prev: 1000 },
+        },
+    },
+};
+
+function assertSuccessResults(testParams, cb) {
+    const { newVal, retValues, initRef, resRef, params } = testParams;
+    mongoTestClient.dataCount.set(initRef);
+    mongoTestClient.db.setReturnValues(retValues);
+    assert.deepStrictEqual(mongoTestClient.dataCount.results(), initRef);
+    mongoTestClient.putObject(bucketName, objectName, newVal, params, log,
+    err => {
+        assert.ifError(err, `Expected success, but got error ${err}`);
+        assert.deepStrictEqual(
+            mongoTestClient.dataCount.results(), resRef);
+        cb();
+    });
+}
+
+function assertFailureResults(testParams, cb) {
+    const { newVal, retValues, initRef, params } = testParams;
+    mongoTestClient.db.fail = true;
+    mongoTestClient.dataCount.set(initRef);
+    mongoTestClient.db.setReturnValues(retValues);
+    assert.deepStrictEqual(mongoTestClient.dataCount.results(), initRef);
+    mongoTestClient.putObject(bucketName, objectName, newVal, params, log,
+    err => {
+        assert(err, 'Expected error, but got success');
+        assert.deepStrictEqual(
+            mongoTestClient.dataCount.results(), initRef);
+        cb();
+    });
+}
+
+describe('MongoClientInterface::dataCount', () => {
+    describe('MongoClientInterface::putObject', () => {
+        beforeEach(() => {
+            mongoTestClient.db.reset();
+        });
+
+        const failTests = [
+            {
+                it: 'should not add count when NonVer put object call fails',
+                params: {},
+            },
+            {
+                it: 'should not add count when verCase1 put object call fails',
+                params: { versioning: true },
+            },
+            {
+                it: 'should not add count when verCase2 put object call fails',
+                params: { versionId: '' },
+            },
+            {
+                it: 'should not add count when verCase3 put object call fails',
+                params: { versionId: 'vercase' },
+            },
+        ];
+
+        failTests.forEach(test => it(test.it, done => {
+            const retValues = [];
+            const newVal = generateMD(objectName, 200);
+            const testParams = {
+                newVal,
+                retValues,
+                initRef: zeroRef,
+                params: test.params,
+            };
+            assertFailureResults(testParams, done);
+        }));
+
+        it('should call putObjectNonVer and add object',
+        done => {
+            const retValues = [];
+            const newVal = generateMD(objectName, 200, '',
+                [{ site: 'repsite', status: 'COMPLETED' }]);
+            const expectedRes = {
+                objects: 1,
+                versions: 0,
+                buckets: 0,
+                bucketList: [],
+                dataManaged: {
+                    total: { curr: 400, prev: 0 },
+                    byLocation: {
+                        mongotest: { curr: 200, prev: 0 },
+                        repsite: { curr: 200, prev: 0 },
+                    },
+                },
+            };
+            const testParams = {
+                newVal,
+                retValues,
+                initRef: zeroRef,
+                resRef: expectedRes,
+                params: {},
+            };
+            assertSuccessResults(testParams, done);
+        });
+
+        it('should call putObjectNonVer and add object, overwrite',
+        done => {
+            const retValues = [
+                { _id: objectName, value: generateMD(objectName, 100) },
+            ];
+            const newVal = generateMD(objectName, 200, '',
+                [{ site: 'repsite', status: 'COMPLETED' }]);
+            const expectedRes = {
+                objects: 10,
+                versions: 10,
+                buckets: 0,
+                bucketList: [],
+                dataManaged: {
+                    total: { curr: 1300, prev: 1000 },
+                    byLocation: {
+                        mongotest: { curr: 1100, prev: 1000 },
+                        repsite: { curr: 200, prev: 0 },
+                    },
+                },
+            };
+            const testParams = {
+                newVal,
+                retValues,
+                initRef: startRef,
+                resRef: expectedRes,
+                params: {},
+            };
+            assertSuccessResults(testParams, done);
+        });
+
+        it('should call putObjectVerCase1 and add versioned object',
+        done => {
+            const retValues = [
+                { _id: objectName, value: generateMD(objectName, 100) },
+            ];
+            const newVal = generateMD(objectName, 200, '',
+                [{ site: 'repsite', status: 'COMPLETED' }]);
+            const expectedRes = {
+                objects: 10,
+                versions: 11,
+                buckets: 0,
+                bucketList: [],
+                dataManaged: {
+                    total: { curr: 1300, prev: 1100 },
+                    byLocation: {
+                        mongotest: { curr: 1100, prev: 1100 },
+                        repsite: { curr: 200, prev: 0 },
+                    },
+                },
+            };
+            const testParams = {
+                newVal,
+                retValues,
+                initRef: startRef,
+                resRef: expectedRes,
+                params: { versioning: true },
+            };
+            assertSuccessResults(testParams, done);
+        });
+
+        it('should call putObjectVerCase2 and add null versioned object',
+        done => {
+            const retValues = [
+                { _id: objectName, value: generateMD(objectName, 100) },
+            ];
+            const newVal = generateMD(objectName, 200, '',
+                [{ site: 'repsite', status: 'COMPLETED' }]);
+            const expectedRes = {
+                objects: 10,
+                versions: 10,
+                buckets: 0,
+                bucketList: [],
+                dataManaged: {
+                    total: { curr: 1300, prev: 1000 },
+                    byLocation: {
+                        mongotest: { curr: 1100, prev: 1000 },
+                        repsite: { curr: 200, prev: 0 },
+                    },
+                },
+            };
+            const testParams = {
+                newVal,
+                retValues,
+                initRef: startRef,
+                resRef: expectedRes,
+                params: { versionId: '' },
+            };
+            assertSuccessResults(testParams, done);
+        });
+
+        it('should call putObjectVerCase3 and update versioned object',
+        done => {
+            const retValues = [
+                [
+                    { _id: objectName, value: generateMD(objectName, 100, '',
+                        [{ site: 'repsite', status: 'COMPLETED' },
+                        { site: 'repsite2', status: 'PENDING' }]) },
+                ],
+                null,
+            ];
+            const newVal = generateMD(objectName, 100, '',
+                [
+                    { site: 'repsite', status: 'COMPLETED' },
+                    { site: 'repsite2', status: 'COMPLETED' },
+                ]);
+            const initRef = {
+                objects: 10,
+                versions: 10,
+                buckets: 0,
+                bucketList: [],
+                dataManaged: {
+                    total: { curr: 1000, prev: 1100 },
+                    byLocation: {
+                        mongotest: { curr: 1000, prev: 1000 },
+                        repsite: { curr: 0, prev: 100 },
+                    },
+                },
+            };
+            const expectedRes = {
+                objects: 10,
+                versions: 10,
+                buckets: 0,
+                bucketList: [],
+                dataManaged: {
+                    total: { curr: 1000, prev: 1200 },
+                    byLocation: {
+                        mongotest: { curr: 1000, prev: 1000 },
+                        repsite: { curr: 0, prev: 100 },
+                        repsite2: { curr: 0, prev: 100 },
+                    },
+                },
+            };
+            const testParams = {
+                newVal,
+                retValues,
+                initRef,
+                resRef: expectedRes,
+                params: { versionId: 'versioned' },
+            };
+            assertSuccessResults(testParams, done);
+        });
+
+        it('should call putObjectVerCase3 and update master object', done => {
+            const retValues = [
+                [
+                    { _id: objectName, value: generateMD(objectName, 100, '',
+                        [{ site: 'repsite', status: 'COMPLETED' },
+                        { site: 'repsite2', status: 'PENDING' }]) },
+                    { _id: objectName, value: generateMD(objectName, 100, '',
+                        [{ site: 'repsite', status: 'COMPLETED' },
+                        { site: 'repsite2', status: 'PENDING' }]) },
+                ],
+                null,
+            ];
+            const newVal = generateMD(objectName, 100, '',
+                [
+                    { site: 'repsite', status: 'COMPLETED' },
+                    { site: 'repsite2', status: 'COMPLETED' },
+                ]);
+            const initRef = {
+                objects: 10,
+                versions: 10,
+                buckets: 0,
+                bucketList: [],
+                dataManaged: {
+                    total: { curr: 1100, prev: 1000 },
+                    byLocation: {
+                        mongotest: { curr: 1000, prev: 1000 },
+                        repsite: { curr: 100, prev: 0 },
+                    },
+                },
+            };
+            const expectedRes = {
+                objects: 10,
+                versions: 10,
+                buckets: 0,
+                bucketList: [],
+                dataManaged: {
+                    total: { curr: 1200, prev: 1000 },
+                    byLocation: {
+                        mongotest: { curr: 1000, prev: 1000 },
+                        repsite: { curr: 100, prev: 0 },
+                        repsite2: { curr: 100, prev: 0 },
+                    },
+                },
+            };
+            const testParams = {
+                newVal,
+                retValues,
+                initRef,
+                resRef: expectedRes,
+                params: { versionId: 'master' },
+            };
+            assertSuccessResults(testParams, done);
+        });
+    });
+});

--- a/tests/unit/storage/metadata/mongoclient/utils/DummyMongoDB.js
+++ b/tests/unit/storage/metadata/mongoclient/utils/DummyMongoDB.js
@@ -1,0 +1,87 @@
+const testError = new Error('test error');
+
+class DummyCollection {
+    constructor(name, isFail) {
+        this.s = {
+            name,
+        };
+        this.fail = isFail;
+        this.retQueue = [];
+    }
+
+    setReturnValues(retArray) {
+        this.retQueue.push(...retArray);
+    }
+
+    bulkWrite(cmds, opt, cb) {
+        process.stdout.write('mock mongodb.bulkWrite call\n');
+        if (this.fail) {
+            return cb(testError);
+        }
+        return cb();
+    }
+
+    update(target, doc, opt, cb) {
+        process.stdout.write('mock mongodb.update call\n');
+        if (this.fail) {
+            return cb(testError);
+        }
+        return cb();
+    }
+
+    find() {
+        return {
+            toArray: cb => {
+                if (this.retQueue.length <= 0) {
+                    return cb(null, []);
+                }
+                const retVal = this.retQueue[0];
+                this.retQueue = this.retQueue.slice(1);
+                if (retVal instanceof Error) {
+                    return cb(retVal);
+                }
+                return cb(null, retVal);
+            },
+        };
+    }
+
+    findOne(query, opt, cb) {
+        if (typeof opt === 'function' && cb === undefined) {
+            // eslint-disable-next-line no-param-reassign
+            cb = opt;
+        }
+        if (this.retQueue.length <= 0) {
+            return cb(null);
+        }
+        const retVal = this.retQueue[0];
+        this.retQueue = this.retQueue.slice(1);
+        if (retVal instanceof Error) {
+            return cb(retVal);
+        }
+        return cb(null, retVal);
+    }
+}
+
+class DummyMongoDB {
+    contructor() {
+        this.fail = false;
+        this.returnQueue = [];
+    }
+
+    reset() {
+        this.fail = false;
+        this.returnQueue = [];
+    }
+
+    setReturnValues(retValues) {
+        this.returnQueue.push(...retValues);
+    }
+
+    collection(name) {
+        const c = new DummyCollection(name, this.fail);
+        c.setReturnValues(this.returnQueue);
+        return c;
+    }
+}
+
+module.exports = DummyMongoDB;

--- a/tests/unit/storage/metadata/mongoclient/utils/DummyRequestLogger.js
+++ b/tests/unit/storage/metadata/mongoclient/utils/DummyRequestLogger.js
@@ -1,0 +1,58 @@
+class DummyRequestLogger {
+    constructor() {
+        this.ops = [];
+        this.counts = {
+            trace: 0,
+            debug: 0,
+            info: 0,
+            warn: 0,
+            error: 0,
+            fatal: 0,
+        };
+        this.defaultFields = {};
+    }
+
+    trace(msg) {
+        this.ops.push(['trace', [msg]]);
+        this.counts.trace += 1;
+    }
+
+    debug(msg) {
+        this.ops.push(['debug', [msg]]);
+        this.counts.debug += 1;
+    }
+
+    info(msg) {
+        this.ops.push(['info', [msg]]);
+        this.counts.info += 1;
+    }
+
+    warn(msg) {
+        this.ops.push(['warn', [msg]]);
+        this.counts.warn += 1;
+    }
+
+    error(msg) {
+        this.ops.push(['error', [msg]]);
+        this.counts.error += 1;
+    }
+
+    fatal(msg) {
+        this.ops.push(['fatal', [msg]]);
+        this.counts.fatal += 1;
+    }
+
+    getSerializedUids() { // eslint-disable-line class-methods-use-this
+        return 'dummy:Serialized:Uids';
+    }
+
+    addDefaultFields(fields) {
+        Object.assign(this.defaultFields, fields);
+    }
+
+    end() {
+        return this;
+    }
+}
+
+module.exports = DummyRequestLogger;

--- a/tests/unit/storage/metadata/mongoclient/utils/helper.js
+++ b/tests/unit/storage/metadata/mongoclient/utils/helper.js
@@ -1,0 +1,24 @@
+const basicMD = {
+    'content-length': 0,
+    'key': '',
+    'versionId': '',
+    'replicationInfo': {
+        backends: [], // site, status
+    },
+    'dataStoreName': 'mongotest',
+};
+
+function generateMD(objKey, size, versionId, repBackends) {
+    const retMD = JSON.parse(JSON.stringify(basicMD));
+    retMD.key = objKey;
+    retMD['content-length'] = size;
+    retMD.versionId = versionId;
+    if (repBackends && Array.isArray(repBackends)) {
+        retMD.replicationInfo.backends.push(...repBackends);
+    }
+    return retMD;
+}
+
+module.exports = {
+    generateMD,
+};


### PR DESCRIPTION
Use of `Object` object instead of the string `object` for validating `typeof` lead to counter not being triggered.