### PR TITLE
bugfix: update master if version is gte

### DIFF
--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -536,10 +536,10 @@ class MongoClientInterface {
      * objVal already contains the destination versionId. We first
      * update the version if it exists or create it. We then call
      * getLatestVersion() to get the latest version. We update the
-     * master only if the returned version is greater than the stored
-     * one. Caveat: this function is not optimized for multiple
-     * updates to the same objName, a batch would be more suited to
-     * avoid the parallel attempts to update the master.
+     * master only if the returned version is greater or equal than
+     * the stored one. Caveat: this function is not optimized for
+     * multiple updates to the same objName, a batch would be more
+     * suited to avoid the parallel attempts to update the master.
      */
     putObjectVerCase4(c, bucketName, objName, objVal, params, log, cb) {
         const vObjName = formatVersionKey(objName, params.versionId);
@@ -567,7 +567,17 @@ class MongoClientInterface {
                 c.update({
                     _id: objName,
                     'value.versionId': {
-                        $gt: mstObjVal.versionId,
+                        // We break the semantic correctness here with
+                        // $gte instead of $gt because we do not have
+                        // a microVersionId to capture the micro
+                        // changes (tags, ACLs, etc). If we do not use
+                        // $gte currently the micro changes are not
+                        // propagated. We are now totally dependent of
+                        // the order of changes (which Backbeat
+                        // replication and ingestion can hopefully
+                        // ensure), but this would not work e.g. in
+                        // the case of an active-active replication.
+                        $gte: mstObjVal.versionId,
                     },
                 }, {
                     _id: objName,


### PR DESCRIPTION
This change is a workaround to palliate the fact we do not have micro
version to manage micro changes such as ACLs or tags changed. Indeed in
the AWS S3 specification such changes do not trigger a new version but
update the version (and the master) in place.