### PR TITLE
ZENKO-833: add ingestion param for BucketInfo

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -79,4 +79,8 @@ module.exports = {
     // - Max bucket name length if bucket match false of 63
     // - Extra prefix slash for bucket prefix if bucket match of 1
     objectKeyByteLimit: 915,
+    /* delimiter for location-constraint. The location constraint will be able
+     * to include the ingestion flag
+     */
+    zenkoSeparator: ':',
 };

--- a/lib/models/BucketInfo.js
+++ b/lib/models/BucketInfo.js
@@ -4,10 +4,9 @@ const uuid = require('uuid/v4');
 const { WebsiteConfiguration } = require('./WebsiteConfiguration');
 const ReplicationConfiguration = require('./ReplicationConfiguration');
 const LifecycleConfiguration = require('./LifecycleConfiguration');
-
 // WHEN UPDATING THIS NUMBER, UPDATE MODELVERSION.MD CHANGELOG
 // MODELVERSION.MD can be found in S3 repo: lib/metadata/ModelVersion.md
-const modelVersion = 9;
+const modelVersion = 10;
 
 class BucketInfo {
     /**
@@ -36,7 +35,8 @@ class BucketInfo {
     * @param {object} versioningConfiguration - versioning configuration
     * @param {string} versioningConfiguration.Status - versioning status
     * @param {object} versioningConfiguration.MfaDelete - versioning mfa delete
-    * @param {string} locationConstraint - locationConstraint for bucket
+    * @param {string} locationConstraint - locationConstraint for bucket that
+    * also includes the ingestion flag
     * @param {WebsiteConfiguration} [websiteConfiguration] - website
     * configuration
     * @param {object[]} [cors] - collection of CORS rules to apply
@@ -54,13 +54,14 @@ class BucketInfo {
     * @param {string} readLocationConstraint - readLocationConstraint for bucket
     * addition for use with lifecycle operations
     * @param {boolean} [isNFS] - whether the bucket is on NFS
+    * @param {object} [ingestionConfig] - object for ingestion status: en/dis
     */
     constructor(name, owner, ownerDisplayName, creationDate,
                 mdBucketModelVersion, acl, transient, deleted,
                 serverSideEncryption, versioningConfiguration,
                 locationConstraint, websiteConfiguration, cors,
                 replicationConfiguration, lifecycleConfiguration, uid,
-                readLocationConstraint, isNFS) {
+                readLocationConstraint, isNFS, ingestionConfig) {
         assert.strictEqual(typeof name, 'string');
         assert.strictEqual(typeof owner, 'string');
         assert.strictEqual(typeof ownerDisplayName, 'string');
@@ -97,6 +98,9 @@ class BucketInfo {
         }
         if (locationConstraint) {
             assert.strictEqual(typeof locationConstraint, 'string');
+        }
+        if (ingestionConfig) {
+            assert.strictEqual(typeof ingestionConfig, 'object');
         }
         if (readLocationConstraint) {
             assert.strictEqual(typeof readLocationConstraint, 'string');
@@ -155,6 +159,7 @@ class BucketInfo {
         this._lifecycleConfiguration = lifecycleConfiguration || null;
         this._uid = uid || uuid();
         this._isNFS = isNFS || null;
+        this._ingestion = ingestionConfig || null;
         return this;
     }
     /**
@@ -181,6 +186,7 @@ class BucketInfo {
             lifecycleConfiguration: this._lifecycleConfiguration,
             uid: this._uid,
             isNFS: this._isNFS,
+            ingestion: this._ingestion,
         };
         if (this._websiteConfiguration) {
             bucketInfos.websiteConfiguration =
@@ -202,7 +208,7 @@ class BucketInfo {
             obj.transient, obj.deleted, obj.serverSideEncryption,
             obj.versioningConfiguration, obj.locationConstraint, websiteConfig,
             obj.cors, obj.replicationConfiguration, obj.lifecycleConfiguration,
-            obj.uid, obj.readLocationConstraint, obj.isNFS);
+            obj.uid, obj.readLocationConstraint, obj.isNFS, obj.ingestion);
     }
 
     /**
@@ -226,7 +232,8 @@ class BucketInfo {
             data._versioningConfiguration, data._locationConstraint,
             data._websiteConfiguration, data._cors,
             data._replicationConfiguration, data._lifecycleConfiguration,
-            data._uid, data._readLocationConstraint, data._isNFS);
+            data._uid, data._readLocationConstraint, data._isNFS,
+            data._ingestion);
     }
 
     /**
@@ -577,6 +584,50 @@ class BucketInfo {
     setIsNFS(isNFS) {
         this._isNFS = isNFS;
         return this;
+    }
+    /**
+     * enable ingestion, set 'this._ingestion' to { status: 'enabled' }
+     * @return {BucketInfo} - bucket info instance
+     */
+    enableIngestion() {
+        this._ingestion = { status: 'enabled' };
+        return this;
+    }
+    /**
+     * disable ingestion, set 'this._ingestion' to { status: 'disabled' }
+     * @return {BucketInfo} - bucket info instance
+     */
+    disableIngestion() {
+        this._ingestion = { status: 'disabled' };
+        return this;
+    }
+    /**
+     * Get ingestion configuration
+     * @return {object} - bucket ingestion configuration: Enabled or Disabled
+     */
+    getIngestion() {
+        return this._ingestion;
+    }
+
+    /**
+     ** Check if bucket is an ingestion bucket
+     * @return {boolean} - 'true' if bucket is ingestion bucket, 'false' if
+     * otherwise
+     */
+    isIngestionBucket() {
+        const ingestionConfig = this.getIngestion();
+        if (ingestionConfig) {
+            return true;
+        }
+        return false;
+    }
+    /**
+     * Check if ingestion is enabled
+     * @return {boolean} - 'true' if ingestion is enabled, otherwise 'false'
+     */
+    isIngestionEnabled() {
+        const ingestionConfig = this.getIngestion();
+        return ingestionConfig ? ingestionConfig.status === 'enabled' : false;
     }
 }
 

--- a/lib/storage/metadata/MetadataWrapper.js
+++ b/lib/storage/metadata/MetadataWrapper.js
@@ -45,6 +45,7 @@ function _parseListEntries(entries) {
                 EventualStorageBucket: tmp.eventualStorageBucket,
                 partLocations: tmp.partLocations,
                 creationDate: tmp.creationDate,
+                ingestion: tmp.ingestion,
             },
         };
     });

--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -1054,6 +1054,7 @@ class MongoClientInterface {
                             isVersioned:
                                 !!bucketInfo.getVersioningConfiguration(),
                             ownerCanonicalId: bucketInfo.getOwner(),
+                            ingestion: bucketInfo.isIngestionBucket(),
                         };
                         res.bucketList.push(retBucketInfo);
                         return next(null, bucketInfo);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "arsenal",
-  "version": "8.0.2",
+  "version": "8.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=8"
   },
-  "version": "8.0.5",
+  "version": "8.1.0",
   "description": "Common utilities for the S3 project components",
   "main": "index.js",
   "repository": {

--- a/tests/unit/models/BucketInfo.js
+++ b/tests/unit/models/BucketInfo.js
@@ -60,6 +60,7 @@ const testWebsiteConfiguration = new WebsiteConfiguration({
 
 const testLocationConstraint = 'us-west-1';
 const testReadLocationConstraint = 'us-west-2';
+const testLocationConstraintIngest = 'us-west-3:ingest';
 
 const testCorsConfiguration = [
     { id: 'test',
@@ -117,6 +118,7 @@ const testLifecycleConfiguration = {
     ],
 };
 
+const testIngestionConfiguration = { status: 'enabled' };
 const testUid = '99ae3446-7082-4c17-ac97-52965dc004ec';
 // create a dummy bucket to test getters and setters
 
@@ -165,6 +167,7 @@ Object.keys(acl).forEach(
                         dummyBucket._lifecycleConfiguration,
                     uid: dummyBucket._uid,
                     isNFS: dummyBucket._isNFS,
+                    ingestion: dummyBucket._ingestion,
                 };
                 assert.strictEqual(serialized, JSON.stringify(bucketInfos));
                 done();
@@ -407,6 +410,16 @@ Object.keys(acl).forEach(
                 assert.deepStrictEqual(dummyBucket.getLifecycleConfiguration(),
                     newLifecycleConfig);
             });
+            it('enableIngestion should set ingestion status to enabled', () => {
+                dummyBucket.enableIngestion();
+                assert.deepStrictEqual(dummyBucket.getIngestion(),
+                    { status: 'enabled' });
+            });
+            it('disableIngestion should set ingestion status to null', () => {
+                dummyBucket.disableIngestion();
+                assert.deepStrictEqual(dummyBucket.getIngestion(),
+                    { status: 'disabled' });
+            });
         });
     })
 );
@@ -431,5 +444,52 @@ describe('uid default', () => {
         const defaultUid = dummyBucket.getUid();
         assert(defaultUid);
         assert.strictEqual(defaultUid.length, 36);
+    });
+});
+
+describe('ingest', () => {
+    it('should enable ingestion if ingestion param sent on bucket creation',
+    () => {
+        const dummyBucket = new BucketInfo(
+            bucketName, owner, ownerDisplayName, testDate,
+            BucketInfo.currentModelVersion(), acl[emptyAcl],
+            false, false, {
+                cryptoScheme: 1,
+                algorithm: 'sha1',
+                masterKeyId: 'somekey',
+                mandatory: true,
+            }, testVersioningConfiguration,
+            testLocationConstraintIngest,
+            testWebsiteConfiguration,
+            testCorsConfiguration,
+            testReplicationConfiguration,
+            testLifecycleConfiguration,
+            testUid, undefined, true, testIngestionConfiguration);
+        assert.deepStrictEqual(dummyBucket.getIngestion(),
+            { status: 'enabled' });
+        assert.strictEqual(dummyBucket.isIngestionBucket(), true);
+        assert.strictEqual(dummyBucket.isIngestionEnabled(), true);
+    });
+
+    it('should have ingestion as null if no ingestion param was sent on' +
+    'bucket creation', () => {
+        const dummyBucket = new BucketInfo(
+            bucketName, owner, ownerDisplayName, testDate,
+            BucketInfo.currentModelVersion(), acl[emptyAcl],
+            false, false, {
+                cryptoScheme: 1,
+                algorithm: 'sha1',
+                masterKeyId: 'somekey',
+                mandatory: true,
+            }, testVersioningConfiguration,
+            testLocationConstraintIngest,
+            testWebsiteConfiguration,
+            testCorsConfiguration,
+            testReplicationConfiguration,
+            testLifecycleConfiguration,
+            testUid, undefined, true);
+        assert.deepStrictEqual(dummyBucket.getIngestion(), null);
+        assert.strictEqual(dummyBucket.isIngestionBucket(), false);
+        assert.strictEqual(dummyBucket.isIngestionEnabled(), false);
     });
 });


### PR DESCRIPTION
The ingestion flag will be sent in the locationConstraint string as `<location name>:ingest`.
The standard location constraint string looks like `us-east-1`. With the ingestion flag, it would look like `us-east-1:ingest`. 

