### PR TITLE
feat: passthroughFile service

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -23,6 +23,7 @@ module.exports = {
     zenkoServiceAccount: 'http://acs.zenko.io/accounts/service',
     metadataFileNamespace: '/MDFile',
     dataFileURL: '/DataFile',
+    passthroughFileURL: '/PassthroughFile',
     // AWS states max size for user-defined metadata
     // (x-amz-meta- headers) is 2 KB:
     // http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html

--- a/lib/network/rest/RESTClient.js
+++ b/lib/network/rest/RESTClient.js
@@ -79,6 +79,7 @@ class RESTClient {
 
         this.host = params.host;
         this.port = params.port;
+        this.isPassthrough = params.isPassthrough || false;
         this.setupLogging(params.logApi);
         this.httpAgent = new http.Agent({ keepAlive: true });
     }
@@ -104,11 +105,13 @@ class RESTClient {
     doRequest(method, headers, key, log, responseCb) {
         const reqHeaders = headers || {};
         const urlKey = key || '';
+        const prefix = this.isPassthrough ?
+            constants.passthroughFileURL : constants.dataFileURL;
         const reqParams = {
             hostname: this.host,
             port: this.port,
             method,
-            path: `${constants.dataFileURL}/${urlKey}`,
+            path: `${prefix}/${urlKey}`,
             headers: reqHeaders,
             agent: this.httpAgent,
         };

--- a/lib/network/rest/RESTServer.js
+++ b/lib/network/rest/RESTServer.js
@@ -52,7 +52,8 @@ function sendError(res, log, error, optMessage) {
 function parseURL(urlStr, expectKey) {
     const urlObj = url.parse(urlStr);
     const pathInfo = utils.explodePath(urlObj.path);
-    if (pathInfo.service !== constants.dataFileURL) {
+    if ((pathInfo.service !== constants.dataFileURL)
+        && (pathInfo.service !== constants.passthroughFileURL)) {
         throw errors.InvalidAction.customizeDescription(
             `unsupported service '${pathInfo.service}'`);
     }

--- a/lib/network/rest/utils.js
+++ b/lib/network/rest/utils.js
@@ -1,8 +1,17 @@
 'use strict'; // eslint-disable-line
 
 const errors = require('../../errors');
+const constants = require('../../constants');
+const passthroughPrefixLength = constants.passthroughFileURL.length;
 
 module.exports.explodePath = function explodePath(path) {
+    if (path.startsWith(constants.passthroughFileURL)) {
+        const key = path.slice(passthroughPrefixLength + 1);
+        return {
+            service: constants.passthroughFileURL,
+            key: key.length > 0 ? key : undefined,
+        };
+    }
     const pathMatch = /^(\/[a-zA-Z0-9]+)(\/([0-9a-f]*))?$/.exec(path);
     if (pathMatch) {
         return {

--- a/lib/storage/data/file/DataFileStore.js
+++ b/lib/storage/data/file/DataFileStore.js
@@ -1,6 +1,7 @@
 'use strict'; // eslint-disable-line
 
 const fs = require('fs');
+const path = require('path');
 const crypto = require('crypto');
 const async = require('async');
 const diskusage = require('diskusage');
@@ -51,6 +52,7 @@ class DataFileStore {
         this.logger = new (logApi || werelogs).Logger('DataFileStore');
         this.dataPath = dataConfig.dataPath;
         this.noSync = dataConfig.noSync || false;
+        this.isPassthrough = dataConfig.isPassthrough || false;
     }
 
     /**
@@ -70,7 +72,9 @@ class DataFileStore {
                                   { error: err });
                 return callback(err);
             }
-
+            if (this.isPassthrough) {
+                return callback();
+            }
             // Create FOLDER_HASH subdirectories
             const subDirs = Array.from({ length: FOLDER_HASH },
                                        (v, k) => (k).toString());
@@ -109,6 +113,15 @@ class DataFileStore {
      *   object contents
      */
     getFilePath(key) {
+        if (this.isPassthrough) {
+            const dirname = path.resolve(this.dataPath);
+            const filePath = path.resolve(dirname, key);
+            if (filePath.startsWith(dirname) &&
+                filePath !== dirname) {
+                return filePath;
+            }
+            return '';
+        }
         const hash = stringHash(key);
         const folderHashPath = ((hash % FOLDER_HASH)).toString();
         return `${this.dataPath}/${folderHashPath}/${key}`;
@@ -125,8 +138,16 @@ class DataFileStore {
      * @return {undefined}
      */
     put(dataStream, size, log, callback) {
+        if (this.isPassthrough) {
+            callback(errors.NotImplemented);
+            return;
+        }
         const key = crypto.pseudoRandomBytes(20).toString('hex');
         const filePath = this.getFilePath(key);
+        if (!filePath) {
+            callback(errors.InvalidArgument);
+            return;
+        }
         log.debug('starting to write data', { method: 'put', key, filePath });
         dataStream.pause();
         fs.open(filePath, 'wx', (err, fd) => {
@@ -223,6 +244,10 @@ class DataFileStore {
      */
     stat(key, log, callback) {
         const filePath = this.getFilePath(key);
+        if (!filePath) {
+            callback(errors.InvalidArgument);
+            return;
+        }
         log.debug('stat file', { key, filePath });
         fs.stat(filePath, (err, stat) => {
             if (err) {
@@ -251,7 +276,10 @@ class DataFileStore {
      */
     get(key, byteRange, log, callback) {
         const filePath = this.getFilePath(key);
-
+        if (!filePath) {
+            callback(errors.InvalidArgument);
+            return;
+        }
         const readStreamOptions = {
             flags: 'r',
             encoding: null,
@@ -289,7 +317,13 @@ class DataFileStore {
      * @return {undefined}
      */
     delete(key, log, callback) {
+        if (this.isPassthrough) {
+            return callback(errors.NotImplemented);
+        }
         const filePath = this.getFilePath(key);
+        if (!filePath) {
+            return callback(errors.InvalidArgument);
+        }
         log.debug('deleting file', { method: 'delete', key, filePath });
         return fs.unlink(filePath, err => {
             if (err) {


### PR DESCRIPTION
This PR adds the `passthroughFile` "service" which is used for the implementation of the `passthrough-fs daemon`, a.k.a `pfsd`. It can be found here: https://github.com/scality/cloudserver/pull/1609

For the full design of `pfsd`, formerly "fs-data", see https://github.com/scality/Zenko-RFCs/pull/5