### PR TITLE
bugfix: ZENKO-1749 fix exception with invalid lifecycle config

### DIFF
--- a/lib/models/LifecycleConfiguration.js
+++ b/lib/models/LifecycleConfiguration.js
@@ -477,19 +477,22 @@ class LifecycleConfiguration {
      * @param {object} rule - The rule to find the prefix in
      * @return {string} - The prefix of filter information
      */
-    _getRuleFilter(rule) {
+    _getRuleFilterDesc(rule) {
         if (rule.Prefix) {
             return `prefix '${rule.Prefix[0]}'`;
         }
         // There must be a filter if no top-level prefix is provided. First
         // check if there are multiple filters (i.e. `Filter.And`).
-        if (rule.Filter[0].And === undefined) {
-            const { Prefix, Tag } = rule.Filter[0];
+        if (rule.Filter[0] === undefined || rule.Filter[0].And === undefined) {
+            const { Prefix, Tag } = rule.Filter[0] || {};
             if (Prefix) {
                 return `filter '(prefix=${Prefix[0]})'`;
             }
-            const { Key, Value } = Tag[0];
-            return `filter '(tag: key=${Key[0]}, value=${Value[0]})'`;
+            if (Tag) {
+                const { Key, Value } = Tag[0];
+                return `filter '(tag: key=${Key[0]}, value=${Value[0]})'`;
+            }
+            return 'filter (all)';
         }
         const filters = [];
         const { Prefix, Tag } = rule.Filter[0].And[0];
@@ -547,7 +550,7 @@ class LifecycleConfiguration {
         }
         if (usedStorageClasses.includes(storageClass)) {
             const msg = `'StorageClass' must be different for '${ancestor}' ` +
-                `actions in same 'Rule' with ${this._getRuleFilter(rule)}`;
+                `actions in same 'Rule' with ${this._getRuleFilterDesc(rule)}`;
             return errors.InvalidRequest.customizeDescription(msg);
         }
         return null;
@@ -586,7 +589,7 @@ class LifecycleConfiguration {
         });
         if (invalidTransition) {
             const timeType = days !== undefined ? 'Days' : 'Date';
-            const filterMsg = this._getRuleFilter(rule);
+            const filterMsg = this._getRuleFilterDesc(rule);
             const compareStorageClass = invalidTransition.StorageClass[0];
             const msg = `'${timeType}' in the 'Transition' action for ` +
                 `StorageClass '${storageClass}' for ${filterMsg} must be at ` +
@@ -612,7 +615,8 @@ class LifecycleConfiguration {
         const { usedTimeType, currentTimeType, rule } = params;
         if (usedTimeType && usedTimeType !== currentTimeType) {
             const msg = "Found mixed 'Date' and 'Days' based Transition " +
-                `actions in lifecycle rule for ${this._getRuleFilter(rule)}`;
+                'actions in lifecycle rule for ' +
+                `${this._getRuleFilterDesc(rule)}`;
             return errors.InvalidRequest.customizeDescription(msg);
         }
         // Transition time type cannot differ from the expiration, if provided.
@@ -620,7 +624,7 @@ class LifecycleConfiguration {
             rule.Expiration[0][currentTimeType] === undefined) {
             const msg = "Found mixed 'Date' and 'Days' based Expiration and " +
                 'Transition actions in lifecycle rule for ' +
-                `${this._getRuleFilter(rule)}`;
+                `${this._getRuleFilterDesc(rule)}`;
             return errors.InvalidRequest.customizeDescription(msg);
         }
         return null;

--- a/tests/unit/models/LifecycleConfiguration.js
+++ b/tests/unit/models/LifecycleConfiguration.js
@@ -381,10 +381,10 @@ describe('LifecycleConfiguration', () => {
         };
     }
 
-    describe('::_getRuleFilter', () => {
+    describe('::_getRuleFilterDesc', () => {
         it('should get Prefix', () => {
             const rule = getParsedXML().LifecycleConfiguration.Rule[0];
-            const ruleFilter = lifecycleConfiguration._getRuleFilter(rule);
+            const ruleFilter = lifecycleConfiguration._getRuleFilterDesc(rule);
             assert.strictEqual(ruleFilter, "prefix ''");
         });
 
@@ -392,7 +392,7 @@ describe('LifecycleConfiguration', () => {
             const rule = getParsedXML().LifecycleConfiguration.Rule[0];
             delete rule.Prefix;
             rule.Filter = [{ Prefix: [''] }];
-            const ruleFilter = lifecycleConfiguration._getRuleFilter(rule);
+            const ruleFilter = lifecycleConfiguration._getRuleFilterDesc(rule);
             assert.strictEqual(ruleFilter, "filter '(prefix=)'");
         });
 
@@ -400,7 +400,7 @@ describe('LifecycleConfiguration', () => {
             const rule = getParsedXML().LifecycleConfiguration.Rule[0];
             delete rule.Prefix;
             rule.Filter = [{ Tag: [{ Key: ['a'], Value: [''] }] }];
-            const ruleFilter = lifecycleConfiguration._getRuleFilter(rule);
+            const ruleFilter = lifecycleConfiguration._getRuleFilterDesc(rule);
             assert.strictEqual(ruleFilter, "filter '(tag: key=a, value=)'");
         });
 
@@ -420,7 +420,7 @@ describe('LifecycleConfiguration', () => {
                     }],
                 }],
             }];
-            const ruleFilter = lifecycleConfiguration._getRuleFilter(rule);
+            const ruleFilter = lifecycleConfiguration._getRuleFilterDesc(rule);
             assert.strictEqual(ruleFilter, 'filter ' +
                 "'(prefix= and tag: key=a, value=b and tag: key=c, value=d)'");
         });
@@ -440,9 +440,35 @@ describe('LifecycleConfiguration', () => {
                     }],
                 }],
             }];
-            const ruleFilter = lifecycleConfiguration._getRuleFilter(rule);
+            const ruleFilter = lifecycleConfiguration._getRuleFilterDesc(rule);
             assert.strictEqual(ruleFilter,
                 "filter '(tag: key=a, value=b and tag: key=c, value=d)'");
+        });
+
+        it('should get Filter with empty object', () => {
+            const rule = {
+                ID: ['test-id'],
+                Status: ['Enabled'],
+                Expiration: [{
+                    Days: 1,
+                }],
+            };
+            rule.Filter = [{}];
+            const ruleFilter = lifecycleConfiguration._getRuleFilterDesc(rule);
+            assert.strictEqual(ruleFilter, 'filter (all)');
+        });
+
+        it('should get empty Filter', () => {
+            const rule = {
+                ID: ['test-id'],
+                Status: ['Enabled'],
+                Expiration: [{
+                    Days: 1,
+                }],
+            };
+            rule.Filter = [];
+            const ruleFilter = lifecycleConfiguration._getRuleFilterDesc(rule);
+            assert.strictEqual(ruleFilter, 'filter (all)');
         });
     });
 


### PR DESCRIPTION
An empty Filter attribute along with invalid rule caused an exception
in LifecycleConfiguration._getRuleFilter(): make it return a proper
description string.

Also renamed the function to _getRuleFilterDesc().