### PR TITLE
ft: S3C-2789 put objlock bucketinfo update

### DIFF
--- a/lib/models/BucketInfo.js
+++ b/lib/models/BucketInfo.js
@@ -2,10 +2,11 @@ const assert = require('assert');
 const { WebsiteConfiguration } = require('./WebsiteConfiguration');
 const ReplicationConfiguration = require('./ReplicationConfiguration');
 const LifecycleConfiguration = require('./LifecycleConfiguration');
+const ObjectLockConfiguration = require('./ObjectLockConfiguration');
 const BucketPolicy = require('./BucketPolicy');
 
 // WHEN UPDATING THIS NUMBER, UPDATE MODELVERSION.MD CHANGELOG
-const modelVersion = 6;
+const modelVersion = 7;
 
 class BucketInfo {
     /**
@@ -50,13 +51,14 @@ class BucketInfo {
     * @param {object} [lifecycleConfiguration] - lifecycle configuration
     * @param {object} [bucketPolicy] - bucket policy
     * @param {boolean} [objectLockEnabled] - true when object lock enabled
+    * @param {object} [objectLockConfiguration] - object lock configuration
     */
     constructor(name, owner, ownerDisplayName, creationDate,
                 mdBucketModelVersion, acl, transient, deleted,
                 serverSideEncryption, versioningConfiguration,
                 locationConstraint, websiteConfiguration, cors,
                 replicationConfiguration, lifecycleConfiguration,
-                bucketPolicy, objectLockEnabled) {
+                bucketPolicy, objectLockEnabled, objectLockConfiguration) {
         assert.strictEqual(typeof name, 'string');
         assert.strictEqual(typeof owner, 'string');
         assert.strictEqual(typeof ownerDisplayName, 'string');
@@ -119,6 +121,9 @@ class BucketInfo {
         if (bucketPolicy) {
             BucketPolicy.validatePolicy(bucketPolicy);
         }
+        if (objectLockConfiguration) {
+            ObjectLockConfiguration.validateConfig(objectLockConfiguration);
+        }
         const aclInstance = acl || {
             Canned: 'private',
             FULL_CONTROL: [],
@@ -146,6 +151,7 @@ class BucketInfo {
         this._lifecycleConfiguration = lifecycleConfiguration || null;
         this._bucketPolicy = bucketPolicy || null;
         this._objectLockEnabled = objectLockEnabled || false;
+        this._objectLockConfiguration = objectLockConfiguration || null;
         return this;
     }
     /**
@@ -171,6 +177,7 @@ class BucketInfo {
             lifecycleConfiguration: this._lifecycleConfiguration,
             bucketPolicy: this._bucketPolicy,
             objectLockEnabled: this._objectLockEnabled,
+            objectLockConfiguration: this._objectLockConfiguration,
         };
         if (this._websiteConfiguration) {
             bucketInfos.websiteConfiguration =
@@ -192,7 +199,8 @@ class BucketInfo {
             obj.transient, obj.deleted, obj.serverSideEncryption,
             obj.versioningConfiguration, obj.locationConstraint, websiteConfig,
             obj.cors, obj.replicationConfiguration, obj.lifecycleConfiguration,
-            obj.bucketPolicy, obj.objectLockEnabled);
+            obj.bucketPolicy, obj.objectLockEnabled,
+            obj.objectLockConfiguration);
     }
 
     /**
@@ -216,7 +224,8 @@ class BucketInfo {
             data._versioningConfiguration, data._locationConstraint,
             data._websiteConfiguration, data._cors,
             data._replicationConfiguration, data._lifecycleConfiguration,
-            data._bucketPolicy, data._objectLockEnabled);
+            data._bucketPolicy, data._objectLockEnabled,
+            data._objectLockConfiguration);
     }
 
     /**
@@ -359,6 +368,23 @@ class BucketInfo {
      */
     setBucketPolicy(bucketPolicy) {
         this._bucketPolicy = bucketPolicy;
+        return this;
+    }
+    /**
+     * Get object lock configuration
+     * @return {object|null} object lock configuration information or `null` if
+     * the bucket does not have an object lock configuration
+     */
+    getObjectLockConfiguration() {
+        return this._objectLockConfiguration;
+    }
+    /**
+     * Set object lock configuration
+     * @param {object} objectLockConfiguration - object lock information
+     * @return {BucketInfo} - bucket info instance
+     */
+    setObjectLockConfiguration(objectLockConfiguration) {
+        this._objectLockConfiguration = objectLockConfiguration;
         return this;
     }
     /**

--- a/lib/models/ObjectLockConfiguration.js
+++ b/lib/models/ObjectLockConfiguration.js
@@ -1,0 +1,58 @@
+const assert = require('assert');
+
+/**
+ * Format of xml request:
+ *
+ * <ObjectLockConfiguration>
+ *      <ObjectLockEnabled>Enabled</ObjectLockEnabled>
+ *      <Rule>
+ *          <DefaultRetention>
+ *              <Mode>GOVERNANCE|COMPLIANCE</Mode>
+ *              <Days>1</Days>
+ *              <Years>1</Years>z
+ *          </DefaultRetention>
+ *      </Rule>
+ * </ObjectLockConfiguration>
+ */
+
+ /**
+  * Format of config:
+  *
+  * config = {
+  *     rule: {
+  *         mode: GOVERNANCE|COMPLIANCE,
+  *         days|years: integer,
+  *     }
+  * }
+  */
+class ObjectLockConfiguration {
+    /**
+     * Create an Object Lock Configuration instance
+     * @param {string} xml - the parsed configuration xml
+     * @return {object} - ObjectLockConfiguration instance
+     */
+    constructor(xml) {
+        this._parsedXml = xml;
+        this._config = {};
+    }
+
+    /**
+     * Validate the bucket metadata lifecycle configuration structure and
+     * value types
+     * @param {object} config - The lifecycle configuration to validate
+     * @return {undefined}
+     */
+    static validateConfig(config) {
+        assert.strictEqual(typeof config, 'object');
+        const rule = config.rule;
+        assert.strictEqual(typeof rule, 'object');
+        assert.strictEqual(typeof rule.mode, 'string');
+        if (rule.days) {
+            assert.strictEqual(typeof rule.days, 'number');
+        } else {
+            assert.strictEqual(typeof rule.years, 'number');
+        }
+    }
+}
+
+module.exports = ObjectLockConfiguration;

--- a/tests/unit/models/BucketInfo.js
+++ b/tests/unit/models/BucketInfo.js
@@ -130,8 +130,14 @@ const testBucketPolicy = {
 
 const testobjectLockEnabled = false;
 
-// create a dummy bucket to test getters and setters
+const testObjectLockConfiguration = {
+    rule: {
+        mode: 'GOVERNANCE',
+        days: 1,
+    },
+};
 
+// create a dummy bucket to test getters and setters
 Object.keys(acl).forEach(
     aclObj => describe(`different acl configurations : ${aclObj}`, () => {
         const dummyBucket = new BucketInfo(
@@ -149,7 +155,8 @@ Object.keys(acl).forEach(
             testReplicationConfiguration,
             testLifecycleConfiguration,
             testBucketPolicy,
-            testobjectLockEnabled);
+            testobjectLockEnabled,
+            testObjectLockConfiguration);
 
         describe('serialize/deSerialize on BucketInfo class', () => {
             const serialized = dummyBucket.serialize();
@@ -177,6 +184,8 @@ Object.keys(acl).forEach(
                         dummyBucket._lifecycleConfiguration,
                     bucketPolicy: dummyBucket._bucketPolicy,
                     objectLockEnabled: dummyBucket._objectLockEnabled,
+                    objectLockConfiguration:
+                        dummyBucket._objectLockConfiguration,
                 };
                 assert.strictEqual(serialized, JSON.stringify(bucketInfos));
                 done();
@@ -284,6 +293,10 @@ Object.keys(acl).forEach(
             it('object lock should be disabled by default', () => {
                 assert.deepStrictEqual(
                     dummyBucket.isObjectLockEnabled(), false);
+            });
+            it('getObjectLockConfiguration should return configuration', () => {
+                assert.deepStrictEqual(dummyBucket.getObjectLockConfiguration(),
+                    testObjectLockConfiguration);
             });
         });
 
@@ -421,6 +434,18 @@ Object.keys(acl).forEach(
                 dummyBucket.setBucketPolicy(newBucketPolicy);
                 assert.deepStrictEqual(
                     dummyBucket.getBucketPolicy(), newBucketPolicy);
+            });
+            it('setObjectLockConfiguration should set object lock ' +
+                'configuration', () => {
+                const newObjectLockConfig = {
+                    rule: {
+                        mode: 'COMPLIANCE',
+                        years: 1,
+                    },
+                };
+                dummyBucket.setObjectLockConfiguration(newObjectLockConfig);
+                assert.deepStrictEqual(dummyBucket.getObjectLockConfiguration(),
+                    newObjectLockConfig);
             });
         });
     })


### PR DESCRIPTION
The necessary updates to BucketInfo and supporting methods for PutObjectLockConfiguration API. Full ObjectLockConfiguration model to follow.
Also updates Model Version of BucketInfo model.
To be merged after https://github.com/scality/Arsenal/pull/992