### PR TITLE
INTEGRATION [PR#999 > development/8.1] ft: S3C-2790 add getObjectLockConfiguration route

### DIFF
--- a/lib/s3routes/routes/routeGET.js
+++ b/lib/s3routes/routes/routeGET.js
@@ -51,11 +51,11 @@ function routerGET(request, response, api, log, statsClient, dataRetrievalFn) {
                 });
         } else if (request.query.lifecycle !== undefined) {
             api.callApiMethod('bucketGetLifecycle', request, response, log,
-            (err, xml, corsHeaders) => {
-                routesUtils.statsReport500(err, statsClient);
-                routesUtils.responseXMLBody(err, xml, response, log,
-                    corsHeaders);
-            });
+                (err, xml, corsHeaders) => {
+                    routesUtils.statsReport500(err, statsClient);
+                    routesUtils.responseXMLBody(err, xml, response, log,
+                        corsHeaders);
+                });
         } else if (request.query.uploads !== undefined) {
             // List MultipartUploads
             api.callApiMethod('listMultipartUploads', request, response, log,
@@ -73,6 +73,13 @@ function routerGET(request, response, api, log, statsClient, dataRetrievalFn) {
                 });
         } else if (request.query.policy !== undefined) {
             api.callApiMethod('bucketGetPolicy', request, response, log,
+                (err, xml, corsHeaders) => {
+                    routesUtils.statsReport500(err, statsClient);
+                    return routesUtils.responseXMLBody(err, xml, response,
+                        log, corsHeaders);
+                });
+        } else if (request.query['object-lock'] !== undefined) {
+            api.callApiMethod('bucketGetObjectLock', request, response, log,
                 (err, xml, corsHeaders) => {
                     routesUtils.statsReport500(err, statsClient);
                     return routesUtils.responseXMLBody(err, xml, response,


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #999.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/feature/S3C-2790_AddGetObjectLockRoute`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/feature/S3C-2790_AddGetObjectLockRoute
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/feature/S3C-2790_AddGetObjectLockRoute
```

Please always comment pull request #999 instead of this one.