### PR TITLE
bf: ZENKO-1155 add index restriction for mongo find call

### DIFF
--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -551,7 +551,9 @@ class MongoClientInterface {
         const { objName, versionId, collectionName } = params;
         if (isUserBucket(collectionName)) {
             if (isUpdate) {
+                const findId = new RegExp(objName);
                 return c.find({
+                    '_id': { $regex: findId },
                     'value.versionId': versionId,
                 }, {}).toArray((err, entries) => {
                     if (err) {


### PR DESCRIPTION
Fixes the issue in which mongo performs looks through a collection to find an entry with specify version-id