### PR TITLE
ft: ZENKO-1585 editable replication group id

### DIFF
--- a/lib/storage/metadata/MetadataWrapper.js
+++ b/lib/storage/metadata/MetadataWrapper.js
@@ -319,6 +319,14 @@ class MetadataWrapper {
         return this.client.getUUID(log, cb);
     }
 
+    getReplicationGroupId(log, cb) {
+        if (!this.client.getReplicationGroupID) {
+            log.debug('returning default replication group id');
+            return cb(null, '');
+        }
+        return this.client.getReplicationGroupID(log, cb);
+    }
+
     getDiskUsage(log, cb) {
         if (!this.client.getDiskUsage) {
             log.debug('returning empty disk usage as fallback', {

--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -133,14 +133,13 @@ class MongoClientInterface {
             });
             return async.series([
                 next => this.usersBucketHack(next),
-                next => this.getReplicationGroupID(this.logger,
-                    (err, repGroupId) => {
-                        if (err) {
-                            return next(err);
-                        }
-                        this.replicationGroupId = repGroupId;
-                        return next();
-                    }),
+                next => this._setupReplicationGroupID((err, repGroupId) => {
+                    if (err) {
+                        return next(err);
+                    }
+                    this.replicationGroupId = repGroupId;
+                    return next();
+                }),
             ], cb);
         });
     }
@@ -988,13 +987,34 @@ class MongoClientInterface {
         });
     }
 
-    readReplicationGroupID(log, cb) {
+    _setupReplicationGroupID(cb) {
+        // random 7 characters
+        const repGroupId = crypto.randomBytes(4).toString('hex').slice(1);
+        this.writeToInfostoreIfNotExists(__REP_GROUP_ID, repGroupId,
+        this.logger, err => {
+            if (err) {
+                if (err === errors.InternalError) {
+                    this.logger.error('_setupReplicationGroupID: error ' +
+                        'getting replication group id', {
+                            error: err.message,
+                        });
+                    return cb(err);
+                }
+                return this.getReplicationGroupID(this.logger, cb);
+            }
+            // need to save to instance
+            this.replicationGroupId = repGroupId;
+            return cb(null, repGroupId);
+        });
+    }
+
+    getReplicationGroupID(log, cb) {
         const i = this.getCollection(INFOSTORE);
         i.findOne({
             _id: __REP_GROUP_ID,
         }, {}, (err, doc) => {
             if (err) {
-                log.error('readReplicationGroupID: error reading ' +
+                log.error('getReplicationGroupID: error reading ' +
                     'replication group id', {
                         error: err.message,
                     });
@@ -1002,29 +1022,9 @@ class MongoClientInterface {
             }
             if (!doc) {
                 return cb(errors.NoSuchKey);
+                // return cb(null, this.replicationGroupId);
             }
             return cb(null, doc.value);
-        });
-    }
-
-    getReplicationGroupID(log, cb) {
-        // random 7 characters
-        const repGroupId = crypto.randomBytes(4).toString('hex').slice(1);
-        this.writeToInfostoreIfNotExists(__REP_GROUP_ID, repGroupId, log,
-        err => {
-            if (err) {
-                if (err === errors.InternalError) {
-                    log.error('getReplicationGroupID: error getting ' +
-                        'replication group id', {
-                            error: err.message,
-                        });
-                    return cb(err);
-                }
-                return this.readReplicationGroupID(log, cb);
-            }
-            // need to save to instance
-            this.replicationGroupId = repGroupId;
-            return cb(null, repGroupId);
         });
     }
 

--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -10,6 +10,7 @@
  * We use proper atomic operations when needed.
  */
 const async = require('async');
+const crypto = require('crypto');
 
 const { EventEmitter } = require('events');
 const constants = require('../../../constants');
@@ -33,6 +34,7 @@ const USERSBUCKET = '__usersbucket';
 const METASTORE = '__metastore';
 const INFOSTORE = '__infostore';
 const __UUID = 'uuid';
+const __REP_GROUP_ID = 'repGroupID';
 const PENSIEVE = 'PENSIEVE';
 const ASYNC_REPAIR_TIMEOUT = 15000;
 const itemScanRefreshDelay = 1000 * 60 * 60; // 1 hour
@@ -937,18 +939,18 @@ class MongoClientInterface {
         });
     }
 
-    writeUUIDIfNotExists(uuid, log, cb) {
+    writeToInfostoreIfNotExists(id, value, log, cb) {
         const i = this.getCollection(INFOSTORE);
         i.insert({
-            _id: __UUID,
-            value: uuid,
+            _id: id,
+            value,
         }, {}, err => {
             if (err) {
                 if (err.code === 11000) {
                     // duplicate key error
                     return cb(errors.KeyAlreadyExists);
                 }
-                log.error('writeUUIDIfNotExists: error writing UUID',
+                log.error(`writeToInfostoreIfNotExists: error writing to ${id}`,
                 { error: err.message });
                 return cb(errors.InternalError);
             }
@@ -963,7 +965,7 @@ class MongoClientInterface {
      */
     getUUID(log, cb) {
         const uuid = initialInstanceID || Uuid.v4();
-        this.writeUUIDIfNotExists(uuid, log, err => {
+        this.writeToInfostoreIfNotExists(__UUID, uuid, log, err => {
             if (err) {
                 if (err === errors.InternalError) {
                     log.error('getUUID: error getting UUID',
@@ -973,6 +975,46 @@ class MongoClientInterface {
                 return this.readUUID(log, cb);
             }
             return cb(null, uuid);
+        });
+    }
+
+    readReplicationGroupID(log, cb) {
+        const i = this.getCollection(INFOSTORE);
+        i.findOne({
+            _id: __REP_GROUP_ID,
+        }, {}, (err, doc) => {
+            if (err) {
+                log.error('readReplicationGroupID: error reading ' +
+                    'replication group id', {
+                        error: err.message,
+                    });
+                return cb(errors.InternalError);
+            }
+            if (!doc) {
+                return cb(errors.NoSuchKey);
+            }
+            return cb(null, doc.value);
+        });
+    }
+
+    getReplicationGroupID(log, cb) {
+        // random 7 characters
+        const repGroupId = crypto.randomBytes(4).toString('hex').slice(1);
+        this.writeToInfostoreIfNotExists(__REP_GROUP_ID, repGroupId, log,
+        err => {
+            if (err) {
+                if (err === errors.InternalError) {
+                    log.error('getReplicationGroupID: error getting ' +
+                        'replication group id', {
+                            error: err.message,
+                        });
+                    return cb(err);
+                }
+                return this.readReplicationGroupID(log, cb);
+            }
+            // need to save to instance
+            this.replicationGroupId = repGroupId;
+            return cb(null, repGroupId);
         });
     }
 

--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -131,7 +131,17 @@ class MongoClientInterface {
             this.db = client.db(this.database, {
                 ignoreUndefined: true,
             });
-            return this.usersBucketHack(cb);
+            return async.series([
+                next => this.usersBucketHack(next),
+                next => this.getReplicationGroupID(this.logger,
+                    (err, repGroupId) => {
+                        if (err) {
+                            return next(err);
+                        }
+                        this.replicationGroupId = repGroupId;
+                        return next();
+                    }),
+            ], cb);
         });
     }
     usersBucketHack(cb) {


### PR DESCRIPTION
On setup of MongoClientInterface instance, create and save a new replication group id if `infostore` does not already have a stored replication group id. We update the replication group id instance variable in MongoClientInterface. New versions will now use this updated replication group id.

During the initManagement phase for cloudserver and backbeat, we just fetch the replication group id from mongo using the MongoClientInterface and patch configurations.

A potential problem is that during the initManagement phase, if replication group id has not yet been stored in `infostore`, we will be forced to retry initManagement. 
