### PR TITLE
ft: ZENKO-1566 add ingestion metrics

### DIFF
--- a/lib/backbeat/Metrics.js
+++ b/lib/backbeat/Metrics.js
@@ -130,7 +130,7 @@ class Metrics {
     }
 
     /**
-     * Get replication backlog in ops count and size in bytes
+     * Get backlog in ops count and size in bytes
      * @param {object} details - route details from lib/backbeat/routes.js
      * @param {function} cb - callback(error, data)
      * @param {array} data - optional field providing already fetched data in
@@ -170,7 +170,7 @@ class Metrics {
     }
 
     /**
-     * Get completed replicated stats by ops count and size in bytes
+     * Get completed stats by ops count and size in bytes
      * @param {object} details - route details from lib/backbeat/routes.js
      * @param {function} cb - callback(error, data)
      * @param {array} data - optional field providing already fetched data in
@@ -199,23 +199,52 @@ class Metrics {
                     acc + i, 0)
             ));
 
-            const response = {
-                completions: {
-                    description: 'Number of completed replication operations ' +
-                        '(count) and number of bytes transferred (size) in ' +
-                        `the last ${Math.floor(uptime)} seconds`,
-                    results: {
-                        count: opsDone,
-                        size: bytesDone,
-                    },
-                },
-            };
-            return cb(null, response);
+            const { service } = details;
+            if (service === 'crr') {
+                return this._sendCompletionsResponseReplication(uptime, opsDone,
+                    bytesDone, cb);
+            }
+            if (service === 'ingestion') {
+                return this._sendCompletionsResponseIngestion(uptime, opsDone,
+                    cb);
+            }
+            return cb(errors.InternalError.customizeDescription(
+                `unknown service ${service} when getting completions metric`));
         });
     }
 
+    _sendCompletionsResponseReplication(uptime, ops, bytes, cb) {
+        const results = {
+            count: ops,
+            size: bytes,
+        };
+        const response = {
+            completions: {
+                description: 'Number of completed replication operations ' +
+                    '(count) and number of bytes transferred (size) in the ' +
+                    `last ${Math.floor(uptime)} seconds`,
+                results,
+            },
+        };
+        return cb(null, response);
+    }
+
+    _sendCompletionsResponseIngestion(uptime, ops, cb) {
+        const results = {
+            count: ops,
+        };
+        const response = {
+            completions: {
+                description: 'Number of completed ingestion operations ' +
+                    `(count) in the last ${Math.floor(uptime)} seconds`,
+                results,
+            },
+        };
+        return cb(null, response);
+    }
+
     /**
-     * Get failed replication stats by ops count and size in bytes
+     * Get failed stats by ops count and size in bytes
      * @param {object} details - route details from lib/backbeat/routes.js
      * @param {function} cb - callback(error, data)
      * @param {array} data - optional field providing already fetched data in
@@ -308,19 +337,48 @@ class Metrics {
                 return (total / uptime);
             });
 
-            const response = {
-                throughput: {
-                    description: 'Current throughput for replication ' +
-                        'operations in ops/sec (count) and bytes/sec (size) ' +
-                        `in the last ${Math.floor(uptime)} seconds`,
-                    results: {
-                        count: opsThroughput.toFixed(2),
-                        size: bytesThroughput.toFixed(2),
-                    },
-                },
-            };
-            return cb(null, response);
+            const { service } = details;
+            if (service === 'crr') {
+                return this._sendThroughputResponseReplication(uptime,
+                    opsThroughput, bytesThroughput, cb);
+            }
+            if (service === 'ingestion') {
+                return this._sendThroughputResponseIngestion(uptime,
+                    opsThroughput, cb);
+            }
+            return cb(errors.InternalError.customizeDescription(
+                `unknown service ${service} when getting throughput metric`));
         });
+    }
+
+    _sendThroughputResponseReplication(uptime, ops, bytes, cb) {
+        const results = {
+            count: ops.toFixed(2),
+            size: bytes.toFixed(2),
+        };
+        const response = {
+            throughput: {
+                description: 'Current throughput for replication operations ' +
+                    'in ops/sec (count) and bytes/sec (size) in the last ' +
+                    `${Math.floor(uptime)} seconds`,
+                results,
+            },
+        };
+        return cb(null, response);
+    }
+
+    _sendThroughputResponseIngestion(uptime, ops, cb) {
+        const results = {
+            count: ops.toFixed(2),
+        };
+        const response = {
+            throughput: {
+                description: 'Current throughput for ingestion operations in ' +
+                    `ops/sec (count) in the last ${Math.floor(uptime)} seconds`,
+                results,
+            },
+        };
+        return cb(null, response);
     }
 
     /**
@@ -422,7 +480,7 @@ class Metrics {
     }
 
     /**
-     * Get pending replication stats by ops count and size in bytes
+     * Get pending stats by ops count and size in bytes
      * @param {object} details - route details from lib/backbeat/routes.js
      * @param {function} cb - callback(error, data)
      * @param {array} data - optional field providing already fetched data in
@@ -451,18 +509,45 @@ class Metrics {
             }
             const count = Number.parseInt(res[0].requests, 10);
             const size = Number.parseInt(res[1].requests, 10);
-            const response = {
-                pending: {
-                    description: 'Number of pending replication ' +
-                        'operations (count) and bytes (size)',
-                    results: {
-                        count: count < 0 ? 0 : count,
-                        size: size < 0 ? 0 : size,
-                    },
-                },
-            };
-            return cb(null, response);
+
+            const { service } = details;
+            if (service === 'crr') {
+                return this._sendPendingResponseReplication(count, size, cb);
+            }
+            if (service === 'ingestion') {
+                return this._sendPendingResponseIngestion(count, cb);
+            }
+            return cb(errors.InternalError.customizeDescription(
+                `unknown service ${service} when getting pending metric`));
         });
+    }
+
+    _sendPendingResponseReplication(ops, bytes, cb) {
+        const results = {
+            count: ops,
+            size: bytes,
+        };
+        const response = {
+            pending: {
+                description: 'Number of pending replication operations ' +
+                    '(count) and bytes (size)',
+                results,
+            },
+        };
+        return cb(null, response);
+    }
+
+    _sendPendingResponseIngestion(ops, cb) {
+        const results = {
+            count: ops,
+        };
+        const response = {
+            pending: {
+                description: 'Number of pending ingestion operations (count)',
+                results,
+            },
+        };
+        return cb(null, response);
     }
 
     /**
@@ -474,6 +559,13 @@ class Metrics {
      * @return {undefined}
      */
     getAllMetrics(details, cb, data) {
+        function _adjustedDetails(details, size) {
+            const dataPointLength = size >= 0 ? size : 2;
+            return Object.assign({},
+                                 details,
+                                 { dataPoints: new Array(dataPointLength) });
+        }
+
         this._getData(details, data, (err, res) => {
             if (err && err.type) {
                 this._logger.error('error getting metric: all', {
@@ -488,21 +580,18 @@ class Metrics {
                 });
                 return cb(errors.InternalError);
             }
-            // NOTE: Edited to fit failed metrics
-            const failMetricsDetails = Object.assign({}, details,
-                { dataPoints: new Array(2) });
             // res = [ ops, ops_done, ops_fail, bytes, bytes_done, bytes_fail,
             // opsPending, bytesPending ]
             return async.parallel([
-                done => this.getBacklog({ dataPoints: new Array(2) }, done,
+                done => this.getBacklog(_adjustedDetails(details), done,
                     [res[6], res[7]]),
-                done => this.getCompletions({ dataPoints: new Array(2) }, done,
+                done => this.getCompletions(_adjustedDetails(details), done,
                     [res[1], res[4]]),
-                done => this.getFailedMetrics(failMetricsDetails, done,
+                done => this.getFailedMetrics(_adjustedDetails(details), done,
                     [res[2], res[5]]),
-                done => this.getThroughput({ dataPoints: new Array(2) }, done,
+                done => this.getThroughput(_adjustedDetails(details), done,
                     [res[1], res[4]]),
-                done => this.getPending({ dataPoints: new Array(2) }, done,
+                done => this.getPending(_adjustedDetails(details), done,
                     [res[6], res[7]]),
             ], (err, results) => {
                 if (err) {

--- a/lib/backbeat/routes.js
+++ b/lib/backbeat/routes.js
@@ -25,11 +25,15 @@ function routes(locations) {
             extensions: {},
         },
         // Route: /_/metrics/crr/<location>/pending
+        // Route: /_/metrics/ingestion/<location>/pending
         {
             httpMethod: 'GET',
             category: 'metrics',
             type: 'pending',
-            extensions: { crr: [...locations.crr, 'all'] },
+            extensions: {
+                crr: [...locations.crr, 'all'],
+                ingestion: [...locations.ingestion, 'all'],
+            },
             method: 'getPending',
             dataPoints: ['opsPending', 'bytesPending'],
         },
@@ -43,11 +47,15 @@ function routes(locations) {
             dataPoints: ['opsPending', 'bytesPending'],
         },
         // Route: /_/metrics/crr/<location>/completions
+        // Route: /_/metrics/ingestion/<location>/completions
         {
             httpMethod: 'GET',
             category: 'metrics',
             type: 'completions',
-            extensions: { crr: [...locations.crr, 'all'] },
+            extensions: {
+                crr: [...locations.crr, 'all'],
+                ingestion: [...locations.ingestion, 'all'],
+            },
             method: 'getCompletions',
             dataPoints: ['opsDone', 'bytesDone'],
         },
@@ -61,11 +69,15 @@ function routes(locations) {
             dataPoints: ['opsFail', 'bytesFail'],
         },
         // Route: /_/metrics/crr/<location>/throughput
+        // Route: /_/metrics/ingestion/<location>/throughput
         {
             httpMethod: 'GET',
             category: 'metrics',
             type: 'throughput',
-            extensions: { crr: [...locations.crr, 'all'] },
+            extensions: {
+                crr: [...locations.crr, 'all'],
+                ingestion: [...locations.ingestion, 'all'],
+            },
             method: 'getThroughput',
             dataPoints: ['opsDone', 'bytesDone'],
         },

--- a/tests/functional/backbeat/Metrics.js
+++ b/tests/functional/backbeat/Metrics.js
@@ -50,6 +50,7 @@ describe('Metrics class', () => {
         const details = routes.find(route =>
             route.category === 'metrics' && route.type === 'all');
         details.site = 'all';
+        details.service = 'crr';
         metrics.getAllMetrics(details, (err, res) => {
             assert.ifError(err);
             const expected = {


### PR DESCRIPTION
Goes with https://github.com/scality/backbeat/pull/642

Add ingestion metric routes to backbeat routes.
Needed to add a conditional on response objects to not include
bytes in response.

Includes ingestion: pending, throughput, completions