### PR TITLE
feature: S3C-2944 put object legal hold

### DIFF
--- a/lib/models/ObjectMD.js
+++ b/lib/models/ObjectMD.js
@@ -884,6 +884,24 @@ class ObjectMD {
     }
 
     /**
+     * Set object legal hold status
+     * @param {boolean} legalHold - true if legal hold is 'ON' false if 'OFF'
+     * @return {ObjectMD} itself
+     */
+    setLegalHold(legalHold) {
+        this._data.legalHold = legalHold || false;
+        return this;
+    }
+
+    /**
+     * Get object legal hold status
+     * @return {boolean} legal hold status
+     */
+    getLegalHold() {
+        return this._data.legalHold || false;
+    }
+
+    /**
      * Returns metadata object
      *
      * @return {object} metadata object
@@ -891,6 +909,7 @@ class ObjectMD {
     getValue() {
         return this._data;
     }
+
 }
 
 module.exports = ObjectMD;

--- a/lib/policyEvaluator/RequestContext.js
+++ b/lib/policyEvaluator/RequestContext.js
@@ -54,6 +54,7 @@ const _actionMap = {
     objectPut: 's3:PutObject',
     objectPutACL: 's3:PutObjectAcl',
     objectPutACLVersion: 's3:PutObjectVersionAcl',
+    objectPutLegalHold: 's3:PutObjectLegalHold',
     objectPutPart: 's3:PutObject',
     objectPutTagging: 's3:PutObjectTagging',
     objectPutTaggingVersion: 's3:PutObjectVersionTagging',

--- a/lib/s3middleware/objectLegalHold.js
+++ b/lib/s3middleware/objectLegalHold.js
@@ -1,0 +1,112 @@
+const { parseString } = require('xml2js');
+const errors = require('../errors');
+
+/*
+    Format of the xml request:
+    <LegalHold>
+        <Status>ON|OFF</Status>
+    </LegalHold>
+*/
+
+/**
+ * @param {string[]} status - legal hold status parsed from xml to be validated
+ * @return {Error|object} - legal hold status or error
+ */
+function _validateStatus(status) {
+    const validatedStatus = {};
+    const expectedValues = new Set(['OFF', 'ON']);
+    if (!status || status[0] === '') {
+        validatedStatus.error = errors.MalformedXML.customizeDescription(
+            'request xml does not contain Status');
+        return validatedStatus;
+    }
+    if (status.length > 1) {
+        validatedStatus.error = errors.MalformedXML.customizeDescription(
+            'request xml contains more than one Status');
+        return validatedStatus;
+    }
+    if (!expectedValues.has(status[0])) {
+        validatedStatus.error = errors.MalformedXML.customizeDescription(
+            'Status request xml must be one of "ON", "OFF"');
+        return validatedStatus;
+    }
+    validatedStatus.status = status[0];
+    return validatedStatus;
+}
+
+/**
+ * validate legal hold - validates legal hold xml
+ * @param {object} parsedXml - parsed legal hold xml object
+ * @return {object} - object with status or error
+ */
+function _validateLegalHold(parsedXml) {
+    const validatedLegalHold = {};
+    if (!parsedXml) {
+        validatedLegalHold.error = errors.MalformedXML.customizeDescription(
+            'request xml is undefined or empty');
+        return validatedLegalHold;
+    }
+    if (!parsedXml.LegalHold) {
+        validatedLegalHold.error = errors.MalformedXML.customizeDescription(
+            'request xml does not contain LegalHold');
+        return validatedLegalHold;
+    }
+    const validatedStatus = _validateStatus(parsedXml.LegalHold.Status);
+    if (validatedStatus.error) {
+        validatedLegalHold.error = validatedStatus.error;
+        return validatedLegalHold;
+    }
+    validatedLegalHold.status = validatedStatus.status;
+    return validatedLegalHold;
+}
+
+/**
+ * parse object legal hold - parse and validate xml body
+ * @param {string} xml - xml body to parse and validate
+ * @param {object} log - werelogs logger
+ * @param {function} cb - callback to server
+ * @return {undefined} - calls callback with legal hold status or error
+ */
+function parseLegalHoldXml(xml, log, cb) {
+    parseString(xml, (err, result) => {
+        if (err) {
+            log.debug('xml parsing failed', {
+                error: { message: err.message },
+                method: 'parseLegalHoldXml',
+                xml,
+            });
+            return cb(errors.MalformedXML);
+        }
+        const validatedLegalHold = _validateLegalHold(result);
+        const validatedLegalHoldStatus = validatedLegalHold.status === 'ON';
+        if (validatedLegalHold.error) {
+            log.debug('legal hold validation failed', {
+                error: { message: validatedLegalHold.error.message },
+                method: 'parseLegalHoldXml',
+                xml,
+            });
+            return cb(validatedLegalHold.error);
+        }
+        return cb(null, validatedLegalHoldStatus);
+    });
+}
+
+/**
+ * convert to xml - generates legal hold xml
+ * @param {boolean} legalHold - true if legal hold is on else false
+ * @return {string} - returns legal hold xml
+ */
+function convertToXml(legalHold) {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <LegalHold>
+        <Status>
+        ${legalHold ? 'ON' : 'OFF'}
+        </Status>
+        </LegalHold>`;
+    return xml;
+}
+
+module.exports = {
+    convertToXml,
+    parseLegalHoldXml,
+};

--- a/lib/s3routes/routes/routePUT.js
+++ b/lib/s3routes/routes/routePUT.js
@@ -16,7 +16,6 @@ function routePUT(request, response, api, log, statsClient) {
             return routesUtils.responseNoBody(
               errors.BadRequest, null, response, null, log);
         }
-
         // PUT bucket ACL
         if (request.query.acl !== undefined) {
             api.callApiMethod('bucketPutACL', request, response, log,
@@ -87,8 +86,8 @@ function routePUT(request, response, api, log, statsClient) {
                 });
         }
     } else {
-        // PUT object, PUT object ACL, PUT object multipart or
-        // PUT object copy
+        // PUT object, PUT object ACL, PUT object multipart,
+        // PUT object copy or PUT object legal hold
         // if content-md5 is not present in the headers, try to
         // parse content-md5 from meta headers
 
@@ -146,6 +145,13 @@ function routePUT(request, response, api, log, statsClient) {
                     return routesUtils.responseNoBody(err, resHeaders,
                         response, 200, log);
                 });
+        } else if (request.query['legal-hold'] !== undefined) {
+            api.callApiMethod('objectPutLegalHold', request, response, log,
+                (err, resHeaders) => {
+                    routesUtils.statsReport500(err, statsClient);
+                    return routesUtils.responseNoBody(err, resHeaders,
+                        response, 200, log);
+                });
         } else if (request.query.tagging !== undefined) {
             api.callApiMethod('objectPutTagging', request, response, log,
                 (err, resHeaders) => {
@@ -174,7 +180,6 @@ function routePUT(request, response, api, log, statsClient) {
             log.end().addDefaultFields({
                 contentLength: request.parsedContentLength,
             });
-
             api.callApiMethod('objectPut', request, response, log,
             (err, resHeaders) => {
                 routesUtils.statsReport500(err, statsClient);

--- a/tests/unit/models/object.js
+++ b/tests/unit/models/object.js
@@ -99,6 +99,8 @@ describe('ObjectMD class setters/getters', () => {
             dataStoreVersionId: '',
         }],
         ['DataStoreName', null, ''],
+        ['LegalHold', null, false],
+        ['LegalHold', true],
     ].forEach(test => {
         const property = test[0];
         const testValue = test[1];

--- a/tests/unit/s3middleware/objectLegalHold.js
+++ b/tests/unit/s3middleware/objectLegalHold.js
@@ -1,0 +1,71 @@
+const assert = require('assert');
+const { parseLegalHoldXml } = require('../../../lib/s3middleware/objectLegalHold');
+const DummyRequestLogger = require('../helpers').DummyRequestLogger;
+
+const log = new DummyRequestLogger();
+
+function generateXml(status) {
+    return `<LegalHold><Status>${status}</Status></LegalHold>`;
+}
+
+const failTests = [
+    {
+        description: 'should fail with empty status',
+        params: { status: '' },
+        error: 'MalformedXML',
+        errMessage: 'request xml does not contain Status',
+    },
+    {
+        description: 'should fail with invalid status "on"',
+        params: { status: 'on' },
+        error: 'MalformedXML',
+        errMessage: 'Status request xml must be one of "ON", "OFF"',
+    },
+    {
+        description: 'should fail with invalid status "On"',
+        params: { status: 'On' },
+        error: 'MalformedXML',
+        errMessage: 'Status request xml must be one of "ON", "OFF"',
+    },
+    {
+        description: 'should fail with invalid status "off"',
+        params: { status: 'off' },
+        error: 'MalformedXML',
+        errMessage: 'Status request xml must be one of "ON", "OFF"',
+    },
+    {
+        description: 'should fail with invalid status "Off"',
+        params: { status: 'Off' },
+        error: 'MalformedXML',
+        errMessage: 'Status request xml must be one of "ON", "OFF"',
+    },
+];
+
+describe('object legal hold validation', () => {
+    failTests.forEach(test => {
+        it(test.description, done => {
+            const status = test.params.status;
+            parseLegalHoldXml(generateXml(status), log, err => {
+                assert(err[test.error]);
+                assert.strictEqual(err.description, test.errMessage);
+                done();
+            });
+        });
+    });
+
+    it('should pass with legal hold status "ON"', done => {
+        parseLegalHoldXml(generateXml('ON'), log, (err, result) => {
+            assert.ifError(err);
+            assert.strictEqual(result, true);
+            done();
+        });
+    });
+
+    it('should pass with legal hold status "OFF"', done => {
+        parseLegalHoldXml(generateXml('OFF'), log, (err, result) => {
+            assert.ifError(err);
+            assert.strictEqual(result, false);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
- Adds setter and getter to get/set object's legal hold status.
- Adds helper methods to be consumed by PUT/GET Object legal hold APIs and the corresponding unit tests.
- Adds the route to `objectPutLegalHold`.