### PR TITLE
bf: apply multiple lifecycle filter tags if exists

### DIFF
--- a/lib/models/LifecycleConfiguration.js
+++ b/lib/models/LifecycleConfiguration.js
@@ -269,7 +269,7 @@ class LifecycleConfiguration {
             return filterObj;
         }
         if (filter.Tag) {
-            const tagObj = this._parseTags(filter.Tag[0]);
+            const tagObj = this._parseTags(filter.Tag);
             if (tagObj.error) {
                 filterObj.error = tagObj.error;
                 return filterObj;
@@ -287,7 +287,7 @@ class LifecycleConfiguration {
             if (andF.Prefix && andF.Prefix.length >= 1) {
                 filterObj.rulePrefix = andF.Prefix.pop();
             }
-            const tagObj = this._parseTags(andF.Tag[0]);
+            const tagObj = this._parseTags(andF.Tag);
             if (tagObj.error) {
                 filterObj.error = tagObj.error;
                 return filterObj;
@@ -320,31 +320,28 @@ class LifecycleConfiguration {
         // reset _tagKeys to empty because keys cannot overlap within a rule,
         // but different rules can have the same tag keys
         this._tagKeys = [];
-        if (!tags.Key || !tags.Value) {
-            tagObj.error = errors.MissingRequiredParameter.customizeDescription(
-                'Tag XML does not contain both Key and Value');
-            return tagObj;
-        }
-        if (tags.Key.length !== tags.Value.length) {
-            tagObj.error = errors.MalformedXML.customizeDescription(
-                'Tag XML should contain same number of Keys and Values');
-            return tagObj;
-        }
-        for (let i = 0; i < tags.Key.length; i++) {
-            if (tags.Key[i].length < 1 || tags.Key[i].length > 128) {
+        for (let i = 0; i < tags.length; i++) {
+            if (!tags[i].Key || !tags[i].Value) {
+                tagObj.error =
+                    errors.MissingRequiredParameter.customizeDescription(
+                    'Tag XML does not contain both Key and Value');
+                break;
+            }
+
+            if (tags[i].Key[0].length < 1 || tags[i].Key[0].length > 128) {
                 tagObj.error = errors.InvalidRequest.customizeDescription(
                     'Tag Key must be a length between 1 and 128 char');
                 break;
             }
-            if (this._tagKeys.includes(tags.Key[i])) {
+            if (this._tagKeys.includes(tags[i].Key[0])) {
                 tagObj.error = errors.InvalidRequest.customizeDescription(
                     'Tag Keys must be unique');
                 break;
             }
-            this._tagKeys.push(tags.Key[i]);
+            this._tagKeys.push(tags[i].Key[0]);
             const tag = {
-                key: tags.Key[i],
-                val: tags.Value[i],
+                key: tags[i].Key[0],
+                val: tags[i].Value[0],
             };
             tagObj.tags.push(tag);
         }
@@ -677,13 +674,12 @@ class LifecycleConfiguration {
             const Prefix = rulePrefix ? `<Prefix>${rulePrefix}</Prefix>` : '';
             let tagXML = '';
             if (tags) {
-                const keysVals = tags.map(t => {
+                tagXML = tags.map(t => {
                     const { key, val } = t;
-                    const Tag = `<Key>${key}</Key>` +
-                        `<Value>${val}</Value>`;
+                    const Tag = `<Tag><Key>${key}</Key>` +
+                        `<Value>${val}</Value></Tag>`;
                     return Tag;
                 }).join('');
-                tagXML = `<Tag>${keysVals}</Tag>`;
             }
             let Filter;
             if (rulePrefix && !tags) {

--- a/tests/unit/models/LifecycleConfiguration.js
+++ b/tests/unit/models/LifecycleConfiguration.js
@@ -175,6 +175,10 @@ function generateFilter(errorTag, tagObj) {
             middleTags = '<Prefix>foo</Prefix><Prefix>bar</Prefix>' +
                 `<Prefix>${tagObj.lastPrefix}</Prefix>`;
         }
+        if (tagObj.label === 'mult-tags') {
+            middleTags = '<And><Tag><Key>color</Key><Value>blue</Value></Tag>' +
+                '<Tag><Key>shape</Key><Value>circle</Value></Tag></And>';
+        }
         Filter = `<Filter>${middleTags}</Filter>`;
         if (tagObj.label === 'also-prefix') {
             Filter = '<Filter></Filter><Prefix></Prefix>';
@@ -346,6 +350,18 @@ describe('LifecycleConfiguration class getLifecycleConfiguration', () => {
                 getLifecycleConfiguration();
             assert.strictEqual(tagObj.lastPrefix,
                 lcConfig.rules[0].filter.rulePrefix);
+            done();
+        });
+    });
+
+    it('should apply all unique Key tags if multiple tags included', done => {
+        tagObj.label = 'mult-tags';
+        generateParsedXml('Filter', tagObj, parsedXml => {
+            const lcConfig = new LifecycleConfiguration(parsedXml).
+                getLifecycleConfiguration();
+            const expected = [{ key: 'color', val: 'blue' },
+                { key: 'shape', val: 'circle' }];
+            assert.deepStrictEqual(expected, lcConfig.rules[0].filter.tags);
             done();
         });
     });


### PR DESCRIPTION
When setting multiple lifecycle filter tags, we previously only applied one tag.
This fix should apply all unique tags. If all tags are not unique, should error out.