### PR TITLE
bf: ZENKO-1585 zenko user-metadata header constant

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -112,4 +112,6 @@ module.exports = {
     clientsRequireStringKey: { sproxyd: true, cdmi: true },
     hasCopyPartBackends: { aws_s3: true, gcp: true },
     versioningNotImplBackends: { azure: true, gcp: true },
+    // user metadata applied on zenko-created objects
+    zenkoIDHeader: 'x-amz-meta-zenko-instance-id',
 };


### PR DESCRIPTION
This constant will be used in backbeat and cloudserver as
a user metadata defined header indicating if an object has
been created in a zenko deployment