### PR TITLE
INTEGRATION [PR#777 > development/8.1] bugfix: ZENKO-1738 bucket names with period trimmed by backbeat

### DIFF
--- a/lib/storage/metadata/mongoclient/ListRecordStream.js
+++ b/lib/storage/metadata/mongoclient/ListRecordStream.js
@@ -87,7 +87,7 @@ class ListRecordStream extends stream.Readable {
             return true; // read next record
         }
 
-        const dbName = itemObj.ns.split('.');
+        const dbName = itemObj.ns.slice(itemObj.ns.indexOf('.') + 1);
         let entry;
         if (itemObj.op === 'i' &&
             itemObj.o && itemObj.o._id) {
@@ -125,7 +125,7 @@ class ListRecordStream extends stream.Readable {
         const streamObject = {
             timestamp: new Date((itemObj.ts ?
                                  itemObj.ts.toNumber() * 1000 : 0)),
-            db: dbName[1],
+            db: dbName,
             entries: [entry],
         };
         // push object to the stream, then return false to wait until


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #777.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/ZENKO-1738-bucketNamesWithPeriodsTrimmed`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/ZENKO-1738-bucketNamesWithPeriodsTrimmed
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/ZENKO-1738-bucketNamesWithPeriodsTrimmed
```

Please always comment pull request #777 instead of this one.