### PR TITLE
INTEGRATION [PR#1108 > development/7.8] bugfix: S3C-2987 add v0v1 versioning key format

### DIFF
--- a/lib/versioning/constants.js
+++ b/lib/versioning/constants.js
@@ -10,6 +10,7 @@ module.exports.VersioningConstants = {
         current: 'v1',
         v0: 'v0',
         v0mig: 'v0mig',
+        v0v1: 'v0v1',
         v1mig: 'v1mig',
         v1: 'v1',
     },


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1108.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.8/bugfix/S3C-2987-add-v0v1-vFormat`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.8/bugfix/S3C-2987-add-v0v1-vFormat
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.8/bugfix/S3C-2987-add-v0v1-vFormat
```

Please always comment pull request #1108 instead of this one.