### PR TITLE
rf: ZENKO-1566 backbeat route dataPoints by id

### DIFF
--- a/lib/backbeat/routes.js
+++ b/lib/backbeat/routes.js
@@ -4,13 +4,12 @@
 
 /**
  * The metrics route model.
- * @param {Object} redisKeys - The Redis keys used for Backbeat metrics
  * @param {Object} locations - Locations by service
  * @param {Array} locations.crr - The list of replication location names
  * @param {Array} locations.ingestion - The list of ingestion location names
  * @return {Array} The array of route objects
  */
-function routes(redisKeys, locations) {
+function routes(locations) {
     /* eslint-disable no-param-reassign */
     locations.crr = locations.crr || [];
     locations.ingestion = locations.ingestion || [];
@@ -32,7 +31,7 @@ function routes(redisKeys, locations) {
             type: 'pending',
             extensions: { crr: [...locations.crr, 'all'] },
             method: 'getPending',
-            dataPoints: [redisKeys.opsPending, redisKeys.bytesPending],
+            dataPoints: ['opsPending', 'bytesPending'],
         },
         // Route: /_/metrics/crr/<location>/backlog
         {
@@ -41,7 +40,7 @@ function routes(redisKeys, locations) {
             type: 'backlog',
             extensions: { crr: [...locations.crr, 'all'] },
             method: 'getBacklog',
-            dataPoints: [redisKeys.opsPending, redisKeys.bytesPending],
+            dataPoints: ['opsPending', 'bytesPending'],
         },
         // Route: /_/metrics/crr/<location>/completions
         {
@@ -50,7 +49,7 @@ function routes(redisKeys, locations) {
             type: 'completions',
             extensions: { crr: [...locations.crr, 'all'] },
             method: 'getCompletions',
-            dataPoints: [redisKeys.opsDone, redisKeys.bytesDone],
+            dataPoints: ['opsDone', 'bytesDone'],
         },
         // Route: /_/metrics/crr/<location>/failures
         {
@@ -59,7 +58,7 @@ function routes(redisKeys, locations) {
             type: 'failures',
             extensions: { crr: [...locations.crr, 'all'] },
             method: 'getFailedMetrics',
-            dataPoints: [redisKeys.opsFail, redisKeys.bytesFail],
+            dataPoints: ['opsFail', 'bytesFail'],
         },
         // Route: /_/metrics/crr/<location>/throughput
         {
@@ -68,7 +67,7 @@ function routes(redisKeys, locations) {
             type: 'throughput',
             extensions: { crr: [...locations.crr, 'all'] },
             method: 'getThroughput',
-            dataPoints: [redisKeys.opsDone, redisKeys.bytesDone],
+            dataPoints: ['opsDone', 'bytesDone'],
         },
         // Route: /_/metrics/crr/<location>/all
         {
@@ -77,9 +76,8 @@ function routes(redisKeys, locations) {
             type: 'all',
             extensions: { crr: [...locations.crr, 'all'] },
             method: 'getAllMetrics',
-            dataPoints: [redisKeys.ops, redisKeys.opsDone, redisKeys.opsFail,
-                redisKeys.bytes, redisKeys.bytesDone, redisKeys.bytesFail,
-                redisKeys.opsPending, redisKeys.bytesPending],
+            dataPoints: ['ops', 'opsDone', 'opsFail', 'bytes', 'bytesDone',
+                'bytesFail', 'opsPending', 'bytesPending'],
         },
         // Route: /_/metrics/crr/<site>/progress/<bucket>/<key>
         {
@@ -89,7 +87,7 @@ function routes(redisKeys, locations) {
             level: 'object',
             extensions: { crr: [...locations.crr] },
             method: 'getObjectProgress',
-            dataPoints: [redisKeys.objectBytes, redisKeys.objectBytesDone],
+            dataPoints: ['objectBytes', 'objectBytesDone'],
         },
         // Route: /_/metrics/crr/<site>/throughput/<bucket>/<key>
         {
@@ -99,7 +97,7 @@ function routes(redisKeys, locations) {
             level: 'object',
             extensions: { crr: [...locations.crr] },
             method: 'getObjectThroughput',
-            dataPoints: [redisKeys.objectBytesDone],
+            dataPoints: ['objectBytesDone'],
         },
         // Route: /_/crr/failed?site=<site>&marker=<marker>
         {


### PR DESCRIPTION
Goes with https://github.com/scality/backbeat/pull/641

Do not pass redis keys to backbeat routes function. Instead
data points should be by common identifier (as strings) and
we can map these data points to their respective redis keys
for a given service