### PR TITLE
INTEGRATION [PR#899 > development/7.6] bugfix: S3C-1805 Support consecutive hyphens in bucket names

### DIFF
--- a/lib/s3routes/routesUtils.js
+++ b/lib/s3routes/routesUtils.js
@@ -884,7 +884,7 @@ const routesUtils = {
         }
         const ipAddressRegex = new RegExp(/^(\d+\.){3}\d+$/);
         // eslint-disable-next-line no-useless-escape
-        const dnsRegex = new RegExp(/^[a-z0-9]+([\.\-]{1}[a-z0-9]+)*$/);
+        const dnsRegex = new RegExp(/^[a-z0-9]+((\.|\-+)[a-z0-9]+)*$/);
         // Must be at least 3 and no more than 63 characters long.
         if (bucketname.length < 3 || bucketname.length > 63) {
             return false;

--- a/tests/unit/s3routes/routesUtils/isValidBucketName.js
+++ b/tests/unit/s3routes/routesUtils/isValidBucketName.js
@@ -3,6 +3,28 @@ const routesUtils = require('../../../../lib/s3routes/routesUtils.js');
 
 const bannedStr = 'banned';
 const prefixBlacklist = [];
+const validBucketNamesWithDotsAndHyphens = [
+    'my-bucket',
+    'my.bucket',
+    'my-bucket-01',
+    '01-my-bucket',
+    'my.bucket.01',
+    '01.my.bucket',
+    'my.bucket-01',
+    'my-bucket.01',
+    'my--bucket--01',
+    'my--bucket.01',
+    'my.bucket--01',
+];
+const invalidBucketNamesWithDotsAndHyphens = [
+    '-my-bucket',
+    '.my.bucket',
+    'my-bucket-',
+    'my.bucket.',
+    'my..bucket',
+    'my-.bucket',
+    'my.-bucket',
+];
 
 describe('routesUtils.isValidBucketName', () => {
     it('should return false if bucketname is fewer than ' +
@@ -55,5 +77,31 @@ describe('routesUtils.isValidBucketName', () => {
     it('should return true if bucketname does not break rules', () => {
         const result = routesUtils.isValidBucketName('okay', prefixBlacklist);
         assert.strictEqual(result, true);
+    });
+
+    describe('should return true when bucket name has valid' +
+        ' combination of dots and hyphens', () => {
+        validBucketNamesWithDotsAndHyphens.forEach(bucketName => {
+            it(`should return true if bucketname is '${bucketName}'`,
+                () => {
+                    const result =
+                        routesUtils.isValidBucketName(bucketName,
+                            prefixBlacklist);
+                    assert.strictEqual(result, true);
+                });
+        });
+    });
+
+    describe('should return false when bucket name has invalid' +
+        ' combination of dots and hyphens', () => {
+        invalidBucketNamesWithDotsAndHyphens.forEach(bucketName => {
+            it(`should return false if bucketname is '${bucketName}'`,
+                () => {
+                    const result =
+                        routesUtils.isValidBucketName(bucketName,
+                            prefixBlacklist);
+                    assert.strictEqual(result, false);
+                });
+        });
     });
 });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #899.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.6/bugfix/S3C-1805/bucket_name_with_consecutive_hyphens`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.6/bugfix/S3C-1805/bucket_name_with_consecutive_hyphens
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.6/bugfix/S3C-1805/bucket_name_with_consecutive_hyphens
```

Please always comment pull request #899 instead of this one.