### PR TITLE
INTEGRATION [PR#1180 > development/7.7] build(deps): Bump debug from 2.3.3 to 2.6.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "JSONStream": "^1.0.0",
     "ajv": "6.12.2",
     "async": "~2.1.5",
-    "debug": "~2.3.3",
+    "debug": "~2.6.9",
     "diskusage": "^1.1.1",
     "ioredis": "4.9.5",
     "ipaddr.js": "1.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -370,7 +370,7 @@ debug@2.2.0:
   dependencies:
     ms "0.7.1"
 
-debug@^2.1.1:
+debug@^2.1.1, debug@~2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -383,13 +383,6 @@ debug@^3.1.0:
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
-
-debug@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.3.3.tgz#40c453e67e6e13c901ddec317af8986cda9eff8c"
-  integrity sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=
-  dependencies:
-    ms "0.7.2"
 
 debug@~3.1.0:
   version "3.1.0"
@@ -1298,11 +1291,6 @@ ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
   integrity sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=
-
-ms@0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
-  integrity sha1-riXPJRKziFodldfwN4aNhDESR2U=
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1180.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.7/dependabot/npm_and_yarn/development/7.4/debug-2.6.9`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.7/dependabot/npm_and_yarn/development/7.4/debug-2.6.9
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.7/dependabot/npm_and_yarn/development/7.4/debug-2.6.9
```

Please always comment pull request #1180 instead of this one.