### PR TITLE
improvement: S3C-3044-add-audit-log-fields

### DIFF
--- a/lib/auth/Vault.js
+++ b/lib/auth/Vault.js
@@ -24,6 +24,12 @@ function vaultSignatureCb(err, authInfo, log, callback, streamingV4Params) {
     const info = authInfo.message.body;
     const userInfo = new AuthInfo(info.userInfo);
     const authorizationResults = info.authorizationResults;
+    const auditLog = { accountDisplayName: userInfo.getAccountDisplayName() };
+    const iamDisplayName = userInfo.getIAMdisplayName();
+    if (iamDisplayName) {
+        auditLog.IAMdisplayName = iamDisplayName;
+    }
+    log.addDefaultFields(auditLog);
     return callback(null, userInfo, authorizationResults, streamingV4Params);
 }
 


### PR DESCRIPTION
This PR adds audit log fields for Cloudserver without adding an extra log line

Extra fields:
accountDisplayName: account name
iamDisplayName: username