### PR TITLE
INTEGRATION [PR#992 > development/8.1] feature: S3C-2785 add object lock check

### DIFF
--- a/lib/models/BucketInfo.js
+++ b/lib/models/BucketInfo.js
@@ -49,13 +49,14 @@ class BucketInfo {
     * @param {object} [replicationConfiguration] - replication configuration
     * @param {object} [lifecycleConfiguration] - lifecycle configuration
     * @param {object} [bucketPolicy] - bucket policy
+    * @param {boolean} [objectLockEnabled] - true when object lock enabled
     */
     constructor(name, owner, ownerDisplayName, creationDate,
                 mdBucketModelVersion, acl, transient, deleted,
                 serverSideEncryption, versioningConfiguration,
                 locationConstraint, websiteConfiguration, cors,
                 replicationConfiguration, lifecycleConfiguration,
-                bucketPolicy) {
+                bucketPolicy, objectLockEnabled) {
         assert.strictEqual(typeof name, 'string');
         assert.strictEqual(typeof owner, 'string');
         assert.strictEqual(typeof ownerDisplayName, 'string');
@@ -144,6 +145,7 @@ class BucketInfo {
         this._cors = cors || null;
         this._lifecycleConfiguration = lifecycleConfiguration || null;
         this._bucketPolicy = bucketPolicy || null;
+        this._objectLockEnabled = objectLockEnabled || false;
         return this;
     }
     /**
@@ -168,6 +170,7 @@ class BucketInfo {
             replicationConfiguration: this._replicationConfiguration,
             lifecycleConfiguration: this._lifecycleConfiguration,
             bucketPolicy: this._bucketPolicy,
+            objectLockEnabled: this._objectLockEnabled,
         };
         if (this._websiteConfiguration) {
             bucketInfos.websiteConfiguration =
@@ -189,7 +192,7 @@ class BucketInfo {
             obj.transient, obj.deleted, obj.serverSideEncryption,
             obj.versioningConfiguration, obj.locationConstraint, websiteConfig,
             obj.cors, obj.replicationConfiguration, obj.lifecycleConfiguration,
-            obj.bucketPolicy);
+            obj.bucketPolicy, obj.objectLockEnabled);
     }
 
     /**
@@ -213,7 +216,7 @@ class BucketInfo {
             data._versioningConfiguration, data._locationConstraint,
             data._websiteConfiguration, data._cors,
             data._replicationConfiguration, data._lifecycleConfiguration,
-            data._bucketPolicy);
+            data._bucketPolicy, data._objectLockEnabled);
     }
 
     /**
@@ -547,6 +550,13 @@ class BucketInfo {
     isVersioningOn() {
         return this._versioningConfiguration &&
             this._versioningConfiguration.Status === 'Enabled';
+    }
+    /**
+    * Check is object lock enabled.
+    * @return {boolean} - depending on whether object lock is enabled
+    */
+    isObjectLockEnabled() {
+        return !!this._objectLockEnabled;
     }
 }
 

--- a/lib/models/BucketInfo.js
+++ b/lib/models/BucketInfo.js
@@ -67,8 +67,7 @@ class BucketInfo {
                 locationConstraint, websiteConfiguration, cors,
                 replicationConfiguration, lifecycleConfiguration,
                 bucketPolicy, uid, readLocationConstraint, isNFS,
-                ingestionConfig, azureInfo,
-                bucketPolicy, objectLockEnabled) {
+                ingestionConfig, azureInfo, objectLockEnabled) {
         assert.strictEqual(typeof name, 'string');
         assert.strictEqual(typeof owner, 'string');
         assert.strictEqual(typeof ownerDisplayName, 'string');
@@ -228,8 +227,7 @@ class BucketInfo {
             obj.versioningConfiguration, obj.locationConstraint, websiteConfig,
             obj.cors, obj.replicationConfiguration, obj.lifecycleConfiguration,
             obj.bucketPolicy, obj.uid, obj.readLocationConstraint, obj.isNFS,
-            obj.ingestion, obj.azureInfo,
-            obj.bucketPolicy, obj.objectLockEnabled);
+            obj.ingestion, obj.azureInfo, obj.objectLockEnabled);
     }
 
     /**

--- a/tests/unit/models/BucketInfo.js
+++ b/tests/unit/models/BucketInfo.js
@@ -172,7 +172,6 @@ Object.keys(acl).forEach(
             testLifecycleConfiguration,
             testBucketPolicy, testUid, undefined,
             true, undefined, testAzureInfo,
-            testBucketPolicy,
             testobjectLockEnabled);
 
         describe('serialize/deSerialize on BucketInfo class', () => {

--- a/tests/unit/models/BucketInfo.js
+++ b/tests/unit/models/BucketInfo.js
@@ -127,6 +127,9 @@ const testBucketPolicy = {
         },
     ],
 };
+
+const testobjectLockEnabled = false;
+
 // create a dummy bucket to test getters and setters
 
 Object.keys(acl).forEach(
@@ -145,7 +148,8 @@ Object.keys(acl).forEach(
             testCorsConfiguration,
             testReplicationConfiguration,
             testLifecycleConfiguration,
-            testBucketPolicy);
+            testBucketPolicy,
+            testobjectLockEnabled);
 
         describe('serialize/deSerialize on BucketInfo class', () => {
             const serialized = dummyBucket.serialize();
@@ -172,6 +176,7 @@ Object.keys(acl).forEach(
                     lifecycleConfiguration:
                         dummyBucket._lifecycleConfiguration,
                     bucketPolicy: dummyBucket._bucketPolicy,
+                    objectLockEnabled: dummyBucket._objectLockEnabled,
                 };
                 assert.strictEqual(serialized, JSON.stringify(bucketInfos));
                 done();
@@ -188,15 +193,16 @@ Object.keys(acl).forEach(
         });
 
         describe('constructor', () => {
-            it('this should have the right BucketInfo types',
-               () => {
-                   assert.strictEqual(typeof dummyBucket.getName(), 'string');
-                   assert.strictEqual(typeof dummyBucket.getOwner(), 'string');
-                   assert.strictEqual(typeof dummyBucket.getOwnerDisplayName(),
-                                      'string');
-                   assert.strictEqual(typeof dummyBucket.getCreationDate(),
-                                      'string');
-               });
+            it('this should have the right BucketInfo types', () => {
+                assert.strictEqual(typeof dummyBucket.getName(), 'string');
+                assert.strictEqual(typeof dummyBucket.getOwner(), 'string');
+                assert.strictEqual(typeof dummyBucket.getOwnerDisplayName(),
+                                    'string');
+                assert.strictEqual(typeof dummyBucket.getCreationDate(),
+                                    'string');
+                assert.strictEqual(typeof dummyBucket.isObjectLockEnabled(),
+                                    'boolean');
+            });
             it('this should have the right acl\'s types', () => {
                 assert.strictEqual(typeof dummyBucket.getAcl(), 'object');
                 assert.strictEqual(
@@ -274,6 +280,10 @@ Object.keys(acl).forEach(
             it('getBucketPolicy should return policy', () => {
                 assert.deepStrictEqual(
                     dummyBucket.getBucketPolicy(), testBucketPolicy);
+            });
+            it('object lock should be disabled by default', () => {
+                assert.deepStrictEqual(
+                    dummyBucket.isObjectLockEnabled(), false);
             });
         });
 


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #992.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/feature/S3C-2785_ObjectLockCheckToBucketInfoModel`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/feature/S3C-2785_ObjectLockCheckToBucketInfoModel
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/feature/S3C-2785_ObjectLockCheckToBucketInfoModel
```

Please always comment pull request #992 instead of this one.