### PR TITLE
INTEGRATION [PR#1006 > development/8.1] bugfix: S3C-2899 add constants to support versioning key formats

### DIFF
--- a/lib/versioning/constants.js
+++ b/lib/versioning/constants.js
@@ -2,4 +2,15 @@ module.exports.VersioningConstants = {
     VersionId: {
         Separator: '\0',
     },
+    DbPrefixes: {
+        Master: '\x7fM',
+        Version: '\x7fV',
+    },
+    BucketVersioningKeyFormat: {
+        current: 'v1',
+        v0: 'v0',
+        v0mig: 'v0mig',
+        v1mig: 'v1mig',
+        v1: 'v1',
+    },
 };


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1006.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-2899-versioningKeyFormatConstants`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-2899-versioningKeyFormatConstants
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-2899-versioningKeyFormatConstants
```

Please always comment pull request #1006 instead of this one.