### PR TITLE
bf: ZENKO-751 tempfix set max object key limit

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -72,4 +72,10 @@ module.exports = {
     permittedCapitalizedBuckets: {
         METADATA: true,
     },
+    // Setting a lower object key limit to account for:
+    // - Mongo key limit of 1012 bytes
+    // - Version ID in Mongo Key if versioned of 33
+    // - Max bucket name length if bucket match false of 63
+    // - Extra prefix slash for bucket prefix if bucket match of 1
+    objectKeyByteLimit: 915,
 };

--- a/lib/s3routes/routes.js
+++ b/lib/s3routes/routes.js
@@ -10,6 +10,8 @@ const routeOPTIONS = require('./routes/routeOPTIONS');
 const routesUtils = require('./routesUtils');
 const routeWebsite = require('./routes/routeWebsite');
 
+const { objectKeyByteLimit } = require('../constants');
+
 const routeMap = {
     GET: routeGET,
     PUT: routePUT,
@@ -52,8 +54,14 @@ function checkBucketAndKey(bucketName, objectKey, method, reqQuery,
             blacklistedPrefixes.object);
         if (!result.isValid) {
             log.debug('invalid object key', { objectKey });
-            return errors.InvalidArgument.customizeDescription('Object key ' +
-            `must not start with "${result.invalidPrefix}".`);
+            if (result.invalidPrefix) {
+                return errors.InvalidArgument.customizeDescription('Invalid ' +
+                    'prefix - object key cannot start with ' +
+                    `"${result.invalidPrefix}".`);
+            }
+            return errors.KeyTooLong.customizeDescription('Object key is too ' +
+                'long. Maximum number of bytes allowed in keys is ' +
+                `${objectKeyByteLimit}.`);
         }
     }
     if ((reqQuery.partNumber || reqQuery.uploadId)

--- a/lib/s3routes/routesUtils.js
+++ b/lib/s3routes/routesUtils.js
@@ -4,6 +4,8 @@ const errors = require('../errors');
 const constants = require('../constants');
 const { eachSeries } = require('async');
 
+const { objectKeyByteLimit } = require('../constants');
+
 const responseErr = new Error();
 responseErr.code = 'ResponseError';
 responseErr.message = 'response closed by client request before all data sent';
@@ -873,6 +875,9 @@ const routesUtils = {
             objectKey.startsWith(prefix));
         if (invalidPrefix) {
             return { isValid: false, invalidPrefix };
+        }
+        if (Buffer.byteLength(objectKey, 'utf8') > objectKeyByteLimit) {
+            return { isValid: false };
         }
         return { isValid: true };
     },

--- a/tests/unit/s3routes/routesUtils/isValidObjectKey.js
+++ b/tests/unit/s3routes/routesUtils/isValidObjectKey.js
@@ -1,0 +1,36 @@
+const assert = require('assert');
+const routesUtils = require('../../../../lib/s3routes/routesUtils.js');
+
+const bannedStr = 'banned';
+const prefixBlacklist = [];
+
+// byte size of 915
+const keyutf8 = '%EA%9D%8B崰㈌㒈保轖䳷䀰⺩ቆ楪秲ⴝ㿅鼎ꓜ퇬枅࿷염곞召㸾⌙ꪊᆐ庍뉆䌗幐鸆䛃➟녩' +
+    'ˍ뙪臅⠙≼绒벊냂詴 끴鹲萯⇂㭢䈊퉉楝舳㷖족痴䧫㾵᏷ำꎆ꼵껪멷㄀誕㳓腜쒃컹㑻鳃삚舿췈孨੦⮀Ǌ곓⵪꺼꜈' +
+    '嗼뫘悕錸瑺⁤륒㜓垻ㆩꝿ詀펉ᆙ舑䜾힑藪碙ꀎꂰ췊Ᏻ  㘺幽醛잯ද汧Ꟑꛒⶨ쪸숞헹㭔ꡔᘼ뺓ᡆ᡾ᑟ䅅퀭耓弧⢠⇙' +
+    '폪ް蛧⃪Ἔ돫ꕢ븥ヲ캂䝄쟐颺ᓾ둾Ұ껗礞ᾰ瘹蒯硳풛瞋襎奺熝妒컚쉴⿂㽝㝳駵鈚䄖戭䌸᫲ᇁ䙪鸮ᐴ稫ⶭ뀟ھ⦿' +
+    '䴳稉ꉕ捈袿놾띐✯伤䃫⸧ꠏ瘌틳藔ˋ㫣敀䔩㭘식↴⧵佶痊牌ꪌ搒꾛æᤈべ쉴挜敗羥誜嘳ֶꫜ걵ࣀ묟ኋ拃秷膤䨸菥' +
+    '䟆곘縧멀煣卲챸⧃⏶혣ਔ뙞밺㊑ک씌촃Ȅ頰ᖅ懚ホῐ꠷㯢먈㝹୥밷㮇䘖桲阥黾噘烻ᓧ鈠ᴥ徰穆ꘛ蹕綻表鯍裊' +
+    '鮕漨踒ꠍ픸Ä☶莒浏钸목탬툖氭ˠٸ൪㤌ᶟ訧ᜒೳ揪Ⴛ摖㸣᳑⹞걀ꢢ䏹ῖ"';
+
+describe('routesUtils.isValidObjectKey', () => {
+    it('should return isValid false if object key name starts with a ' +
+    'blacklisted prefix', () => {
+        const result = routesUtils.isValidObjectKey('bannedkey', [bannedStr]);
+        // return { isValid: false, invalidPrefix };
+        assert.strictEqual(result.isValid, false);
+        assert.strictEqual(result.invalidPrefix, bannedStr);
+    });
+
+    it('should return isValid false if object key name exceeds length of 915',
+    () => {
+        const key = 'a'.repeat(916);
+        const result = routesUtils.isValidObjectKey(key, prefixBlacklist);
+        assert.strictEqual(result.isValid, false);
+    });
+
+    it('should return isValid true for a utf8 string of byte size 915', () => {
+        const result = routesUtils.isValidObjectKey(keyutf8, prefixBlacklist);
+        assert.strictEqual(result.isValid, true);
+    });
+});


### PR DESCRIPTION
Max key length will be set to 915 to account for different
situations. Default AWS key length is 1024, but mongo keys
allow for length of up to 1012. Factoring in version id,
and bucket match false (bucket name prefix), for now,
we will limit the key length to 915 and return an error
right away if object key length exceeds this limit.

1012 - 63 (max bucket name length) - 1 (for prefix slash) - 33 (for version id)