### PR TITLE
ft: ZENKO-717: move replicationBackends constant from cloudServer.

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -83,4 +83,6 @@ module.exports = {
      * to include the ingestion flag
      */
     zenkoSeparator: ':',
+    /* eslint-disable camelcase */
+    replicationBackends: { aws_s3: true, azure: true, gcp: true },
 };


### PR DESCRIPTION
With the management code moved from cloud server to its own repository,
this constant should be shared in Arsenal constants.