### PR TITLE
ZENKO-1310 Fix HealthProbeServer flaky test

### DIFF
--- a/tests/unit/network/probe/HealthProbeServer.spec.js
+++ b/tests/unit/network/probe/HealthProbeServer.spec.js
@@ -30,8 +30,8 @@ describe('network.probe.HealthProbeServer', () => {
         let server;
         function setup(done) {
             server = new HealthProbeServer({ port: 4042 });
+            server._cbOnListening = done;
             server.start();
-            done();
         }
 
         before(done => {


### PR DESCRIPTION
The likely cause of this flakiness is the test running to fast and not letting the HealthProbeServer start before making calls.
This is supported by the build logs
```
  ✓ should return InvalidRange on empty object when start and end are provided
      service is "up"
{"name":"HealthProbeServer","time":1541717385012,"method":"arsenal.network.Server.start","port":4042,"level":"info","message":"starting Server under http","hostname":"worker-1608-f8a307f9","pid":1529}
{"name":"HealthProbeServer","time":1541717385022,"method":"arsenal.network.Server._onListening","address":{"address":"127.0.0.1","family":"IPv4","port":4042},"level":"info","message":"Server is listening","hostname":"worker-1608-f8a307f9","pid":1529}
  1) should perform a GET and return 200 OK

  ✓ should perform a GET and return 200 OK
```
Notice  that the first call fails, but the subsequent one succeeds, pointing to this as the cause.