### PR TITLE
ft: S3C-3112 add object lock enabled setter to bucket

### DIFF
--- a/lib/models/BucketInfo.js
+++ b/lib/models/BucketInfo.js
@@ -578,11 +578,20 @@ class BucketInfo {
             this._versioningConfiguration.Status === 'Enabled';
     }
     /**
-    * Check is object lock enabled.
+    * Check if object lock is enabled.
     * @return {boolean} - depending on whether object lock is enabled
     */
     isObjectLockEnabled() {
         return !!this._objectLockEnabled;
+    }
+    /**
+    * Set the value of objectLockEnabled field.
+    * @param {boolean} enabled - true if object lock enabled else false.
+    * @return {BucketInfo} - bucket info instance
+    */
+    setObjectLockEnabled(enabled) {
+        this._objectLockEnabled = enabled;
+        return this;
     }
 }
 

--- a/tests/unit/models/BucketInfo.js
+++ b/tests/unit/models/BucketInfo.js
@@ -447,6 +447,13 @@ Object.keys(acl).forEach(
                 assert.deepStrictEqual(dummyBucket.getObjectLockConfiguration(),
                     newObjectLockConfig);
             });
+            [true, false].forEach(bool => {
+                it('setObjectLockEnabled should set object lock status', () => {
+                    dummyBucket.setObjectLockEnabled(bool);
+                    assert.deepStrictEqual(dummyBucket.isObjectLockEnabled(),
+                        bool);
+                });
+            });
         });
     })
 );


### PR DESCRIPTION
Adds setter to the `bucketInfo` model to set the value of the object lock enabled field, and a unit test for the setter method.