### PR TITLE
bf: ZENKO-2768 encode tags properly

### DIFF
--- a/lib/storage/metadata/mongoclient/ListRecordStream.js
+++ b/lib/storage/metadata/mongoclient/ListRecordStream.js
@@ -1,4 +1,5 @@
 const stream = require('stream');
+const unescape = require('./utils').unescape;
 
 /**
  * @class ListRecordStream
@@ -64,12 +65,6 @@ class ListRecordStream extends stream.Readable {
         // always update to most recent uniqID
         this._lastConsumedID = itemObj.h.toString();
 
-        const decode = tags => (
-            JSON.parse(JSON.stringify(tags).
-                       replace(/\uFF0E/g, '.').
-                       replace(/\uFF04/g, '$'))
-        );
-
         // only push to stream unpublished objects
         if (!this._lastSavedID) {
             // process from the first entry
@@ -99,7 +94,7 @@ class ListRecordStream extends stream.Readable {
             itemObj.o && itemObj.o._id) {
             const value = itemObj.o.value;
             if (value && value.tags) {
-                value.tags = decode(value.tags);
+                value.tags = unescape(value.tags);
             }
             entry = {
                 type: 'put',
@@ -111,7 +106,7 @@ class ListRecordStream extends stream.Readable {
                    itemObj.o && itemObj.o2 && itemObj.o2._id) {
             const value = (itemObj.o.$set ? itemObj.o.$set : itemObj.o).value;
             if (value && value.tags) {
-                value.tags = decode(value.tags);
+                value.tags = unescape(value.tags);
             }
             entry = {
                 type: 'put', // updates overwrite the whole metadata,

--- a/lib/storage/metadata/mongoclient/utils.js
+++ b/lib/storage/metadata/mongoclient/utils.js
@@ -5,15 +5,25 @@ const {
 } = require('../conditions');
 
 function escape(obj) {
-    return JSON.parse(JSON.stringify(obj).
-                      replace(/\$/g, '\uFF04').
-                      replace(/\./g, '\uFF0E'));
+    const _obj = {};
+    Object.keys(obj).forEach(prop => {
+        const _prop = prop.
+              replace(/\$/g, '\uFF04').
+              replace(/\./g, '\uFF0E');
+        _obj[_prop] = obj[prop];
+    });
+    return _obj;
 }
 
 function unescape(obj) {
-    return JSON.parse(JSON.stringify(obj).
-                      replace(/\uFF04/g, '$').
-                      replace(/\uFF0E/g, '.'));
+    const _obj = {};
+    Object.keys(obj).forEach(prop => {
+        const _prop = prop.
+              replace(/\uFF04/g, '$').
+              replace(/\uFF0E/g, '.');
+        _obj[_prop] = obj[prop];
+    });
+    return _obj;
 }
 
 function serialize(objMD) {

--- a/tests/unit/storage/metadata/mongoclient/ListRecordStream.spec.js
+++ b/tests/unit/storage/metadata/mongoclient/ListRecordStream.spec.js
@@ -376,7 +376,7 @@ describe('mongoclient.ListRecordStream', () => {
                 value: {
                     tags: {
                         'some\uFF04weird\uFF0Ekey':
-                        'some\uFF04weird\uFF0Evalue',
+                        'some$weird.value',
                     },
                 },
             },


### PR DESCRIPTION
Even if >= Mongo3.6 supports . (dot) and $ (dollar) in property names, not all drivers support it (as per their doc -- see ZENKO ticket).

Escaping is problematic for values as some users directly query MongoDB and expect their values with a specific format.

Decision to keep the escaping for the property names (in order to match the AWS spec allowing . and $ in tag names). Note we decided to keep tags as properties and not key/values in an array for users to build their own compound indexes on them.

Since this is not backward compatible, this will require a straightforward migration script for existing deployment using tags. 

- Force LogReader to use MongoUtils.unescape().
- Change MongoUtils escape/unescape to encode only the property names
and not the values.
- Add a unit test to check that the escape/unescape works.