### PR TITLE
bf: S3C-2502 move ip util to arsenal

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ module.exports = {
             .validateUserPolicy,
         evaluatePrincipal: require('./lib/policyEvaluator/principal'),
         RequestContext: require('./lib/policyEvaluator/RequestContext.js'),
+        requestUtils: require('./lib/policyEvaluator/requestUtils'),
     },
     Clustering: require('./lib/Clustering'),
     testing: {

--- a/lib/policyEvaluator/requestUtils.js
+++ b/lib/policyEvaluator/requestUtils.js
@@ -1,0 +1,34 @@
+const ipCheck = require('../ipCheck');
+
+/**
+ * getClientIp - Gets the client IP from the request
+ * @param {object} request - http request object
+ * @param {object} s3config - s3 config
+ * @return {string} - returns client IP from the request
+ */
+function getClientIp(request, s3config) {
+    const clientIp = request.socket.remoteAddress;
+    const requestConfig = s3config ? s3config.requests : {};
+    if (requestConfig && requestConfig.viaProxy) {
+        /**
+         * if requests are configured to come via proxy,
+         * check from config which proxies are to be trusted and
+         * which header to be used to extract client IP
+         */
+        if (ipCheck.ipMatchCidrList(requestConfig.trustedProxyCIDRs,
+            clientIp)) {
+            const ipFromHeader
+            // eslint-disable-next-line operator-linebreak
+                = request.headers[requestConfig.extractClientIPFromHeader];
+            if (ipFromHeader && ipFromHeader.trim().length) {
+                return ipFromHeader.split(',')[0].trim();
+            }
+        }
+    }
+
+    return clientIp;
+}
+
+module.exports = {
+    getClientIp,
+};

--- a/tests/unit/policyEvaluator/requestUtils.js
+++ b/tests/unit/policyEvaluator/requestUtils.js
@@ -1,0 +1,64 @@
+const assert = require('assert');
+const DummyRequest = require('../../utils/DummyRequest');
+const requestUtils = require('../../../lib/policyEvaluator/requestUtils');
+
+describe('requestUtils.getClientIp', () => {
+    // s3 config with 'requests.viaProxy` enabled
+    const configWithProxy
+        = require('../../utils/dummyS3ConfigProxy.json');
+    // s3 config with 'requests.viaProxy` disabled
+    const configWithoutProxy = require('../../utils/dummyS3Config.json');
+    const testClientIp1 = '192.168.100.1';
+    const testClientIp2 = '192.168.104.0';
+    const testProxyIp = '192.168.100.2';
+
+    it('should return client Ip address from header ' +
+        'if the request comes via proxies', () => {
+        const request = new DummyRequest({
+            headers: {
+                'x-forwarded-for': [testClientIp1, testProxyIp].join(','),
+            },
+            url: '/',
+            parsedHost: 'localhost',
+            socket: {
+                remoteAddress: testProxyIp,
+            },
+        });
+        const result = requestUtils.getClientIp(request, configWithProxy);
+        assert.strictEqual(result, testClientIp1);
+    });
+
+    it('should not return client Ip address from header ' +
+        'if the request is not forwarded from proxies or ' +
+        'fails ip check', () => {
+        const request = new DummyRequest({
+            headers: {
+                'x-forwarded-for': [testClientIp1, testProxyIp].join(','),
+            },
+            url: '/',
+            parsedHost: 'localhost',
+            socket: {
+                remoteAddress: testClientIp2,
+            },
+        });
+        const result = requestUtils.getClientIp(request, configWithoutProxy);
+        assert.strictEqual(result, testClientIp2);
+    });
+
+    it('should not return client Ip address from header ' +
+        'if the request is forwarded from proxies, but the request' +
+        'has no expected header or the header value is empty', () => {
+        const request = new DummyRequest({
+            headers: {
+                'x-forwarded-for': ' ',
+            },
+            url: '/',
+            parsedHost: 'localhost',
+            socket: {
+                remoteAddress: testClientIp2,
+            },
+        });
+        const result = requestUtils.getClientIp(request, configWithProxy);
+        assert.strictEqual(result, testClientIp2);
+    });
+});

--- a/tests/utils/dummyS3Config.json
+++ b/tests/utils/dummyS3Config.json
@@ -1,0 +1,81 @@
+{
+    "port": 8000,
+    "listenOn": [],
+    "replicationGroupId": "RG001",
+    "restEndpoints": {
+        "localhost": "us-east-1",
+        "127.0.0.1": "us-east-1",
+        "cloudserver-front": "us-east-1",
+        "s3.docker.test": "us-east-1",
+        "127.0.0.2": "us-east-1",
+        "s3.amazonaws.com": "us-east-1"
+    },
+    "websiteEndpoints": ["s3-website-us-east-1.amazonaws.com",
+                        "s3-website.us-east-2.amazonaws.com",
+                        "s3-website-us-west-1.amazonaws.com",
+                        "s3-website-us-west-2.amazonaws.com",
+                        "s3-website.ap-south-1.amazonaws.com",
+                        "s3-website.ap-northeast-2.amazonaws.com",
+                        "s3-website-ap-southeast-1.amazonaws.com",
+                        "s3-website-ap-southeast-2.amazonaws.com",
+                        "s3-website-ap-northeast-1.amazonaws.com",
+                        "s3-website.eu-central-1.amazonaws.com",
+                        "s3-website-eu-west-1.amazonaws.com",
+                        "s3-website-sa-east-1.amazonaws.com",
+                        "s3-website.localhost",
+                        "s3-website.scality.test"],
+    "replicationEndpoints": [{
+        "site": "zenko",
+        "servers": ["127.0.0.1:8000"],
+        "default": true
+    }, {
+        "site": "us-east-2",
+        "type": "aws_s3"
+    }],
+    "cdmi": {
+        "host": "localhost",
+        "port": 81,
+        "path": "/dewpoint",
+        "readonly": true
+    },
+    "bucketd": {
+        "bootstrap": ["localhost:9000"]
+    },
+    "vaultd": {
+        "host": "localhost",
+        "port": 8500
+    },
+    "clusters": 10,
+    "log": {
+        "logLevel": "info",
+        "dumpLevel": "error"
+    },
+    "healthChecks": {
+        "allowFrom": ["127.0.0.1/8", "::1"]
+    },
+    "metadataClient": {
+        "host": "localhost",
+        "port": 9990
+    },
+    "dataClient": {
+        "host": "localhost",
+        "port": 9991
+    },
+    "metadataDaemon": {
+        "bindAddress": "localhost",
+        "port": 9990
+    },
+    "dataDaemon": {
+        "bindAddress": "localhost",
+        "port": 9991
+    },
+    "recordLog": {
+        "enabled": false,
+        "recordLogName": "s3-recordlog"
+    },
+    "mongodb": {
+	"host": "localhost",
+	"port": 27018,
+	"database": "metadata"
+    }
+}

--- a/tests/utils/dummyS3ConfigProxy.json
+++ b/tests/utils/dummyS3ConfigProxy.json
@@ -1,0 +1,86 @@
+{
+    "port": 8000,
+    "listenOn": [],
+    "replicationGroupId": "RG001",
+    "restEndpoints": {
+        "localhost": "us-east-1",
+        "127.0.0.1": "us-east-1",
+        "cloudserver-front": "us-east-1",
+        "s3.docker.test": "us-east-1",
+        "127.0.0.2": "us-east-1",
+        "s3.amazonaws.com": "us-east-1"
+    },
+    "websiteEndpoints": ["s3-website-us-east-1.amazonaws.com",
+                        "s3-website.us-east-2.amazonaws.com",
+                        "s3-website-us-west-1.amazonaws.com",
+                        "s3-website-us-west-2.amazonaws.com",
+                        "s3-website.ap-south-1.amazonaws.com",
+                        "s3-website.ap-northeast-2.amazonaws.com",
+                        "s3-website-ap-southeast-1.amazonaws.com",
+                        "s3-website-ap-southeast-2.amazonaws.com",
+                        "s3-website-ap-northeast-1.amazonaws.com",
+                        "s3-website.eu-central-1.amazonaws.com",
+                        "s3-website-eu-west-1.amazonaws.com",
+                        "s3-website-sa-east-1.amazonaws.com",
+                        "s3-website.localhost",
+                        "s3-website.scality.test"],
+    "replicationEndpoints": [{
+        "site": "zenko",
+        "servers": ["127.0.0.1:8000"],
+        "default": true
+    }, {
+        "site": "us-east-2",
+        "type": "aws_s3"
+    }],
+    "cdmi": {
+        "host": "localhost",
+        "port": 81,
+        "path": "/dewpoint",
+        "readonly": true
+    },
+    "bucketd": {
+        "bootstrap": ["localhost:9000"]
+    },
+    "vaultd": {
+        "host": "localhost",
+        "port": 8500
+    },
+    "clusters": 10,
+    "log": {
+        "logLevel": "info",
+        "dumpLevel": "error"
+    },
+    "healthChecks": {
+        "allowFrom": ["127.0.0.1/8", "::1"]
+    },
+    "metadataClient": {
+        "host": "localhost",
+        "port": 9990
+    },
+    "dataClient": {
+        "host": "localhost",
+        "port": 9991
+    },
+    "metadataDaemon": {
+        "bindAddress": "localhost",
+        "port": 9990
+    },
+    "dataDaemon": {
+        "bindAddress": "localhost",
+        "port": 9991
+    },
+    "recordLog": {
+        "enabled": false,
+        "recordLogName": "s3-recordlog"
+    },
+    "mongodb": {
+	"host": "localhost",
+	"port": 27018,
+	"database": "metadata"
+    },
+    "requests": {
+        "viaProxy": true,
+        "trustedProxyCIDRs": ["192.168.100.0/22"],
+        "extractClientIPFromHeader": "x-forwarded-for"
+    }
+}


### PR DESCRIPTION
Move the `getClientIp` utility from https://github.com/scality/cloudserver/pull/2201 to Arsenal so it can be used by Vault