### PR TITLE
bf: ZENKO-1718 ingestion mongo putObjectVerCase4

### DIFF
--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -509,6 +509,53 @@ class MongoClientInterface {
     }
 
     /*
+     * In this case the caller provides a versionId and a flag called usePHD.
+     * This function will save the versionId object as is and will set PHD on
+     * master. If a user performs any operation to find IsLatest, the PHD flag
+     * indicates to perform a search on the bucket to find the latest version.
+     * We rely on the natural ordering of versions for listings. We rely on
+     * internal MongoClientInterface operations for master version and repairs.
+     */
+    putObjectVerCase4(c, bucketName, objName, objVal, params, log, cb) {
+        const vObjName = formatVersionKey(objName, params.versionId);
+        const mst = generatePHDVersion(params.versionId);
+        return c.bulkWrite([{
+            updateOne: {
+                filter: {
+                    _id: vObjName,
+                },
+                update: {
+                    $set: {
+                        _id: vObjName,
+                        value: objVal,
+                    },
+                },
+                upsert: true,
+            },
+        }, {
+            updateOne: {
+                filter: {
+                    _id: objName,
+                },
+                update: {
+                    _id: objName, value: mst,
+                },
+                upsert: true,
+            },
+        }], {
+            ordered: 1,
+        }, err => {
+            if (err) {
+                log.error('putObjectVerCase4: error putting object version', {
+                    error: err.message,
+                });
+                return cb(errors.InternalError);
+            }
+            return cb(null, `{"versionId": "${objVal.versionId}"}`);
+        });
+    }
+
+    /*
      * Put object when versioning is not enabled
      */
     putObjectNoVer(c, bucketName, objName, objVal, params, log, cb) {
@@ -539,8 +586,11 @@ class MongoClientInterface {
         } else if (params && params.versionId === '') {
             return this.putObjectVerCase2(c, bucketName, objName, objVal,
                                           params, log, cb);
-        } else if (params && params.versionId) {
+        } else if (params && params.versionId && !params.usePHD) {
             return this.putObjectVerCase3(c, bucketName, objName, objVal,
+                                          params, log, cb);
+        } else if (params && params.versionId && params.usePHD) {
+            return this.putObjectVerCase4(c, bucketName, objName, objVal,
                                           params, log, cb);
         }
         return this.putObjectNoVer(c, bucketName, objName, objVal,


### PR DESCRIPTION
Add a putObjectVerCase to MongoClientInterface for ingestion
use-cases. Remove management of master versions in the
ingestion process and rely on the natural ordering of
objects stored in mongo. Get and Delete operations will
rely on internal MongoClientInterface methods for performing
relevant operations. To do this, we set PHD on master for
each object version ingested.