### PR TITLE
Bugfix/zenko 1197/s3 data leak

### DIFF
--- a/lib/network/http/server.js
+++ b/lib/network/http/server.js
@@ -351,6 +351,8 @@ class Server {
             error: err.stack || err,
             address: sock.address(),
         });
+        // socket is not systematically destroyed
+        sock.destroy();
     }
 
     /**

--- a/lib/storage/data/file/DataFileStore.js
+++ b/lib/storage/data/file/DataFileStore.js
@@ -199,6 +199,15 @@ class DataFileStore {
                 return cbOnce(errors.InternalError.customizeDescription(
                     `read stream error: ${err.code}`));
             });
+            dataStream.on('close', () => {
+                // this means the underlying socket has been closed
+                log.debug('Client closed socket while streaming',
+                          { method: 'put', key, filePath });
+                // destroying the write stream forces a close(fd)
+                fileStream.destroy();
+                // we need to unlink the file ourselves
+                fs.unlinkSync(filePath);
+            });
             return undefined;
         });
     }


### PR DESCRIPTION
Fixes a leak occurring when cloudserver abruptly closes the s3-data socket. The root-cause of this socket hang-up is for the moment unclear, but is probably due to some overload.

The main source of the leak is that we don't listen to the 'close' event on the dataStream. When receiving this event we have to destroy the fileStream and delete the filePath by ourselves because it is not managed by the pipe. Without this, the file descriptor is never closed, the incomplete file is never deleted, leaking disk space, and leaking VFS cache which is critical in e.g. kubernetes pods.

Another problem is that we don't destroy the socket upon receiving of a clientError event in the lib/network/http/server.js. Indeed the socket is not necessarily closed automatically by the underlying layers (e.g. upon receiving a RST it seems that the underlying socket is closed, but not in some cases when it is a normal FIN/ACK termination handshake). If we don't explicitly destroy the socket sometimes the 'close' event is not emitted to the dataStream.


