### PR TITLE
bf: ZENKO-1718 putObjectCase4 handle delete marker

### DIFF
--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -62,11 +62,15 @@ function inc(str) {
 
 const VID_SEPPLUS = inc(VID_SEP);
 
-function generatePHDVersion(versionId) {
-    return {
+function generatePHDVersion(versionId, isDeleteMarker) {
+    const phdVersion = {
         isPHD: true,
         versionId,
     };
+    if (isDeleteMarker) {
+        phdVersion.isDeleteMarker = isDeleteMarker;
+    }
+    return phdVersion;
 }
 
 /**
@@ -518,7 +522,7 @@ class MongoClientInterface {
      */
     putObjectVerCase4(c, bucketName, objName, objVal, params, log, cb) {
         const vObjName = formatVersionKey(objName, params.versionId);
-        const mst = generatePHDVersion(params.versionId);
+        const mst = generatePHDVersion(params.versionId, params.isDeleteMarker);
         return c.bulkWrite([{
             updateOne: {
                 filter: {


### PR DESCRIPTION
MongoClientInterface.putObjectVerCase4 will save master
as placeholders (isPHD).

The listing algorithm (delimiterMaster) used for listObjects
calls has a filter for delete markers. Since we can have
an isPHD master that is a delete marker, we should mark
them accordingly in its value.