### PR TITLE
ft: ZENKO-1282 add scheduled resume for ingestion

### DIFF
--- a/lib/backbeat/routes.js
+++ b/lib/backbeat/routes.js
@@ -145,6 +145,7 @@ function routes(redisKeys, locations) {
         // Route: /_/crr/resume/<location>
         // Route: /_/ingestion/resume/<location>
         // Route: /_/crr/resume/<location>/schedule
+        // Route: /_/ingestion/resume/<location>/schedule
         // Where <location> is an optional field unless "schedule" route
         {
             httpMethod: 'POST',
@@ -158,15 +159,22 @@ function routes(redisKeys, locations) {
         {
             httpMethod: 'DELETE',
             type: 'resume',
-            extensions: { crr: [...locations.crr, 'all'] },
+            extensions: {
+                crr: [...locations.crr, 'all'],
+                ingestion: [...locations.ingestion, 'all'],
+            },
             method: 'deleteScheduledResumeService',
         },
         // Route: /_/crr/resume/<location>
+        // Route: /_/ingestion/resume/<location>
         {
             httpMethod: 'GET',
             type: 'resume',
-            extensions: { crr: [...locations.crr, 'all'] },
-            method: 'getResumeCRRSchedule',
+            extensions: {
+                crr: [...locations.crr, 'all'],
+                ingestion: [...locations.ingestion, 'all'],
+            },
+            method: 'getResumeSchedule',
         },
         // Route: /_/crr/status/<location>
         // Route: /_/ingestion/status/<location>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "arsenal",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=8"
   },
-  "version": "8.1.0",
+  "version": "8.1.1",
   "description": "Common utilities for the S3 project components",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Extend backbeat api routes scheduled resume to support ingestion service