### PR TITLE
ft: add awsClient meta-mdonly put

### DIFF
--- a/lib/storage/data/external/AwsClient.js
+++ b/lib/storage/data/external/AwsClient.js
@@ -111,6 +111,18 @@ class AwsClient {
         if (keyContext.isDeleteMarker) {
             return this._client.deleteObject(params, putCb);
         }
+        if (keyContext.metaHeaders['x-amz-meta-mdonly'] === 'true') {
+            const b64 = keyContext.metaHeaders['x-amz-meta-md5chksum'];
+            let md5 = null;
+            if (b64) {
+                md5 = new Buffer(b64, 'base64').toString('hex');
+            }
+            return callback(null, awsKey,
+                keyContext.metaHeaders['x-amz-version-id'],
+                keyContext.metaHeaders['x-amz-meta-size'],
+                md5
+            );
+        }
         const uploadParams = params;
         uploadParams.Metadata = metaHeaders;
         uploadParams.ContentLength = size;


### PR DESCRIPTION
Allow puts with the header `x-amz-meta-mdonly` to bypass an actual AwsClient put resulting in a purely metadata operation.