### PR TITLE
ft: ZENKO-582 preferred read location

### DIFF
--- a/lib/models/ReplicationConfiguration.js
+++ b/lib/models/ReplicationConfiguration.js
@@ -59,6 +59,7 @@ class ReplicationConfiguration {
         this._rules = null;
         this._prevStorageClass = null;
         this._hasScalityDestination = null;
+        this._preferredReadLocation = null;
     }
 
     /**
@@ -86,6 +87,18 @@ class ReplicationConfiguration {
     }
 
     /**
+     * The preferred read location
+     * @return {string|null} - The preferred read location if defined,
+     * otherwise null
+     *
+     * FIXME ideally we should be able to specify one preferred read
+     * location for each rule
+     */
+    getPreferredReadLocation() {
+        return this._preferredReadLocation;
+    }
+
+    /**
      * Get the replication configuration
      * @return {object} - The replication configuration
      */
@@ -94,6 +107,7 @@ class ReplicationConfiguration {
             role: this.getRole(),
             destination: this.getDestination(),
             rules: this.getRules(),
+            preferredReadLocation: this.getPreferredReadLocation(),
         };
     }
 
@@ -292,6 +306,14 @@ class ReplicationConfiguration {
             return undefined;
         }
         const storageClasses = destination.StorageClass[0].split(',');
+        const prefReadIndex = storageClasses.findIndex(storageClass =>
+            storageClass.endsWith(':preferred_read'));
+        if (prefReadIndex !== -1) {
+            const prefRead = storageClasses[prefReadIndex].split(':')[0];
+            // remove :preferred_read tag from storage class name
+            storageClasses[prefReadIndex] = prefRead;
+            this._preferredReadLocation = prefRead;
+        }
         const isValidStorageClass = storageClasses.every(storageClass => {
             if (validStorageClasses.includes(storageClass)) {
                 this._hasScalityDestination =

--- a/tests/unit/models/ReplicationConfiguration.spec.js
+++ b/tests/unit/models/ReplicationConfiguration.spec.js
@@ -1,0 +1,74 @@
+const assert = require('assert');
+const { parseString } = require('xml2js');
+
+const werelogs = require('werelogs');
+
+const ReplicationConfiguration =
+      require('../../../lib/models/ReplicationConfiguration');
+
+const logger = new werelogs.Logger('test:ReplicationConfiguration');
+
+const mockedConfig = {
+    replicationEndpoints: [{
+        type: 'scality',
+        site: 'ring',
+        default: true,
+    }, {
+        type: 'aws_s3',
+        site: 'awsbackend',
+    }, {
+        type: 'gcp',
+        site: 'gcpbackend',
+    }, {
+        type: 'azure',
+        site: 'azurebackend',
+    }],
+};
+
+
+function getXMLConfig(hasPreferredRead) {
+    return `
+    <ReplicationConfiguration>
+        <Role>arn:aws:iam::root:role/s3-replication-role</Role>
+        <Rule>
+            <ID>Replication-Rule-1</ID>
+            <Status>Enabled</Status>
+            <Prefix>someprefix/</Prefix>
+            <Destination>
+                <Bucket>arn:aws:s3:::destbucket</Bucket>
+                <StorageClass>awsbackend,` +
+        `gcpbackend${hasPreferredRead ? ':preferred_read' : ''},azurebackend` +
+        `</StorageClass>
+            </Destination>
+        </Rule>
+    </ReplicationConfiguration>
+`;
+}
+
+describe('ReplicationConfiguration class', () => {
+    it('should parse replication config XML without preferred read', done => {
+        const repConfigXML = getXMLConfig(false);
+        parseString(repConfigXML, (err, parsedXml) => {
+            assert.ifError(err);
+            const repConf = new ReplicationConfiguration(
+                parsedXml, logger, mockedConfig);
+            const repConfErr = repConf.parseConfiguration();
+            assert.ifError(repConfErr);
+            assert.strictEqual(repConf.getPreferredReadLocation(), null);
+            done();
+        });
+    });
+    it('should parse replication config XML with preferred read', done => {
+        const repConfigXML = getXMLConfig(true);
+        parseString(repConfigXML, (err, parsedXml) => {
+            assert.ifError(err);
+            const repConf = new ReplicationConfiguration(
+                parsedXml, logger, mockedConfig);
+            const repConfErr = repConf.parseConfiguration();
+            assert.ifError(repConfErr);
+            assert.strictEqual(repConf.getPreferredReadLocation(),
+                               'gcpbackend');
+            done();
+        });
+    });
+});


### PR DESCRIPTION
Add preferred read location specification in replication configuration

E.g. `<StorageClass>aws,gcp:preferred_read</StorageClass>`