### PR TITLE
bf: do not sort when searching

### DIFF
--- a/lib/storage/metadata/mongoclient/readStream.js
+++ b/lib/storage/metadata/mongoclient/readStream.js
@@ -63,9 +63,13 @@ class MongoReadStream extends Readable {
             Object.assign(query, searchOptions);
         }
 
-        this._cursor = c.find(query).sort({
-            _id: options.reverse ? -1 : 1,
-        });
+        this._cursor = c.find(query);
+
+        if (!searchOptions) {
+            this._cursor.sort({
+                _id: options.reverse ? -1 : 1,
+            });
+        }
         if (options.limit && options.limit !== -1) {
             this._cursor = this._cursor.limit(options.limit);
         }


### PR DESCRIPTION
We change the default behavior of search by removing the sort directive.
Indeed some search queries may use other customer created index and
therefore cannot use the primary key _id, so it has to wait for
all results client side and sort them in memory which is highly
inefficient. Note that the sort might be useful when searching
so a long term fix shall have the sort optional.