### PR TITLE
bf: S3C-2440 fix get bucket policy xml error

### DIFF
--- a/lib/s3routes/routes/routeGET.js
+++ b/lib/s3routes/routes/routeGET.js
@@ -73,9 +73,9 @@ function routerGET(request, response, api, log, statsClient, dataRetrievalFn) {
                 });
         } else if (request.query.policy !== undefined) {
             api.callApiMethod('bucketGetPolicy', request, response, log,
-                (err, json, corsHeaders) => {
+                (err, xml, corsHeaders) => {
                     routesUtils.statsReport500(err, statsClient);
-                    return routesUtils.responseJSONBody(err, json, response,
+                    return routesUtils.responseXMLBody(err, xml, response,
                         log, corsHeaders);
                 });
         } else {


### PR DESCRIPTION
When an error is the expected return for bucketGetPolicy API, an XMLParserError is returned instead of expected err