### PR TITLE
bf: ZENKO-1736 count items scan rework

### DIFF
--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -34,8 +34,8 @@ const METASTORE = '__metastore';
 const INFOSTORE = '__infostore';
 const __UUID = 'uuid';
 const PENSIEVE = 'PENSIEVE';
+const __COUNT_ITEMS = 'countitems';
 const ASYNC_REPAIR_TIMEOUT = 15000;
-const itemScanRefreshDelay = 1000 * 60 * 60; // 1 hour
 const CONNECT_TIMEOUT_MS = 5000;
 
 const initialInstanceID = process.env.INITIAL_INSTANCE_ID;
@@ -96,7 +96,6 @@ class MongoClientInterface {
         this.path = path;
         this.replicationGroupId = replicationGroupId;
         this.database = database;
-        this.lastItemScanTime = null;
         this.dataCount = new DataCounter();
         if (config && config instanceof EventEmitter) {
             this.config = config;
@@ -151,6 +150,10 @@ class MongoClientInterface {
                 }
                 return cb();
             });
+    }
+
+    close() {
+        this.client.close();
     }
 
     getCollection(name) {
@@ -1035,11 +1038,148 @@ class MongoClientInterface {
                         this.path : '/', cb);
     }
 
-    countItems(log, cb) {
-        const doFullScan = this.lastItemScanTime === null ||
-            (Date.now() - this.lastItemScanTime) > itemScanRefreshDelay;
+    readCountItems(log, cb) {
+        const i = this.getCollection(INFOSTORE);
+        i.findOne({
+            _id: __COUNT_ITEMS,
+        }, {}, (err, doc) => {
+            if (err) {
+                log.error('readCountItems: error reading count items', {
+                    error: err.message,
+                });
+                return cb(errors.InternalError);
+            }
+            if (!doc) {
+                // defaults
+                const res = {
+                    objects: 0,
+                    versions: 0,
+                    buckets: 0,
+                    bucketList: [],
+                    dataManaged: {
+                        total: { curr: 0, prev: 0 },
+                        byLocation: {},
+                    },
+                    stalled: 0,
+                };
+                return cb(null, res);
+            }
+            return cb(null, doc.value);
+        });
+    }
 
-        const res = {
+    updateCountItems(value, log, cb) {
+        const i = this.getCollection(INFOSTORE);
+        i.update({
+            _id: __COUNT_ITEMS,
+        }, {
+            _id: __COUNT_ITEMS,
+            value,
+        }, {
+            upsert: true,
+        }, err => {
+            if (err) {
+                log.error('updateCountItems: error updating count items', {
+                    error: err.message,
+                });
+                return cb(errors.InternalError);
+            }
+            return cb();
+        });
+    }
+
+    /*
+     * get bucket related information for count items, used by cloudserver
+     * and s3utils
+     */
+    _getBucketInfos(log, cb) {
+        let bucketCount = 0;
+        const bucketInfos = [];
+
+        this.db.listCollections().toArray((err, collInfos) => {
+            if (err) {
+                log.error('could not get list of collections', {
+                    method: '_getBucketInfos',
+                    error: err,
+                });
+                return cb(err);
+            }
+            return async.eachLimit(collInfos, 10, (value, next) => {
+                if (value.name === METASTORE ||
+                    value.name === INFOSTORE ||
+                    value.name === USERSBUCKET ||
+                    value.name === PENSIEVE ||
+                    value.name.startsWith(constants.mpuBucketPrefix)
+                ) {
+                    // skip
+                    return next();
+                }
+                bucketCount++;
+                const bucketName = value.name;
+                // FIXME: there is currently no way of distinguishing
+                // master from versions and searching for VID_SEP
+                // does not work because there cannot be null bytes
+                // in $regex
+
+                return this.getBucketAttributes(bucketName, log,
+                    (err, bucketInfo) => {
+                        if (err) {
+                            log.error('failed to get bucket attributes', {
+                                bucketName,
+                                error: err,
+                            });
+                            return next(errors.InternalError);
+                        }
+                        bucketInfos.push(bucketInfo);
+                        return next();
+                    });
+            }, err => {
+                if (err) {
+                    return cb(err);
+                }
+                return cb(null, {
+                    bucketCount,
+                    bucketInfos,
+                });
+            });
+        });
+    }
+
+    countItems(log, cb) {
+        this._getBucketInfos(log, (err, res) => {
+            if (err) {
+                log.error('error getting bucket info', {
+                    method: 'countItems',
+                    error: err,
+                });
+                return cb(err);
+            }
+            const { bucketCount, bucketInfos } = res;
+
+            const retBucketInfos = bucketInfos.map(bucket => ({
+                name: bucket.getName(),
+                location: bucket.getLocationConstraint(),
+                isVersioned: !!bucket.getVersioningConfiguration(),
+                ownerCanonicalId: bucket.getOwner(),
+                ingestion: bucket.isIngestionBucket(),
+            }));
+
+            return this.readCountItems(log, (err, results) => {
+                if (err) {
+                    return cb(err);
+                }
+                // overwrite bucket info since we have latest info
+                /* eslint-disable */
+                results.bucketList = retBucketInfos;
+                results.buckets = bucketCount;
+                /* eslint-enable */
+                return cb(null, results);
+            });
+        });
+    }
+
+    scanItemCount(log, cb) {
+        const store = {
             objects: 0,
             versions: 0,
             buckets: 0,
@@ -1054,98 +1194,106 @@ class MongoClientInterface {
         const consolidateData = dataManaged => {
             if (dataManaged && dataManaged.locations && dataManaged.total) {
                 const locations = dataManaged.locations;
-                res.dataManaged.total.curr += dataManaged.total.curr;
-                res.dataManaged.total.prev += dataManaged.total.prev;
+                store.dataManaged.total.curr += dataManaged.total.curr;
+                store.dataManaged.total.prev += dataManaged.total.prev;
                 Object.keys(locations).forEach(site => {
-                    if (!res.dataManaged.byLocation[site]) {
-                        res.dataManaged.byLocation[site] =
+                    if (!store.dataManaged.byLocation[site]) {
+                        store.dataManaged.byLocation[site] =
                             Object.assign({}, locations[site]);
                     } else {
-                        res.dataManaged.byLocation[site].curr +=
+                        store.dataManaged.byLocation[site].curr +=
                             locations[site].curr;
-                        res.dataManaged.byLocation[site].prev +=
+                        store.dataManaged.byLocation[site].prev +=
                             locations[site].prev;
                     }
                 });
             }
         };
 
-        this.db.listCollections().toArray((err, collInfos) => {
-            async.eachLimit(collInfos, 10, (value, next) => {
-                if (value.name === METASTORE ||
-                    value.name === INFOSTORE ||
-                    value.name === USERSBUCKET ||
-                    value.name === PENSIEVE ||
-                    value.name.startsWith(constants.mpuBucketPrefix)
-                ) {
-                    // skip
-                    return next();
-                }
-                res.buckets++;
-                const bucketName = value.name;
-                // FIXME: there is currently no way of distinguishing
-                // master from versions and searching for VID_SEP
-                // does not work because there cannot be null bytes
-                // in $regex
+        this._getBucketInfos(log, (err, res) => {
+            if (err) {
+                log.error('error getting bucket info', {
+                    method: 'scanItemCount',
+                    error: err,
+                });
+                return cb(err);
+            }
 
-                return async.waterfall([
-                    next => this.getBucketAttributes(
-                    bucketName, log, (err, bucketInfo) => {
-                        if (err) {
-                            log.error('error occured in countItems', {
-                                method: 'countItems',
-                                error: err,
-                            });
-                            return next(errors.InternalError);
-                        }
-                        const retBucketInfo = {
-                            name: bucketName,
-                            location: bucketInfo.getLocationConstraint(),
-                            isVersioned:
-                                !!bucketInfo.getVersioningConfiguration(),
-                            ownerCanonicalId: bucketInfo.getOwner(),
-                            ingestion: bucketInfo.isIngestionBucket(),
-                        };
-                        res.bucketList.push(retBucketInfo);
-                        return next(null, bucketInfo);
-                    }),
-                    (bucketInfo, next) => {
-                        if (!doFullScan) {
-                            return next(null, {});
-                        }
-                        return this.getObjectMDStats(
-                        bucketName, bucketInfo, log, next);
+            const { bucketCount, bucketInfos } = res;
+            const retBucketInfos = bucketInfos.map(bucket => ({
+                name: bucket.getName(),
+                location: bucket.getLocationConstraint(),
+                isVersioned: !!bucket.getVersioningConfiguration(),
+                ownerCanonicalId: bucket.getOwner(),
+                ingestion: bucket.isIngestionBucket(),
+            }));
+
+            store.buckets = bucketCount;
+            store.bucketList = retBucketInfos;
+
+            return async.eachLimit(bucketInfos, 10, (bucketInfo, done) => {
+                async.waterfall([
+                    next => this._getIsTransient(bucketInfo, log, next),
+                    (isTransient, next) => {
+                        const bucketName = bucketInfo.getName();
+                        this.getObjectMDStats(bucketName, bucketInfo,
+                            isTransient, log, next);
                     },
                 ], (err, results) => {
                     if (err) {
-                        return next(errors.InternalError);
+                        return done(err);
                     }
                     if (results.dataManaged) {
-                        res.objects += results.objects;
-                        res.versions += results.versions;
-                        res.stalled += results.stalled;
+                        store.objects += results.objects;
+                        store.versions += results.versions;
+                        store.stalled += results.stalled;
                         consolidateData(results.dataManaged);
                     }
-                    return next();
+                    return done();
                 });
             }, err => {
                 if (err) {
                     return cb(err);
                 }
-
-                if (!doFullScan) {
-                    const cachedRes = this.dataCount.results();
-                    cachedRes.bucketList = res.bucketList;
-                    cachedRes.buckets = res.buckets;
-                    return cb(null, cachedRes);
-                }
-
-                this.lastItemScanTime = Date.now();
-                this.dataCount.set(res);
-                return cb(null, res);
+                // save to infostore
+                return this.updateCountItems(store, log, err => {
+                    if (err) {
+                        log.error('error saving count items in mongo', {
+                            method: 'scanItemCount',
+                            error: err,
+                        });
+                        return cb(err);
+                    }
+                    return cb(null, store);
+                });
             });
         });
         return undefined;
+    }
+
+    _getIsTransient(bucketInfo, log, cb) {
+        const overlayVersionId = 'configuration/overlay-version';
+
+        async.waterfall([
+            next => this.getObject(PENSIEVE, overlayVersionId, {}, log, next),
+            (version, next) => {
+                const overlayConfigId = `configuration/overlay/${version}`;
+                return this.getObject(PENSIEVE, overlayConfigId, {}, log, next);
+            },
+        ], (err, res) => {
+            if (err) {
+                log.error('error getting configuration overlay', {
+                    method: '_getIsTransient',
+                    error: err,
+                });
+                return cb(err);
+            }
+            const locConstraint = bucketInfo.getLocationConstraint();
+            const isTransient =
+                Boolean(res.locations[locConstraint].isTransient);
+
+            return cb(null, isTransient);
+        });
     }
 
     _getLocName(loc) {
@@ -1367,14 +1515,8 @@ class MongoClientInterface {
         });
     }
 
-    getObjectMDStats(bucketName, bucketInfo, log, callback) {
+    getObjectMDStats(bucketName, bucketInfo, isTransient, log, callback) {
         const c = this.getCollection(bucketName);
-        let isTransient;
-        if (this.config) {
-            isTransient = this.config
-                .getLocationConstraint(bucketInfo.getLocationConstraint())
-                .isTransient;
-        }
         const mstFilter = {
             '_id': { $regex: /^[^\0]+$/ },
             'value.versionId': { $exists: true },


### PR DESCRIPTION
Count items scan, called by cloudserver reportHandler,
returns metrics by aggregate counts of mongo objects
and buckets. The scan is triggered each hour, but
holds the request hostage.

The change here is to separate the aggregate scan
from the countItems call made by reportHandler.
The scan will instead be called by a kubernetes
cronjob. Results of the scan will be saved in infostore.

Bucket info and bucket count will be collected every time
still and this should not take too long.