### PR TITLE
bf: ZENKO-1024 use pending metrics for backlog

### DIFF
--- a/lib/backbeat/Metrics.js
+++ b/lib/backbeat/Metrics.js
@@ -164,25 +164,16 @@ class Metrics {
                 });
                 return cb(errors.InternalError);
             }
-            const uptime = this._getMaxUptime(EXPIRY);
-            const numOfIntervals = Math.ceil(uptime / INTERVAL);
-            const [ops, opsDone, bytes, bytesDone] = res.map(r => (
-                r.requests.slice(0, numOfIntervals).reduce((acc, i) =>
-                    acc + i, 0)
-            ));
-
-            let opsBacklog = ops - opsDone;
-            if (opsBacklog < 0) opsBacklog = 0;
-            let bytesBacklog = bytes - bytesDone;
-            if (bytesBacklog < 0) bytesBacklog = 0;
+            const count = Number.parseInt(res[0].requests, 10);
+            const size = Number.parseInt(res[1].requests, 10);
             const response = {
                 backlog: {
                     description: 'Number of incomplete replication ' +
                         'operations (count) and number of incomplete bytes ' +
                         'transferred (size)',
                     results: {
-                        count: opsBacklog,
-                        size: bytesBacklog,
+                        count: count < 0 ? 0 : count,
+                        size: size < 0 ? 0 : size,
                     },
                 },
             };
@@ -512,8 +503,8 @@ class Metrics {
             // res = [ ops, ops_done, ops_fail, bytes, bytes_done, bytes_fail,
             // opsPending, bytesPending ]
             return async.parallel([
-                done => this.getBacklog({ dataPoints: new Array(4) }, done,
-                    [res[0], res[1], res[3], res[4]]),
+                done => this.getBacklog({ dataPoints: new Array(2) }, done,
+                    [res[6], res[7]]),
                 done => this.getCompletions({ dataPoints: new Array(2) }, done,
                     [res[1], res[4]]),
                 done => this.getFailedMetrics({ dataPoints: new Array(2) },

--- a/lib/backbeat/routes.js
+++ b/lib/backbeat/routes.js
@@ -34,8 +34,7 @@ function routes(redisKeys, allLocations) {
             type: 'backlog',
             extensions: { crr: [...allLocations, 'all'] },
             method: 'getBacklog',
-            dataPoints: [redisKeys.ops, redisKeys.opsDone, redisKeys.bytes,
-                redisKeys.bytesDone],
+            dataPoints: [redisKeys.opsPending, redisKeys.bytesPending],
         },
         // Route: /_/metrics/crr/<location>/completions
         {


### PR DESCRIPTION
Pending metrics don't expire which was a cause for problems
with current backlog. This quick fix is to use pending
metrics in place of backlog but keeping the same names
and routes in place to avoid regression.

To be merged with https://github.com/scality/backbeat/pull/415