### PR TITLE
Revert "bugfix: S3C-2052 Delete orphaned data"

### DIFF
--- a/lib/storage/data/in_memory/datastore.js
+++ b/lib/storage/data/in_memory/datastore.js
@@ -19,8 +19,6 @@ function resetCount() {
 }
 
 const backend = {
-    errors: {}, // Used for simulation of data errors.
-
     toObjectGetInfo: function toObjectGetInfo(objectKey) {
         return { key: objectKey };
     },
@@ -85,11 +83,8 @@ const backend = {
     },
 
     delete: function delMem(objectGetInfo, reqUids, callback) {
-        if (backend.errors.delete) {
-            return process.nextTick(() => callback(backend.errors.delete));
-        }
         const key = objectGetInfo.key ? objectGetInfo.key : objectGetInfo;
-        return process.nextTick(() => {
+        process.nextTick(() => {
             delete ds[key];
             return callback(null);
         });

--- a/lib/storage/metadata/in_memory/metastore.js
+++ b/lib/storage/metadata/in_memory/metastore.js
@@ -26,8 +26,6 @@ function inc(str) {
 }
 
 const metastore = {
-    errors: {}, // Used for simulation of metadata errors.
-
     createBucket: (bucketName, bucketMD, log, cb) => {
         process.nextTick(() => {
             metastore.getBucketAttributes(bucketName, log, (err, bucket) => {
@@ -83,10 +81,7 @@ const metastore = {
     },
 
     putObject: (bucketName, objName, objVal, params, log, cb) => {
-        if (metastore.errors.putObject) {
-            return process.nextTick(() => cb(metastore.errors.putObject));
-        }
-        return process.nextTick(() => {
+        process.nextTick(() => {
             metastore.getBucketAttributes(bucketName, log, err => {
                 if (err) {
                     return cb(err);


### PR DESCRIPTION
This reverts commit 5de85713ef0db0b36f5243728646b72103d8377a.

In the course of testing a metadata orphan persisted when the data had been cleaned up after an error was returned by metadata (the operation later succeeded despite returning an error). We are reverting this change in anticipation of the 8.0 release as a data orphan would be preferable to a metadata orphan.