### PR TITLE
improvement: ZENKO-2535 add microVersionId to ObjectMD

### DIFF
--- a/lib/models/ObjectMD.js
+++ b/lib/models/ObjectMD.js
@@ -1,3 +1,5 @@
+const crypto = require('crypto');
+
 const constants = require('../constants');
 const VersionIDUtils = require('../versioning/VersionID');
 
@@ -1026,6 +1028,40 @@ class ObjectMD {
     overrideMetadataValues(headers) {
         Object.assign(this._data, headers);
         return this;
+    }
+
+    /**
+     * Create or update the microVersionId field
+     *
+     * This field can be used to force an update in MongoDB. This can
+     * be needed in the following cases:
+     *
+     * - in case no other metadata field changes
+     *
+     * - to detect a change when fields change but object version does
+     *   not change e.g. when ingesting a putObjectTagging coming from
+     *   S3C to Zenko
+     *
+     * - to manage conflicts during concurrent updates, using
+     *   conditions on the microVersionId field.
+     *
+     * It's a field of 16 hexadecimal characters randomly generated
+     *
+     * @return {ObjectMD} itself
+     */
+    updateMicroVersionId() {
+        this._data.microVersionId = crypto.randomBytes(8).toString('hex');
+        return this;
+    }
+
+    /**
+     * Get the microVersionId field, or null if not set
+     *
+     * @return {string|null} the microVersionId field if exists, or
+     * {null} if it does not exist
+     */
+    getMicroVersionId() {
+        return this._data.microVersionId || null;
     }
 
     /**

--- a/tests/unit/models/ObjectMD.js
+++ b/tests/unit/models/ObjectMD.js
@@ -257,6 +257,25 @@ describe('ObjectMD class setters/getters', () => {
         md.clearMetadataValues();
         assert.strictEqual(md.getUserMetadata(), undefined);
     });
+
+    it('ObjectMD::microVersionId unset', () => {
+        assert.strictEqual(md.getMicroVersionId(), null);
+    });
+
+    it('ObjectMD::microVersionId set', () => {
+        const generatedIds = new Set();
+        for (let i = 0; i < 100; ++i) {
+            md.updateMicroVersionId();
+            generatedIds.add(md.getMicroVersionId());
+        }
+        // all generated IDs should be different
+        assert.strictEqual(generatedIds.size, 100);
+        generatedIds.forEach(key => {
+            // length is always 16 in hex because leading 0s are
+            // also encoded in the 8-byte random buffer.
+            assert.strictEqual(key.length, 16);
+        });
+    });
 });
 
 describe('ObjectMD import from stored blob', () => {


### PR DESCRIPTION
Add a new microVersionId field that is a hex-encoded field of 64
bits randomly generated.

It can be useful to:

- force updates in MongoDB when no other metadata changes, by updating
  the microVersionId field

- manage concurrent updates, by adding a condition on the
  microVersionId and updating it for each metadata update to perform

In order for the change to be less intrusive, it is an optional field:
if ObjectMD.updateMicroVersionId() is not called by the client, the
metadata will not contain a microVersionId field. Clients will call
this function when needed on a case-by-case basis.