### PR TITLE
bugfix: prevent stack err for !metaHeaders

### DIFF
--- a/lib/storage/data/external/utils.js
+++ b/lib/storage/data/external/utils.js
@@ -160,10 +160,12 @@ const utils = {
             });
             translatedMetaHeaders.tags = JSON.stringify(tagObj);
         }
-        Object.keys(metaHeaders).forEach(headerName => {
-            const translated = headerName.substring(11).replace(/-/g, '_');
-            translatedMetaHeaders[translated] = metaHeaders[headerName];
-        });
+        if (metaHeaders) {
+            Object.keys(metaHeaders).forEach(headerName => {
+                const translated = headerName.substring(11).replace(/-/g, '_');
+                translatedMetaHeaders[translated] = metaHeaders[headerName];
+            });
+        }
         return translatedMetaHeaders;
     },
     /**


### PR DESCRIPTION
prevent error being thrown if `metaHeaders` isn't present.