### PR TITLE
bugfix: fix skip scan on Mongo

### DIFF
--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -43,6 +43,7 @@ const __UUID = 'uuid';
 const PENSIEVE = 'PENSIEVE';
 const ASYNC_REPAIR_TIMEOUT = 15000;
 const itemScanRefreshDelay = 1000 * 60 * 60; // 1 hour
+const MAX_STREAK_LENGTH = 100;
 
 const initialInstanceID = process.env.INITIAL_INSTANCE_ID;
 
@@ -919,19 +920,48 @@ class MongoClientInterface {
                                       params, log, cb);
     }
 
-    internalListObject(bucketName, params, log, cb) {
-        const extName = params.listingType;
-        const extension = new listAlgos[extName](params, log);
-        const requestParams = extension.genMDParams();
+    internalListObject(bucketName, params, extension, log, cb) {
         const c = this.getCollection(bucketName);
         let cbDone = false;
-        const stream = new MongoReadStream(c, requestParams,
+        let streakLength = 0;
+        const stream = new MongoReadStream(c, params,
                                            params.mongifiedSearch);
         stream
             .on('data', e => {
-                if (extension.filter(e) < 0) {
+                // filtering result:
+                // - filteringResult > 0: entry accepted and included in the
+                //                        listing result
+                // - filteringResult = 0: entry accepted but not included in
+                //                        the listing result (skipping)
+                // - filteringResult < 0: entry is rejected, listing finishes
+                const filteringResult = extension.filter(e);
+                // skipping: provides insight into why the extension is
+                // skipping the entry, for example: entry starts with a
+                // commonPrefix or entry is a specific version; in such
+                // case, repd needs to skip this range and go on with the next
+                const skippingRange = extension.skipping();
+                if (filteringResult < 0) {
                     stream.emit('end');
                     stream.destroy();
+                } else if (filteringResult === 0 && skippingRange) {
+                    // check if MAX_STREAK_LENGTH consecutive keys have been
+                    // skipped
+                    if (++streakLength === MAX_STREAK_LENGTH) {
+                        // stop listing this key range
+                        stream.destroy();
+                        // update the new listing parameters here
+                        // eslint-disable-next-line no-param-reassign
+                        params.start = undefined; // 'start' is deprecated
+                        // eslint-disable-next-line no-param-reassign
+                        params.gt = undefined;
+                        // eslint-disable-next-line no-param-reassign
+                        params.gte = inc(skippingRange);
+                        // then continue listing the next key range
+                        this.internalListObject(bucketName, params,
+                                                extension, log, cb);
+                    }
+                } else {
+                    streakLength = 1;
                 }
             })
             .on('error', err => {
@@ -958,11 +988,21 @@ class MongoClientInterface {
     }
 
     listObject(bucketName, params, log, cb) {
-        return this.internalListObject(bucketName, params, log, cb);
+        const extName = params.listingType;
+        const extension = new listAlgos[extName](params, log);
+        const internalParams = extension.genMDParams();
+        internalParams.mongifiedSearch = params.mongifiedSearch;
+        return this.internalListObject(bucketName, internalParams, extension,
+                                       log, cb);
     }
 
     listMultipartUploads(bucketName, params, log, cb) {
-        return this.internalListObject(bucketName, params, log, cb);
+        const extName = params.listingType;
+        const extension = new listAlgos[extName](params, log);
+        const internalParams = extension.genMDParams();
+        internalParams.mongifiedSearch = params.mongifiedSearch;
+        return this.internalListObject(bucketName, internalParams, extension,
+                                       log, cb);
     }
 
     readUUID(log, cb) {


### PR DESCRIPTION
This allows to skip scans when it is too long to jump
over a prefix. Also it has the side effect of batching
more common prefixes in one s3 list call with delimiter