### PR TITLE
bf: ZENKO-1144 remove redis scan from crr metrics

### DIFF
--- a/lib/backbeat/Metrics.js
+++ b/lib/backbeat/Metrics.js
@@ -34,31 +34,19 @@ class Metrics {
         return async.map(ops, (op, done) => {
             const hasGlobalKey = this._hasGlobalKey(op);
             if (site === 'all') {
-                const queryString = hasGlobalKey ? `*:${op}` : `*:${op}:*`;
-                return this._redisClient.scan(queryString, undefined,
-                (err, res) => {
-                    if (err) {
-                        // escalate error to log later
-                        return done({
-                            message: `Redis error: ${err.message}`,
-                            type: errors.InternalError,
-                            method: 'Metrics._queryStats',
-                        });
+                const queryStrings = this._validSites.map(s => {
+                    if (bucketName && objectKey && versionId) {
+                        return `${s}:${bucketName}:${objectKey}:` +
+                               `${versionId}:${op}`;
                     }
-                    if (hasGlobalKey) {
-                        return this._statsClient.getAllGlobalStats(res,
-                            this._logger, done);
-                    }
-                    const allKeys = res.map(key => {
-                        const arr = key.split(':');
-                        // Remove the "requests:<timestamp>" and process
-                        return arr.slice(0, arr.length - 2).join(':');
-                    });
-                    const reducedKeys = [...new Set(allKeys)];
-
-                    return this._statsClient.getAllStats(this._logger,
-                        reducedKeys, done);
+                    return `${s}:${op}`;
                 });
+                if (hasGlobalKey) {
+                    return this._statsClient.getAllGlobalStats(queryStrings,
+                        this._logger, done);
+                }
+                return this._statsClient.getAllStats(this._logger, queryStrings,
+                    done);
             }
             // Query only a single given site or storage class
             // First, validate the site or storage class


### PR DESCRIPTION
Avoid any use of O(N) ops for crr metrics

Changes in this PR:
- Remove use of Redis#scan. Instead build query strings manually
