### PR TITLE
INTEGRATION [PR#795 > development/7.5] S3C-2034: bump ioredis version to 4.9 to use redis 5.0 func

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "async": "~2.1.5",
     "debug": "~2.3.3",
     "diskusage": "^0.2.2",
-    "ioredis": "2.4.0",
+    "ioredis": "4.9.5",
     "ipaddr.js": "1.2.0",
     "joi": "^10.6",
     "JSONStream": "^1.0.0",


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #795.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.5/improvement/S3C-2034-bump-ioredis`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.5/improvement/S3C-2034-bump-ioredis
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.5/improvement/S3C-2034-bump-ioredis
```

Please always comment pull request #795 instead of this one.