### PR TITLE
bf: ZENKO-1144 add support for Redis sorted sets

### DIFF
--- a/lib/metrics/RedisClient.js
+++ b/lib/metrics/RedisClient.js
@@ -204,6 +204,16 @@ class RedisClient {
         return this._client.zrangebyscore(key, min, max, cb);
     }
 
+    /**
+     * get TTL or expiration in seconds
+     * @param {string} key - name of key
+     * @param {function} cb - callback
+     * @return {undefined}
+     */
+    ttl(key, cb) {
+        return this._client.ttl(key, cb);
+    }
+
     clear(cb) {
         return this._client.flushdb(cb);
     }

--- a/lib/metrics/RedisClient.js
+++ b/lib/metrics/RedisClient.js
@@ -69,6 +69,20 @@ class RedisClient {
     }
 
     /**
+     * increment value of a key by a given amount and set a ttl
+     * @param {string} key - key holding the value
+     * @param {number} amount - amount to increase by
+     * @param {number} expiry - expiry in seconds
+     * @param {callback} cb - callback
+     * @return {undefined}
+     */
+    incrbyEx(key, amount, expiry, cb) {
+        return this._client
+            .multi([['incrby', key, amount], ['expire', key, expiry]])
+            .exec(cb);
+    }
+
+    /**
      * decrement value of a key by a given amount
      * @param {string} key - key holding the value
      * @param {number} amount - amount to increase by
@@ -90,17 +104,15 @@ class RedisClient {
     }
 
     /**
-     * increment value of a key by a given amount and set a ttl
-     * @param {string} key - key holding the value
-     * @param {number} amount - amount to increase by
-     * @param {number} expiry - expiry in seconds
-     * @param {callback} cb - callback
+     * Checks if a key exists
+     * @param {string} key - name of key
+     * @param {function} cb - callback
+     *   If cb response returns 0, key does not exist.
+     *   If cb response returns 1, key exists.
      * @return {undefined}
      */
-    incrbyEx(key, amount, expiry, cb) {
-        return this._client
-            .multi([['incrby', key, amount], ['expire', key, expiry]])
-            .exec(cb);
+    exists(key, cb) {
+        return this._client.exists(key, cb);
     }
 
     /**
@@ -111,6 +123,85 @@ class RedisClient {
     */
     batch(cmds, cb) {
         return this._client.pipeline(cmds).exec(cb);
+    }
+
+    /**
+     * Add a value and its score to a sorted set. If no sorted set exists, this
+     * will create a new one for the given key.
+     * @param {string} key - name of key
+     * @param {integer} score - score used to order set
+     * @param {string} value - value to store
+     * @param {callback} cb - callback
+     * @return {undefined}
+     */
+    zadd(key, score, value, cb) {
+        return this._client.zadd(key, score, value, cb);
+    }
+
+    /**
+     * Get number of elements in a sorted set.
+     * Note: using this on a key that does not exist will return 0.
+     * Note: using this on an existing key that isn't a sorted set will
+     * return an error WRONGTYPE.
+     * @param {string} key - name of key
+     * @param {function} cb - callback
+     * @return {undefined}
+     */
+    zcard(key, cb) {
+        return this._client.zcard(key, cb);
+    }
+
+    /**
+     * Get the score for given value in a sorted set
+     * Note: using this on a key that does not exist will return nil.
+     * Note: using this on a value that does not exist in a valid sorted set key
+     *       will return nil.
+     * @param {string} key - name of key
+     * @param {string} value - value within sorted set
+     * @param {function} cb - callback
+     * @return {undefined}
+     */
+    zscore(key, value, cb) {
+        return this._client.zscore(key, value, cb);
+    }
+
+    /**
+     * Remove a value from a sorted set
+     * @param {string} key - name of key
+     * @param {string|array} value - value within sorted set. Can specify
+     *   multiple values within an array
+     * @param {function} cb - callback
+     *   The cb response returns number of values removed
+     * @return {undefined}
+     */
+    zrem(key, value, cb) {
+        return this._client.zrem(key, value, cb);
+    }
+
+    /**
+     * Get specified range of elements in a sorted set
+     * @param {string} key - name of key
+     * @param {integer} start - start index (inclusive)
+     * @param {integer} end - end index (inclusive) (can use -1)
+     * @param {function} cb - callback
+     * @return {undefined}
+     */
+    zrange(key, start, end, cb) {
+        return this._client.zrange(key, start, end, cb);
+    }
+
+    /**
+     * Get range of elements in a sorted set based off score
+     * @param {string} key - name of key
+     * @param {integer|string} min - min score value (inclusive)
+     *   (can use "-inf")
+     * @param {integer|string} max - max score value (inclusive)
+     *   (can use "+inf")
+     * @param {function} cb - callback
+     * @return {undefined}
+     */
+    zrangebyscore(key, min, max, cb) {
+        return this._client.zrangebyscore(key, min, max, cb);
     }
 
     clear(cb) {

--- a/lib/metrics/StatsModel.js
+++ b/lib/metrics/StatsModel.js
@@ -143,6 +143,86 @@ class StatsModel extends StatsClient {
             return cb(null, statsRes);
         });
     }
+
+    /**
+     * normalize date timestamp to the nearest hour
+     * @param {Date} d - Date instance
+     * @return {number} timestamp - normalized to the nearest hour
+     */
+    _normalizeTimestampByHour(d) {
+        return d.setMinutes(0, 0, 0);
+    }
+
+    /**
+     * get previous hour to date given
+     * @param {Date} d - Date instance
+     * @return {number} timestamp - one hour prior to date passed
+     */
+    _getDatePreviousHour(d) {
+        return d.setHours(d.getHours() - 1);
+    }
+
+    /**
+     * get list of sorted set key timestamps
+     * @param {number} epoch - epoch time
+     * @return {array} array of sorted set key timestamps
+     */
+    getSortedSetHours(epoch) {
+        const timestamps = [];
+        let date = this._normalizeTimestampByHour(new Date(epoch));
+        while (timestamps.length < 24) {
+            timestamps.push(date);
+            date = this._getDatePreviousHour(new Date(date));
+        }
+        return timestamps;
+    }
+
+    /**
+     * get the normalized hour timestamp for given epoch time
+     * @param {number} epoch - epoch time
+     * @return {string} normalized hour timestamp for given time
+     */
+    getSortedSetCurrentHour(epoch) {
+        return this._normalizeTimestampByHour(new Date(epoch));
+    }
+
+    /**
+     * helper method to add element to a sorted set, applying TTL if new set
+     * @param {string} key - name of key
+     * @param {integer} score - score used to order set
+     * @param {string} value - value to store
+     * @param {callback} cb - callback
+     * @return {undefined}
+     */
+    addToSortedSet(key, score, value, cb) {
+        this._redis.exists(key, (err, resCode) => {
+            if (err) {
+                return cb(err);
+            }
+            if (resCode === 0) {
+                // milliseconds in a day
+                const msInADay = 24 * 60 * 60 * 1000;
+                const nearestHour = this._normalizeTimestampByHour(new Date());
+                const ttl = msInADay - (Date.now() - nearestHour);
+                const cmds = [
+                    ['zadd', key, score, value],
+                    ['expire', key, ttl],
+                ];
+                return this._redis.batch(cmds, (err, res) => {
+                    if (err) {
+                        return cb(err);
+                    }
+                    const cmdErr = res.find(r => r[0] !== null);
+                    if (cmdErr) {
+                        return cb(cmdErr);
+                    }
+                    const successResponse = res[0][1];
+                    return cb(null, successResponse);
+                });
+            }
+            return this._redis.zadd(key, score, value, cb);
+        });
+    }
 }
 
 module.exports = StatsModel;


### PR DESCRIPTION
These changes are to support use of sorted sets in Redis for crr metrics. Plan is to use hourly sorted sets to track failure metrics and keep a epoch sorted list of failure keys.

Changes in this PR:
- Add wrapper for Redis sorted set methods: ZADD, ZCARD, ZRANGE, ZRANGEBYSCORE, ZREM, ZSCORE
- Add wrapper for Redis methods: SET, EXISTS, TTL
- `StatsModel.getSortedSetCurrentHour` returns array of 24 normalized hourly timestamps
- `StatsModel.addToSortedSet` adds to a sorted set and applies expiry if adding to new sorted set
