### PR TITLE
bugfix: ZENKO-1681 remove deprecation warnings

### DIFF
--- a/lib/storage/data/file/DataFileStore.js
+++ b/lib/storage/data/file/DataFileStore.js
@@ -193,7 +193,17 @@ class DataFileStore {
                     if (this.noCache) {
                         releasePageCacheSync(filePath, fd, log);
                     }
-                    fs.close(fd);
+                    const reqUid = log.getSerializedUids();
+                    fs.close(fd, err => {
+                        if (err) {
+                            this.logger.error('error closing fd after write', {
+                                errorMsg: err.message,
+                                errStack: err.stack,
+                                requestId: reqUid,
+                                key,
+                            });
+                        }
+                    });
                     return ok();
                 }
                 fs.fsync(fd, err => {
@@ -208,7 +218,17 @@ class DataFileStore {
                     if (this.noCache) {
                         releasePageCacheSync(filePath, fd, log);
                     }
-                    fs.close(fd);
+                    const reqUid = log.getSerializedUids();
+                    fs.close(fd, err => {
+                        if (err) {
+                            this.logger.error('error closing fd after write', {
+                                errorMsg: err.message,
+                                errStack: err.stack,
+                                requestId: reqUid,
+                                key,
+                            });
+                        }
+                    });
                     if (err) {
                         log.error('fsync error',
                             { method: 'put', key, filePath,


### PR DESCRIPTION
Removes warning "node:24) [DEP0013] DeprecationWarning: Calling an asynchronous
 function without callback is deprecated."