### PR TITLE
INTEGRATION [PR#1155 > development/7.8] build(deps): Bump ipaddr.js from 1.2.0 to 1.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "debug": "~2.3.3",
     "diskusage": "^1.1.1",
     "ioredis": "4.9.5",
-    "ipaddr.js": "1.2.0",
+    "ipaddr.js": "1.9.1",
     "level": "~5.0.1",
     "level-sublevel": "~6.6.5",
     "node-forge": "^0.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -893,10 +893,10 @@ ioredis@4.9.5:
     redis-parser "^3.0.0"
     standard-as-callback "^2.0.1"
 
-ipaddr.js@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.2.0.tgz#8aba49c9192799585bdd643e0ccb50e8ae777ba4"
-  integrity sha1-irpJyRknmVhb3WQ+DMtQ6K53e6Q=
+ipaddr.js@1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
+  integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1155.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.8/dependabot/npm_and_yarn/development/7.4/ipaddr.js-1.9.1`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.8/dependabot/npm_and_yarn/development/7.4/ipaddr.js-1.9.1
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.8/dependabot/npm_and_yarn/development/7.4/ipaddr.js-1.9.1
```

Please always comment pull request #1155 instead of this one.