### PR TITLE
bugfix: fix versioningGeneral2 test failing with Mongo

### DIFF
--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -340,6 +340,10 @@ class MongoClientInterface {
      * It is possible that 2 version creations are inverted
      * in flight so we also check that we update a master only
      * if the version in place is greater that the one we set.
+     *
+     * We also test the existence of the versionId property
+     * to manage the case of an object created before the
+     * versioning was enabled.
      */
     putObjectVerCase1(c, bucketName, objName, objVal, params, log, cb) {
         const versionId = generateVersionId(this.replicationGroupId);
@@ -361,9 +365,17 @@ class MongoClientInterface {
                 // eslint-disable-next-line
                 filter: {
                     _id: objName,
-                    'value.versionId': {
-                        $gt: objVal.versionId,
+                    $or: [{
+                        'value.versionId': {
+                            $exists: false,
+                        },
                     },
+                    {
+                        'value.versionId': {
+                            $gt: objVal.versionId,
+                        },
+                    },
+                         ],
                 },
                 update: {
                     _id: objName, value: objVal,


### PR DESCRIPTION
When an object has been created without versioning and
the versioning has been enabled, when creating a version
we must consider the case that the object doesn't have
the versionId property.