### PR TITLE
bf: ZENKO-578 mongoDB error replies

### DIFF
--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -373,10 +373,23 @@ class MongoClientInterface {
         }], {
             ordered: 1,
         }, err => {
-            if (err) {
+            /*
+             * Related to https://jira.mongodb.org/browse/SERVER-14322
+             * It happens when we are pushing two versions "at the same time"
+             * and the master one does not exist. In MongoDB, two threads are
+             * trying to create the same key, the master version, and one of
+             * them, the one with the highest versionID (less recent one),
+             * fails.
+             * We check here than than the MongoDB error is related to the
+             * second operation, the master version update and than the error
+             * code is the one related to mentionned issue.
+             */
+            if (err &&
+                (!err.index || err.index !== 1
+                 || !err.code || err.code !== 11000)) {
                 log.error(
                     'putObjectVerCase1: error putting object version',
-                { error: err.message });
+                { error: err.errmsg });
                 return cb(errors.InternalError);
             }
             return cb(null, `{"versionId": "${versionId}"}`);


### PR DESCRIPTION
Do not raise an internalError to upper layer when mongoDB fails to
update the master version with a specific error code. This fix is
related to the mongoDB issue: SERVER-19600.

This commit fixes too the message field name of the mongoDB error, it is
'errmsg' and not 'message'.