### PR TITLE
feat: add checkHealth to mongodb interface

### DIFF
--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -1046,6 +1046,14 @@ class MongoClientInterface {
                                        log, cb);
     }
 
+    checkHealth(implName, log, cb) {
+        if (this.client.isConnected()) {
+            return cb();
+        }
+        log.error('disconnected from mongodb');
+        return cb(errors.InternalError, []);
+    }
+
     readUUID(log, cb) {
         const i = this.getCollection(INFOSTORE);
         i.findOne({


### PR DESCRIPTION
This adds a simple health check function to the `MongoClientInterface`.
The main purpose for this is https://github.com/scality/S3/pull/1442 (reviews required), which checks if mongodb is connected to cloudserver when the route `/_/healthcheck` is requested.