### PR TITLE
bugfix(ZENKO-1362): request path encoding

### DIFF
--- a/lib/network/rest/RESTClient.js
+++ b/lib/network/rest/RESTClient.js
@@ -111,7 +111,7 @@ class RESTClient {
             hostname: this.host,
             port: this.port,
             method,
-            path: `${prefix}/${urlKey}`,
+            path: encodeURI(`${prefix}/${urlKey}`),
             headers: reqHeaders,
             agent: this.httpAgent,
         };

--- a/lib/network/rest/RESTServer.js
+++ b/lib/network/rest/RESTServer.js
@@ -51,7 +51,7 @@ function sendError(res, log, error, optMessage) {
  */
 function parseURL(urlStr, expectKey) {
     const urlObj = url.parse(urlStr);
-    const pathInfo = utils.explodePath(urlObj.path);
+    const pathInfo = utils.explodePath(decodeURI(urlObj.path));
     if ((pathInfo.service !== constants.dataFileURL)
         && (pathInfo.service !== constants.passthroughFileURL)) {
         throw errors.InvalidAction.customizeDescription(

--- a/lib/network/rest/RESTServer.js
+++ b/lib/network/rest/RESTServer.js
@@ -7,7 +7,7 @@ const werelogs = require('werelogs');
 
 const httpServer = require('../http/server');
 const constants = require('../../constants');
-const utils = require('./utils');
+const { parseURL } = require('./utils');
 const httpUtils = require('../http/utils');
 const errors = require('../../errors');
 
@@ -35,43 +35,6 @@ function sendError(res, log, error, optMessage) {
         error: message });
     res.end(`${JSON.stringify({ errorType: error.message,
         errorMessage: message })}\n`);
-}
-
-/**
- * Parse the given url and return a pathInfo object. Sanity checks are
- * performed.
- *
- * @param {String} urlStr - URL to parse
- * @param {Boolean} expectKey - whether the command expects to see a
- *   key in the URL
- * @return {Object} a pathInfo object with URL items containing the
- * following attributes:
- *   - pathInfo.service {String} - The name of REST service ("DataFile")
- *   - pathInfo.key {String} - The requested key
- */
-function parseURL(urlStr, expectKey) {
-    const urlObj = url.parse(urlStr);
-    const pathInfo = utils.explodePath(decodeURI(urlObj.path));
-    if ((pathInfo.service !== constants.dataFileURL)
-        && (pathInfo.service !== constants.passthroughFileURL)) {
-        throw errors.InvalidAction.customizeDescription(
-            `unsupported service '${pathInfo.service}'`);
-    }
-    if (expectKey && pathInfo.key === undefined) {
-        throw errors.MissingParameter.customizeDescription(
-            'URL is missing key');
-    }
-    if (!expectKey && pathInfo.key !== undefined) {
-        // note: we may implement rewrite functionality by allowing a
-        // key in the URL, though we may still provide the new key in
-        // the Location header to keep immutability property and
-        // atomicity of the update (we would just remove the old
-        // object when the new one has been written entirely in this
-        // case, saving a request over an equivalent PUT + DELETE).
-        throw errors.InvalidURI.customizeDescription(
-            'PUT url cannot contain a key');
-    }
-    return pathInfo;
 }
 
 /**

--- a/lib/network/rest/utils.js
+++ b/lib/network/rest/utils.js
@@ -2,9 +2,11 @@
 
 const errors = require('../../errors');
 const constants = require('../../constants');
+const url = require('url');
+
 const passthroughPrefixLength = constants.passthroughFileURL.length;
 
-module.exports.explodePath = function explodePath(path) {
+function explodePath(path) {
     if (path.startsWith(constants.passthroughFileURL)) {
         const key = path.slice(passthroughPrefixLength + 1);
         return {
@@ -21,4 +23,46 @@ module.exports.explodePath = function explodePath(path) {
         };
     }
     throw errors.InvalidURI.customizeDescription('malformed URI');
+}
+
+/**
+ * Parse the given url and return a pathInfo object. Sanity checks are
+ * performed.
+ *
+ * @param {String} urlStr - URL to parse
+ * @param {Boolean} expectKey - whether the command expects to see a
+ *   key in the URL
+ * @return {Object} a pathInfo object with URL items containing the
+ * following attributes:
+ *   - pathInfo.service {String} - The name of REST service ("DataFile")
+ *   - pathInfo.key {String} - The requested key
+ */
+function parseURL(urlStr, expectKey) {
+    const urlObj = url.parse(urlStr);
+    const pathInfo = explodePath(decodeURI(urlObj.path));
+    if ((pathInfo.service !== constants.dataFileURL)
+        && (pathInfo.service !== constants.passthroughFileURL)) {
+        throw errors.InvalidAction.customizeDescription(
+            `unsupported service '${pathInfo.service}'`);
+    }
+    if (expectKey && pathInfo.key === undefined) {
+        throw errors.MissingParameter.customizeDescription(
+            'URL is missing key');
+    }
+    if (!expectKey && pathInfo.key !== undefined) {
+        // note: we may implement rewrite functionality by allowing a
+        // key in the URL, though we may still provide the new key in
+        // the Location header to keep immutability property and
+        // atomicity of the update (we would just remove the old
+        // object when the new one has been written entirely in this
+        // case, saving a request over an equivalent PUT + DELETE).
+        throw errors.InvalidURI.customizeDescription(
+            'PUT url cannot contain a key');
+    }
+    return pathInfo;
+}
+
+module.exports = {
+    explodePath,
+    parseURL,
 };

--- a/tests/unit/network/rest/utils.js
+++ b/tests/unit/network/rest/utils.js
@@ -1,0 +1,31 @@
+'use strict'; // eslint-disable-line
+
+const assert = require('assert');
+const constants = require('../../../../lib/constants');
+const { parseURL } = require('../../../../lib/network/rest/utils');
+
+describe('parseURL function', () => {
+    [
+        {
+            inputUrl: `${constants.passthroughFileURL}/test`,
+            expectedKey: 'test',
+        },
+        {
+            inputUrl: `${constants.passthroughFileURL}/test with spaces`,
+            expectedKey: 'test with spaces',
+        },
+        {
+            inputUrl: `${constants.passthroughFileURL}` +
+                '/test%20with%20encoded%20spaces',
+            expectedKey: 'test with encoded spaces',
+        },
+    ].forEach(testCase => {
+        const { inputUrl, expectedKey } = testCase;
+
+        it(`should return ${expectedKey} with url "${inputUrl}"`,
+        () => {
+            const pathInfo = parseURL(inputUrl, true);
+            assert.strictEqual(pathInfo.key, expectedKey);
+        });
+    });
+});


### PR DESCRIPTION
This PR will make the `RESTClient` encode the path of its requests and allow the `RESTServer` to decode them.

With this change, PFSD will be able to read request properly when there are extraneous characters (like whitespaces) on the request's path, therefore allowing to read and delete files with such names. 