### PR TITLE
bf: ZENKO-1424 add bucket info to MD mock

### DIFF
--- a/lib/testing/mockRes.json
+++ b/lib/testing/mockRes.json
@@ -48,6 +48,10 @@
             "/_/metadata/default/bucket/bucket1": {
                 "resType": "objectList",
                 "name": "objectList1"
+            },
+            "/_/metadata/default/informations/bucket1": {
+                "resType": "raftInformation",
+                "name": "1"
             }
         }
     },
@@ -411,5 +415,12 @@
     "raftId": {
         "bucket1": 1,
         "bucket2": 5
+    },
+    "raftInformation": {
+        "1": {
+            "info": {
+                "cseq": 7
+            }
+        }
     }
 }


### PR DESCRIPTION
Goes with https://github.com/scality/backbeat/pull/601

Changes in this PR:
- Add the bucket informations route to Metadata mock.
  This is to support changes to tests in backbeat. Route
  only fetches cseq of bucket