### PR TITLE
ft: S3C 2787 put object retention

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,6 +87,7 @@ module.exports = {
             SubStreamInterface:
                 require('./lib/s3middleware/azureHelpers/SubStreamInterface'),
         },
+        retention: require('./lib/s3middleware/objectRetention'),
     },
     storage: {
         metadata: {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -75,4 +75,6 @@ module.exports = {
     // Default expiration value of the S3 pre-signed URL duration
     // 604800 seconds (seven days).
     defaultPreSignedURLExpiry: 7 * 24 * 60 * 60,
+    // Regex for ISO-8601 formatted date
+    iso8601Regex: /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/,
 };

--- a/lib/models/ObjectMD.js
+++ b/lib/models/ObjectMD.js
@@ -902,6 +902,28 @@ class ObjectMD {
     }
 
     /**
+     * Set object retention information
+     * @param {object} retentionInfo - retention information object
+     * @return {ObjectMD} itself
+     */
+    setRetentionInfo(retentionInfo) {
+        const { mode, retainUntilDate } = retentionInfo;
+        this._data.retentionInfo = {
+            mode,
+            retainUntilDate,
+        };
+        return this;
+    }
+
+    /**
+     * Returns object retention information
+     * @return {object} metadata object
+     */
+    getRetentionInfo() {
+        return this._data.retentionInfo;
+    }
+
+    /**
      * Returns metadata object
      *
      * @return {object} metadata object
@@ -909,7 +931,6 @@ class ObjectMD {
     getValue() {
         return this._data;
     }
-
 }
 
 module.exports = ObjectMD;

--- a/lib/s3middleware/objectRetention.js
+++ b/lib/s3middleware/objectRetention.js
@@ -1,0 +1,135 @@
+const { parseString } = require('xml2js');
+
+const constants = require('../constants');
+const errors = require('../errors');
+
+/*
+    Format of xml request:
+    <ObjectRetention>
+      <Mode>COMPLIANCE|GOVERNANCE</Mode>
+      <RetainUntilDate>2020-05-20T04:58:45.413000Z</RetainUntilDate>
+    </ObjectRetention>
+*/
+
+/**
+ * validateMode - validate retention mode
+ * @param {array} mode - parsed xml mode array
+ * @return {object} - contains mode or error
+ */
+function validateMode(mode) {
+    const modeObj = {};
+    const expectedModes = new Set(['GOVERNANCE', 'COMPLIANCE']);
+    if (!mode || !mode[0]) {
+        modeObj.error = errors.MalformedXML.customizeDescription(
+            'request xml does not contain Mode');
+        return modeObj;
+    }
+    if (mode.length > 1) {
+        modeObj.error = errors.MalformedXML.customizeDescription(
+            'request xml contains more than one Mode');
+        return modeObj;
+    }
+    if (!expectedModes.has(mode[0])) {
+        modeObj.error = errors.MalformedXML.customizeDescription(
+            'Mode request xml must be one of "GOVERNANCE", "COMPLIANCE"');
+        return modeObj;
+    }
+    modeObj.mode = mode[0];
+    return modeObj;
+}
+
+/**
+ * validateRetainDate - validate retain until date
+ * @param {array} retainDate - parsed xml retention date array
+ * @return {object} - contains retain until date or error
+ */
+function validateRetainDate(retainDate) {
+    const dateObj = {};
+    if (!retainDate || !retainDate[0]) {
+        dateObj.error = errors.MalformedXML.customizeDescription(
+            'request xml does not contain RetainUntilDate');
+        return dateObj;
+    }
+    if (!constants.iso8601Regex.test(retainDate[0])) {
+        dateObj.error = errors.InvalidRequest.customizeDescription(
+            'RetainUntilDate timestamp must be ISO-8601 format');
+        return dateObj;
+    }
+    const date = new Date(retainDate[0]);
+    if (date < Date.now()) {
+        dateObj.error = errors.InvalidRequest.customizeDescription(
+            'RetainUntilDate must be in the future');
+        return dateObj;
+    }
+    dateObj.date = retainDate[0];
+    return dateObj;
+}
+
+/**
+ * validate retention - validate retention xml
+ * @param {object} parsedXml - parsed retention xml object
+ * @return {object} - contains retention information on success,
+ * error on failure
+ */
+function validateRetention(parsedXml) {
+    const retentionObj = {};
+    if (!parsedXml) {
+        retentionObj.error = errors.MalformedXML.customizeDescription(
+            'request xml is undefined or empty');
+        return retentionObj;
+    }
+    const retention = parsedXml.ObjectRetention;
+    if (!retention) {
+        retentionObj.error = errors.MalformedXML.customizeDescription(
+            'request xml does not contain ObjectRetention');
+        return retentionObj;
+    }
+    const modeObj = validateMode(retention.Mode);
+    if (modeObj.error) {
+        retentionObj.error = modeObj.error;
+        return retentionObj;
+    }
+    const dateObj = validateRetainDate(retention.RetainUntilDate);
+    if (dateObj.error) {
+        retentionObj.error = dateObj.error;
+        return retentionObj;
+    }
+    retentionObj.retention = {
+        mode: modeObj.mode,
+        retainUntilDate: dateObj.date,
+    };
+    return retentionObj;
+}
+
+/**
+ * parseRetentionXml - Parse and validate xml body, returning callback with
+ * object retentionInfo: { mode: <value>, retainUntilDate: <value> }
+ * @param {string} xml - xml body to parse and validate
+ * @param {object} log - Werelogs logger
+ * @param {function} cb - callback to server
+ * @return {undefined} - calls callback with object retention or error
+ */
+function parseRetentionXml(xml, log, cb) {
+    parseString(xml, (err, result) => {
+        if (err) {
+            log.trace('xml parsing failed', {
+                error: err,
+                method: 'parseRetentionXml',
+            });
+            log.debug('invalid xml', { xml });
+            return cb(errors.MalformedXML);
+        }
+        const retentionObj = validateRetention(result);
+        if (retentionObj.error) {
+            log.debug('retention validation failed', {
+                error: retentionObj.error,
+                method: 'validateRetention',
+                xml,
+            });
+            return cb(retentionObj.error);
+        }
+        return cb(null, retentionObj);
+    });
+}
+
+module.exports = { parseRetentionXml };

--- a/lib/s3routes/routes/routePUT.js
+++ b/lib/s3routes/routes/routePUT.js
@@ -159,6 +159,13 @@ function routePUT(request, response, api, log, statsClient) {
                     return routesUtils.responseNoBody(err, resHeaders,
                         response, 200, log);
                 });
+        } else if (request.query.retention !== undefined) {
+            api.callApiMethod('objectPutRetention', request, response, log,
+                (err, resHeaders) => {
+                    routesUtils.statsReport500(err, statsClient);
+                    return routesUtils.responseNoBody(err, resHeaders,
+                        response, 200, log);
+                });
         } else if (request.headers['x-amz-copy-source']) {
             return api.callApiMethod('objectCopy', request, response, log,
                 (err, xml, additionalHeaders) => {

--- a/tests/unit/models/object.js
+++ b/tests/unit/models/object.js
@@ -2,6 +2,9 @@ const assert = require('assert');
 const ObjectMD = require('../../../lib/models/ObjectMD');
 const constants = require('../../../lib/constants');
 
+const retainDate = new Date();
+retainDate.setDate(retainDate.getDate() + 1);
+
 describe('ObjectMD class setters/getters', () => {
     let md = null;
 
@@ -101,6 +104,10 @@ describe('ObjectMD class setters/getters', () => {
         ['DataStoreName', null, ''],
         ['LegalHold', null, false],
         ['LegalHold', true],
+        ['RetentionInfo', {
+            mode: 'GOVERNANCE',
+            retainUntilDate: retainDate.toISOString(),
+        }],
     ].forEach(test => {
         const property = test[0];
         const testValue = test[1];
@@ -193,6 +200,17 @@ describe('ObjectMD class setters/getters', () => {
         });
         assert.strictEqual(
             md.getReplicationSiteDataStoreVersionId('zenko'), 'a');
+    });
+
+    it('ObjectMD::set/getRetentionInfo', () => {
+        md.setRetentionInfo({
+            mode: 'COMPLIANCE',
+            retainUntilDate: retainDate.toISOString(),
+        });
+        assert.deepStrictEqual(md.getRetentionInfo(), {
+            mode: 'COMPLIANCE',
+            retainUntilDate: retainDate.toISOString(),
+        });
     });
 });
 

--- a/tests/unit/s3middleware/objectRetention.js
+++ b/tests/unit/s3middleware/objectRetention.js
@@ -1,0 +1,100 @@
+const assert = require('assert');
+const { parseRetentionXml } = require('../../../lib/s3middleware/objectRetention');
+const DummyRequestLogger = require('../helpers').DummyRequestLogger;
+
+const log = new DummyRequestLogger();
+
+const date = new Date();
+date.setDate(date.getDate() + 1);
+const failDate = new Date('05/01/2020');
+const passDate = new Date();
+passDate.setDate(passDate.getDate() + 2);
+
+
+function buildXml(key, value) {
+    const mode = key === 'Mode' ?
+        `<Mode>${value}</Mode>` :
+        '<Mode>GOVERNANCE</Mode>';
+    const retainDate = key === 'RetainDate' ?
+        `<RetainUntilDate>${value}</RetainUntilDate>` :
+        `<RetainUntilDate>${date}</RetainUntilDate>`;
+    const retention = key === 'Retention' ?
+        `<ObjectRetention>${value}</ObjectRetention>` :
+        `<ObjectRetention>${mode}${retainDate}</ObjectRetention>`;
+    return retention;
+}
+
+const expectedRetention = {
+    retention: {
+        mode: 'GOVERNANCE',
+        retainUntilDate: passDate.toISOString(),
+    },
+};
+
+const failTests = [
+    {
+        name: 'should fail with empty retention',
+        params: { key: 'Retention', value: '' },
+        error: 'MalformedXML',
+        errMessage: 'request xml does not contain ObjectRetention',
+    },
+    {
+        name: 'should fail with empty mode',
+        params: { key: 'Mode', value: '' },
+        error: 'MalformedXML',
+        errMessage: 'request xml does not contain Mode',
+    },
+    {
+        name: 'should fail with empty retain until date',
+        params: { key: 'RetainDate', value: '' },
+        error: 'MalformedXML',
+        errMessage: 'request xml does not contain RetainUntilDate',
+    },
+    {
+        name: 'should fail with invalid mode',
+        params: { key: 'Mode', value: 'GOVERPLIANCE' },
+        error: 'MalformedXML',
+        errMessage: 'Mode request xml must be one of "GOVERNANCE", ' +
+            '"COMPLIANCE"',
+    },
+    {
+        name: 'should fail with retain until date in UTC format',
+        params: { key: 'RetainDate', value: `${date.toUTCString()}` },
+        error: 'InvalidRequest',
+        errMessage: 'RetainUntilDate timestamp must be ISO-8601 format',
+    },
+    {
+        name: 'should fail with retain until date in GMT format',
+        params: { key: 'RetainDate', value: `${date.toString()}` },
+        error: 'InvalidRequest',
+        errMessage: 'RetainUntilDate timestamp must be ISO-8601 format',
+    },
+    {
+        name: 'should fail with retain until date in past',
+        params: { key: 'RetainDate', value: failDate.toISOString() },
+        error: 'InvalidRequest',
+        errMessage: 'RetainUntilDate must be in the future',
+    },
+];
+
+describe('object Retention validation', () => {
+    failTests.forEach(t => {
+        it(t.name, done => {
+            parseRetentionXml(buildXml(t.params.key, t.params.value), log,
+            err => {
+                assert(err[t.error]);
+                assert.strictEqual(err.description, t.errMessage);
+                done();
+            });
+        });
+    });
+
+    it('should pass with valid retention', done => {
+        parseRetentionXml(buildXml('RetainDate', passDate.toISOString()), log,
+        (err, result) => {
+            assert.ifError(err);
+            assert.deepStrictEqual(result, expectedRetention);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
Adds necessary changes for Put Object Retention API.
Includes new route, new ObjectMD field, and tests.