### PR TITLE
bf: ZENKO-1024 fix fail metrics in all route

### DIFF
--- a/lib/backbeat/Metrics.js
+++ b/lib/backbeat/Metrics.js
@@ -500,6 +500,9 @@ class Metrics {
                 });
                 return cb(errors.InternalError);
             }
+            // NOTE: Edited to fit failed metrics
+            const failMetricsDetails = Object.assign({}, details,
+                { dataPoints: new Array(2) });
             // res = [ ops, ops_done, ops_fail, bytes, bytes_done, bytes_fail,
             // opsPending, bytesPending ]
             return async.parallel([
@@ -507,8 +510,8 @@ class Metrics {
                     [res[6], res[7]]),
                 done => this.getCompletions({ dataPoints: new Array(2) }, done,
                     [res[1], res[4]]),
-                done => this.getFailedMetrics({ dataPoints: new Array(2) },
-                    done, [res[2], res[5]]),
+                done => this.getFailedMetrics(failMetricsDetails, done,
+                    [res[2], res[5]]),
                 done => this.getThroughput({ dataPoints: new Array(2) }, done,
                     [res[1], res[4]]),
                 done => this.getPending({ dataPoints: new Array(2) }, done,


### PR DESCRIPTION
All metrics function will query redis once for all data.
With the change to failure metrics, we want to pass
the request details object to the getFailedMetrics fxn


To be merged with https://github.com/scality/backbeat/pull/416

