### PR TITLE
ZENKO-1930 don't call batchDelete inconditionnally

### DIFF
--- a/lib/storage/data/DataWrapper.js
+++ b/lib/storage/data/DataWrapper.js
@@ -188,6 +188,9 @@ class DataWrapper {
             if (typeof l === 'string') {
                 return false;
             }
+            if (!('batchDelete' in this.client)) {
+                return false;
+            }
             const { dataStoreName, key } = l;
             backendName = dataStoreName;
             const type = this.config.getLocationConstraintType(dataStoreName);
@@ -198,7 +201,7 @@ class DataWrapper {
             }
             return false;
         });
-        if (shouldBatchDelete) {
+        if (shouldBatchDelete && keys.length > 1) {
             return this.client.batchDelete(backendName, { keys }, log, cb);
         }
         return async.eachLimit(locations, 5, (loc, next) => {


### PR DESCRIPTION
If backend does not expose API, don't call batchDelete

Also add a minimum of 2 keys to delete at once for the batch delete to
qualify.