### PR TITLE
improvement: increase the limit of num. of allowed tags

### DIFF
--- a/lib/s3middleware/tagging.js
+++ b/lib/s3middleware/tagging.js
@@ -9,8 +9,8 @@ const errorInvalidArgument = errors.InvalidArgument
   .customizeDescription('The header \'x-amz-tagging\' shall be ' +
   'encoded as UTF-8 then URLEncoded URL query parameters without ' +
   'tag name duplicates.');
-const errorBadRequestLimit10 = errors.BadRequest
-  .customizeDescription('Object tags cannot be greater than 10');
+const errorBadRequestLimit50 = errors.BadRequest
+  .customizeDescription('Object tags cannot be greater than 50');
 
 /*
     Format of xml request:
@@ -73,9 +73,9 @@ function _validateTags(tags) {
     if (tags.length === 0) {
         return tagsResult;
     }
-    // Maximum number of tags per resource: 10
-    if (tags.length > 10) {
-        return errorBadRequestLimit10;
+    // Maximum number of tags per resource: 50
+    if (tags.length > 50) {
+        return errorBadRequestLimit50;
     }
     for (let i = 0; i < tags.length; i++) {
         const tag = tags[i];
@@ -212,8 +212,8 @@ function parseTagFromQuery(tagQuery) {
     if (pairs.length - emptyTag > Object.keys(tagsResult).length) {
         return errorInvalidArgument;
     }
-    if (Object.keys(tagsResult).length > 10) {
-        return errorBadRequestLimit10;
+    if (Object.keys(tagsResult).length > 50) {
+        return errorBadRequestLimit50;
     }
     return tagsResult;
 }


### PR DESCRIPTION
This increases the limit of number of allowed tags on an object
from 10 to 50. This is to be inline and retain compatibility with
AWS S3.