### PR TITLE
bf: removing dead code

### DIFF
--- a/lib/storage/data/external/PfsClient.js
+++ b/lib/storage/data/external/PfsClient.js
@@ -36,18 +36,6 @@ class PfsClient {
 
     put(stream, size, keyContext, reqUids, callback) {
         const log = createLogger(reqUids);
-        if (keyContext.metaHeaders['x-amz-meta-mdonly'] === 'true'
-                || keyContext.isDeleteMarker === true) {
-            const b64 = keyContext.metaHeaders['x-amz-meta-md5chksum'];
-            let md5 = null;
-            if (b64) {
-                md5 = new Buffer(b64, 'base64').toString('hex');
-            }
-            return callback(null, keyContext.objectKey, '',
-                keyContext.metaHeaders['x-amz-meta-size'],
-                md5
-            );
-        }
         logHelper(log, 'error', 'Not implemented', errors.NotImplemented,
             this._dataStoreName, this.clientType);
         return callback(errors.NotImplemented);


### PR DESCRIPTION
The special header handling for metadata only operation
is done in clouserver:lib/api/apiUtils/object/createAndStoreObject.js
This code is actually never reached therefore we remove it.