### PR TITLE
INTEGRATION [PR#1028 > development/8.1] bugfix: S3C-2899 support v1 in Delimiter, DelimiterMaster

### DIFF
--- a/lib/algos/list/basic.js
+++ b/lib/algos/list/basic.js
@@ -28,14 +28,14 @@ class List extends Extension {
     }
 
     genMDParams() {
-        const params = {
+        const params = this.parameters ? {
             gt: this.parameters.gt,
             gte: this.parameters.gte || this.parameters.start,
             lt: this.parameters.lt,
             lte: this.parameters.lte || this.parameters.end,
             keys: this.parameters.keys,
             values: this.parameters.values,
-        };
+        } : {};
         Object.keys(params).forEach(key => {
             if (params[key] === null || params[key] === undefined) {
                 delete params[key];

--- a/lib/algos/list/delimiter.js
+++ b/lib/algos/list/delimiter.js
@@ -2,9 +2,10 @@
 
 const errors = require('../../errors');
 const Extension = require('./Extension').default;
-const { inc, FILTER_END, FILTER_ACCEPT, FILTER_SKIP } = require('./tools');
+const { inc, listingParamsMasterKeysV0ToV1,
+        FILTER_END, FILTER_ACCEPT, FILTER_SKIP } = require('./tools');
 const VSConst = require('../../versioning/constants').VersioningConstants;
-const { BucketVersioningKeyFormat } = VSConst;
+const { DbPrefixes, BucketVersioningKeyFormat } = VSConst;
 
 /**
  * Find the common prefix in the path
@@ -98,6 +99,9 @@ class Delimiter extends Extension {
         if (this.vFormat === BucketVersioningKeyFormat.v0) {
             return this.genMDParamsV0();
         }
+        if (this.vFormat === BucketVersioningKeyFormat.v1) {
+            return this.genMDParamsV1();
+        }
         throw errors.NotImplemented;
     }
 
@@ -116,6 +120,11 @@ class Delimiter extends Extension {
             params.gt = startVal;
         }
         return params;
+    }
+
+    genMDParamsV1() {
+        const params = this.genMDParamsV0();
+        return listingParamsMasterKeysV0ToV1(params);
     }
 
     /**
@@ -153,6 +162,9 @@ class Delimiter extends Extension {
     _getObjectKey(obj) {
         if (this.vFormat === BucketVersioningKeyFormat.v0) {
             return obj.key;
+        }
+        if (this.vFormat === BucketVersioningKeyFormat.v1) {
+            return obj.key.slice(DbPrefixes.Master.length);
         }
         throw errors.NotImplemented;
     }
@@ -219,11 +231,18 @@ class Delimiter extends Extension {
         if (this.vFormat === BucketVersioningKeyFormat.v0) {
             return this.skippingV0();
         }
+        if (this.vFormat === BucketVersioningKeyFormat.v1) {
+            return this.skippingV1();
+        }
         throw errors.NotImplemented;
     }
 
     skippingV0() {
         return this[this.nextContinueMarker];
+    }
+
+    skippingV1() {
+        return `${DbPrefixes.Master}${this[this.nextContinueMarker]}`;
     }
 
     /**

--- a/lib/algos/list/delimiterMaster.js
+++ b/lib/algos/list/delimiterMaster.js
@@ -8,6 +8,7 @@ const { BucketVersioningKeyFormat } = VSConst;
 const { FILTER_ACCEPT, FILTER_SKIP, SKIP_NONE } = require('./tools');
 
 const VID_SEP = VSConst.VersionId.Separator;
+const { DbPrefixes } = VSConst;
 
 /**
  * Handle object listing with parameters. This extends the base class Delimiter
@@ -34,9 +35,23 @@ class DelimiterMaster extends Delimiter {
         this.prvPHDKey = undefined;
     }
 
+    /**
+     *  Filter to apply on each iteration, based on:
+     *  - prefix
+     *  - delimiter
+     *  - maxKeys
+     *  The marker is being handled directly by levelDB
+     *  @param {Object} obj       - The key and value of the element
+     *  @param {String} obj.key   - The key of the element
+     *  @param {String} obj.value - The value of the element
+     *  @return {number}          - indicates if iteration should continue
+     */
     filter(obj) {
         if (this.vFormat === BucketVersioningKeyFormat.v0) {
             return this.filterV0(obj);
+        }
+        if (this.vFormat === BucketVersioningKeyFormat.v1) {
+            return this.filterV1(obj);
         }
         throw errors.NotImplemented;
     }
@@ -120,7 +135,24 @@ class DelimiterMaster extends Delimiter {
         return this.addContents(key, value);
     }
 
+    filterV1(obj) {
+        // Filtering master keys in v1 is simply listing the master
+        // keys, as the state of version keys do not change the
+        // result, so we can use Delimiter method directly.
+        return super.filter(obj);
+    }
+
     skipping() {
+        if (this.vFormat === BucketVersioningKeyFormat.v0) {
+            return this.skippingV0();
+        }
+        if (this.vFormat === BucketVersioningKeyFormat.v1) {
+            return this.skippingV1();
+        }
+        throw errors.NotImplemented;
+    }
+
+    skippingV0() {
         if (this[this.nextContinueMarker]) {
             // next marker or next continuation token:
             // - foo/ : skipping foo/
@@ -133,6 +165,14 @@ class DelimiterMaster extends Delimiter {
             return this[this.nextContinueMarker] + VID_SEP;
         }
         return SKIP_NONE;
+    }
+
+    skippingV1() {
+        const skipTo = this.skippingV0();
+        if (skipTo === SKIP_NONE) {
+            return SKIP_NONE;
+        }
+        return `${DbPrefixes.Master}${skipTo}`;
     }
 }
 

--- a/lib/algos/list/tools.js
+++ b/lib/algos/list/tools.js
@@ -1,3 +1,5 @@
+const { DbPrefixes } = require('../../versioning/constants').VersioningConstants;
+
 // constants for extensions
 const SKIP_NONE = undefined; // to be inline with the values of NextMarker
 const FILTER_ACCEPT = 1;
@@ -31,9 +33,36 @@ function inc(str) {
             String.fromCharCode(str.charCodeAt(str.length - 1) + 1)) : str;
 }
 
+/**
+ * Transform listing parameters for v0 versioning key format to make
+ * it compatible with v1 format
+ *
+ * @param {object} v0params - listing parameters for v0 format
+ * @return {object} - listing parameters for v1 format
+ */
+function listingParamsMasterKeysV0ToV1(v0params) {
+    const v1params = Object.assign({}, v0params);
+    if (v0params.gt !== undefined) {
+        v1params.gt = `${DbPrefixes.Master}${v0params.gt}`;
+    } else if (v0params.gte !== undefined) {
+        v1params.gte = `${DbPrefixes.Master}${v0params.gte}`;
+    } else {
+        v1params.gte = DbPrefixes.Master;
+    }
+    if (v0params.lt !== undefined) {
+        v1params.lt = `${DbPrefixes.Master}${v0params.lt}`;
+    } else if (v0params.lte !== undefined) {
+        v1params.lte = `${DbPrefixes.Master}${v0params.lte}`;
+    } else {
+        v1params.lt = inc(DbPrefixes.Master); // stop after the last master key
+    }
+    return v1params;
+}
+
 module.exports = {
     checkLimit,
     inc,
+    listingParamsMasterKeysV0ToV1,
     SKIP_NONE,
     FILTER_END,
     FILTER_SKIP,

--- a/tests/unit/algos/list/delimiterMaster.js
+++ b/tests/unit/algos/list/delimiterMaster.js
@@ -13,6 +13,7 @@ const VSConst =
     require('../../../../lib/versioning/constants').VersioningConstants;
 const Version = require('../../../../lib/versioning/Version').Version;
 const { generateVersionId } = require('../../../../lib/versioning/VersionID');
+const { DbPrefixes } = VSConst;
 
 
 const VID_SEP = VSConst.VersionId.Separator;
@@ -33,395 +34,426 @@ const fakeLogger = {
     fatal: () => {},
 };
 
-describe('Delimiter All masters listing algorithm', () => {
-    it('should return SKIP_NONE for DelimiterMaster when both NextMarker ' +
-       'and NextContinuationToken are undefined', () => {
-        const delimiter = new DelimiterMaster({ delimiter: '/' }, fakeLogger);
+function getListingKey(key, vFormat) {
+    if (vFormat === 'v0') {
+        return key;
+    }
+    if (vFormat === 'v1') {
+        return `${DbPrefixes.Master}${key}`;
+    }
+    return assert.fail(`bad vFormat ${vFormat}`);
+}
 
-        assert.strictEqual(delimiter.NextMarker, undefined);
+['v0', 'v1'].forEach(vFormat => {
+    describe(`Delimiter All masters listing algorithm vFormat=${vFormat}`, () => {
+        it('should return SKIP_NONE for DelimiterMaster when both NextMarker ' +
+        'and NextContinuationToken are undefined', () => {
+            const delimiter = new DelimiterMaster({ delimiter: '/' }, fakeLogger, vFormat);
 
-        // When there is no NextMarker or NextContinuationToken, it should
-        // return SKIP_NONE
-        assert.strictEqual(delimiter.skipping(), SKIP_NONE);
-    });
+            assert.strictEqual(delimiter.NextMarker, undefined);
 
-    it('should return <key><VersionIdSeparator> for DelimiterMaster when ' +
-       'NextMarker is set and there is a delimiter', () => {
-        const key = 'key';
-        const delimiter = new DelimiterMaster({ delimiter: '/', marker: key },
-                                             fakeLogger);
-
-        /* Filter a master version to set NextMarker. */
-        // TODO: useless once S3C-1628 is fixed.
-        delimiter.filter({ key, value: '' });
-        assert.strictEqual(delimiter.NextMarker, key);
-
-        /* With a delimiter skipping should return previous key + VID_SEP
-         * (except when a delimiter is set and the NextMarker ends with the
-         * delimiter) . */
-        assert.strictEqual(delimiter.skipping(), key + VID_SEP);
-    });
-
-    it('should return <key><VersionIdSeparator> for DelimiterMaster when ' +
-       'NextContinuationToken is set and there is a delimiter', () => {
-        const key = 'key';
-        const delimiter = new DelimiterMaster(
-            { delimiter: '/', startAfter: key, v2: true },
-            fakeLogger);
-
-        // Filter a master version to set NextContinuationToken
-        delimiter.filter({ key, value: '' });
-        assert.strictEqual(delimiter.NextContinuationToken, key);
-
-        assert.strictEqual(delimiter.skipping(), key + VID_SEP);
-    });
-
-    it('should return NextMarker for DelimiterMaster when NextMarker is set' +
-       ', there is a delimiter and the key ends with the delimiter', () => {
-        const delimiterChar = '/';
-        const keyWithEndingDelimiter = `key${delimiterChar}`;
-        const delimiter = new DelimiterMaster({
-            delimiter: delimiterChar,
-            marker: keyWithEndingDelimiter,
-        }, fakeLogger);
-
-        /* When a delimiter is set and the NextMarker ends with the
-         * delimiter it should return the next marker value. */
-        assert.strictEqual(delimiter.NextMarker, keyWithEndingDelimiter);
-        assert.strictEqual(delimiter.skipping(), keyWithEndingDelimiter);
-    });
-
-    it('should skip entries not starting with prefix', () => {
-        const delimiter = new DelimiterMaster({ prefix: 'prefix' }, fakeLogger);
-
-        assert.strictEqual(delimiter.filter({ key: 'wrong' }), FILTER_SKIP);
-        assert.strictEqual(delimiter.NextMarker, undefined);
-        assert.strictEqual(delimiter.prvKey, undefined);
-        assert.deepStrictEqual(delimiter.result(), EmptyResult);
-    });
-
-    it('should skip entries inferior to next marker', () => {
-        const delimiter = new DelimiterMaster({ marker: 'b' }, fakeLogger);
-
-        assert.strictEqual(delimiter.filter({ key: 'a' }), FILTER_SKIP);
-        assert.strictEqual(delimiter.NextMarker, 'b');
-        assert.strictEqual(delimiter.prvKey, undefined);
-        assert.deepStrictEqual(delimiter.result(), EmptyResult);
-    });
-
-    it('should accept a master version', () => {
-        const delimiter = new DelimiterMaster({}, fakeLogger);
-        const key = 'key';
-        const value = '';
-
-        assert.strictEqual(delimiter.filter({ key, value }), FILTER_ACCEPT);
-        assert.strictEqual(delimiter.prvKey, key);
-        assert.strictEqual(delimiter.NextMarker, key);
-        assert.deepStrictEqual(delimiter.result(), {
-            CommonPrefixes: [],
-            Contents: [{ key, value }],
-            IsTruncated: false,
-            NextMarker: undefined,
-            Delimiter: undefined,
+            // When there is no NextMarker or NextContinuationToken, it should
+            // return SKIP_NONE
+            assert.strictEqual(delimiter.skipping(), SKIP_NONE);
         });
-    });
 
-    it('should accept a PHD version as first input', () => {
-        const delimiter = new DelimiterMaster({}, fakeLogger);
-        const keyPHD = 'keyPHD';
-        const objPHD = {
-            key: keyPHD,
-            value: Version.generatePHDVersion(generateVersionId('', '')),
-        };
+        it('should return <key><VersionIdSeparator> for DelimiterMaster when ' +
+        'NextMarker is set and there is a delimiter', () => {
+            const key = 'key';
+            const delimiter = new DelimiterMaster({ delimiter: '/', marker: key },
+                                                  fakeLogger, vFormat);
 
-        /* When filtered, it should return FILTER_ACCEPT and set the prvKey.
-         * to undefined. It should not be added to result the content or common
-         * prefixes. */
-        assert.strictEqual(delimiter.filter(objPHD), FILTER_ACCEPT);
-        assert.strictEqual(delimiter.prvKey, undefined);
-        assert.strictEqual(delimiter.NextMarker, undefined);
-        assert.deepStrictEqual(delimiter.result(), EmptyResult);
-    });
+            /* Filter a master version to set NextMarker. */
+            // TODO: useless once S3C-1628 is fixed.
+            const listingKey = getListingKey(key, vFormat);
+            delimiter.filter({ key: listingKey, value: '' });
+            assert.strictEqual(delimiter.NextMarker, key);
 
-    it('should accept a PHD version', () => {
-        const delimiter = new DelimiterMaster({}, fakeLogger);
-        const key = 'keyA';
-        const value = '';
-        const keyPHD = 'keyBPHD';
-        const objPHD = {
-            key: keyPHD,
-            value: Version.generatePHDVersion(generateVersionId('', '')),
-        };
-
-        /* Filter a master version to set the NextMarker, the prvKey and add
-         * and element in result content. */
-        delimiter.filter({ key, value });
-
-        /* When filtered, it should return FILTER_ACCEPT and set the prvKey.
-         * to undefined. It should not be added to the result content or common
-         * prefixes. */
-        assert.strictEqual(delimiter.filter(objPHD), FILTER_ACCEPT);
-        assert.strictEqual(delimiter.prvKey, undefined);
-        assert.strictEqual(delimiter.NextMarker, key);
-        assert.deepStrictEqual(delimiter.result(), {
-            CommonPrefixes: [],
-            Contents: [{ key, value }],
-            IsTruncated: false,
-            NextMarker: undefined,
-            Delimiter: undefined,
+            /* With a delimiter skipping should return previous key + VID_SEP
+             * (except when a delimiter is set and the NextMarker ends with the
+             * delimiter) . */
+            assert.strictEqual(delimiter.skipping(), listingKey + VID_SEP);
         });
-    });
 
-    it('should accept a version after a PHD', () => {
-        const delimiter = new DelimiterMaster({}, fakeLogger);
-        const masterKey = 'key';
-        const keyVersion = `${masterKey}${VID_SEP}version`;
-        const value = '';
-        const objPHD = {
-            key: masterKey,
-            value: Version.generatePHDVersion(generateVersionId('', '')),
-        };
+        it('should return <key><VersionIdSeparator> for DelimiterMaster when ' +
+        'NextContinuationToken is set and there is a delimiter', () => {
+            const key = 'key';
+            const delimiter = new DelimiterMaster(
+                { delimiter: '/', startAfter: key, v2: true },
+                fakeLogger, vFormat);
 
-        /* Filter the PHD object. */
-        delimiter.filter(objPHD);
+            // Filter a master version to set NextContinuationToken
+            const listingKey = getListingKey(key, vFormat);
+            delimiter.filter({ key: listingKey, value: '' });
+            assert.strictEqual(delimiter.NextContinuationToken, key);
 
-        /* The filtering of the PHD object has no impact, the version is
-         * accepted and added to the result. */
-        assert.strictEqual(delimiter.filter({
-            key: keyVersion,
-            value,
-        }), FILTER_ACCEPT);
-        assert.strictEqual(delimiter.prvKey, masterKey);
-        assert.strictEqual(delimiter.NextMarker, masterKey);
-        assert.deepStrictEqual(delimiter.result(), {
-            CommonPrefixes: [],
-            Contents: [{ key: masterKey, value }],
-            IsTruncated: false,
-            NextMarker: undefined,
-            Delimiter: undefined,
+            assert.strictEqual(delimiter.skipping(), listingKey + VID_SEP);
         });
-    });
 
-    it('should accept a delete marker', () => {
-        const delimiter = new DelimiterMaster({}, fakeLogger);
-        const version = new Version({ isDeleteMarker: true });
-        const key = 'key';
-        const obj = {
-            key: `${key}${VID_SEP}version`,
-            value: version.toString(),
-        };
+        it('should return NextMarker for DelimiterMaster when NextMarker is set' +
+        ', there is a delimiter and the key ends with the delimiter', () => {
+            const delimiterChar = '/';
+            const keyWithEndingDelimiter = `key${delimiterChar}`;
+            const delimiter = new DelimiterMaster({
+                delimiter: delimiterChar,
+                marker: keyWithEndingDelimiter,
+            }, fakeLogger, vFormat);
 
-        /* When filtered, it should return FILTER_SKIP and set the prvKey. It
-         * should not be added to the result content or common prefixes. */
-        assert.strictEqual(delimiter.filter(obj), FILTER_SKIP);
-        assert.strictEqual(delimiter.NextMarker, undefined);
-        assert.strictEqual(delimiter.prvKey, key);
-        assert.deepStrictEqual(delimiter.result(), EmptyResult);
-    });
-
-    it('should skip version after a delete marker', () => {
-        const delimiter = new DelimiterMaster({}, fakeLogger);
-        const version = new Version({ isDeleteMarker: true });
-        const key = 'key';
-        const versionKey = `${key}${VID_SEP}version`;
-
-        delimiter.filter({ key, value: version.toString() });
-        assert.strictEqual(delimiter.filter({
-            key: versionKey,
-            value: 'value',
-        }), FILTER_SKIP);
-        assert.strictEqual(delimiter.NextMarker, undefined);
-        assert.strictEqual(delimiter.prvKey, key);
-        assert.deepStrictEqual(delimiter.result(), EmptyResult);
-    });
-
-    it('should accept a new key after a delete marker', () => {
-        const delimiter = new DelimiterMaster({}, fakeLogger);
-        const version = new Version({ isDeleteMarker: true });
-        const key1 = 'key1';
-        const key2 = 'key2';
-        const value = 'value';
-
-        delimiter.filter({ key: key1, value: version.toString() });
-        assert.strictEqual(delimiter.filter({
-            key: key2,
-            value: 'value',
-        }), FILTER_ACCEPT);
-        assert.strictEqual(delimiter.NextMarker, key2);
-        assert.strictEqual(delimiter.prvKey, key2);
-        assert.deepStrictEqual(delimiter.result(), {
-            CommonPrefixes: [],
-            Contents: [{ key: key2, value }],
-            IsTruncated: false,
-            NextMarker: undefined,
-            Delimiter: undefined,
+            /* When a delimiter is set and the NextMarker ends with the
+             * delimiter it should return the next marker value. */
+            assert.strictEqual(delimiter.NextMarker, keyWithEndingDelimiter);
+            const skipKey = vFormat === 'v1' ?
+                  `${DbPrefixes.Master}${keyWithEndingDelimiter}` :
+                  keyWithEndingDelimiter;
+            assert.strictEqual(delimiter.skipping(), skipKey);
         });
-    });
 
-    it('should accept the master version and skip the other ones', () => {
-        const delimiter = new DelimiterMaster({}, fakeLogger);
-        const masterKey = 'key';
-        const masterValue = 'value';
-        const versionKey = `${masterKey}${VID_SEP}version`;
-        const versionValue = 'versionvalue';
+        it('should skip entries not starting with prefix', () => {
+            const delimiter = new DelimiterMaster({ prefix: 'prefix' }, fakeLogger, vFormat);
 
-        /* Filter the master version. */
-        delimiter.filter({ key: masterKey, value: masterValue });
-
-        /* Version is skipped, not added to the result. The delimiter
-         * NextMarker and prvKey value are unmodified and set to the
-         * masterKey. */
-        assert.strictEqual(delimiter.filter({
-            key: versionKey,
-            value: versionValue,
-        }), FILTER_SKIP);
-        assert.strictEqual(delimiter.NextMarker, masterKey);
-        assert.strictEqual(delimiter.prvKey, masterKey);
-        assert.deepStrictEqual(delimiter.result(), {
-            CommonPrefixes: [],
-            Contents: [{ key: masterKey, value: masterValue }],
-            IsTruncated: false,
-            NextMarker: undefined,
-            Delimiter: undefined,
+            const listingKey = getListingKey('wrong', vFormat);
+            assert.strictEqual(delimiter.filter({ key: listingKey }), FILTER_SKIP);
+            assert.strictEqual(delimiter.NextMarker, undefined);
+            assert.strictEqual(delimiter.prvKey, undefined);
+            assert.deepStrictEqual(delimiter.result(), EmptyResult);
         });
-    });
 
-    it('should return good listing result for version', () => {
-        const delimiter = new DelimiterMaster({}, fakeLogger);
-        const masterKey = 'key';
-        const versionKey1 = `${masterKey}${VID_SEP}version1`;
-        const versionKey2 = `${masterKey}${VID_SEP}version2`;
-        const value2 = 'value2';
+        it('should skip entries inferior to next marker', () => {
+            const delimiter = new DelimiterMaster({ marker: 'b' }, fakeLogger, vFormat);
 
-        /* Filter the PHD version. */
-        assert.strictEqual(delimiter.filter({
-            key: masterKey,
-            value: '{ "isPHD": true, "value": "version" }',
-        }), FILTER_ACCEPT);
-
-        /* Filter a delete marker version. */
-        assert.strictEqual(delimiter.filter({
-            key: versionKey1,
-            value: '{ "isDeleteMarker": true }',
-        }), FILTER_ACCEPT);
-
-        /* Filter a last version with a specific value. */
-        assert.strictEqual(delimiter.filter({
-            key: versionKey2,
-            value: value2,
-        }), FILTER_ACCEPT);
-
-        assert.deepStrictEqual(delimiter.result(), {
-            CommonPrefixes: [],
-            Contents: [{ key: masterKey, value: value2 }],
-            IsTruncated: false,
-            NextMarker: undefined,
-            Delimiter: undefined,
+            const listingKey = getListingKey('a', vFormat);
+            assert.strictEqual(delimiter.filter({ key: listingKey }), FILTER_SKIP);
+            assert.strictEqual(delimiter.NextMarker, 'b');
+            assert.strictEqual(delimiter.prvKey, undefined);
+            assert.deepStrictEqual(delimiter.result(), EmptyResult);
         });
-    });
 
-    it('should return good values for entries with different common prefixes',
-       () => {
-           const delimiterChar = '/';
-           const commonPrefix1 = `commonPrefix1${delimiterChar}`;
-           const commonPrefix2 = `commonPrefix2${delimiterChar}`;
-           const prefix1Key1 = `${commonPrefix1}key1`;
-           const prefix1Key2 = `${commonPrefix1}key2`;
-           const prefix2Key1 = `${commonPrefix2}key1`;
-           const value = 'value';
+        it('should accept a master version', () => {
+            const delimiter = new DelimiterMaster({}, fakeLogger, vFormat);
+            const key = 'key';
+            const value = '';
 
-           const delimiter = new DelimiterMaster({ delimiter: delimiterChar },
-                                                 fakeLogger);
-
-           /* Filter the first entry with a common prefix. It should be
-            * accepted and added to the result. */
-           assert.strictEqual(delimiter.filter({ key: prefix1Key1, value }),
-                              FILTER_ACCEPT);
-           assert.deepStrictEqual(delimiter.result(), {
-               CommonPrefixes: [commonPrefix1],
-               Contents: [],
-               IsTruncated: false,
-               NextMarker: undefined,
-               Delimiter: delimiterChar,
-           });
-
-           /* Filter the second entry with the same common prefix than the
-            * first entry. It should be skipped and not added to the result. */
-           assert.strictEqual(delimiter.filter({ key: prefix1Key2, value }),
-                              FILTER_SKIP);
-           assert.deepStrictEqual(delimiter.result(), {
-               CommonPrefixes: [commonPrefix1],
-               Contents: [],
-               IsTruncated: false,
-               NextMarker: undefined,
-               Delimiter: delimiterChar,
-           });
-
-           /* Filter an entry with a new common prefix. It should be accepted
-            * and not added to the result. */
-           assert.strictEqual(delimiter.filter({ key: prefix2Key1, value }),
-                              FILTER_ACCEPT);
-           assert.deepStrictEqual(delimiter.result(), {
-               CommonPrefixes: [commonPrefix1, commonPrefix2],
-               Contents: [],
-               IsTruncated: false,
-               NextMarker: undefined,
-               Delimiter: delimiterChar,
-           });
-       });
-
-    /* We test here the internal management of the prvKey field of the
-     * DelimiterMaster class, in particular once it has been set to an entry
-     * key before to finally skip this entry because of an already present
-     * common prefix. */
-    it('should accept a version after skipping an object because of its ' +
-       'commonPrefix', () => {
-        const delimiterChar = '/';
-        const commonPrefix1 = `commonPrefix1${delimiterChar}`;
-        const commonPrefix2 = `commonPrefix2${delimiterChar}`;
-        const prefix1Key1 = `${commonPrefix1}key1`;
-        const prefix1Key2 = `${commonPrefix1}key2`;
-        const prefix2VersionKey1 = `${commonPrefix2}key1${VID_SEP}version`;
-        const value = 'value';
-
-        const delimiter = new DelimiterMaster({ delimiter: delimiterChar },
-                                              fakeLogger);
-
-        /* Filter the two first entries with the same common prefix to add
-         * it to the result and reach the state where an entry is skipped
-         * because of an already present common prefix in the result. */
-        delimiter.filter({ key: prefix1Key1, value });
-        delimiter.filter({ key: prefix1Key2, value });
-
-        /* Filter an object with a key containing a version part and a new
-         * common prefix. It should be accepted and the new common prefix
-         * added to the result. */
-        assert.strictEqual(delimiter.filter({
-            key: prefix2VersionKey1,
-            value,
-        }), FILTER_ACCEPT);
-        assert.deepStrictEqual(delimiter.result(), {
-            CommonPrefixes: [commonPrefix1, commonPrefix2],
-            Contents: [],
-            IsTruncated: false,
-            NextMarker: undefined,
-            Delimiter: delimiterChar,
+            const listingKey = getListingKey(key, vFormat);
+            assert.strictEqual(delimiter.filter({ key: listingKey, value }), FILTER_ACCEPT);
+            if (vFormat === 'v0') {
+                assert.strictEqual(delimiter.prvKey, key);
+            }
+            assert.strictEqual(delimiter.NextMarker, key);
+            assert.deepStrictEqual(delimiter.result(), {
+                CommonPrefixes: [],
+                Contents: [{ key, value }],
+                IsTruncated: false,
+                NextMarker: undefined,
+                Delimiter: undefined,
+            });
         });
-    });
 
-    it('should skip a versioned entry when there is a delimiter and the key ' +
-       'starts with the NextMarker value', () => {
-        const delimiterChar = '/';
-        const commonPrefix = `commonPrefix${delimiterChar}`;
-        const key = `${commonPrefix}key${VID_SEP}version`;
-        const value = 'value';
+        it('should return good values for entries with different common prefixes', () => {
+            const delimiterChar = '/';
+            const commonPrefix1 = `commonPrefix1${delimiterChar}`;
+            const commonPrefix2 = `commonPrefix2${delimiterChar}`;
+            const prefix1Key1 = `${commonPrefix1}key1`;
+            const prefix1Key2 = `${commonPrefix1}key2`;
+            const prefix2Key1 = `${commonPrefix2}key1`;
+            const value = 'value';
 
-        const delimiter = new DelimiterMaster({ delimiter: delimiterChar },
-                                              fakeLogger);
-        /* TODO: should be set to a whole key instead of just a common prefix
-         * once ZENKO-1048 is fixed. */
-        delimiter.NextMarker = commonPrefix;
+            const delimiter = new DelimiterMaster({ delimiter: delimiterChar },
+                                                  fakeLogger, vFormat);
 
-        assert.strictEqual(delimiter.filter({ key, value }), FILTER_SKIP);
+            /* Filter the first entry with a common prefix. It should be
+             * accepted and added to the result. */
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(prefix1Key1, vFormat),
+                value,
+            }),
+                               FILTER_ACCEPT);
+            assert.deepStrictEqual(delimiter.result(), {
+                CommonPrefixes: [commonPrefix1],
+                Contents: [],
+                IsTruncated: false,
+                NextMarker: undefined,
+                Delimiter: delimiterChar,
+            });
+
+            /* Filter the second entry with the same common prefix than the
+             * first entry. It should be skipped and not added to the result. */
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(prefix1Key2, vFormat),
+                value,
+            }),
+                               FILTER_SKIP);
+            assert.deepStrictEqual(delimiter.result(), {
+                CommonPrefixes: [commonPrefix1],
+                Contents: [],
+                IsTruncated: false,
+                NextMarker: undefined,
+                Delimiter: delimiterChar,
+            });
+
+            /* Filter an entry with a new common prefix. It should be accepted
+             * and not added to the result. */
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(prefix2Key1, vFormat),
+                value,
+            }),
+                               FILTER_ACCEPT);
+            assert.deepStrictEqual(delimiter.result(), {
+                CommonPrefixes: [commonPrefix1, commonPrefix2],
+                Contents: [],
+                IsTruncated: false,
+                NextMarker: undefined,
+                Delimiter: delimiterChar,
+            });
+        });
+
+        if (vFormat === 'v0') {
+            it('should accept a PHD version as first input', () => {
+                const delimiter = new DelimiterMaster({}, fakeLogger, vFormat);
+                const keyPHD = 'keyPHD';
+                const objPHD = {
+                    key: keyPHD,
+                    value: Version.generatePHDVersion(generateVersionId('', '')),
+                };
+
+                /* When filtered, it should return FILTER_ACCEPT and set the prvKey.
+                 * to undefined. It should not be added to result the content or common
+                 * prefixes. */
+                assert.strictEqual(delimiter.filter(objPHD), FILTER_ACCEPT);
+                assert.strictEqual(delimiter.prvKey, undefined);
+                assert.strictEqual(delimiter.NextMarker, undefined);
+                assert.deepStrictEqual(delimiter.result(), EmptyResult);
+            });
+
+            it('should accept a PHD version', () => {
+                const delimiter = new DelimiterMaster({}, fakeLogger, vFormat);
+                const key = 'keyA';
+                const value = '';
+                const keyPHD = 'keyBPHD';
+                const objPHD = {
+                    key: keyPHD,
+                    value: Version.generatePHDVersion(generateVersionId('', '')),
+                };
+
+                /* Filter a master version to set the NextMarker, the prvKey and add
+                 * and element in result content. */
+                delimiter.filter({ key, value });
+
+                /* When filtered, it should return FILTER_ACCEPT and set the prvKey.
+                 * to undefined. It should not be added to the result content or common
+                 * prefixes. */
+                assert.strictEqual(delimiter.filter(objPHD), FILTER_ACCEPT);
+                assert.strictEqual(delimiter.prvKey, undefined);
+                assert.strictEqual(delimiter.NextMarker, key);
+                assert.deepStrictEqual(delimiter.result(), {
+                    CommonPrefixes: [],
+                    Contents: [{ key, value }],
+                    IsTruncated: false,
+                    NextMarker: undefined,
+                    Delimiter: undefined,
+                });
+            });
+
+            it('should accept a version after a PHD', () => {
+                const delimiter = new DelimiterMaster({}, fakeLogger, vFormat);
+                const masterKey = 'key';
+                const keyVersion = `${masterKey}${VID_SEP}version`;
+                const value = '';
+                const objPHD = {
+                    key: masterKey,
+                    value: Version.generatePHDVersion(generateVersionId('', '')),
+                };
+
+                /* Filter the PHD object. */
+                delimiter.filter(objPHD);
+
+                /* The filtering of the PHD object has no impact, the version is
+                 * accepted and added to the result. */
+                assert.strictEqual(delimiter.filter({
+                    key: keyVersion,
+                    value,
+                }), FILTER_ACCEPT);
+                assert.strictEqual(delimiter.prvKey, masterKey);
+                assert.strictEqual(delimiter.NextMarker, masterKey);
+                assert.deepStrictEqual(delimiter.result(), {
+                    CommonPrefixes: [],
+                    Contents: [{ key: masterKey, value }],
+                    IsTruncated: false,
+                    NextMarker: undefined,
+                    Delimiter: undefined,
+                });
+            });
+
+            it('should accept a delete marker', () => {
+                const delimiter = new DelimiterMaster({}, fakeLogger, vFormat);
+                const version = new Version({ isDeleteMarker: true });
+                const key = 'key';
+                const obj = {
+                    key: `${key}${VID_SEP}version`,
+                    value: version.toString(),
+                };
+
+                /* When filtered, it should return FILTER_SKIP and set the prvKey. It
+                 * should not be added to the result content or common prefixes. */
+                assert.strictEqual(delimiter.filter(obj), FILTER_SKIP);
+                assert.strictEqual(delimiter.NextMarker, undefined);
+                assert.strictEqual(delimiter.prvKey, key);
+                assert.deepStrictEqual(delimiter.result(), EmptyResult);
+            });
+
+            it('should skip version after a delete marker', () => {
+                const delimiter = new DelimiterMaster({}, fakeLogger, vFormat);
+                const version = new Version({ isDeleteMarker: true });
+                const key = 'key';
+                const versionKey = `${key}${VID_SEP}version`;
+
+                delimiter.filter({ key, value: version.toString() });
+                assert.strictEqual(delimiter.filter({
+                    key: versionKey,
+                    value: 'value',
+                }), FILTER_SKIP);
+                assert.strictEqual(delimiter.NextMarker, undefined);
+                assert.strictEqual(delimiter.prvKey, key);
+                assert.deepStrictEqual(delimiter.result(), EmptyResult);
+            });
+
+            it('should accept a new key after a delete marker', () => {
+                const delimiter = new DelimiterMaster({}, fakeLogger, vFormat);
+                const version = new Version({ isDeleteMarker: true });
+                const key1 = 'key1';
+                const key2 = 'key2';
+                const value = 'value';
+
+                delimiter.filter({ key: key1, value: version.toString() });
+                assert.strictEqual(delimiter.filter({
+                    key: key2,
+                    value: 'value',
+                }), FILTER_ACCEPT);
+                assert.strictEqual(delimiter.NextMarker, key2);
+                assert.strictEqual(delimiter.prvKey, key2);
+                assert.deepStrictEqual(delimiter.result(), {
+                    CommonPrefixes: [],
+                    Contents: [{ key: key2, value }],
+                    IsTruncated: false,
+                    NextMarker: undefined,
+                    Delimiter: undefined,
+                });
+            });
+
+            it('should accept the master version and skip the other ones', () => {
+                const delimiter = new DelimiterMaster({}, fakeLogger, vFormat);
+                const masterKey = 'key';
+                const masterValue = 'value';
+                const versionKey = `${masterKey}${VID_SEP}version`;
+                const versionValue = 'versionvalue';
+
+                /* Filter the master version. */
+                delimiter.filter({ key: masterKey, value: masterValue });
+
+                /* Version is skipped, not added to the result. The delimiter
+                 * NextMarker and prvKey value are unmodified and set to the
+                 * masterKey. */
+                assert.strictEqual(delimiter.filter({
+                    key: versionKey,
+                    value: versionValue,
+                }), FILTER_SKIP);
+                assert.strictEqual(delimiter.NextMarker, masterKey);
+                assert.strictEqual(delimiter.prvKey, masterKey);
+                assert.deepStrictEqual(delimiter.result(), {
+                    CommonPrefixes: [],
+                    Contents: [{ key: masterKey, value: masterValue }],
+                    IsTruncated: false,
+                    NextMarker: undefined,
+                    Delimiter: undefined,
+                });
+            });
+
+            it('should return good listing result for version', () => {
+                const delimiter = new DelimiterMaster({}, fakeLogger, vFormat);
+                const masterKey = 'key';
+                const versionKey1 = `${masterKey}${VID_SEP}version1`;
+                const versionKey2 = `${masterKey}${VID_SEP}version2`;
+                const value2 = 'value2';
+
+                /* Filter the PHD version. */
+                assert.strictEqual(delimiter.filter({
+                    key: masterKey,
+                    value: '{ "isPHD": true, "value": "version" }',
+                }), FILTER_ACCEPT);
+
+                /* Filter a delete marker version. */
+                assert.strictEqual(delimiter.filter({
+                    key: versionKey1,
+                    value: '{ "isDeleteMarker": true }',
+                }), FILTER_ACCEPT);
+
+                /* Filter a last version with a specific value. */
+                assert.strictEqual(delimiter.filter({
+                    key: versionKey2,
+                    value: value2,
+                }), FILTER_ACCEPT);
+
+                assert.deepStrictEqual(delimiter.result(), {
+                    CommonPrefixes: [],
+                    Contents: [{ key: masterKey, value: value2 }],
+                    IsTruncated: false,
+                    NextMarker: undefined,
+                    Delimiter: undefined,
+                });
+            });
+
+            /* We test here the internal management of the prvKey field of the
+             * DelimiterMaster class, in particular once it has been set to an entry
+             * key before to finally skip this entry because of an already present
+             * common prefix. */
+            it('should accept a version after skipping an object because of its commonPrefix', () => {
+                const delimiterChar = '/';
+                const commonPrefix1 = `commonPrefix1${delimiterChar}`;
+                const commonPrefix2 = `commonPrefix2${delimiterChar}`;
+                const prefix1Key1 = `${commonPrefix1}key1`;
+                const prefix1Key2 = `${commonPrefix1}key2`;
+                const prefix2VersionKey1 = `${commonPrefix2}key1${VID_SEP}version`;
+                const value = 'value';
+
+                const delimiter = new DelimiterMaster({ delimiter: delimiterChar },
+                                                      fakeLogger, vFormat);
+
+                /* Filter the two first entries with the same common prefix to add
+                 * it to the result and reach the state where an entry is skipped
+                 * because of an already present common prefix in the result. */
+                delimiter.filter({ key: prefix1Key1, value });
+                delimiter.filter({ key: prefix1Key2, value });
+
+                /* Filter an object with a key containing a version part and a new
+                 * common prefix. It should be accepted and the new common prefix
+                 * added to the result. */
+                assert.strictEqual(delimiter.filter({
+                    key: prefix2VersionKey1,
+                    value,
+                }), FILTER_ACCEPT);
+                assert.deepStrictEqual(delimiter.result(), {
+                    CommonPrefixes: [commonPrefix1, commonPrefix2],
+                    Contents: [],
+                    IsTruncated: false,
+                    NextMarker: undefined,
+                    Delimiter: delimiterChar,
+                });
+            });
+
+            it('should skip a versioned entry when there is a delimiter and the key ' +
+            'starts with the NextMarker value', () => {
+                const delimiterChar = '/';
+                const commonPrefix = `commonPrefix${delimiterChar}`;
+                const key = `${commonPrefix}key${VID_SEP}version`;
+                const value = 'value';
+
+                const delimiter = new DelimiterMaster({ delimiter: delimiterChar },
+                                                      fakeLogger, vFormat);
+                /* TODO: should be set to a whole key instead of just a common prefix
+                 * once ZENKO-1048 is fixed. */
+                delimiter.NextMarker = commonPrefix;
+
+                assert.strictEqual(delimiter.filter({ key, value }), FILTER_SKIP);
+            });
+        }
     });
 });

--- a/tests/unit/algos/list/tools.js
+++ b/tests/unit/algos/list/tools.js
@@ -2,7 +2,10 @@
 
 const assert = require('assert');
 
-const checkLimit = require('../../../../lib/algos/list/tools').checkLimit;
+const { checkLimit, inc, listingParamsMasterKeysV0ToV1 } =
+      require('../../../../lib/algos/list/tools');
+const VSConst = require('../../../../lib/versioning/constants').VersioningConstants;
+const { DbPrefixes } = VSConst;
 
 describe('checkLimit function', () => {
     const tests = [
@@ -20,6 +23,82 @@ describe('checkLimit function', () => {
             const res = checkLimit(test.input[0], test.input[1]);
             assert.deepStrictEqual(res, test.output);
             done();
+        });
+    });
+});
+
+describe('listingParamsMasterKeysV0ToV1', () => {
+    const testCases = [
+        {
+            v0params: {},
+            v1params: {
+                gte: DbPrefixes.Master,
+                lt: inc(DbPrefixes.Master),
+            },
+        },
+        {
+            v0params: {
+                gt: 'foo/bar',
+            },
+            v1params: {
+                gt: `${DbPrefixes.Master}foo/bar`,
+                lt: inc(DbPrefixes.Master),
+            },
+        },
+        {
+            v0params: {
+                gte: 'foo/bar',
+            },
+            v1params: {
+                gte: `${DbPrefixes.Master}foo/bar`,
+                lt: inc(DbPrefixes.Master),
+            },
+        },
+        {
+            v0params: {
+                lt: 'foo/bar',
+            },
+            v1params: {
+                gte: DbPrefixes.Master,
+                lt: `${DbPrefixes.Master}foo/bar`,
+            },
+        },
+        {
+            v0params: {
+                lte: 'foo/bar',
+            },
+            v1params: {
+                gte: DbPrefixes.Master,
+                lte: `${DbPrefixes.Master}foo/bar`,
+            },
+        },
+        {
+            v0params: {
+                gt: 'baz/qux',
+                lt: 'foo/bar',
+            },
+            v1params: {
+                gt: `${DbPrefixes.Master}baz/qux`,
+                lt: `${DbPrefixes.Master}foo/bar`,
+            },
+        },
+        {
+            v0params: {
+                gte: 'baz/qux',
+                lte: 'foo/bar',
+                limit: 5,
+            },
+            v1params: {
+                gte: `${DbPrefixes.Master}baz/qux`,
+                lte: `${DbPrefixes.Master}foo/bar`,
+                limit: 5,
+            },
+        },
+    ];
+    testCases.forEach(testCase => {
+        it(`${JSON.stringify(testCase.v0params)} => ${JSON.stringify(testCase.v1params)}`, () => {
+            const converted = listingParamsMasterKeysV0ToV1(testCase.v0params);
+            assert.deepStrictEqual(converted, testCase.v1params);
         });
     });
 });

--- a/tests/utils/performListing.js
+++ b/tests/utils/performListing.js
@@ -1,5 +1,9 @@
-module.exports = function performListing(data, Extension, params, logger) {
-    const listing = new Extension(params, logger);
+const assert = require('assert');
+
+module.exports = function performListing(data, Extension, params, logger, vFormat) {
+    const listing = new Extension(params, logger, vFormat);
+    const mdParams = listing.genMDParams();
+    assert(typeof mdParams === 'object');
     data.every(e => listing.filter(e) >= 0);
     return listing.result();
 };


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1028.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-2899-vformatV1delimiterMaster`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-2899-vformatV1delimiterMaster
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-2899-vformatV1delimiterMaster
```

Please always comment pull request #1028 instead of this one.