### PR TITLE
INTEGRATION [PR#1151 > development/7.8] build(deps): Bump xml2js from 0.4.19 to 0.4.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "utf8": "2.1.2",
     "uuid": "^3.0.1",
     "werelogs": "scality/werelogs#0ff7ec82",
-    "xml2js": "~0.4.16"
+    "xml2js": "~0.4.23"
   },
   "optionalDependencies": {
     "ioctl": "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1935,18 +1935,18 @@ wtf-8@1.0.0:
   resolved "https://registry.yarnpkg.com/wtf-8/-/wtf-8-1.0.0.tgz#392d8ba2d0f1c34d1ee2d630f15d0efb68e1048a"
   integrity sha1-OS2LotDxw00e4tYw8V0O+2jhBIo=
 
-xml2js@~0.4.16:
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
-  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+xml2js@~0.4.23:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
+  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
   dependencies:
     sax ">=0.6.0"
-    xmlbuilder "~9.0.1"
+    xmlbuilder "~11.0.0"
 
-xmlbuilder@~9.0.1:
-  version "9.0.7"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
-  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xmlhttprequest-ssl@1.5.3:
   version "1.5.3"


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1151.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.8/dependabot/npm_and_yarn/development/7.4/xml2js-0.4.23`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.8/dependabot/npm_and_yarn/development/7.4/xml2js-0.4.23
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.8/dependabot/npm_and_yarn/development/7.4/xml2js-0.4.23
```

Please always comment pull request #1151 instead of this one.