### PR TITLE
INTEGRATION [PR#982 > development/7.6] bugfix: Remove tag regex to allow utf8 characters

### DIFF
--- a/lib/s3middleware/tagging.js
+++ b/lib/s3middleware/tagging.js
@@ -3,8 +3,6 @@ const { parseString } = require('xml2js');
 const errors = require('../errors');
 const escapeForXml = require('./escapeForXml');
 
-const tagRegex = new RegExp(/[^a-zA-Z0-9 +-=._:/]/g);
-
 const errorInvalidArgument = errors.InvalidArgument
   .customizeDescription('The header \'x-amz-tagging\' shall be ' +
   'encoded as UTF-8 then URLEncoded URL query parameters without ' +
@@ -48,13 +46,13 @@ const _validator = {
         ),
 
     validateKeyValue: (key, value) => {
-        if (key.length > 128 || key.match(tagRegex)) {
+        if (key.length > 128) {
             return errors.InvalidTag.customizeDescription('The TagKey you ' +
-              'have provided is invalid');
+              'have provided is too long, max 128');
         }
-        if (value.length > 256 || value.match(tagRegex)) {
+        if (value.length > 256) {
             return errors.InvalidTag.customizeDescription('The TagValue you ' +
-              'have provided is invalid');
+              'have provided is too long, max 256');
         }
         return true;
     },

--- a/tests/unit/s3middleware/tagging.js
+++ b/tests/unit/s3middleware/tagging.js
@@ -1,0 +1,21 @@
+const assert = require('assert');
+const { _validator } = require('../../../lib/s3middleware/tagging');
+
+describe('tagging validator', () => {
+    it('validates keys and values are less than 128 and 256', () => {
+        const result = _validator.validateKeyValue('hey', 'you guys');
+        assert.strictEqual(result, true);
+    });
+    it('returns error for keys greater than 128', () => {
+        const result = _validator.validateKeyValue('Y'.repeat(200), 'you guys');
+        assert(result instanceof Error);
+    });
+    it('returns error for values greater than 256', () => {
+        const result = _validator.validateKeyValue('X', 'Z'.repeat(300));
+        assert(result instanceof Error);
+    });
+    it('allows any utf8 string in keys and values', () => {
+        const result = _validator.validateKeyValue('あいう', '😀😄');
+        assert.strictEqual(result, true);
+    });
+});


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #982.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.6/bugfix/S3C-2668_allow_utf8_characters_in_tags`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.6/bugfix/S3C-2668_allow_utf8_characters_in_tags
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.6/bugfix/S3C-2668_allow_utf8_characters_in_tags
```

Please always comment pull request #982 instead of this one.