### PR TITLE
bugfix: S3C-2172 change error message for compatibility

### DIFF
--- a/lib/s3routes/routes.js
+++ b/lib/s3routes/routes.js
@@ -45,6 +45,9 @@ function checkBucketAndKey(bucketName, objectKey, method, reqQuery,
     if (bucketName !== undefined && routesUtils.isValidBucketName(bucketName,
         blacklistedPrefixes.bucket) === false) {
         log.debug('invalid bucket name', { bucketName });
+        if (method === 'DELETE') {
+            return errors.NoSuchBucket;
+        }
         return errors.InvalidBucketName;
     }
     if (objectKey !== undefined) {


### PR DESCRIPTION
When a delete bucket request is sent with an invalid bucket name
the server returns NoSuchBucket instead of InvalidBucketName error
to be compatible with AWS S3.
Note: It will be followed by a functional test in Cloudserver