### PR TITLE
bugfix: S3C-1985 fix crash in vault-md on listing

### DIFF
--- a/lib/algos/list/Extension.js
+++ b/lib/algos/list/Extension.js
@@ -45,15 +45,16 @@ class Extension {
      * shall be applied on any value that is to be returned as part of the
      * result of a listing extension.
      *
-     * @param {Object} value - The JSON value of a listing item
+     * @param {String|undefined} value - The JSON value of a listing item
      *
-     * @return {Object} The value that may have been trimmed of some
-     * heavy unused fields, or left untouched (depending on size
-     * heuristics)
+     * @return {String|undefined} The value that may have been trimmed
+     * of some heavy unused fields, or left untouched (depending on
+     * size heuristics)
      */
     trimMetadata(value) {
         let ret = undefined;
-        if (value.length >= TRIM_METADATA_MIN_BLOB_SIZE) {
+        if (value !== undefined &&
+            value.length >= TRIM_METADATA_MIN_BLOB_SIZE) {
             try {
                 ret = JSON.parse(value);
                 delete ret.location;

--- a/tests/unit/algos/list/basic.js
+++ b/tests/unit/algos/list/basic.js
@@ -40,4 +40,42 @@ describe('Basic listing algorithm', () => {
             done();
         });
     });
+
+    it('Should support entries with no key', () => {
+        const res1 = performListing([{
+            value: '{"data":"foo"}',
+        }], Basic, { maxKeys: 1 }, logger);
+        assert.deepStrictEqual(res1, [{
+            key: undefined,
+            value: '{"data":"foo"}',
+        }]);
+
+        const res2 = performListing([{
+            key: undefined,
+            value: '{"data":"foo"}',
+        }], Basic, { maxKeys: 1 }, logger);
+        assert.deepStrictEqual(res2, [{
+            key: undefined,
+            value: '{"data":"foo"}',
+        }]);
+    });
+
+    it('Should support entries with no value', () => {
+        const res1 = performListing([{
+            key: 'foo',
+        }], Basic, { maxKeys: 1 }, logger);
+        assert.deepStrictEqual(res1, [{
+            key: 'foo',
+            value: undefined,
+        }]);
+
+        const res2 = performListing([{
+            key: 'foo',
+            value: undefined,
+        }], Basic, { maxKeys: 1 }, logger);
+        assert.deepStrictEqual(res2, [{
+            key: 'foo',
+            value: undefined,
+        }]);
+    });
 });


### PR DESCRIPTION
Add a check on 'value' being defined in trimMetadata().