### PR TITLE
bugfix: S3C-2899 handle MergeStream.destroy()

### DIFF
--- a/lib/algos/stream/MergeStream.js
+++ b/lib/algos/stream/MergeStream.js
@@ -32,6 +32,15 @@ class MergeStream extends stream.Readable {
         }
     }
 
+    _destroy(err, callback) {
+        for (let i = 0; i < 2; ++i) {
+            if (!this._streamEof[i]) {
+                this._streams[i].destroy();
+            }
+        }
+        callback();
+    }
+
     _onItem(myStream, myItem, myIndex, otherIndex) {
         this._peekItems[myIndex] = myItem;
         const otherItem = this._peekItems[otherIndex];
@@ -58,10 +67,6 @@ class MergeStream extends stream.Readable {
         }
         this._streamToResume = otherStream;
         return undefined;
-    }
-
-    _showPeek() {
-        return `[${this._peekItems[0]},${this._peekItems[1]}]`;
     }
 
     _onEnd(myStream, myIndex, otherIndex) {


### PR DESCRIPTION
Make sure MergeStream destroys the non-ended input streams when
destroy() is called