### PR TITLE
bf: S3C-2192 delimiterMaster similar key listing

### DIFF
--- a/lib/algos/list/delimiterMaster.js
+++ b/lib/algos/list/delimiterMaster.js
@@ -74,8 +74,8 @@ class DelimiterMaster extends Delimiter {
              *   value. (TODO: remove this test once ZENKO-1048 is fixed. ).
              *   */
             if (key === this.prvKey || key === this[this.nextContinueMarker] ||
-                (this.delimiter &&
-                key.startsWith(this[this.nextContinueMarker]))) {
+                (this.delimiter && key.startsWith(
+                    `${this[this.nextContinueMarker]}${this.delimiter}`))) {
                 /* master version already filtered */
                 return FILTER_SKIP;
             }


### PR DESCRIPTION
Given the following situation:
- master isPHD and key name for example is "test1"
- version "test1"
- master isPHD and key name for example is "test10"
- version "test10"

We were filtering out "test10" from listings even though it
was considered a valid entry in the listing.

There was a check made where given the above scenario, we
would check if `this.delimiter` exists, then see if current
key startsWith the previous continue marker. Instead, we
should check if the current key startsWith the previous
continue marker + `this.delimiter`.