### PR TITLE
ft: ZENKO-1452 md mock remove version id in url

### DIFF
--- a/lib/testing/MetadataMock.js
+++ b/lib/testing/MetadataMock.js
@@ -6,11 +6,22 @@ const objectList = mockRes.objectList.objectList1;
 const dummyBucketMD = mockRes.bucketMD;
 const objectMD = mockRes.objectMD;
 
+/**
+ * Strip version id from request url to fetch metadata mock entry by specified
+ * bucket and object names
+ * @param {String} path - request path
+ * @return {String} path with no version id
+ */
+function _versionIdRemovedURLPath(path) {
+    const urlEncodedNullCharacter = '%00';
+    return path.split(urlEncodedNullCharacter)[0];
+}
+
 class MetadataMock {
     onRequest(req, res) {
         // TODO: for PUT/POST, edit the mockRes object
         if (req.method === 'GET') {
-            const url = req.url.split('?')[0];
+            const url = _versionIdRemovedURLPath(req.url.split('?')[0]);
             const resObj = mockRes.GET.responses[url];
             if (!resObj && req.url.startsWith('/default/attributes')) {
                 const err = errors.NoSuchBucket;


### PR DESCRIPTION
Goes with: https://github.com/scality/backbeat/pull/603

For metadata mock, remove the version id in the url. The
expected response is the same.
