### PR TITLE
Revert "bugfix: S3C-2052 Add error functions"

### DIFF
--- a/lib/storage/metadata/in_memory/metastore.js
+++ b/lib/storage/metadata/in_memory/metastore.js
@@ -26,18 +26,7 @@ function inc(str) {
 }
 
 const metastore = {
-    // Used for simulation of metadata errors.
-    error: () => {},
-
-    setErrorFunc(func) {
-        this.error = func;
-        return this;
-    },
-
-    clearErrorFunc() {
-        this.error = () => {};
-        return this;
-    },
+    errors: {}, // Used for simulation of metadata errors.
 
     createBucket: (bucketName, bucketMD, log, cb) => {
         process.nextTick(() => {
@@ -94,9 +83,8 @@ const metastore = {
     },
 
     putObject: (bucketName, objName, objVal, params, log, cb) => {
-        const err = metastore.error(metastore.putObject.name);
-        if (err) {
-            return process.nextTick(() => cb(err));
+        if (metastore.errors.putObject) {
+            return process.nextTick(() => cb(metastore.errors.putObject));
         }
         return process.nextTick(() => {
             metastore.getBucketAttributes(bucketName, log, err => {
@@ -169,11 +157,7 @@ const metastore = {
     },
 
     getObject: (bucketName, objName, params, log, cb) => {
-        const err = metastore.error(metastore.getObject.name, objName);
-        if (err) {
-            return process.nextTick(() => cb(err));
-        }
-        return process.nextTick(() => {
+        process.nextTick(() => {
             metastore.getBucketAttributes(bucketName, log, err => {
                 if (err) {
                     return cb(err);


### PR DESCRIPTION
This reverts commit 9d02f86cf58b7d37cc7c75604e2112f5571b1950.

In the course of testing a metadata orphan persisted when the data had been cleaned up after an error was returned by metadata (the operation later succeeded despite returning an error). We are reverting this change in anticipation of the 8.0 release as a data orphan would be preferable to a metadata orphan.