### PR TITLE
INTEGRATION [PR#1086 > development/7.8] ft: S3C-2788 add get object retention route

### DIFF
--- a/lib/s3routes/routes/routeGET.js
+++ b/lib/s3routes/routes/routeGET.js
@@ -125,6 +125,13 @@ function routerGET(request, response, api, log, statsClient, dataRetrievalFn) {
                     return routesUtils.responseXMLBody(err, xml, response, log,
                         corsHeaders);
                 });
+        } else if (request.query.retention !== undefined) {
+            api.callApiMethod('objectGetRetention', request, response, log,
+                (err, xml, corsHeaders) => {
+                    routesUtils.statsReport500(err, statsClient);
+                    return routesUtils.responseXMLBody(err, xml, response, log,
+                        corsHeaders);
+                });
         } else {
             // GET object
             api.callApiMethod('objectGet', request, response, log,


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1086.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.8/feature/S3C-2788-get-retention-route`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.8/feature/S3C-2788-get-retention-route
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.8/feature/S3C-2788-get-retention-route
```

Please always comment pull request #1086 instead of this one.