### PR TITLE
bugfix: ZENKO-2352 send back HTTP 424 when location does not exist

### DIFF
--- a/errors/arsenalErrors.json
+++ b/errors/arsenalErrors.json
@@ -476,6 +476,10 @@
     "code": 409,
     "description": "The bucket you tried to delete has an ongoing multipart upload."
   },
+  "LocationNotFound": {
+    "code": 424,
+    "description": "The object data location does not exist."
+  },
   "_comment": "-------------- Internal project errors --------------",
   "_comment": "----------------------- Vault -----------------------",
   "_comment": "#### formatErrors ####",

--- a/lib/storage/data/external/AwsClient.js
+++ b/lib/storage/data/external/AwsClient.js
@@ -148,21 +148,19 @@ class AwsClient {
             VersionId: dataStoreVersionId,
         }, (err, data) => {
             if (err) {
-                logHelper(log, 'error', 'error heading object ' +
-                'from datastore', err, this._dataStoreName);
+                let logLevel;
+                let retError;
                 if (err.code === 'NotFound') {
-                    const error = errors.ServiceUnavailable
-                    .customizeDescription(
-                        `Unexpected error from ${this.type}: ` +
-                        `"NotFound". Data on ${this.type} ` +
-                        'may have been altered outside of CloudServer.'
-                    );
-                    return callback(error);
+                    logLevel = 'info';
+                    retError = errors.LocationNotFound;
+                } else {
+                    logLevel = 'error';
+                    retError = errors.ServiceUnavailable.customizeDescription(
+                        `Error returned from ${this.type}: ${err.message}`);
                 }
-                return callback(errors.ServiceUnavailable
-                  .customizeDescription('Error returned from ' +
-                  `${this.type}: ${err.message}`)
-                );
+                logHelper(log, logLevel, 'error heading object ' +
+                'from datastore', err, this._dataStoreName);
+                return callback(retError);
             }
             return callback(null, data);
         });
@@ -181,10 +179,20 @@ class AwsClient {
                 backendType: this.clientType });
         });
         const stream = request.createReadStream().on('error', err => {
-            logHelper(log, 'error',
+            let logLevel;
+            let retError;
+            if (err.code === 'NotFound') {
+                logLevel = 'info';
+                retError = errors.LocationNotFound;
+            } else {
+                logLevel = 'error';
+                retError = errors.ServiceUnavailable.customizeDescription(
+                    `Error returned from ${this.type}: ${err.message}`);
+            }
+            logHelper(log, logLevel,
               `error streaming data from ${this.type}`,
               err, this._dataStoreName, this.clientType);
-            return callback(err);
+            return callback(retError);
         });
         return callback(null, stream);
     }

--- a/lib/storage/data/external/AzureClient.js
+++ b/lib/storage/data/external/AzureClient.js
@@ -177,19 +177,20 @@ class AzureClient {
             [this._azureContainerName, key, azureStreamingOptions,
             (err, data) => {
                 if (err) {
-                    logHelper(log, 'error', 'err from Azure HEAD data backend',
-                        err, this._dataStoreName);
+                    let logLevel;
+                    let retError;
                     if (err.code === 'NotFound') {
-                        const error = errors.ServiceUnavailable
-                        .customizeDescription(
-                            'Unexpected error from Azure: "NotFound". Data ' +
-                            'on Azure may have been altered outside of ' +
-                            'CloudServer.');
-                        return callback(error);
+                        logLevel = 'info';
+                        retError = errors.LocationNotFound;
+                    } else {
+                        logLevel = 'error';
+                        retError = errors.ServiceUnavailable
+                            .customizeDescription(
+                                `Error returned from Azure: ${err.message}`);
                     }
-                    return callback(errors.ServiceUnavailable
-                        .customizeDescription('Error returned from ' +
-                        `Azure: ${err.message}`));
+                    logHelper(log, logLevel, 'err from Azure HEAD data backend',
+                        err, this._dataStoreName);
+                    return callback(retError);
                 }
                 return callback(null, data);
             }], log, callback);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=8"
   },
-  "version": "8.2.0",
+  "version": "8.2.1",
   "description": "Common utilities for the S3 project components",
   "main": "index.js",
   "repository": {

--- a/tests/unit/storage/data/DummyService.js
+++ b/tests/unit/storage/data/DummyService.js
@@ -14,6 +14,12 @@ class DummyService {
         return callback(null, {});
     }
     headObject(params, callback) {
+        if (params.Key ===
+            'externalBackendTestBucket/externalBackendMissingKey') {
+            const err = new Error();
+            err.code = 'NotFound';
+            return callback(err);
+        }
         const retObj = {
             ContentLength: `${1024 * 1024 * 1024}`,
         };
@@ -54,6 +60,17 @@ class DummyService {
         if (this.versioning) {
             retObj.VersionId = uuid().replace(/-/g, '');
         }
+        return callback(null, retObj);
+    }
+    getBlobProperties(containerName, key, streamingOptions, callback) {
+        if (key === 'externalBackendTestBucket/externalBackendMissingKey') {
+            const err = new Error();
+            err.code = 'NotFound';
+            return callback(err);
+        }
+        const retObj = {
+            ContentLength: `${1024 * 1024 * 1024}`,
+        };
         return callback(null, retObj);
     }
     // To-Do: add tests for other methods

--- a/tests/unit/storage/data/external/ExternalClients.js
+++ b/tests/unit/storage/data/external/ExternalClients.js
@@ -102,6 +102,18 @@ describe('external backend clients', () => {
                 dataStoreName: backend.config.dataStoreName,
             });
         });
+
+        it(`${backend.name} head() should return HTTP 424 if location ` +
+        'does not exist', done => {
+            testClient.head({
+                key: 'externalBackendTestBucket/externalBackendMissingKey',
+                dataStoreName: backend.config.dataStoreName,
+            }, null, err => {
+                assert(err);
+                assert(err.LocationNotFound);
+                done();
+            });
+        });
         // To-Do: test the other external client methods
     });
 });


### PR DESCRIPTION
Send back an HTTP error 424 (Failed Dependency, a WebDAV extension)
instead of HTTP 503 (Service Unavailable), when the backend client
cannot retrieve the location of the data and gets a 404 error from the
server when issuing a HEAD request. This HEAD request is triggered on
the backend when a client issues a GET request on Zenko for an object
stored in a cloud backend. The error returned to the client also
contains a more specific error code "LocationNotFound", which is not
part of AWS standard.

The immediate purpose is to have backbeat not retry on such errors, as
they might arise if e.g. a Zenko bucket is backed by an S3C location,
and the out-of-band updates lag behind, so a user might have deleted
versions on S3C before Zenko got notified of the deletion, thinking
the object is still available.

More generally, even in the hypothetic case where a server-side bug
would have deleted the data, it's better not to have the client retry
as this is a definite failure and the client will just retry vainly
until it times out. Sending back a 4xx error makes this clear to the
client that it should not retry (not until something changes on its
side, like writing the same key again).

The patch applies on all supported backends: AWS, Azure, GCP.