### PR TITLE
bugfix: use default auth DB in mongo log reader

### DIFF
--- a/lib/storage/metadata/mongoclient/LogConsumer.js
+++ b/lib/storage/metadata/mongoclient/LogConsumer.js
@@ -19,7 +19,7 @@ class LogConsumer {
     constructor(mongoConfig, logger) {
         const { authCredentials, replicaSetHosts, database } = mongoConfig;
         const cred = MongoUtils.credPrefix(authCredentials);
-        this._mongoUrl = `mongodb://${cred}${replicaSetHosts}/local`;
+        this._mongoUrl = `mongodb://${cred}${replicaSetHosts}/`;
         this._logger = logger;
         this._oplogNsRegExp = new RegExp(`^${database}\\.`);
         // oplog collection


### PR DESCRIPTION
The mongodb log reader included `/local` in its connection string. The path element in mongodb's connection URI is actually the DB authenticate against, not the DB to work on. This lead to authentication failures even though roles, users, passwords etc were correct.