### PR TITLE
improvement: ZENKO-760 use callback instead of throw

### DIFF
--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -140,7 +140,7 @@ class MongoClientInterface {
             if (err) {
                 this.logger.error('error connecting to mongodb',
                     { error: err.message });
-                throw (errors.InternalError);
+                return cb(errors.InternalError);
             }
             this.logger.info('connected to mongodb', { url: this.mongoUrl });
             this.client = client;


### PR DESCRIPTION
This lets CloudServer handle MongoClient issues more gracefully