### PR TITLE
feat(DataFileStore): add noCache option

### DIFF
--- a/lib/storage/data/file/DataFileStore.js
+++ b/lib/storage/data/file/DataFileStore.js
@@ -45,13 +45,20 @@ class DataFileStore {
      *   sync calls that ensure files and directories are fully
      *   written on the physical drive before returning an
      *   answer. Used to speed up unit tests, may have other uses.
+     * @param {Boolean} [dataConfig.noCache=true] - If true, attempt
+     *   to free page caches associated with the managed files
      * @param {werelogs.API} [logApi] - object providing a constructor function
      *                                for the Logger object
+     * @param {Boolean} [dataConfig.isPassthrough=false] - If true, enable
+     *   passthrough filesystem I/O
+     * @param {Boolean} [dataConfig.isReadOnly=false] - If true, disable
+     *   put and delete
      */
     constructor(dataConfig, logApi) {
         this.logger = new (logApi || werelogs).Logger('DataFileStore');
         this.dataPath = dataConfig.dataPath;
         this.noSync = dataConfig.noSync || false;
+        this.noCache = dataConfig.noCache || false;
         this.isPassthrough = dataConfig.isPassthrough || false;
         this.isReadOnly = dataConfig.isReadOnly || false;
     }
@@ -157,7 +164,6 @@ class DataFileStore {
         log.debug('starting to write data', { method: 'put', key, filePath });
         dataStream.pause();
         fs.open(filePath, 'wx', (err, fd) => {
-            let ret = 0;
             if (err) {
                 log.error('error opening filePath',
                           { method: 'put', key, filePath, error: err });
@@ -178,6 +184,18 @@ class DataFileStore {
                     return cbOnce(null, key);
                 }
                 if (this.noSync) {
+                    /*
+                     * It's is not guaranteed that the Kernel will release page
+                     * caches when this.noSync is true. If you want to ensure
+                     * this behavior, set this.noSync to false.
+                     */
+                    if (this.noCache) {
+                        const ret = posixFadvise(fd, 0, size, 4);
+                        if (ret !== 0) {
+                            log.warning(
+                            `error fadv_dontneed ${filePath} returned ${ret}`);
+                        }
+                    }
                     fs.close(fd);
                     return ok();
                 }
@@ -190,10 +208,12 @@ class DataFileStore {
                      * for the pod and can potentially cause the pod
                      * to be killed under memory pressure:
                      */
-                    ret = posixFadvise(fd, 0, size, 4);
-                    if (ret !== 0) {
-                        log.warning(
+                    if (this.noCache) {
+                        const ret = posixFadvise(fd, 0, size, 4);
+                        if (ret !== 0) {
+                            log.warning(
                             `error fadv_dontneed ${filePath} returned ${ret}`);
+                        }
                     }
                     fs.close(fd);
                     if (err) {
@@ -290,7 +310,7 @@ class DataFileStore {
             flags: 'r',
             encoding: null,
             fd: null,
-            autoClose: true,
+            autoClose: false,
         };
         if (byteRange) {
             readStreamOptions.start = byteRange[0];
@@ -300,18 +320,31 @@ class DataFileStore {
                   { method: 'get', key, filePath, byteRange });
         const cbOnce = jsutil.once(callback);
         const rs = fs.createReadStream(filePath, readStreamOptions)
-                  .on('error', err => {
-                      if (err.code === 'ENOENT') {
-                          return cbOnce(errors.ObjNotFound);
-                      }
-                      log.error('error retrieving file',
-                          { method: 'get', key, filePath,
-                              error: err });
-                      return cbOnce(
-                          errors.InternalError.customizeDescription(
-                              `filesystem read error: ${err.code}`));
-                  })
-                  .on('open', () => { cbOnce(null, rs); });
+                .on('error', err => {
+                    if (err.code === 'ENOENT') {
+                        return cbOnce(errors.ObjNotFound);
+                    }
+                    log.error('error retrieving file',
+                        { method: 'get', key, filePath,
+                            error: err });
+                    return cbOnce(
+                        errors.InternalError.customizeDescription(
+                            `filesystem read error: ${err.code}`));
+                })
+                .on('open', () => { cbOnce(null, rs); })
+                .on('end', () => {
+                    if (this.noCache) {
+                        const ret = posixFadvise(rs.fd, 0, 0, 4);
+                        if (ret !== 0) {
+                            log.debug(`fadv_dont ${filePath} return ${ret}`);
+                        }
+                    }
+                    fs.close(rs.fd, err => {
+                        if (err) {
+                            log.error('unable to close file descriptor');
+                        }
+                    });
+                });
     }
 
     /**


### PR DESCRIPTION
This PR:

- Adds the noCache option.
- "noCache" may (or may not, see comments in PR) work for writes when noSync is true.
- "noCache" will now work for reads where data was already present (i.e. there were no writes before in the current lifetime of the server).
