### PR TITLE
bf: deserialize dots and dollars from oplog

### DIFF
--- a/lib/storage/metadata/mongoclient/ListRecordStream.js
+++ b/lib/storage/metadata/mongoclient/ListRecordStream.js
@@ -64,6 +64,12 @@ class ListRecordStream extends stream.Readable {
         // always update to most recent uniqID
         this._lastConsumedID = itemObj.h.toString();
 
+        const decode = tags => (
+            JSON.parse(JSON.stringify(tags).
+                       replace(/\uFF0E/g, '.').
+                       replace(/\uFF04/g, '$'))
+        );
+
         // only push to stream unpublished objects
         if (!this._lastSavedID) {
             // process from the first entry
@@ -91,14 +97,22 @@ class ListRecordStream extends stream.Readable {
         let entry;
         if (itemObj.op === 'i' &&
             itemObj.o && itemObj.o._id) {
+            const value = itemObj.o.value;
+            if (value.tags) {
+                value.tags = decode(value.tags);
+            }
             entry = {
                 type: 'put',
                 key: itemObj.o._id,
                 // value is given as-is for inserts
-                value: JSON.stringify(itemObj.o.value),
+                value: JSON.stringify(value),
             };
         } else if (itemObj.op === 'u' &&
                    itemObj.o && itemObj.o2 && itemObj.o2._id) {
+            const value = (itemObj.o.$set ? itemObj.o.$set : itemObj.o).value;
+            if (value.tags) {
+                value.tags = decode(value.tags);
+            }
             entry = {
                 type: 'put', // updates overwrite the whole metadata,
                              // so they are considered as puts
@@ -106,8 +120,7 @@ class ListRecordStream extends stream.Readable {
                 // updated value may be either stored directly in 'o'
                 // attribute or in '$set' attribute (supposedly when
                 // the object pre-exists it will be in '$set')
-                value: JSON.stringify(
-                    (itemObj.o.$set ? itemObj.o.$set : itemObj.o).value),
+                value: JSON.stringify(value),
             };
         } else if (itemObj.op === 'd' &&
                    itemObj.o && itemObj.o._id) {


### PR DESCRIPTION
To allow dots and dollars in tags we serialize them into a unicode
version. We need to properly deserialize them when reading the oplog.

This is a far-from-ideal way of serializing those special characters in MongoDB, especially another way of serializing the tags to strings has been discussed in ZENKO-1928 but we need to be backward compatible with existing deployments.