### PR TITLE
feat(DataFileStore): add passthrough delete functionality

### DIFF
--- a/lib/storage/data/file/DataFileStore.js
+++ b/lib/storage/data/file/DataFileStore.js
@@ -53,6 +53,7 @@ class DataFileStore {
         this.dataPath = dataConfig.dataPath;
         this.noSync = dataConfig.noSync || false;
         this.isPassthrough = dataConfig.isPassthrough || false;
+        this.isReadOnly = dataConfig.isReadOnly || false;
     }
 
     /**
@@ -140,6 +141,11 @@ class DataFileStore {
     put(dataStream, size, log, callback) {
         if (this.isPassthrough) {
             callback(errors.NotImplemented);
+            return;
+        }
+        if (this.isReadOnly) {
+            callback(errors.InternalError.customizeDescription(
+                'unable to write in ReadOnly mode'));
             return;
         }
         const key = crypto.pseudoRandomBytes(20).toString('hex');
@@ -317,8 +323,9 @@ class DataFileStore {
      * @return {undefined}
      */
     delete(key, log, callback) {
-        if (this.isPassthrough) {
-            return callback(errors.NotImplemented);
+        if (this.isReadOnly) {
+            return callback(errors.InternalError.customizeDescription(
+                'unable to delete in ReadOnly mode'));
         }
         const filePath = this.getFilePath(key);
         if (!filePath) {


### PR DESCRIPTION
This adds support to delete files when using the Passthrough DataFileStore. It also allows for configuring ReadOnly mode.