### PR TITLE
bugfix: S3C-2987 add v0v1 versioning key format

### DIFF
--- a/lib/versioning/constants.js
+++ b/lib/versioning/constants.js
@@ -10,6 +10,7 @@ module.exports.VersioningConstants = {
         current: 'v1',
         v0: 'v0',
         v0mig: 'v0mig',
+        v0v1: 'v0v1',
         v1mig: 'v1mig',
         v1: 'v1',
     },


### PR DESCRIPTION
Add missing transition format due to spec update