### PR TITLE
improvement: filters out special collections

### DIFF
--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -1115,6 +1115,19 @@ class MongoClientInterface {
     }
 
     /*
+     * return true if it a special collection and therefore
+     * does not need to be collected for infos
+     */
+    _isSpecialCollection(name) {
+        return name === METASTORE ||
+            name === INFOSTORE ||
+            name === USERSBUCKET ||
+            name === PENSIEVE ||
+            name.startsWith(constants.mpuBucketPrefix) ||
+            name.startsWith('__');
+    }
+
+    /*
      * get bucket related information for count items, used by cloudserver
      * and s3utils
      */
@@ -1131,12 +1144,7 @@ class MongoClientInterface {
                 return cb(err);
             }
             return async.eachLimit(collInfos, 10, (value, next) => {
-                if (value.name === METASTORE ||
-                    value.name === INFOSTORE ||
-                    value.name === USERSBUCKET ||
-                    value.name === PENSIEVE ||
-                    value.name.startsWith(constants.mpuBucketPrefix)
-                ) {
+                if (this.isSpecialCollection(value.name)) {
                     // skip
                     return next();
                 }

--- a/tests/unit/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/tests/unit/storage/metadata/mongoclient/MongoClientInterface.js
@@ -236,3 +236,17 @@ describe('MongoClientInterface::_handleMongo', () => {
         });
     });
 });
+
+describe('MongoClientInterface, misc', () => {
+    let s3ConfigObj;
+
+    beforeEach(() => {
+        s3ConfigObj = new DummyConfigObject();
+    });
+
+    it('should filter out collections with special names', () => {
+        const mongoClient = new MongoClientInterface({ config: s3ConfigObj });
+        assert.equal(mongoClient._isSpecialCollection('__foo'), true);
+        assert.equal(mongoClient._isSpecialCollection('bar'), false);
+    });
+});


### PR DESCRIPTION
Exclude collections starting with __
Nevertheless keeping explicit naming on collections
that are used directly by cloudserver even though they start with __
for sake of clarity