### PR TITLE
bf: S3C 2435 fix object action parse

### DIFF
--- a/lib/models/BucketPolicy.js
+++ b/lib/models/BucketPolicy.js
@@ -36,6 +36,19 @@ const { validateResourcePolicy } = require('../policy/policyValidator');
  *  }
  */
 
+const objectActions = [
+    's3:AbortMultipartUpload',
+    's3:DeleteObject',
+    's3:DeleteObjectTagging',
+    's3:GetObject',
+    's3:GetObjectAcl',
+    's3:GetObjectTagging',
+    's3:ListMultipartUploadParts',
+    's3:PutObject',
+    's3:PutObjectAcl',
+    's3:PutObjectTagging',
+];
+
 class BucketPolicy {
     /**
      * Create a Bucket Policy instance
@@ -96,7 +109,8 @@ class BucketPolicy {
                 [s.Action] : s.Action;
             const resources = typeof s.Resource === 'string' ?
                 [s.Resource] : s.Resource;
-            const objectAction = actions.some(a => a.includes('Object'));
+            const objectAction = actions.some(a =>
+                a.includes('Object') || objectActions.includes(a));
             // wildcardObjectAction checks for actions such as 's3:*' or
             // 's3:Put*' but will return false for actions such as
             // 's3:PutBucket*'

--- a/tests/unit/models/BucketPolicy.js
+++ b/tests/unit/models/BucketPolicy.js
@@ -49,6 +49,15 @@ describe('BucketPolicy class getBucketPolicy', () => {
     });
 
     it('should return MalformedPolicy error if request action is for objects ' +
+    'but does\'t include \'Object\' and resource refers to bucket', done => {
+        const newPolicy = createPolicy('Action', 's3:AbortMultipartUpload');
+        const bucketPolicy = new BucketPolicy(JSON.stringify(newPolicy))
+            .getBucketPolicy();
+        checkErr(bucketPolicy, 'MalformedPolicy', mismatchErr);
+        done();
+    });
+
+    it('should return MalformedPolicy error if request action is for objects ' +
     '(with wildcard) but resource refers to bucket', done => {
         const newPolicy = createPolicy('Action', 's3:GetObject*');
         const bucketPolicy = new BucketPolicy(JSON.stringify(newPolicy))


### PR DESCRIPTION
Small error in parsing actions for bucket policies, didn't account for a couple of object actions that don't include the word 'Object'