### PR TITLE
feature: Abstract out locations from item count

### DIFF
--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -81,14 +81,16 @@ function generatePHDVersion(versionId) {
  * // Does backbeat use this at all? Can we make this optional and
  * // set a default so when instantiate the client elsewhere don't need?
  * @param {String} params.database - name of database
+ * @param {function} params.isLocationTransient - optional function
+ *   to get the transient attribute of a location by name
  * @param {werelogs.Logger} params.logger - logger instance
  * @param {String} [params.path] - path for mongo volume
  */
 class MongoClientInterface {
     constructor(params) {
         const { replicaSetHosts, writeConcern, replicaSet, readPreference, path,
-        database, logger, replicationGroupId, authCredentials, config }
-        = params;
+            database, logger, replicationGroupId, authCredentials, config,
+            isLocationTransient } = params;
         const cred = MongoUtils.credPrefix(authCredentials);
         this.mongoUrl = `mongodb://${cred}${replicaSetHosts}/` +
             `?w=${writeConcern}&replicaSet=${replicaSet}` +
@@ -100,6 +102,8 @@ class MongoClientInterface {
         this.replicationGroupId = replicationGroupId;
         this.database = database;
         this.dataCount = new DataCounter();
+        this.isLocationTransient = isLocationTransient;
+
         if (config && config instanceof EventEmitter) {
             this.config = config;
             this.config.on('location-constraints-update', () => {
@@ -1305,6 +1309,17 @@ class MongoClientInterface {
     }
 
     _getIsTransient(bucketInfo, log, cb) {
+        const locConstraint = bucketInfo.getLocationConstraint();
+
+        if (this.isLocationTransient) {
+            this.isLocationTransient(locConstraint, log, cb);
+            return;
+        }
+
+        this._pensieveLocationIsTransient(locConstraint, log, cb);
+    }
+
+    _pensieveLocationIsTransient(locConstraint, log, cb) {
         const overlayVersionId = 'configuration/overlay-version';
 
         async.waterfall([
@@ -1321,7 +1336,6 @@ class MongoClientInterface {
                 });
                 return cb(err);
             }
-            const locConstraint = bucketInfo.getLocationConstraint();
             const isTransient =
                 Boolean(res.locations[locConstraint].isTransient);
 


### PR DESCRIPTION
The item count scan should not really be aware of how specifically
locations are stored and configured, this allows for flexibility.