### PR TITLE
S3C-1665: delimiter*. return FILTER_END ASAP

### DIFF
--- a/lib/algos/list/Extension.js
+++ b/lib/algos/list/Extension.js
@@ -1,6 +1,10 @@
 'use strict'; // eslint-disable-line strict
 
-const { FILTER_SKIP, SKIP_NONE } = require('./tools');
+const {
+    FILTER_SKIP,
+    SKIP_NONE,
+    AWS_LISTING_DEFAULT_MAX_KEYS,
+} = require('./tools');
 
 /**
  *  Base class of listing extensions.
@@ -21,6 +25,8 @@ class Extension {
         // listing results
         this.res = undefined;
         this.keys = 0;
+        this.maxKeys = (parameters && parameters.maxKeys)
+          || AWS_LISTING_DEFAULT_MAX_KEYS;
     }
 
     /**
@@ -69,6 +75,20 @@ class Extension {
      */
     result() {
         return this.res;
+    }
+
+    /**
+     * check if the max keys count has been reached and set the final state of
+     * the result if it is the case.
+     * @return {Boolean} - indicates if the iteration has to stop
+     */
+    _reachedMaxKeys() {
+        if (this.keys >= this.maxKeys) {
+            // In cases of maxKeys <= 0 -> IsTruncated = false
+            this.IsTruncated = this.maxKeys > 0;
+            return true;
+        }
+        return false;
     }
 }
 

--- a/lib/algos/list/MPU.js
+++ b/lib/algos/list/MPU.js
@@ -1,5 +1,6 @@
 'use strict'; // eslint-disable-line strict
 
+const Extension = require('./Extension').default;
 const { inc, checkLimit, FILTER_END, FILTER_ACCEPT } = require('./tools');
 const DEFAULT_MAX_KEYS = 1000;
 
@@ -11,7 +12,7 @@ function numberDefault(num, defaultNum) {
 /**
  *  Class for the MultipartUploads extension
  */
-class MultipartUploads {
+class MultipartUploads extends Extension {
     /**
      *  Constructor of the extension
      *  Init and check parameters
@@ -20,6 +21,7 @@ class MultipartUploads {
      *  @return {undefined}
      */
     constructor(params, logger) {
+        super(params);
         this.params = params;
         this.CommonPrefixes = [];
         this.Uploads = [];
@@ -108,11 +110,10 @@ class MultipartUploads {
      */
     filter(obj) {
         // Check first in case of maxkeys = 0
-        if (this.keys >= this.maxKeys) {
-            // In cases of maxKeys <= 0 => IsTruncated = false
-            this.IsTruncated = this.maxKeys > 0;
+        if (this._reachedMaxKeys()) {
             return FILTER_END;
         }
+
         const key = obj.key;
         const value = obj.value;
         if (this.delimiter) {

--- a/lib/algos/list/basic.js
+++ b/lib/algos/list/basic.js
@@ -53,7 +53,7 @@ class List extends Extension {
      */
     filter(elem) {
         // Check first in case of maxkeys <= 0
-        if (this.keys >= this.maxKeys) {
+        if (this._reachedMaxKeys()) {
             return FILTER_END;
         }
         this.res.push(elem);

--- a/lib/algos/list/delimiter.js
+++ b/lib/algos/list/delimiter.js
@@ -1,7 +1,13 @@
 'use strict'; // eslint-disable-line strict
 
 const Extension = require('./Extension').default;
-const { inc, FILTER_END, FILTER_ACCEPT, FILTER_SKIP } = require('./tools');
+const {
+    inc,
+    FILTER_END,
+    FILTER_ACCEPT,
+    FILTER_SKIP,
+    AWS_LISTING_DEFAULT_MAX_KEYS,
+} = require('./tools');
 
 /**
  * Find the next delimiter in the path
@@ -61,7 +67,7 @@ class Delimiter extends Extension {
         this.delimiter = parameters.delimiter;
         this.prefix = parameters.prefix;
         this.marker = parameters.marker;
-        this.maxKeys = parameters.maxKeys || 1000;
+        this.maxKeys = parameters.maxKeys || AWS_LISTING_DEFAULT_MAX_KEYS;
         this.alphabeticalOrder =
           typeof parameters.alphabeticalOrder !== 'undefined' ?
                                  parameters.alphabeticalOrder : true;
@@ -103,20 +109,6 @@ class Delimiter extends Extension {
     }
 
     /**
-     * check if the max keys count has been reached and set the
-     * final state of the result if it is the case
-     * @return {Boolean} - indicates if the iteration has to stop
-     */
-    _reachedMaxKeys() {
-        if (this.keys >= this.maxKeys) {
-            // In cases of maxKeys <= 0 -> IsTruncated = false
-            this.IsTruncated = this.maxKeys > 0;
-            return true;
-        }
-        return false;
-    }
-
-    /**
      *  Add a (key, value) tuple to the listing
      *  Set the NextMarker to the current key
      *  Increment the keys counter
@@ -125,9 +117,6 @@ class Delimiter extends Extension {
      *  @return {number}      - indicates if iteration should continue
      */
     addContents(key, value) {
-        if (this._reachedMaxKeys()) {
-            return FILTER_END;
-        }
         this.Contents.push({ key, value });
         this.NextMarker = key;
         ++this.keys;
@@ -146,6 +135,10 @@ class Delimiter extends Extension {
      *  @return {number}          - indicates if iteration should continue
      */
     filter(obj) {
+        if (this._reachedMaxKeys()) {
+            return FILTER_END;
+        }
+
         const key = obj.key;
         const value = obj.value;
         if ((this.prefix && !key.startsWith(this.prefix))
@@ -177,9 +170,6 @@ class Delimiter extends Extension {
         const commonPrefix = getCommonPrefix(key, this.delimiter, index);
         if (this.CommonPrefixes.indexOf(commonPrefix) === -1
                 && this.NextMarker !== commonPrefix) {
-            if (this._reachedMaxKeys()) {
-                return FILTER_END;
-            }
             this.CommonPrefixes.push(commonPrefix);
             this.NextMarker = commonPrefix;
             ++this.keys;

--- a/lib/algos/list/delimiterMaster.js
+++ b/lib/algos/list/delimiterMaster.js
@@ -3,7 +3,12 @@
 const Delimiter = require('./delimiter').Delimiter;
 const Version = require('../../versioning/Version').Version;
 const VSConst = require('../../versioning/constants').VersioningConstants;
-const { FILTER_ACCEPT, FILTER_SKIP, SKIP_NONE } = require('./tools');
+const {
+    FILTER_ACCEPT,
+    FILTER_SKIP,
+    SKIP_NONE,
+    FILTER_END,
+} = require('./tools');
 
 const VID_SEP = VSConst.VersionId.Separator;
 
@@ -39,6 +44,10 @@ class DelimiterMaster extends Delimiter {
      *  @return {number}         - indicates if iteration should continue
      */
     filter(obj) {
+        if (this._reachedMaxKeys()) {
+            return FILTER_END;
+        }
+
         let key = obj.key;
         const value = obj.value;
 

--- a/lib/algos/list/delimiterVersions.js
+++ b/lib/algos/list/delimiterVersions.js
@@ -72,9 +72,6 @@ class DelimiterVersions extends Delimiter {
      *  @return {Boolean} - indicates if iteration should continue
      */
     addContents(obj) {
-        if (this._reachedMaxKeys()) {
-            return FILTER_END;
-        }
         this.Contents.push(obj);
         this.NextMarker = obj.key;
         this.NextVersionIdMarker = obj.versionId;
@@ -94,6 +91,9 @@ class DelimiterVersions extends Delimiter {
      *  @return {number}          - indicates if iteration should continue
      */
     filter(obj) {
+        if (this._reachedMaxKeys()) {
+            return FILTER_END;
+        }
         if (Version.isPHD(obj.value)) {
             return FILTER_ACCEPT; // trick repd to not increase its streak
         }

--- a/lib/algos/list/tools.js
+++ b/lib/algos/list/tools.js
@@ -4,6 +4,10 @@ const FILTER_ACCEPT = 1;
 const FILTER_SKIP = 0;
 const FILTER_END = -1;
 
+/* Default bucket objects listing 'max-keys' parameter, from
+ * https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html. */
+const AWS_LISTING_DEFAULT_MAX_KEYS = 1000;
+
 /**
  * This function check if number is valid
  * To be valid a number need to be an Integer and be lower than the limit
@@ -38,4 +42,5 @@ module.exports = {
     FILTER_END,
     FILTER_SKIP,
     FILTER_ACCEPT,
+    AWS_LISTING_DEFAULT_MAX_KEYS,
 };

--- a/tests/unit/algos/list/maxKeys.js
+++ b/tests/unit/algos/list/maxKeys.js
@@ -1,0 +1,47 @@
+const assert = require('assert');
+
+const list = '../../../../lib/algos/list';
+const { MultipartUploads } = require(`${list}/MPU`);
+const { List } = require(`${list}/basic`);
+const { Delimiter } = require(`${list}/delimiter`);
+const { DelimiterMaster } = require(`${list}/delimiterMaster`);
+const { DelimiterVersions } = require(`${list}/delimiterVersions`);
+const { FILTER_ACCEPT, FILTER_END } = require(`${list}/tools`);
+
+
+const extensions = [
+    { name: 'MPU', Ext: MultipartUploads },
+    { name: 'List', Ext: List },
+    { name: 'Delimiter', Ext: Delimiter },
+    { name: 'DelimiterMaster', Ext: DelimiterMaster },
+    { name: 'DelimiterVersion', Ext: DelimiterVersions },
+];
+
+
+describe('Delimiter listing algorithm', () => {
+    const doWhat = 'returns FILTER_END on the next entry once max keys reached';
+    extensions.forEach(extension => {
+        it(`Should extension ${extension.name} ${doWhat}`, () => {
+            /* Use a value complient with MultipartUploads extension
+             * requirements for values. It has no impact on other extensions.
+             **/
+            const initiator1 = { ID: '1', DisplayName: 'initiator1' };
+            const value = JSON.stringify({
+                'key': 'key1',
+                'uploadId': 'uploadId1',
+                'initiator': initiator1,
+                'owner-id': '1',
+                'owner-display-name': 'owner1',
+                'x-amz-storage-class': 'STANDART',
+                'initiated': '',
+            });
+            const obj1 = { key: 'key1', value };
+            const obj2 = { key: 'key2', value };
+
+            const ext = new extension.Ext({ maxKeys: 1 });
+
+            assert.strictEqual(ext.filter(obj1), FILTER_ACCEPT);
+            assert.strictEqual(ext.filter(obj2), FILTER_END);
+        });
+    });
+});


### PR DESCRIPTION
For all the delimiter extension, once we reach the maxKey parameter
entries added to the result, we should return FILTER_END on the next
entry.

Currently, we wait to find the next entry to add to the result to
return FILTER_END (and we don't add this entry to the result).

This commit moves the check to test is maxKeys is reached from
addContent/addCommon methods to the begining of the filter method.