### PR TITLE
bugfix: Remove tag regex to allow utf8 characters

### DIFF
--- a/lib/s3middleware/tagging.js
+++ b/lib/s3middleware/tagging.js
@@ -3,8 +3,6 @@ const { parseString } = require('xml2js');
 const errors = require('../errors');
 const escapeForXml = require('./escapeForXml');
 
-const tagRegex = new RegExp(/[^a-zA-Z0-9 +-=._:/]/g);
-
 const errorInvalidArgument = errors.InvalidArgument
   .customizeDescription('The header \'x-amz-tagging\' shall be ' +
   'encoded as UTF-8 then URLEncoded URL query parameters without ' +
@@ -48,13 +46,13 @@ const _validator = {
         ),
 
     validateKeyValue: (key, value) => {
-        if (key.length > 128 || key.match(tagRegex)) {
+        if (key.length > 128) {
             return errors.InvalidTag.customizeDescription('The TagKey you ' +
-              'have provided is invalid');
+              'have provided is too long, max 128');
         }
-        if (value.length > 256 || value.match(tagRegex)) {
+        if (value.length > 256) {
             return errors.InvalidTag.customizeDescription('The TagValue you ' +
-              'have provided is invalid');
+              'have provided is too long, max 256');
         }
         return true;
     },

--- a/tests/unit/s3middleware/tagging.js
+++ b/tests/unit/s3middleware/tagging.js
@@ -1,0 +1,19 @@
+const assert = require('assert');
+const { _validator } = require('../../../lib/s3middleware/tagging');
+
+describe('tagging validator', () => {
+    it('validates keys and values are less than 128 and 256', () => {
+      assert.strictEqual(_validator.validateKeyValue("hey", "you guys"), true);
+    })
+    it('returns error for keys greater than 128', () => {
+      const longKey = "Z".repeat(200);
+      assert(_validator.validateKeyValue(longKey, "you guys") instanceof Error);
+    })
+    it('returns error for values greater than 256', () => {
+      const longValue = "Z".repeat(300);
+      assert(_validator.validateKeyValue("short key", longValue) instanceof Error);
+    })
+    it('allows any utf8 string in keys and values', () => {
+      assert.strictEqual(_validator.validateKeyValue('あいうえお', "😀😄😀😄"), true);
+    })
+});


### PR DESCRIPTION
Simply removing the regex check should allow utf8 characters. I added some tests as there were none. 