### PR TITLE
bugfix: S3C-2335 Data Server closeSync

### DIFF
--- a/lib/storage/data/file/DataFileStore.js
+++ b/lib/storage/data/file/DataFileStore.js
@@ -153,7 +153,16 @@ class DataFileStore {
                     return ok();
                 }
                 fs.fsync(fd, err => {
-                    fs.close(fd);
+                    fs.close(fd, err => {
+                        if (err) {
+                            log.error('error closing fd after write',
+                                {
+                                    errorMsg: err.message,
+                                    errStack: err.stack,
+                                    key,
+                                });
+                        }
+                    });
                     if (err) {
                         log.error('fsync error',
                             { method: 'put', key, filePath,


### PR DESCRIPTION
**What will this PR do?**
fs.close requires a callback. This was probably not caught in node 8. In node 10 this is an error, so changed to closeSync

**What issue does this PR fix**
[S3C-2335](https://scality.atlassian.net/browse/S3C-2335)