### PR TITLE
bugfix: S3C-2899 add constants to support versioning key formats

### DIFF
--- a/lib/versioning/constants.js
+++ b/lib/versioning/constants.js
@@ -2,4 +2,15 @@ module.exports.VersioningConstants = {
     VersionId: {
         Separator: '\0',
     },
+    DbPrefixes: {
+        Master: '\x7fM',
+        Version: '\x7fV',
+    },
+    BucketVersioningKeyFormat: {
+        current: 'v1',
+        v0: 'v0',
+        v0mig: 'v0mig',
+        v1mig: 'v1mig',
+        v1: 'v1',
+    },
 };


### PR DESCRIPTION
- add constant prefixes for master and version keys

- add versioning key format version numbers

Those constants will be shared between listing logic (in Arsenal) and
put/get/etc. logic (in Metadata), hence needs to be in arsenal.