### PR TITLE
INTEGRATION [PR#1252 > development/8.1] feature: S3C-3183-policy-getAccessKeyLastUsed

### DIFF
--- a/lib/policyEvaluator/RequestContext.js
+++ b/lib/policyEvaluator/RequestContext.js
@@ -105,6 +105,7 @@ const _actionMapIAM = {
     updateAccessKey: 'iam:UpdateAccessKey',
     updateGroup: 'iam:UpdateGroup',
     updateUser: 'iam:UpdateUser',
+    getAccessKeyLastUsed: 'iam:GetAccessKeyLastUsed',
 };
 
 const _actionMapSSO = {


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1252.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/feature/S3C-3183-getAccessKeyLastUsed-policy-support`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/feature/S3C-3183-getAccessKeyLastUsed-policy-support
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/feature/S3C-3183-getAccessKeyLastUsed-policy-support
```

Please always comment pull request #1252 instead of this one.