### PR TITLE
bugfix: S3C-2604-handle-de-serialize-specific-resource

### DIFF
--- a/lib/policyEvaluator/RequestContext.js
+++ b/lib/policyEvaluator/RequestContext.js
@@ -148,14 +148,18 @@ class RequestContext {
     /**
      * deSerialize the JSON string
      * @param {string} stringRequest - the stringified requestContext
+     * @param {string} resource - individual specificResource
      * @return {object} - parsed string
      */
-    static deSerialize(stringRequest) {
+    static deSerialize(stringRequest, resource) {
         let obj;
         try {
             obj = JSON.parse(stringRequest);
         } catch (err) {
             return new Error(err);
+        }
+        if (resource) {
+            obj.specificResource = resource;
         }
         return new RequestContext(obj.headers, obj.query, obj.generalResource,
             obj.specificResource, obj.requesterIp, obj.sslEnabled,


### PR DESCRIPTION
What does this PR do, and why do we need it?

Handles individual-specific resources for request contexts coming from Policy Evaluation of Vault.

Which issue does this PR fix?
fixes #S3C-2604

Special notes for your reviewers:
This is a quick workaround, we are gonna re-architecture UTAPI eventually.