### PR TITLE
bugfix: ZENKO-621 Make _buildKey public method

### DIFF
--- a/lib/metrics/StatsClient.js
+++ b/lib/metrics/StatsClient.js
@@ -41,11 +41,11 @@ class StatsClient {
     /**
     * build redis key to get total number of occurrences on the server
     * @param {string} name - key name identifier
-    * @param {object} d - Date instance
+    * @param {Date} date - Date instance
     * @return {string} key - key for redis
     */
-    _buildKey(name, d) {
-        return `${name}:${this._normalizeTimestamp(d)}`;
+    buildKey(name, date) {
+        return `${name}:${this._normalizeTimestamp(date)}`;
     }
 
     /**
@@ -85,7 +85,7 @@ class StatsClient {
             amount = (typeof incr === 'number') ? incr : 1;
         }
 
-        const key = this._buildKey(`${id}:requests`, new Date());
+        const key = this.buildKey(`${id}:requests`, new Date());
 
         return this._redis.incrbyEx(key, amount, this._expiry, callback);
     }
@@ -101,7 +101,7 @@ class StatsClient {
             return undefined;
         }
         const callback = cb || this._noop;
-        const key = this._buildKey(`${id}:500s`, new Date());
+        const key = this.buildKey(`${id}:500s`, new Date());
         return this._redis.incrEx(key, this._expiry, callback);
     }
 
@@ -165,8 +165,8 @@ class StatsClient {
         const reqsKeys = [];
         const req500sKeys = [];
         for (let i = 0; i < totalKeys; i++) {
-            reqsKeys.push(['get', this._buildKey(`${id}:requests`, d)]);
-            req500sKeys.push(['get', this._buildKey(`${id}:500s`, d)]);
+            reqsKeys.push(['get', this.buildKey(`${id}:requests`, d)]);
+            req500sKeys.push(['get', this.buildKey(`${id}:500s`, d)]);
             this._setPrevInterval(d);
         }
         return async.parallel([


### PR DESCRIPTION
Timestamp key calculation is needed for https://github.com/scality/backbeat/pull/368 so make `_buildKey` a public method.