### PR TITLE
bugfix: S3C-2269 ArnMatch validation correction

### DIFF
--- a/lib/policyEvaluator/utils/checkArnMatch.js
+++ b/lib/policyEvaluator/utils/checkArnMatch.js
@@ -25,7 +25,8 @@ function checkArnMatch(policyArn, requestRelativeId, requestArnArr,
     // Check to see if the relative-id matches first since most likely
     // to diverge.  If not a match, the resource is not applicable so return
     // false
-    if (!policyRelativeIdRegEx.test(requestRelativeId)) {
+    if (!policyRelativeIdRegEx.test(caseSensitive ?
+        requestRelativeId : requestRelativeId.toLowerCase())) {
         return false;
     }
     // Check the other parts of the ARN to make sure they match.  If not,

--- a/tests/unit/policyEvaluator/utils/test_checkArnMatch.js
+++ b/tests/unit/policyEvaluator/utils/test_checkArnMatch.js
@@ -1,0 +1,94 @@
+const assert = require('assert');
+const checkArnMatch
+    = require('../../../../lib/policyEvaluator/utils/checkArnMatch');
+
+const tests = [
+    {
+        policyArn: 'arn:aws:iam::*:policy/1236-Ng',
+        requestArn: 'arn:aws:iam::005978442556:policy/1236-Ng',
+        caseSensitive: true,
+        isMatch: true,
+    },
+    {
+        policyArn: 'arn:aws:iam::*:policy/1236-Ng',
+        requestArn: 'arn:aws:iam::005978442556:policy/1236-Ng',
+        caseSensitive: false,
+        isMatch: true,
+    },
+    {
+        policyArn: 'arn:aws:iam::*:policy/1236-Ng',
+        requestArn: 'arn:aws:iam::005978442556:policy/1236-ng',
+        caseSensitive: true,
+        isMatch: false,
+    },
+    {
+        policyArn: 'arn:aws:iam::*:policy/1236-Ng',
+        requestArn: 'arn:aws:iam::005978442556:policy/1236-ng',
+        caseSensitive: false,
+        isMatch: true,
+    },
+    {
+        policyArn: 'arn:aws:iam::005978442556:policy/1236-Ng',
+        requestArn: 'arn:aws:iam::005978442556:policy/1236-Ng',
+        caseSensitive: true,
+        isMatch: true,
+    },
+    {
+        policyArn: 'arn:aws:iam::005978442556:policy/1236-Ng',
+        requestArn: 'arn:aws:iam::005978442556:policy/1236-Ng',
+        caseSensitive: false,
+        isMatch: true,
+    },
+    {
+        policyArn: 'arn:aws:iam::005978442556:policy/1236-Ng',
+        requestArn: 'arn:aws:iam::005978442556:policy/1236-ng',
+        caseSensitive: true,
+        isMatch: false,
+    },
+    {
+        policyArn: 'arn:aws:iam::005978442556:policy/1236-Ng',
+        requestArn: 'arn:aws:iam::005978442556:policy/1236-ng',
+        caseSensitive: false,
+        isMatch: true,
+    },
+    {
+        policyArn: 'arn:aws:iam::005978442556:policy/1236-Ng',
+        requestArn: 'arn:aws:iam::005978442557:policy/1236-Ng',
+        caseSensitive: true,
+        isMatch: false,
+    },
+    {
+        policyArn: 'arn:aws:iam::005978442556:policy/1236-Ng',
+        requestArn: 'arn:aws:iam::005978442557:policy/1236-Ng',
+        caseSensitive: false,
+        isMatch: false,
+    },
+    {
+        policyArn: 'arn:aws:iam::005978442556:policy/1236-Ng',
+        requestArn: 'arn:aws:iam::005978442557:policy/1236-ng',
+        caseSensitive: true,
+        isMatch: false,
+    },
+    {
+        policyArn: 'arn:aws:iam::005978442556:policy/1236-Ng',
+        requestArn: 'arn:aws:iam::005978442557:policy/1236-ng',
+        caseSensitive: false,
+        isMatch: false,
+    },
+];
+
+describe('policyEvaluator checkArnMatch utility function', () => {
+    tests.forEach(test => {
+        it(`Check '${test.requestArn}' against '${test.policyArn}' with case ` +
+            `sensitive check ${test.caseSensitive ? 'enabled' : 'disabled'} ` +
+            `and it should ${test.isMatch ? 'be' : 'not be'} a match`, () => {
+            const requestArn = test.requestArn;
+            const requestResourceArr = requestArn.split(':');
+            const requestRelativeId = requestResourceArr.slice(5).join(':');
+            const caseSensitive = test.caseSensitive;
+            const result = checkArnMatch(test.policyArn, requestRelativeId,
+                requestResourceArr, caseSensitive);
+            assert.deepStrictEqual(result, test.isMatch);
+        });
+    });
+});


### PR DESCRIPTION
#### Why is this change required? What problem does it solve?
Policy arn compare utility fails to match if case sensitive check is disabled. This is corrected now. New tests are added to check the corrected utility.