### PR TITLE
INTEGRATION [PR#1174 > development/7.7] ft: S3C-3112 add object lock enabled setter to bucket

### DIFF
--- a/lib/models/BucketInfo.js
+++ b/lib/models/BucketInfo.js
@@ -578,11 +578,20 @@ class BucketInfo {
             this._versioningConfiguration.Status === 'Enabled';
     }
     /**
-    * Check is object lock enabled.
+    * Check if object lock is enabled.
     * @return {boolean} - depending on whether object lock is enabled
     */
     isObjectLockEnabled() {
         return !!this._objectLockEnabled;
+    }
+    /**
+    * Set the value of objectLockEnabled field.
+    * @param {boolean} enabled - true if object lock enabled else false.
+    * @return {BucketInfo} - bucket info instance
+    */
+    setObjectLockEnabled(enabled) {
+        this._objectLockEnabled = enabled;
+        return this;
     }
 }
 

--- a/tests/unit/models/BucketInfo.js
+++ b/tests/unit/models/BucketInfo.js
@@ -447,6 +447,13 @@ Object.keys(acl).forEach(
                 assert.deepStrictEqual(dummyBucket.getObjectLockConfiguration(),
                     newObjectLockConfig);
             });
+            [true, false].forEach(bool => {
+                it('setObjectLockEnabled should set object lock status', () => {
+                    dummyBucket.setObjectLockEnabled(bool);
+                    assert.deepStrictEqual(dummyBucket.isObjectLockEnabled(),
+                        bool);
+                });
+            });
         });
     })
 );


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1174.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.7/feature/S3C-3112_ObjectLockEnabledSetterForBucket`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.7/feature/S3C-3112_ObjectLockEnabledSetterForBucket
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.7/feature/S3C-3112_ObjectLockEnabledSetterForBucket
```

Please always comment pull request #1174 instead of this one.