### PR TITLE
bugfix: ZENKO 2702 Use replica set config instead of rs0

### DIFF
--- a/lib/storage/metadata/mongoclient/LogConsumer.js
+++ b/lib/storage/metadata/mongoclient/LogConsumer.js
@@ -17,9 +17,10 @@ class LogConsumer {
      * @param {string} logger - logger
      */
     constructor(mongoConfig, logger) {
-        const { authCredentials, replicaSetHosts, database } = mongoConfig;
+        const { authCredentials, replicaSetHosts, replicaSet, database } = mongoConfig;
         const cred = MongoUtils.credPrefix(authCredentials);
         this._mongoUrl = `mongodb://${cred}${replicaSetHosts}/`;
+        this._replicaSet = replicaSet;
         this._logger = logger;
         this._oplogNsRegExp = new RegExp(`^${database}\\.`);
         // oplog collection
@@ -36,7 +37,7 @@ class LogConsumer {
     */
     connectMongo(done) {
         MongoClient.connect(this._mongoUrl, {
-            replicaSet: 'rs0',
+            replicaSet: this._replicaSet,
             useNewUrlParser: true,
         },
         (err, client) => {

--- a/tests/unit/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/tests/unit/storage/metadata/mongoclient/MongoClientInterface.js
@@ -14,7 +14,7 @@ const mongoserver = new MongoMemoryReplSet({
         { port: 27018 },
     ],
     replSet: {
-        name: 'rs0',
+        name: 'customSetName',
         count: 1,
         dbName,
         storageEngine: 'ephemeralForTest',
@@ -471,7 +471,7 @@ describe('MongoClientInterface::getObjectMDStats', () => {
             const opts = {
                 replicaSetHosts: 'localhost:27018',
                 writeConcern: 'majority',
-                replicaSet: 'rs0',
+                replicaSet: 'customSetName',
                 readPreference: 'primary',
                 database: dbName,
                 replicationGroupId: 'GR001',


### PR DESCRIPTION
We already had the replica set value in the config and was loading it but was using a fixed `rs0` in place of the real value.