### PR TITLE
bugfix(DataFileStore): add noCache option

### DIFF
--- a/lib/storage/data/file/DataFileStore.js
+++ b/lib/storage/data/file/DataFileStore.js
@@ -5,12 +5,12 @@ const crypto = require('crypto');
 const async = require('async');
 const diskusage = require('diskusage');
 const werelogs = require('werelogs');
-const posixFadvise = require('fcntl');
 
 const errors = require('../../../errors');
 const stringHash = require('../../../stringHash');
 const jsutil = require('../../../jsutil');
 const storageUtils = require('../../utils');
+const releasePageCacheSync = require('./utils');
 
 // The FOLDER_HASH constant refers to the number of base directories
 // used for directory hashing of stored objects.
@@ -44,6 +44,8 @@ class DataFileStore {
      *   sync calls that ensure files and directories are fully
      *   written on the physical drive before returning an
      *   answer. Used to speed up unit tests, may have other uses.
+     * @param {Boolean} [dataConfig.noCache=false] - If true, attempt
+     *   to free page caches associated with the managed files
      * @param {werelogs.API} [logApi] - object providing a constructor function
      *                                for the Logger object
      */
@@ -51,6 +53,7 @@ class DataFileStore {
         this.logger = new (logApi || werelogs).Logger('DataFileStore');
         this.dataPath = dataConfig.dataPath;
         this.noSync = dataConfig.noSync || false;
+        this.noCache = dataConfig.noCache || false;
     }
 
     /**
@@ -130,7 +133,6 @@ class DataFileStore {
         log.debug('starting to write data', { method: 'put', key, filePath });
         dataStream.pause();
         fs.open(filePath, 'wx', (err, fd) => {
-            let ret = 0;
             if (err) {
                 log.error('error opening filePath',
                           { method: 'put', key, filePath, error: err });
@@ -151,6 +153,14 @@ class DataFileStore {
                     return cbOnce(null, key);
                 }
                 if (this.noSync) {
+                    /*
+                     * It's not guaranteed that the Kernel will release page
+                     * caches when this.noSync is true. If you want to ensure
+                     * this behavior, set this.noSync to false.
+                     */
+                    if (this.noCache) {
+                        releasePageCacheSync(filePath, fd, log);
+                    }
                     fs.close(fd);
                     return ok();
                 }
@@ -163,10 +173,8 @@ class DataFileStore {
                      * for the pod and can potentially cause the pod
                      * to be killed under memory pressure:
                      */
-                    ret = posixFadvise(fd, 0, size, 4);
-                    if (ret !== 0) {
-                        log.warning(
-                            `error fadv_dontneed ${filePath} returned ${ret}`);
+                    if (this.noCache) {
+                        releasePageCacheSync(filePath, fd, log);
                     }
                     fs.close(fd);
                     if (err) {
@@ -256,7 +264,7 @@ class DataFileStore {
             flags: 'r',
             encoding: null,
             fd: null,
-            autoClose: true,
+            autoClose: false,
         };
         if (byteRange) {
             readStreamOptions.start = byteRange[0];
@@ -266,18 +274,31 @@ class DataFileStore {
                   { method: 'get', key, filePath, byteRange });
         const cbOnce = jsutil.once(callback);
         const rs = fs.createReadStream(filePath, readStreamOptions)
-                  .on('error', err => {
-                      if (err.code === 'ENOENT') {
-                          return cbOnce(errors.ObjNotFound);
-                      }
-                      log.error('error retrieving file',
-                          { method: 'get', key, filePath,
-                              error: err });
-                      return cbOnce(
-                          errors.InternalError.customizeDescription(
-                              `filesystem read error: ${err.code}`));
-                  })
-                  .on('open', () => { cbOnce(null, rs); });
+                .on('error', err => {
+                    if (err.code === 'ENOENT') {
+                        return cbOnce(errors.ObjNotFound);
+                    }
+                    log.error('error retrieving file',
+                        { method: 'DataFileStore.get', key, filePath,
+                            error: err });
+                    return cbOnce(
+                        errors.InternalError.customizeDescription(
+                            `filesystem read error: ${err.code}`));
+                })
+                .on('open', () => { cbOnce(null, rs); })
+                .on('end', () => {
+                    if (this.noCache) {
+                        releasePageCacheSync(filePath, rs.fd, log);
+                    }
+                    fs.close(rs.fd, err => {
+                        if (err) {
+                            log.error('unable to close file descriptor', {
+                                method: 'DataFileStore.get', key, filePath,
+                                error: err,
+                            });
+                        }
+                    });
+                });
     }
 
     /**

--- a/lib/storage/data/file/utils.js
+++ b/lib/storage/data/file/utils.js
@@ -1,0 +1,19 @@
+const posixFadvise = require('fcntl');
+
+/**
+ * Release free cached pages associated with a file
+ *
+ * @param {String} filePath - absolute path of the associated file
+ * @param {Int} fd - file descriptor of the associated file
+ * @param {werelogs.RequestLogger} log - logging object
+ * @return {undefined}
+ */
+function releasePageCacheSync(filePath, fd, log) {
+    const ret = posixFadvise(fd, 0, 0, 4);
+    if (ret !== 0) {
+        log.warning(
+        `error fadv_dontneed ${filePath} returned ${ret}`);
+    }
+}
+
+module.exports = releasePageCacheSync;


### PR DESCRIPTION
Reopening #634 with the right target branch.

This PR:

- Adds the noCache option.
- "noCache" may (or may not, see comments in PR) work for writes when noSync is true.
- "noCache" will now work for reads where data was already present (i.e. there were no writes before in the current lifetime of the server). This fixes the issue of virtual memory ballooning when reading.