### PR TITLE
bugfix: S3C-2017 remove CI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Arsenal
 
-[![CircleCI][badgepub]](https://circleci.com/gh/scality/Arsenal)
-[![Scality CI][badgepriv]](http://ci.ironmann.io/gh/scality/Arsenal)
-
 Common utilities for the S3 project components
 
 Within this repository, you will be able to find the shared libraries for the


### PR DESCRIPTION
This commit removes the CI badges that are no longer active. It also helps mitigate
a cornercase bug in BertE