### PR TITLE
ft: S3C-2790 get object lock configuration

### DIFF
--- a/errors/arsenalErrors.json
+++ b/errors/arsenalErrors.json
@@ -268,6 +268,10 @@
     "code": 404,
     "description": "The replication configuration was not found"
   },
+  "ObjectLockConfigurationNotFoundError": {
+    "code": 404,
+    "description": "The object lock configuration was not found"
+  },
   "NotImplemented": {
     "code": 501,
     "description": "A header you provided implies functionality that is not implemented."

--- a/lib/models/ObjectLockConfiguration.js
+++ b/lib/models/ObjectLockConfiguration.js
@@ -199,6 +199,38 @@ class ObjectLockConfiguration {
         }
     }
 
+    /**
+     * Get the XML representation of the configuration object
+     * @param {object} config - The bucket object lock configuration
+     * @return {string} - The XML representation of the configuration
+     */
+    static getConfigXML(config) {
+        // object lock is enabled on the bucket but object lock configuration
+        // not set
+        if (config.rule === undefined) {
+            return '<?xml version="1.0" encoding="UTF-8"?>' +
+                '<ObjectLockConfiguration ' +
+                'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+                '<ObjectLockEnabled>Enabled</ObjectLockEnabled>' +
+                '</ObjectLockConfiguration>';
+        }
+        const { days, years, mode } = config.rule;
+        const Mode = `<Mode>${mode}</Mode>`;
+        const Days = days !== undefined ? `<Days>${days}</Days>` : '';
+        const Years = years !== undefined ? `<Years>${years}</Years>` : '';
+        const Time = Days || Years;
+        return '<?xml version="1.0" encoding="UTF-8"?>' +
+            '<ObjectLockConfiguration ' +
+            'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+            '<ObjectLockEnabled>Enabled</ObjectLockEnabled>' +
+            '<Rule>' +
+            '<DefaultRetention>' +
+            `${Mode}` +
+            `${Time}` +
+            '</DefaultRetention>' +
+            '</Rule>' +
+            '</ObjectLockConfiguration>';
+    }
 }
 
 module.exports = ObjectLockConfiguration;

--- a/lib/s3routes/routes/routeGET.js
+++ b/lib/s3routes/routes/routeGET.js
@@ -51,11 +51,11 @@ function routerGET(request, response, api, log, statsClient, dataRetrievalFn) {
                 });
         } else if (request.query.lifecycle !== undefined) {
             api.callApiMethod('bucketGetLifecycle', request, response, log,
-            (err, xml, corsHeaders) => {
-                routesUtils.statsReport500(err, statsClient);
-                routesUtils.responseXMLBody(err, xml, response, log,
-                    corsHeaders);
-            });
+                (err, xml, corsHeaders) => {
+                    routesUtils.statsReport500(err, statsClient);
+                    routesUtils.responseXMLBody(err, xml, response, log,
+                        corsHeaders);
+                });
         } else if (request.query.uploads !== undefined) {
             // List MultipartUploads
             api.callApiMethod('listMultipartUploads', request, response, log,
@@ -78,6 +78,13 @@ function routerGET(request, response, api, log, statsClient, dataRetrievalFn) {
                     return routesUtils.responseXMLBody(err, xml, response,
                         log, corsHeaders);
                 });
+        } else if (request.query['object-lock'] !== undefined) {
+            api.callApiMethod('bucketGetObjectLock', request, response, log,
+                (err, xml, corsHeaders) => {
+                    routesUtils.statsReport500(err, statsClient);
+                    return routesUtils.responseXMLBody(err, xml, response,
+                        log, corsHeaders);
+                });
         } else {
             // GET bucket
             api.callApiMethod('bucketGet', request, response, log,
@@ -88,7 +95,6 @@ function routerGET(request, response, api, log, statsClient, dataRetrievalFn) {
                 });
         }
     } else {
-        /* eslint-disable no-lonely-if */
         if (request.query.acl !== undefined) {
             // GET object ACL
             api.callApiMethod('objectGetACL', request, response, log,
@@ -128,7 +134,6 @@ function routerGET(request, response, api, log, statsClient, dataRetrievalFn) {
                         range, log);
                 });
         }
-        /* eslint-enable */
     }
 }
 


### PR DESCRIPTION
This PR includes the route, custom error, helper `getConfigXML` method, and the unit tests for the `getConfigXML` method for the `bucketGetObjectLock` API.

Related to https://github.com/scality/cloudserver/pull/2535