### PR TITLE
Correct UTF-16 surrogates URI encoding

### DIFF
--- a/lib/auth/v4/awsURIencode.js
+++ b/lib/auth/v4/awsURIencode.js
@@ -36,7 +36,7 @@ function awsURIencode(input, encodeSlash, noEncodeStar) {
     const encSlash = encodeSlash === undefined ? true : encodeSlash;
     let encoded = '';
     for (let i = 0; i < input.length; i++) {
-        const ch = input.charAt(i);
+        let ch = input.charAt(i);
         if ((ch >= 'A' && ch <= 'Z') ||
             (ch >= 'a' && ch <= 'z') ||
             (ch >= '0' && ch <= '9') ||
@@ -50,6 +50,20 @@ function awsURIencode(input, encodeSlash, noEncodeStar) {
         } else if (ch === '*') {
             encoded = encoded.concat(noEncodeStar ? '*' : '%2A');
         } else {
+            if (ch >= '\uD800' && ch <= '\uDBFF') {
+                // If this character is a high surrogate peek the next character
+                // and join it with this one if the next character is a low
+                // surrogate.
+                // Otherwise the encoded URI will contain the two surrogates as
+                // two distinct UTF-8 sequences which is not valid UTF-8.
+                if (i + 1 < input.length) {
+                    const ch2 = input.charAt(i + 1);
+                    if (ch2 >= '\uDC00' && ch2 <= '\uDFFF') {
+                        i++;
+                        ch += ch2;
+                    }
+                }
+            }
             encoded = encoded.concat(_toHexUTF8(ch));
         }
     }

--- a/tests/unit/auth/v4/awsURIencode.js
+++ b/tests/unit/auth/v4/awsURIencode.js
@@ -53,4 +53,12 @@ describe('should URIencode in accordance with AWS rules', () => {
         const actualOutput = awsURIencode(input);
         assert.strictEqual(actualOutput, expectedOutput);
     });
+
+    it('should encode codepoints that use surrogate pairs in UTF-16 as a ' +
+        'single UTF-8 sequence', () => {
+        const input = '/s3amazonaws.com/I-like-🌮s';
+        const expectedOutput = '%2Fs3amazonaws.com%2FI-like-%F0%9F%8C%AEs';
+        const actualOutput = awsURIencode(input);
+        assert.strictEqual(actualOutput, expectedOutput);
+    });
 });


### PR DESCRIPTION
BF: Correctly encode high-order codepoints in awsURIencode

awsURIencode iterates over and encodes UTF-16 values one by one. As a consequence high order codepoints that are split into two surrogates in UTF-16 get encoded as two separate UTF-8 sequences that encode the codepoint value of each surrogate.
The correct way to encode this type of codepoint is to encode them as a single UTF-8 sequence representing the codepoint value of the recombined surrogates.

Signed-off-by: Pepijn Van Eeckhoudt <pepijn.vaneeckhoudt@datadobi.com>