### PR TITLE
ft: deprecate client mdonly check

### DIFF
--- a/lib/storage/data/external/PfsClient.js
+++ b/lib/storage/data/external/PfsClient.js
@@ -36,8 +36,7 @@ class PfsClient {
 
     put(stream, size, keyContext, reqUids, callback) {
         const log = createLogger(reqUids);
-        if (keyContext.metaHeaders['x-amz-meta-mdonly'] === 'true'
-                || keyContext.isDeleteMarker === true) {
+        if (keyContext.isDeleteMarker === true) {
             const b64 = keyContext.metaHeaders['x-amz-meta-md5chksum'];
             let md5 = null;
             if (b64) {


### PR DESCRIPTION
Deprecates the `x-amz-meta-mdonly` header check in the client since this is now handled by a higher order function here:
https://github.com/scality/cloudserver/pull/2025