### PR TITLE
improvement: perform get bucket and object at once

### DIFF
--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -250,25 +250,62 @@ class MongoClientInterface {
     }
 
     getBucketAndObject(bucketName, objName, params, log, cb) {
-        this.getBucketAttributes(bucketName, log, (err, bucket) => {
+        if (params && params.versionId) {
+            // eslint-disable-next-line
+            objName = formatVersionKey(objName, params.versionId);
+        }
+        const m = this.getCollection(METASTORE);
+        m.aggregate([
+            { $match: { _id: bucketName } },
+            {
+                $lookup: {
+                    from: bucketName,
+                    pipeline: [
+                        { $match: { _id: objName } },
+                    ],
+                    as: 'object',
+                },
+            },
+        ], {}, (err, cursor) => {
             if (err) {
                 log.error(
                     'getBucketAttributes: error getting bucket attributes',
                     { error: err.message });
-                return cb(err);
+                return cb(errors.InternalError);
             }
-            this.getObject(bucketName, objName, params, log, (err, obj) => {
-                if (err) {
-                    if (err === errors.NoSuchKey) {
-                        return cb(null,
-                                  { bucket:
-                                    BucketInfo.fromObj(bucket).serialize(),
-                                  });
-                    }
-                    log.error('getObject: error getting object',
-                    { error: err.message });
-                    return cb(err);
+            if (!cursor) {
+                return cb(errors.NoSuchBucket);
+            }
+            cursor.on('data', doc => {
+                // FIXME: there should be a version of BucketInfo.deserialize()
+                // that properly inits w/o JSON.parse()
+                const bucketMDStr = JSON.stringify(doc.value);
+                const bucket = BucketInfo.deSerialize(bucketMDStr);
+
+                if (doc.object.length === 0) {
+                    return cb(null,
+                              { bucket:
+                                BucketInfo.fromObj(bucket).serialize(),
+                              });
                 }
+                const obj = doc.object[0].value;
+                if (obj.isPHD) {
+                    const c = this.getCollection(bucketName);
+                    this.getLatestVersion(c, objName, log, (err, obj) => {
+                        if (err) {
+                            log.error(
+                                'getLatestVersion: getting latest version',
+                                { error: err.message });
+                            return cb(err);
+                        }
+                        return cb(null, {
+                            bucket: BucketInfo.fromObj(bucket).serialize(),
+                            obj: JSON.stringify(obj),
+                        });
+                    });
+                    return undefined;
+                }
+                MongoUtils.unserialize(obj);
                 return cb(null, {
                     bucket: BucketInfo.fromObj(bucket).serialize(),
                     obj: JSON.stringify(obj),


### PR DESCRIPTION
Instead of doing 2 round trips we perform the 2 queries at once using an
aggregate.

This PR is to check that we pass the end-to-end tests. You can review but we do not want to merge unless we are sure it improves the performance.
