### PR TITLE
bugfix: ZENKO-1738 bucket names with period trimmed by backbeat

### DIFF
--- a/lib/storage/metadata/mongoclient/ListRecordStream.js
+++ b/lib/storage/metadata/mongoclient/ListRecordStream.js
@@ -87,7 +87,7 @@ class ListRecordStream extends stream.Readable {
             return true; // read next record
         }
 
-        const dbName = itemObj.ns.split('.');
+        const dbName = itemObj.ns.slice(itemObj.ns.indexOf('.') + 1);
         let entry;
         if (itemObj.op === 'i' &&
             itemObj.o && itemObj.o._id) {
@@ -125,7 +125,7 @@ class ListRecordStream extends stream.Readable {
         const streamObject = {
             timestamp: new Date((itemObj.ts ?
                                  itemObj.ts.toNumber() * 1000 : 0)),
-            db: dbName[1],
+            db: dbName,
             entries: [entry],
         };
         // push object to the stream, then return false to wait until


### PR DESCRIPTION
Fix mongoclient.ListRecordStream to properly pass on bucket names with
periods (like foo.bar), instead of truncating the name after the first
period.

Down the line, that fixes replication for objects contained in such
buckets.