### PR TITLE
ft: S3C-2797 queue arn parsing

### DIFF
--- a/lib/models/NotificationConfiguration.js
+++ b/lib/models/NotificationConfiguration.js
@@ -100,7 +100,7 @@ class NotificationConfiguration {
             const eventObj = this._parseEvents(queueConfig[i].Event);
             const filterObj = this._parseFilter(queueConfig[i].Filter);
             const idObj = this._parseId(queueConfig[i].Id);
-            const arnObj = this._parseArn(queueConfig[i].QueueArn);
+            const arnObj = this._parseArn(queueConfig[i].Queue);
 
             if (eventObj.error) {
                 parseError = eventObj.error;

--- a/tests/unit/models/NotificationConfiguration.js
+++ b/tests/unit/models/NotificationConfiguration.js
@@ -53,8 +53,8 @@ function generateFilter(testParams) {
 function generateXml(testParams) {
     const id = testParams.key === 'Id' ? `<Id>${testParams.value}</Id>` : '<Id>queue-id</Id>';
     const arn = testParams.key === 'QueueArn' ?
-        `<QueueArn>${testParams.value}</QueueArn>` :
-        '<QueueArn>arn:scality:bucketnotif:::target</QueueArn>';
+        `<Queue>${testParams.value}</Queue>` :
+        '<Queue>arn:scality:bucketnotif:::target</Queue>';
     const event = generateEvent(testParams);
     const filter = generateFilter(testParams);
     let queueConfig = `<QueueConfiguration>${id}${arn}${event}${filter}` +
@@ -88,7 +88,7 @@ const failTests = [
     },
     {
         name: 'fail with empty QueueConfiguration',
-        params: { key: 'QueueConfiguration', value: '<QueueArn>arn:scality:bucketnotif:::target</QueueArn>' },
+        params: { key: 'QueueConfiguration', value: '<Queue>arn:scality:bucketnotif:::target</Queue>' },
         error: 'MalformedXML',
         errorMessage: 'request xml does not include QueueConfiguration',
     },


### PR DESCRIPTION
Even though the key for the queue arn in the aws-sdk parameters is `QueueArn`, for whatever reason when converted to xml, the key becomes just `Queue`
