### PR TITLE
Feature/s3 c 2788 get object retention

### DIFF
--- a/lib/s3middleware/objectRetention.js
+++ b/lib/s3middleware/objectRetention.js
@@ -132,4 +132,26 @@ function parseRetentionXml(xml, log, cb) {
     });
 }
 
-module.exports = { parseRetentionXml };
+/**
+ * convertToXml - Convert retention info object to xml
+ * @param {object} retentionInfo - retention information object
+ * @return {string} - returns retention information xml string
+ */
+function convertToXml(retentionInfo) {
+    const xml = [];
+    const ret = retentionInfo.retention;
+    xml.push('<ObjectRetention xmlns="http://s3.amazonaws.com/doc/2006-03-01/">');
+    if (ret && ret.mode && ret.retainUntilDate) {
+        xml.push(`<Mode>${ret.mode}</Mode>` +
+            `<RetainUntilDate>${ret.retainUntilDate}</RetainUntilDate>`);
+    } else {
+        return '';
+    }
+    xml.push('</ObjectRetention>');
+    return xml.join('');
+}
+
+module.exports = {
+    parseRetentionXml,
+    convertToXml,
+};

--- a/tests/unit/s3middleware/objectRetention.js
+++ b/tests/unit/s3middleware/objectRetention.js
@@ -1,5 +1,8 @@
 const assert = require('assert');
-const { parseRetentionXml } = require('../../../lib/s3middleware/objectRetention');
+const {
+    parseRetentionXml,
+    convertToXml,
+} = require('../../../lib/s3middleware/objectRetention');
 const DummyRequestLogger = require('../helpers').DummyRequestLogger;
 
 const log = new DummyRequestLogger();
@@ -30,6 +33,12 @@ const expectedRetention = {
         retainUntilDate: passDate.toISOString(),
     },
 };
+
+const expectedXml =
+    '<ObjectRetention xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+    '<Mode>GOVERNANCE</Mode>' +
+    `<RetainUntilDate>${passDate.toISOString()}</RetainUntilDate>` +
+    '</ObjectRetention>';
 
 const failTests = [
     {
@@ -96,5 +105,26 @@ describe('object Retention validation', () => {
             assert.deepStrictEqual(result, expectedRetention);
             done();
         });
+    });
+});
+
+describe('object Retention xml', () => {
+    it('should return empty string if no retention info', done => {
+        const xml = convertToXml({});
+        assert.equal(xml, '');
+        done();
+    });
+
+    it('should return empty string if retention info is empty', done => {
+        const xml = convertToXml(
+            { retention: { mode: '', retainUntilDate: '' } });
+        assert.equal(xml, '');
+        done();
+    });
+
+    it('should return xml string', done => {
+        const xml = convertToXml(expectedRetention);
+        assert.strictEqual(xml, expectedXml);
+        done();
     });
 });


### PR DESCRIPTION
Adds support for GET Object Retention API. To be merged after https://github.com/scality/Arsenal/pull/1049