### PR TITLE
bugfix: S3C-2243 fix check for location type

### DIFF
--- a/lib/storage/data/DataWrapper.js
+++ b/lib/storage/data/DataWrapper.js
@@ -182,19 +182,24 @@ class DataWrapper {
             method: 'batchDelete',
         });
         const keys = [];
+        let backendName = '';
         const shouldBatchDelete = locations.every(l => {
+            // legacy sproxyd location, should fallback to using regular delete
             if (typeof l === 'string') {
-                keys.push(l);
-                return true;
+                return false;
             }
-            if (l.dataStoreName === 'sproxyd') {
-                keys.push(l.key);
+            const { dataStoreName, key } = l;
+            backendName = dataStoreName;
+            const type = this.config.getLocationConstraintType(dataStoreName);
+            // filter out possible `null` created by NFS
+            if (key && type === 'scality') {
+                keys.push(key);
                 return true;
             }
             return false;
         });
         if (shouldBatchDelete) {
-            return this.client.batchDelete('sproxyd', keys, log, cb);
+            return this.client.batchDelete(backendName, { keys }, log, cb);
         }
         return async.eachLimit(locations, 5, (loc, next) => {
             process.nextTick(() => this.delete(loc, log, next));

--- a/lib/storage/data/MultipleBackendGateway.js
+++ b/lib/storage/data/MultipleBackendGateway.js
@@ -126,6 +126,7 @@ class MultipleBackendGateway {
     batchDelete(dataStoreName, keys, log, callback) {
         const client = this.clients[dataStoreName];
         if (client.batchDelete) {
+            log.debug('submitting keys for batch delete', { keys });
             return client.batchDelete(keys, log.getSerializedUids(), callback);
         }
         return callback(errors.NotImplemented);


### PR DESCRIPTION
This fixes the check where the logic should be looking at the type
of location instead of the name to leverage batch delete. It also fixes
the format sent to the sproxydclient which expects and object with keys
as an attribute whose value is an array of sproxyd keys.