### PR TITLE
bf: reserialize tags in putobjectver4

### DIFF
--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -563,6 +563,7 @@ class MongoClientInterface {
                               { error: err.message });
                     return cb(err);
                 }
+                MongoUtils.serialize(mstObjVal);
                 // eslint-disable-next-line
                 c.update({
                     _id: objName,


### PR DESCRIPTION
This function obtains the old tags by calling getLatestVersion() which
automatically unserialize the tags, so we should reserialize them before
update, as done e.g. in repair().