### PR TITLE
ZENKO-1420 ObjectMD.getUserMetadata()

### DIFF
--- a/lib/models/ObjectMD.js
+++ b/lib/models/ObjectMD.js
@@ -702,6 +702,20 @@ class ObjectMD {
         return this._data.tags;
     }
 
+    getUserMetadata() {
+        const metaHeaders = {};
+        const data = this.getValue();
+        Object.keys(data).forEach(key => {
+            if (key.startsWith('x-amz-meta-')) {
+                metaHeaders[key] = data[key];
+            }
+        });
+        if (Object.keys(metaHeaders).length > 0) {
+            return JSON.stringify(metaHeaders);
+        }
+        return undefined;
+    }
+
     /**
      * Set replication information
      *

--- a/tests/unit/models/ObjectMD.js
+++ b/tests/unit/models/ObjectMD.js
@@ -201,6 +201,26 @@ describe('ObjectMD class setters/getters', () => {
         assert.strictEqual(
             md.getReplicationSiteDataStoreVersionId('zenko'), 'a');
     });
+
+    it('ObjectMD::getUserMetadata', () => {
+        md.setUserMetadata({
+            'x-amz-meta-foo': 'bar',
+            'x-amz-meta-baz': 'qux',
+            // this one should be filtered out
+            'x-amz-storage-class': 'STANDARD_IA',
+            // ACLs are updated
+            'acl': {
+                FULL_CONTROL: ['john'],
+            },
+        });
+        assert.deepStrictEqual(JSON.parse(md.getUserMetadata()), {
+            'x-amz-meta-foo': 'bar',
+            'x-amz-meta-baz': 'qux',
+        });
+        assert.deepStrictEqual(md.getAcl(), {
+            FULL_CONTROL: ['john'],
+        });
+    });
 });
 
 describe('ObjectMD import from stored blob', () => {


### PR DESCRIPTION
Copy this helper from backbeat ObjectQueueEntry class since it's
related to ObjectMD and will be used by bare ObjectMD instances.

Add a short unit test too.