### PR TITLE
ft(ZENKO-1652): Update MetadataWrapper for List Blobs

### DIFF
--- a/lib/storage/metadata/MetadataWrapper.js
+++ b/lib/storage/metadata/MetadataWrapper.js
@@ -55,13 +55,14 @@ function _parseListEntries(entries) {
  * @param {object[]} entries - Version or Content entries in a metadata listing
  * @param {string} entries[].key - metadata key
  * @param {string} entries[].value - stringified object metadata
+ * @param {function} parser - Parser for object data
  * @return {(object|Error)} - mapped array with parsed value or JSON parsing err
  */
-function parseListEntries(entries) {
+function parseListEntries(entries, parser) {
     // wrap private function in a try/catch clause
     // just in case JSON parsing throws an exception
     try {
-        return _parseListEntries(entries);
+        return parser(entries);
     } catch (e) {
         return e;
     }
@@ -105,6 +106,7 @@ class MetadataWrapper {
             });
             this.implName = 'cdmi';
         }
+        this._listingParser = params.customListingParser || _parseListEntries;
     }
 
     setup(done) {
@@ -250,7 +252,7 @@ class MetadataWrapper {
             log.debug('object listing retrieved from metadata');
             if (listingParams.listingType === 'DelimiterVersions') {
                 // eslint-disable-next-line
-                data.Versions = parseListEntries(data.Versions);
+                data.Versions = parseListEntries(data.Versions, this._listingParser);
                 if (data.Versions instanceof Error) {
                     log.error('error parsing metadata listing', {
                         error: data.Versions,
@@ -262,7 +264,7 @@ class MetadataWrapper {
                 return cb(null, data);
             }
             // eslint-disable-next-line
-            data.Contents = parseListEntries(data.Contents);
+            data.Contents = parseListEntries(data.Contents, this._listingParser);
             if (data.Contents instanceof Error) {
                 log.error('error parsing metadata listing', {
                     error: data.Contents,


### PR DESCRIPTION
Add the ability to pass a custom parser for objects to MetadataWrapper. This is needed as the current parser removes any properties not needed by the S3 response, some of which are required for a Blobserver response. This will allow us to replace the parser for Blobserver and fallback to the existing parser for clients that do not specify a custom parser.