### PR TITLE
improvement: ZENKO-760 add connection timeout for mongoclient

### DIFF
--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -45,6 +45,7 @@ const PENSIEVE = 'PENSIEVE';
 const ASYNC_REPAIR_TIMEOUT = 15000;
 const itemScanRefreshDelay = 1000 * 60 * 60; // 1 hour
 const MAX_STREAK_LENGTH = 100;
+const CONNECT_TIMEOUT_MS = 5000;
 
 const initialInstanceID = process.env.INITIAL_INSTANCE_ID;
 
@@ -132,13 +133,16 @@ class MongoClientInterface {
         // FIXME: constructors shall not have side effect so there
         // should be an async_init(cb) method in the wrapper to
         // initialize this backend
-        return MongoClient.connect(this.mongoUrl, (err, client) => {
+        const connectTimeoutMS = parseInt(process.env.MONGO_CONNECT_TIMEOUT_MS,
+            10) || CONNECT_TIMEOUT_MS;
+        const options = { connectTimeoutMS };
+        return MongoClient.connect(this.mongoUrl, options, (err, client) => {
             if (err) {
                 this.logger.error('error connecting to mongodb',
                     { error: err.message });
                 throw (errors.InternalError);
             }
-            this.logger.info('connected to mongodb');
+            this.logger.info('connected to mongodb', { url: this.mongoUrl });
             this.client = client;
             this.db = client.db(this.database, {
                 ignoreUndefined: true,


### PR DESCRIPTION
Mongoclient checks each node in the replica set to see which one's the primary,
this check has a default timeout of 30s which delays the startup of Cloudserver
when one of the nodes is unavailable. Cutting down the timeout makes it go through the
list of nodes in the replica set quicker to find the primary. MONGO_CONNECT_TIMEOUT_MS env
var is introduced to adjust the timeout in deployments.