### PR TITLE
bugfix: S3C-2006 fix crash in vault-md on listing

### DIFF
--- a/lib/algos/list/Extension.js
+++ b/lib/algos/list/Extension.js
@@ -45,9 +45,9 @@ class Extension {
      * shall be applied on any value that is to be returned as part of the
      * result of a listing extension.
      *
-     * @param {Object} value - The JSON value of a listing item
+     * @param {String} value - The JSON value of a listing item
      *
-     * @return {Object} The value that may have been trimmed of some
+     * @return {String} The value that may have been trimmed of some
      * heavy unused fields, or left untouched (depending on size
      * heuristics)
      */

--- a/lib/algos/list/basic.js
+++ b/lib/algos/list/basic.js
@@ -56,7 +56,14 @@ class List extends Extension {
         if (this.keys >= this.maxKeys) {
             return FILTER_END;
         }
-        this.res.push({ key: elem.key, value: this.trimMetadata(elem.value) });
+        if (typeof elem === 'object') {
+            this.res.push({
+                key: elem.key,
+                value: this.trimMetadata(elem.value),
+            });
+        } else {
+            this.res.push(elem);
+        }
         this.keys++;
         return FILTER_ACCEPT;
     }

--- a/tests/unit/algos/list/basic.js
+++ b/tests/unit/algos/list/basic.js
@@ -40,4 +40,29 @@ describe('Basic listing algorithm', () => {
             done();
         });
     });
+
+    it('Should support entries with no key', () => {
+        const res1 = performListing([{
+            value: '{"data":"foo"}',
+        }], Basic, { maxKeys: 1 }, logger);
+        assert.deepStrictEqual(res1, [{
+            key: undefined,
+            value: '{"data":"foo"}',
+        }]);
+
+        const res2 = performListing([{
+            key: undefined,
+            value: '{"data":"foo"}',
+        }], Basic, { maxKeys: 1 }, logger);
+        assert.deepStrictEqual(res2, [{
+            key: undefined,
+            value: '{"data":"foo"}',
+        }]);
+    });
+
+    it('Should support key-only listing', () => {
+        const res = performListing(['key1', 'key2'],
+                                   Basic, { maxKeys: 1 }, logger);
+        assert.deepStrictEqual(res, ['key1']);
+    });
 });


### PR DESCRIPTION
Listed entries may either be objects { value[, key] } or plain strings
for key-only listings. Fix this by checking the filtered entry type
before calling trimMetadata().

Integration passed here: https://eve.devsca.com/github/scality/integration/#/builders/2/builds/190