### PR TITLE
feature: ZENKO-732 Lifecycle transition policies

### DIFF
--- a/lib/models/LifecycleConfiguration.js
+++ b/lib/models/LifecycleConfiguration.js
@@ -3,6 +3,8 @@ const UUID = require('uuid');
 
 const errors = require('../errors');
 
+const MAX_DAYS = 2147483647; // Max 32-bit signed binary integer.
+
 /**
  * Format of xml request:
 
@@ -83,10 +85,13 @@ class LifecycleConfiguration {
     /**
      * Create a Lifecycle Configuration instance
      * @param {string} xml - the parsed xml
+     * @param {object} config - the CloudServer config
      * @return {object} - LifecycleConfiguration instance
      */
-    constructor(xml) {
+    constructor(xml, config) {
         this._parsedXML = xml;
+        this._storageClasses =
+            config.replicationEndpoints.map(endpoint => endpoint.site);
         this._ruleIDs = [];
         this._tagKeys = [];
         this._config = {};
@@ -179,11 +184,6 @@ class LifecycleConfiguration {
      */
     _parseRule(rule) {
         const ruleObj = {};
-        if (rule.Transition || rule.NoncurrentVersionTransition) {
-            ruleObj.error = errors.NotImplemented.customizeDescription(
-                'Transition lifecycle action not yet implemented');
-            return ruleObj;
-        }
         // Either Prefix or Filter must be included, but can be empty string
         if ((!rule.Filter && rule.Filter !== '') &&
         (!rule.Prefix && rule.Prefix !== '')) {
@@ -255,7 +255,7 @@ class LifecycleConfiguration {
         if (Array.isArray(filter)) {
             // if Prefix was included, not Filter, filter will be Prefix array
             // if more than one Prefix is included, we ignore all but the last
-            filterObj.rulePrefix = filter.pop();
+            filterObj.rulePrefix = filter[filter.length - 1];
             return filterObj;
         }
         if (filter.And && (filter.Prefix || filter.Tag) ||
@@ -265,7 +265,7 @@ class LifecycleConfiguration {
             return filterObj;
         }
         if (filter.Prefix) {
-            filterObj.rulePrefix = filter.Prefix.pop();
+            filterObj.rulePrefix = filter.Prefix[filter.Prefix.length - 1];
             return filterObj;
         }
         if (filter.Tag) {
@@ -285,7 +285,7 @@ class LifecycleConfiguration {
                 return filterObj;
             }
             if (andF.Prefix && andF.Prefix.length >= 1) {
-                filterObj.rulePrefix = andF.Prefix.pop();
+                filterObj.rulePrefix = andF.Prefix[andF.Prefix.length - 1];
             }
             const tagObj = this._parseTags(andF.Tag);
             if (tagObj.error) {
@@ -413,6 +413,267 @@ class LifecycleConfiguration {
     }
 
     /**
+     * Finds the prefix and/or tags of the given rule and gets the error message
+     * @param {object} rule - The rule to find the prefix in
+     * @return {string} - The prefix of filter information
+     */
+    _getRuleFilter(rule) {
+        if (rule.Prefix) {
+            return `prefix '${rule.Prefix[0]}'`;
+        }
+        // There must be a filter if no top-level prefix is provided. First
+        // check if there are multiple filters (i.e. `Filter.And`).
+        if (rule.Filter[0].And === undefined) {
+            const { Prefix, Tag } = rule.Filter[0];
+            if (Prefix) {
+                return `filter '(prefix=${Prefix[0]})'`;
+            }
+            const { Key, Value } = Tag[0];
+            return `filter '(tag: key=${Key[0]}, value=${Value[0]})'`;
+        }
+        const filters = [];
+        const { Prefix, Tag } = rule.Filter[0].And[0];
+        if (Prefix) {
+            filters.push(`prefix=${Prefix[0]}`);
+        }
+        Tag.forEach(tag => {
+            const { Key, Value } = tag;
+            filters.push(`tag: key=${Key[0]}, value=${Value[0]}`);
+        });
+        const joinedFilters = filters.join(' and ');
+        return `filter '(${joinedFilters})'`;
+    }
+
+    /**
+     * Checks the validity of the given field
+     * @param {object} params - Given function parameters
+     * @param {string} params.days - The value of the field to check
+     * @param {string} params.field - The field name with the value
+     * @param {string} params.ancestor - The immediate ancestor field
+     * @return {object|null} Returns an error object or `null`
+     */
+    _checkDays(params) {
+        const { days, field, ancestor } = params;
+        if (days < 0) {
+            const msg = `'${field}' in ${ancestor} action must be nonnegative`;
+            return errors.InvalidArgument.customizeDescription(msg);
+        }
+        if (days > MAX_DAYS) {
+            return errors.MalformedXML.customizeDescription(
+                `'${field}' in ${ancestor} action must not exceed ${MAX_DAYS}`);
+        }
+        return null;
+    }
+
+    /**
+     * Checks the validity of the given storage class
+     * @param {object} params - Given function parameters
+     * @param {array} params.usedStorageClasses - Storage classes used in other
+     * rules
+     * @param {string} params.storageClass - The storage class of the current
+     * rule
+     * @param {string} params.ancestor - The immediate ancestor field
+     * @param {string} params.prefix - The prefix of the rule
+     * @return {object|null} Returns an error object or `null`
+     */
+    _checkStorageClasses(params) {
+        const { usedStorageClasses, storageClass, ancestor, rule } = params;
+        if (!this._storageClasses.includes(storageClass)) {
+            // This differs from the AWS message. This will help the user since
+            // the StorageClass does not conform to AWS specs.
+            const list = `'${this._storageClasses.join("', '")}'`;
+            const msg = `'StorageClass' must be one of ${list}`;
+            return errors.MalformedXML.customizeDescription(msg);
+        }
+        if (usedStorageClasses.includes(storageClass)) {
+            const msg = `'StorageClass' must be different for '${ancestor}' ` +
+                `actions in same 'Rule' with ${this._getRuleFilter(rule)}`;
+            return errors.InvalidRequest.customizeDescription(msg);
+        }
+        return null;
+    }
+
+    /**
+     * Checks transition time type (i.e. 'Date' or 'Days') only occurs once
+     * across transitions and across transitions and expiration policies
+     * @param {object} params - Given function parameters
+     * @param {string} params.usedTimeType - The time type that has been used by
+     * another rule
+     * @param {string} params.currentTimeType - the time type used by the
+     * current rule
+     * @param {string} params.rule - The the current rule
+     * @return {object|null} Returns an error object or `null`
+     */
+    _checkTimeType(params) {
+        const { usedTimeType, currentTimeType, rule } = params;
+        if (usedTimeType && usedTimeType !== currentTimeType) {
+            const msg = "Found mixed 'Date' and 'Days' based Transition " +
+                `actions in lifecycle rule for ${this._getRuleFilter(rule)}`;
+            return errors.InvalidRequest.customizeDescription(msg);
+        }
+        // Transition time type cannot differ from the expiration, if provided.
+        if (rule.Expiration &&
+            rule.Expiration[0][currentTimeType] === undefined) {
+            const msg = "Found mixed 'Date' and 'Days' based Expiration and " +
+                'Transition actions in lifecycle rule for ' +
+                `${this._getRuleFilter(rule)}`;
+            return errors.InvalidRequest.customizeDescription(msg);
+        }
+        return null;
+    }
+
+    /**
+     * Checks the validity of the given date
+     * @param {string} date - The date the check
+     * @return {object|null} Returns an error object or `null`
+     */
+    _checkDate(date) {
+        const isoRegex = new RegExp('^(-?(?:[1-9][0-9]*)?[0-9]{4})-' +
+            '(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9])' +
+            ':([0-5][0-9]):([0-5][0-9])(.[0-9]+)?(Z)?$');
+        if (!isoRegex.test(date)) {
+            const msg = 'Date must be in ISO 8601 format';
+            return errors.InvalidArgument.customizeDescription(msg);
+        }
+        return null;
+    }
+
+    /**
+     * Parses the NonCurrentVersionTransition value
+     * @param {object} rule - Rule object from Rule array from this._parsedXml
+     * @return {object} - Contains error if parsing failed, otherwise contains
+     * the parsed nonCurrentVersionTransition array
+     *
+     * Format of result:
+     * result = {
+     *      error: <error>,
+     *      nonCurrentVersionTransition: [
+     *          {
+     *              noncurrentDays: <non-current-days>,
+     *              storageClass: <storage-class>,
+     *          },
+     *          ...
+     *      ]
+     * }
+     */
+    _parseNoncurrentVersionTransition(rule) {
+        const nonCurrentVersionTransition = [];
+        const usedStorageClasses = [];
+        for (let i = 0; i < rule.NoncurrentVersionTransition.length; i++) {
+            const t = rule.NoncurrentVersionTransition[i]; // Transition object
+            const noncurrentDays =
+                t.NoncurrentDays && Number.parseInt(t.NoncurrentDays[0], 10);
+            const storageClass = t.StorageClass && t.StorageClass[0];
+            if (noncurrentDays === undefined || storageClass === undefined) {
+                return { error: errors.MalformedXML };
+            }
+            let error = this._checkDays({
+                days: noncurrentDays,
+                field: 'NoncurrentDays',
+                ancestor: 'NoncurrentVersionTransition',
+            });
+            if (error) {
+                return { error };
+            }
+            error = this._checkStorageClasses({
+                storageClass,
+                usedStorageClasses,
+                ancestor: 'NoncurrentVersionTransition',
+                rule,
+            });
+            if (error) {
+                return { error };
+            }
+            nonCurrentVersionTransition.push({ noncurrentDays, storageClass });
+            usedStorageClasses.push(storageClass);
+        }
+        return { nonCurrentVersionTransition };
+    }
+
+    /**
+     * Parses the Transition value
+     * @param {object} rule - Rule object from Rule array from this._parsedXml
+     * @return {object} - Contains error if parsing failed, otherwise contains
+     * the parsed transition array
+     *
+     * Format of result:
+     * result = {
+     *      error: <error>,
+     *      transition: [
+     *          {
+     *              days: <days>,
+     *              date: <date>,
+     *              storageClass: <storage-class>,
+     *          },
+     *          ...
+     *      ]
+     * }
+     */
+    _parseTransition(rule) {
+        const transition = [];
+        const usedStorageClasses = [];
+        let usedTimeType = null;
+        for (let i = 0; i < rule.Transition.length; i++) {
+            const t = rule.Transition[i]; // Transition object
+            const days = t.Days && Number.parseInt(t.Days[0], 10);
+            const date = t.Date && t.Date[0];
+            const storageClass = t.StorageClass && t.StorageClass[0];
+            if ((days === undefined && date === undefined) ||
+                (days !== undefined && date !== undefined) ||
+                (storageClass === undefined)) {
+                return { error: errors.MalformedXML };
+            }
+            let error = this._checkStorageClasses({
+                storageClass,
+                usedStorageClasses,
+                ancestor: 'Transition',
+                rule,
+            });
+            if (error) {
+                return { error };
+            }
+            usedStorageClasses.push(storageClass);
+            if (days !== undefined) {
+                error = this._checkTimeType({
+                    usedTimeType,
+                    currentTimeType: 'Days',
+                    rule,
+                });
+                if (error) {
+                    return { error };
+                }
+                usedTimeType = 'Days';
+                error = this._checkDays({
+                    days,
+                    field: 'Days',
+                    ancestor: 'Transition',
+                });
+                if (error) {
+                    return { error };
+                }
+                transition.push({ days, storageClass });
+            }
+            if (date !== undefined) {
+                error = this._checkTimeType({
+                    usedTimeType,
+                    currentTimeType: 'Date',
+                    rule,
+                });
+                if (error) {
+                    return { error };
+                }
+                usedTimeType = 'Date';
+                error = this._checkDate(date);
+                if (error) {
+                    return { error };
+                }
+                transition.push({ date, storageClass });
+            }
+        }
+        return { transition };
+    }
+
+    /**
      * Check that action component of rule is valid
      * @param {object} rule - a rule object from Rule array from this._parsedXml
      * @return {object} - contains error if parsing failed, else contains
@@ -436,8 +697,13 @@ class LifecycleConfiguration {
         const actionsObj = {};
         actionsObj.propName = 'actions';
         actionsObj.actions = [];
-        const validActions = ['AbortIncompleteMultipartUpload',
-            'Expiration', 'NoncurrentVersionExpiration'];
+        const validActions = [
+            'AbortIncompleteMultipartUpload',
+            'Expiration',
+            'NoncurrentVersionExpiration',
+            'NoncurrentVersionTransition',
+            'Transition',
+        ];
         validActions.forEach(a => {
             if (rule[a]) {
                 actionsObj.actions.push({ actionName: `${a}` });
@@ -454,7 +720,8 @@ class LifecycleConfiguration {
             if (action.error) {
                 actionsObj.error = action.error;
             } else {
-                const actionTimes = ['days', 'date', 'deleteMarker'];
+                const actionTimes = ['days', 'date', 'deleteMarker',
+                    'transition', 'nonCurrentVersionTransition'];
                 actionTimes.forEach(t => {
                     if (action[t]) {
                         // eslint-disable-next-line no-param-reassign
@@ -541,12 +808,9 @@ class LifecycleConfiguration {
             return expObj;
         }
         if (subExp.Date) {
-            const isoRegex = new RegExp('^(-?(?:[1-9][0-9]*)?[0-9]{4})-' +
-                '(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9])' +
-                ':([0-5][0-9]):([0-5][0-9])(.[0-9]+)?(Z)?$');
-            if (!isoRegex.test(subExp.Date[0])) {
-                expObj.error = errors.InvalidArgument.customizeDescription(
-                    'Date must be in ISO 8601 format');
+            const error = this._checkDate(subExp.Date[0]);
+            if (error) {
+                expObj.error = error;
             } else {
                 expObj.date = subExp.Date[0];
             }
@@ -654,6 +918,26 @@ class LifecycleConfiguration {
                 if (a.deleteMarker) {
                     assert.strictEqual(typeof a.deleteMarker, 'string');
                 }
+                if (a.nonCurrentVersionTransition) {
+                    assert.strictEqual(
+                        typeof a.nonCurrentVersionTransition, 'object');
+                    a.nonCurrentVersionTransition.forEach(t => {
+                        assert.strictEqual(typeof t.noncurrentDays, 'number');
+                        assert.strictEqual(typeof t.storageClass, 'string');
+                    });
+                }
+                if (a.transition) {
+                    assert.strictEqual(typeof a.transition, 'object');
+                    a.transition.forEach(t => {
+                        if (t.days || t.days === 0) {
+                            assert.strictEqual(typeof t.days, 'number');
+                        }
+                        if (t.date !== undefined) {
+                            assert.strictEqual(typeof t.date, 'string');
+                        }
+                        assert.strictEqual(typeof t.storageClass, 'string');
+                    });
+                }
             });
         });
     }
@@ -692,7 +976,8 @@ class LifecycleConfiguration {
             }
 
             const Actions = actions.map(action => {
-                const { actionName, days, date, deleteMarker } = action;
+                const { actionName, days, date, deleteMarker,
+                    nonCurrentVersionTransition, transition } = action;
                 let Action;
                 if (actionName === 'AbortIncompleteMultipartUpload') {
                     Action = `<${actionName}><DaysAfterInitiation>${days}` +
@@ -708,6 +993,40 @@ class LifecycleConfiguration {
                         '</ExpiredObjectDeleteMarker>' : '';
                     Action = `<${actionName}>${Days}${Date}${DelMarker}` +
                         `</${actionName}>`;
+                }
+                if (actionName === 'NoncurrentVersionTransition') {
+                    const xml = [];
+                    nonCurrentVersionTransition.forEach(transition => {
+                        const { noncurrentDays, storageClass } = transition;
+                        xml.push(
+                            `<${actionName}>`,
+                                `<NoncurrentDays>${noncurrentDays}` +
+                                '</NoncurrentDays>',
+                                `<StorageClass>${storageClass}</StorageClass>`,
+                            `</${actionName}>`
+                        );
+                    });
+                    Action = xml.join('');
+                }
+                if (actionName === 'Transition') {
+                    const xml = [];
+                    transition.forEach(transition => {
+                        const { days, date, storageClass } = transition;
+                        let element;
+                        if (days !== undefined) {
+                            element = `<Days>${days}</Days>`;
+                        }
+                        if (date !== undefined) {
+                            element = `<Date>${date}</Date>`;
+                        }
+                        xml.push(
+                            `<${actionName}>`,
+                                element,
+                                `<StorageClass>${storageClass}</StorageClass>`,
+                            `</${actionName}>`
+                        );
+                    });
+                    Action = xml.join('');
                 }
                 return Action;
             }).join('');


### PR DESCRIPTION
Add support for lifecycle transition policies.

Previously reviewed here https://github.com/scality/Arsenal/pull/604.