### PR TITLE
bugfix: ZENKO-632 check if destroy method is available

### DIFF
--- a/lib/s3routes/routesUtils.js
+++ b/lib/s3routes/routesUtils.js
@@ -284,13 +284,19 @@ function retrieveData(locations, retrieveDataFn, response, log) {
         response.destroy();
         responseDestroyed = true;
     };
+
+    const _destroyReadable = readable => {
+        // s3-data sends Readable stream only which does not implement destroy
+        if (readable && readable.destroy) {
+            readable.destroy();
+        }
+    };
+
     // the S3-client might close the connection while we are processing it
     response.once('close', () => {
         log.debug('received close event before response end');
         responseDestroyed = true;
-        if (currentStream) {
-            currentStream.destroy();
-        }
+        _destroyReadable(currentStream);
     });
 
     return eachSeries(locations,
@@ -311,7 +317,7 @@ function retrieveData(locations, retrieveDataFn, response, log) {
                 if (responseDestroyed || response.isclosed) {
                     log.debug(
                         'response destroyed before readable could stream');
-                    readable.destroy();
+                    _destroyReadable(readable);
                     return next(responseErr);
                 }
                 // readable stream successfully consumed


### PR DESCRIPTION
s3-data returns Readable unlike sproxydclient which returns an instance of
http.IncomingMessage which implements Readable stream and extends it with
destroy method