### PR TITLE
bf: ZENKO-612 use correct MD value for counter

### DIFF
--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -850,6 +850,10 @@ class MongoClientInterface {
                     { error: err.message });
                 return cb(errors.InternalError);
             }
+            if (isUserBucket(c.s.name) && result.value) {
+                const objVal = result.value;
+                this.dataCount.delObject(objVal.value, DEL_VER);
+            }
             return cb(null);
         });
     }
@@ -886,15 +890,7 @@ class MongoClientInterface {
                 });
             }
             return this.deleteObjectVerNotMaster(c, bucketName, objName,
-            params, log, err => {
-                if (err) {
-                    return cb(err);
-                }
-                if (isUserBucket(c.s.name)) {
-                    this.dataCount.delObject(mst.value, DEL_VER);
-                }
-                return cb();
-            });
+            params, log, cb);
         });
     }
 


### PR DESCRIPTION
context: 
when versioned object is deleted, the master MD is for the counter calculation instead of the versioned MD.