### PR TITLE
feature: ZENKO-483 Update Redis key schema

### DIFF
--- a/lib/backbeat/routes.js
+++ b/lib/backbeat/routes.js
@@ -73,7 +73,7 @@ function routes(redisKeys, allLocations) {
             level: 'object',
             extensions: { crr: [...allLocations] },
             method: 'getObjectProgress',
-            dataPoints: [redisKeys.bytes, redisKeys.bytesDone],
+            dataPoints: [redisKeys.objectBytes, redisKeys.objectBytesDone],
         },
         // Route: /_/metrics/crr/<site>/throughput/<bucket>/<key>
         {
@@ -83,7 +83,7 @@ function routes(redisKeys, allLocations) {
             level: 'object',
             extensions: { crr: [...allLocations] },
             method: 'getObjectThroughput',
-            dataPoints: [redisKeys.bytesDone],
+            dataPoints: [redisKeys.objectBytesDone],
         },
         // Route: /_/crr/failed?marker=<marker>
         {


### PR DESCRIPTION
We need a way to distinguish between site-level and object-level CRR metrics since the backbeat API '/all' routes use a glob for fetching all CRR metrics for all sites: https://github.com/scality/Arsenal/blob/development/8.0/lib/backbeat/Metrics.js#L36.

See https://github.com/scality/backbeat/pull/358/files#diff-d1e5364d79fba999b6159f2dd46809f9R17 for proposed Redis key schema.