### PR TITLE
Feature/s3 c 3177 policy condition keys

### DIFF
--- a/lib/policyEvaluator/RequestContext.js
+++ b/lib/policyEvaluator/RequestContext.js
@@ -234,7 +234,7 @@ class RequestContext {
         requesterIp, sslEnabled, apiMethod,
         awsService, locationConstraint, requesterInfo,
         signatureVersion, authType, signatureAge, securityToken, policyArn,
-        action) {
+        action, postXml, requestObjTags, existingObjTag) {
         this._headers = headers;
         this._query = query;
         this._requesterIp = requesterIp;
@@ -263,6 +263,9 @@ class RequestContext {
         this._policyArn = policyArn;
         this._action = action;
         this._needQuota = _actionNeedQuotaCheck[apiMethod] === true;
+        this._postXml = postXml;
+        this._requestObjTags = requestObjTags;
+        this._existingObjTag = existingObjTag;
         return this;
     }
 
@@ -291,6 +294,9 @@ class RequestContext {
             securityToken: this._securityToken,
             policyArn: this._policyArn,
             action: this._action,
+            postXml: this._postXml,
+            requestObjTags: this._requestObjTags,
+            existingObjTag: this._existingObjTag,
         };
         return JSON.stringify(requestInfo);
     }
@@ -316,7 +322,7 @@ class RequestContext {
             obj.apiMethod, obj.awsService, obj.locationConstraint,
             obj.requesterInfo, obj.signatureVersion,
             obj.authType, obj.signatureAge, obj.securityToken, obj.policyArn,
-            obj.action);
+            obj.action, obj.postXml, obj.requestObjTags, obj.existingObjTag);
     }
 
     /**
@@ -658,6 +664,66 @@ class RequestContext {
      */
     isQuotaCheckNeeded() {
         return this._needQuota;
+    }
+
+    /**
+     * Set request post
+     *
+     * @param {string} postXml - request post
+     * @return {RequestContext} itself
+     */
+    setPostXml(postXml) {
+        this._postXml = postXml;
+        return this;
+    }
+
+    /**
+     * Get request post
+     *
+     * @return {string} request post
+     */
+    getPostXml() {
+        return this._postXml;
+    }
+
+    /**
+     * Set request object tags
+     *
+     * @param {string} requestObjTags - object tag(s) included in request in query string form
+     * @return {RequestContext} itself
+     */
+    setRequestObjTags(requestObjTags) {
+        this._requestObjTags = requestObjTags;
+        return this;
+    }
+
+    /**
+     * Get request object tags
+     *
+     * @return {string} request object tag(s)
+     */
+    getRequestObjTags() {
+        return this._requestObjTags;
+    }
+
+    /**
+     * Set info on existing tag on object included in request
+     *
+     * @param {string} existingObjTag - existing object tag in query string form
+     * @return {RequestContext} itself
+     */
+    setExistingObjTag(existingObjTag) {
+        this._existingObjTag = existingObjTag;
+        return this;
+    }
+
+    /**
+     * Get existing object tag
+     *
+     * @return {string} existing object tag
+     */
+    getExistingObjTag() {
+        return this._existingObjTag;
     }
 }
 

--- a/lib/policyEvaluator/RequestContext.js
+++ b/lib/policyEvaluator/RequestContext.js
@@ -234,7 +234,7 @@ class RequestContext {
         requesterIp, sslEnabled, apiMethod,
         awsService, locationConstraint, requesterInfo,
         signatureVersion, authType, signatureAge, securityToken, policyArn,
-        action, postXml, requestObjTags, existingObjTag) {
+        action, postXml) {
         this._headers = headers;
         this._query = query;
         this._requesterIp = requesterIp;
@@ -264,8 +264,9 @@ class RequestContext {
         this._action = action;
         this._needQuota = _actionNeedQuotaCheck[apiMethod] === true;
         this._postXml = postXml;
-        this._requestObjTags = requestObjTags;
-        this._existingObjTag = existingObjTag;
+        this._requestObjTags = null;
+        this._existingObjTag = null;
+        this._needTagEval = false;
         return this;
     }
 
@@ -297,6 +298,7 @@ class RequestContext {
             postXml: this._postXml,
             requestObjTags: this._requestObjTags,
             existingObjTag: this._existingObjTag,
+            needTagEval: this._needTagEval,
         };
         return JSON.stringify(requestInfo);
     }
@@ -322,7 +324,7 @@ class RequestContext {
             obj.apiMethod, obj.awsService, obj.locationConstraint,
             obj.requesterInfo, obj.signatureVersion,
             obj.authType, obj.signatureAge, obj.securityToken, obj.policyArn,
-            obj.action, obj.postXml, obj.requestObjTags, obj.existingObjTag);
+            obj.action, obj.postXml);
     }
 
     /**
@@ -724,6 +726,26 @@ class RequestContext {
      */
     getExistingObjTag() {
         return this._existingObjTag;
+    }
+
+    /**
+     * Set whether IAM policy tag condition keys should be evaluated
+     *
+     * @param {boolean} needTagEval - whether to evaluate tags
+     * @return {RequestContext} itself
+     */
+    setNeedTagEval(needTagEval) {
+        this._needTagEval = needTagEval;
+        return this;
+    }
+
+    /**
+     * Get needTagEval param
+     *
+     * @return {boolean} needTagEval - whether IAM policy tags condition keys should be evaluated
+     */
+    getNeedTagEval() {
+        return this._needTagEval;
     }
 }
 

--- a/lib/policyEvaluator/evaluator.js
+++ b/lib/policyEvaluator/evaluator.js
@@ -146,7 +146,7 @@ evaluators.meetConditions = (requestContext, statementCondition, log) => {
             // condition has "ForAnyValue" or "ForAllValues".
             // (see http://docs.aws.amazon.com/IAM/latest/UserGuide/
             // reference_policies_multi-value-conditions.html)
-            const keyBasedOnRequestContext =
+            let keyBasedOnRequestContext =
                 findConditionKey(transformedKey, requestContext);
             // Handle IfExists and negation operators
             if ((keyBasedOnRequestContext === undefined ||
@@ -166,6 +166,10 @@ evaluators.meetConditions = (requestContext, statementCondition, log) => {
                 'missing info', { operator,
                     conditionKey: transformedKey, policyValue: transformedValue });
                 return false;
+            }
+            // If condition operator prefix is included, the key should be an array
+            if (prefix && !Array.isArray(keyBasedOnRequestContext)) {
+                keyBasedOnRequestContext = [keyBasedOnRequestContext];
             }
             // Transalate operator into function using bareOperator
             const operatorFunction = convertConditionOperator(bareOperator);

--- a/lib/policyEvaluator/evaluator.js
+++ b/lib/policyEvaluator/evaluator.js
@@ -17,6 +17,7 @@ const operatorsWithVariables = ['StringEquals', 'StringNotEquals',
 const operatorsWithNegation = ['StringNotEquals',
     'StringNotEqualsIgnoreCase', 'StringNotLike', 'ArnNotEquals',
     'ArnNotLike', 'NumericNotEquals'];
+const tagConditions = ['s3:ExistingObjectTag', 's3:RequestObjectTagKey', 's3:RequestObjectTagKeys'];
 
 
 /**
@@ -97,11 +98,13 @@ evaluators.isActionApplicable = (requestAction, statementAction, log) => {
  * @param {RequestContext} requestContext - info about request
  * @param {Object} statementCondition - Condition statement from policy
  * @param {Object} log - logger
- * @return {boolean} true if meet conditions, false if not
+ * @return {Object} contains whether conditions are allowed and whether they
+ * contain any tag condition keys
  */
 evaluators.meetConditions = (requestContext, statementCondition, log) => {
     // The Condition portion of a policy is an object with different
     // operators as keys
+    const conditionEval = {};
     const operators = Object.keys(statementCondition);
     const length = operators.length;
     for (let i = 0; i < length; i++) {
@@ -124,6 +127,9 @@ evaluators.meetConditions = (requestContext, statementCondition, log) => {
         // Note: this should be the actual operator name, not the bareOperator
         const conditionsWithSameOperator = statementCondition[operator];
         const conditionKeys = Object.keys(conditionsWithSameOperator);
+        if (conditionKeys.some(key => tagConditions.includes(key))) {
+            conditionEval.tagConditions = true;
+        }
         const conditionKeysLength = conditionKeys.length;
         for (let j = 0; j < conditionKeysLength; j++) {
             const key = conditionKeys[j];
@@ -165,7 +171,7 @@ evaluators.meetConditions = (requestContext, statementCondition, log) => {
                 log.trace('condition not satisfied due to ' +
                 'missing info', { operator,
                     conditionKey: transformedKey, policyValue: transformedValue });
-                return false;
+                return { allow: false };
             }
             // If condition operator prefix is included, the key should be an array
             if (prefix && !Array.isArray(keyBasedOnRequestContext)) {
@@ -179,11 +185,12 @@ evaluators.meetConditions = (requestContext, statementCondition, log) => {
             if (!operatorFunction(keyBasedOnRequestContext, transformedValue, prefix)) {
                 log.trace('did not satisfy condition', { operator: bareOperator,
                     keyBasedOnRequestContext, policyValue: transformedValue });
-                return false;
+                return { allow: false };
             }
         }
     }
-    return true;
+    conditionEval.allow = true;
+    return conditionEval;
 };
 
 /**
@@ -234,10 +241,10 @@ evaluators.evaluatePolicy = (requestContext, policy, log) => {
             currentStatement.NotAction, log)) {
             continue;
         }
+        const conditionEval = evaluators.meetConditions(requestContext,
+            currentStatement.Condition, log);
         // If do not meet conditions move on to next statement
-        if (currentStatement.Condition &&
-            !evaluators.meetConditions(requestContext,
-            currentStatement.Condition, log)) {
+        if (currentStatement.Condition && !conditionEval.allow) {
             continue;
         }
         if (currentStatement.Effect === 'Deny') {
@@ -249,6 +256,9 @@ evaluators.evaluatePolicy = (requestContext, policy, log) => {
         // If statement is applicable, conditions are met and Effect is
         // to Allow, set verdict to Allow
         verdict = 'Allow';
+        if (conditionEval.tagConditions) {
+            verdict = 'NeedTagConditionEval';
+        }
     }
     log.trace('result of evaluating single policy', { verdict });
     return verdict;

--- a/lib/policyEvaluator/evaluator.js
+++ b/lib/policyEvaluator/evaluator.js
@@ -6,6 +6,7 @@ const conditions = require('./utils/conditions.js');
 const findConditionKey = conditions.findConditionKey;
 const convertConditionOperator = conditions.convertConditionOperator;
 const checkArnMatch = require('./utils/checkArnMatch.js');
+const { transformTagKeyValue } = require('./utils/objectTags');
 
 const evaluators = {};
 
@@ -105,11 +106,16 @@ evaluators.meetConditions = (requestContext, statementCondition, log) => {
     const length = operators.length;
     for (let i = 0; i < length; i++) {
         const operator = operators[i];
+        const hasPrefix = operator.startsWith('ForAnyValue') || operator.startsWith('ForAllValues');
         const hasIfExistsCondition = operator.endsWith('IfExists');
-        // If has "IfExists" added to operator name, find operator name
-        // without "IfExists"
-        const bareOperator = hasIfExistsCondition ? operator.slice(0, -8) :
+        // If has "IfExists" added to operator name, or operator has "ForAnyValue" or
+        // "For All Values" prefix, find operator name without "IfExists" or prefix
+        let bareOperator = hasIfExistsCondition ? operator.slice(0, -8) :
             operator;
+        let prefix;
+        if (hasPrefix) {
+            [prefix, bareOperator] = bareOperator.split(':');
+        }
         const operatorCanHaveVariables =
             operatorsWithVariables.indexOf(bareOperator) > -1;
         const isNegationOperator =
@@ -130,6 +136,10 @@ evaluators.meetConditions = (requestContext, statementCondition, log) => {
                 value = value.map(item =>
                     substituteVariables(item, requestContext));
             }
+            // if condition key is RequestObjectTag or ExistingObjectTag,
+            // tag key is included in condition key and needs to be
+            // moved to value for evaluation, otherwise key/value are unchanged
+            const [transformedKey, transformedValue] = transformTagKeyValue(key, value);
             // Pull key using requestContext
             // TODO: If applicable to S3, handle policy set operations
             // where a keyBasedOnRequestContext returns multiple values and
@@ -137,7 +147,7 @@ evaluators.meetConditions = (requestContext, statementCondition, log) => {
             // (see http://docs.aws.amazon.com/IAM/latest/UserGuide/
             // reference_policies_multi-value-conditions.html)
             const keyBasedOnRequestContext =
-                findConditionKey(key, requestContext);
+                findConditionKey(transformedKey, requestContext);
             // Handle IfExists and negation operators
             if ((keyBasedOnRequestContext === undefined ||
                 keyBasedOnRequestContext === null) &&
@@ -154,7 +164,7 @@ evaluators.meetConditions = (requestContext, statementCondition, log) => {
                 bareOperator !== 'Null') {
                 log.trace('condition not satisfied due to ' +
                 'missing info', { operator,
-                    conditionKey: key, policyValue: value });
+                    conditionKey: transformedKey, policyValue: transformedValue });
                 return false;
             }
             // Transalate operator into function using bareOperator
@@ -162,9 +172,9 @@ evaluators.meetConditions = (requestContext, statementCondition, log) => {
             // Note: Wildcards are handled in the comparison operator function
             // itself since StringLike, StringNotLike, ArnLike and ArnNotLike
             // are the only operators where wildcards are allowed
-            if (!operatorFunction(keyBasedOnRequestContext, value)) {
+            if (!operatorFunction(keyBasedOnRequestContext, transformedValue, prefix)) {
                 log.trace('did not satisfy condition', { operator: bareOperator,
-                    keyBasedOnRequestContext, policyValue: value });
+                    keyBasedOnRequestContext, policyValue: transformedValue });
                 return false;
             }
         }

--- a/lib/policyEvaluator/utils/conditions.js
+++ b/lib/policyEvaluator/utils/conditions.js
@@ -243,6 +243,8 @@ conditions.convertConditionOperator = operator => {
             // eslint-disable-next-line new-cap
             return !operatorMap.StringLike(key, value);
         },
+        RequestObjectTagKeys: function tagKeys(key, value) {},
+        RequestObjectTagKey: function tagKey(key, value) {},
         NumericEquals: function numericEquals(key, value) {
             const numberKey = Number.parseInt(key, 10);
             if (Number.isNaN(numberKey)) {
@@ -312,6 +314,7 @@ conditions.convertConditionOperator = operator => {
                 return numberKey >= numberItem;
             });
         },
+        ExistingObjectTag: function existingTag(key, value) {},
         DateEquals: function dateEquals(key, value) {
             const epochKey = convertToEpochTime(key);
             const epochValues = convertToEpochTime(value);

--- a/lib/policyEvaluator/utils/conditions.js
+++ b/lib/policyEvaluator/utils/conditions.js
@@ -4,6 +4,7 @@
 const checkIPinRangeOrMatch = require('../../ipCheck').checkIPinRangeOrMatch;
 const handleWildcards = require('./wildcards.js').handleWildcards;
 const checkArnMatch = require('./checkArnMatch.js');
+const { getTagKeys } = require('./objectTags');
 const conditions = {};
 
 /**
@@ -29,6 +30,9 @@ conditions.findConditionKey = (key, requestContext) => {
     // aws:EpochTime – Used for date/time conditions
     // (see Date Condition Operators).
     map.set('aws:EpochTime', Date.now().toString());
+    // aws:ExistingObjectTag - Used to check that existing object tag has
+    // specific tag key and value. Extraction of correct tag key is done in CloudServer.
+    map.set('aws:ExistingObjectTag', requestContext.getExistingObjTag());
     // aws:TokenIssueTime – Date/time that temporary security
     // credentials were issued (see Date Condition Operators).
     // Only present in requests that are signed using temporary security
@@ -59,6 +63,12 @@ conditions.findConditionKey = (key, requestContext) => {
     // services, such as S3. Value comes from the referer header in the
     // HTTPS request made to AWS.
     map.set('aws:referer', headers.referer);
+    // aws:RequestObjectTag - Used to limit putting object tags to specific
+    // tag key and value. N/A here.
+    map.set('aws:RequestObjectTag', requestContext.getRequestObjTags());
+    // aws:RequestObjectTagKeys - Used to limit putting object tags to
+    // specific keys. N/A here.
+    map.set('aws:RequestObjectTagKeys', getTagKeys(requestContext.getRequestObjTags()));
     // aws:SecureTransport – Used to check whether the request was sent
     // using SSL (see Boolean Condition Operators).
     map.set('aws:SecureTransport',
@@ -210,6 +220,8 @@ conditions.convertConditionOperator = operator => {
     // is only one of these strings so should not have undefined
     // or security issue with object assignment
     const operatorMap = {
+        // key = value contained in request or already existing <--- needs to be converted to query string from post xml in cloudserver
+        // value = value in policy
         StringEquals: function stringEquals(key, value) {
             return value.some(item => {
                 const swtichedOutChars = convertSpecialChars(item);
@@ -232,7 +244,13 @@ conditions.convertConditionOperator = operator => {
                 // eslint-disable-next-line new-cap
                 return !operatorMap.StringEqualsIgnoreCase(key, value);
             },
-        StringLike: function stringLike(key, value) {
+        StringLike: function stringLike(key, value, prefix) {
+            if (prefix === 'ForAnyValue') {
+
+            }
+            if (prefix === 'ForAllValues') {
+                
+            }
             return value.some(item => {
                 const wildItem = handleWildcards(item);
                 const wildRegEx = new RegExp(wildItem);
@@ -243,8 +261,6 @@ conditions.convertConditionOperator = operator => {
             // eslint-disable-next-line new-cap
             return !operatorMap.StringLike(key, value);
         },
-        RequestObjectTagKeys: function tagKeys(key, value) {},
-        RequestObjectTagKey: function tagKey(key, value) {},
         NumericEquals: function numericEquals(key, value) {
             const numberKey = Number.parseInt(key, 10);
             if (Number.isNaN(numberKey)) {
@@ -314,7 +330,6 @@ conditions.convertConditionOperator = operator => {
                 return numberKey >= numberItem;
             });
         },
-        ExistingObjectTag: function existingTag(key, value) {},
         DateEquals: function dateEquals(key, value) {
             const epochKey = convertToEpochTime(key);
             const epochValues = convertToEpochTime(value);

--- a/lib/policyEvaluator/utils/conditions.js
+++ b/lib/policyEvaluator/utils/conditions.js
@@ -32,7 +32,9 @@ conditions.findConditionKey = (key, requestContext) => {
     map.set('aws:EpochTime', Date.now().toString());
     // aws:ExistingObjectTag - Used to check that existing object tag has
     // specific tag key and value. Extraction of correct tag key is done in CloudServer.
-    map.set('aws:ExistingObjectTag', requestContext.getExistingObjTag());
+    // On first pass of policy evaluation, CloudServer information will not be included,
+    // so evaluation should be skipped
+    map.set('aws:ExistingObjectTag', requestContext.getNeedTagEval() ? requestContext.getExistingObjTag() : undefined);
     // aws:TokenIssueTime – Date/time that temporary security
     // credentials were issued (see Date Condition Operators).
     // Only present in requests that are signed using temporary security
@@ -65,10 +67,16 @@ conditions.findConditionKey = (key, requestContext) => {
     map.set('aws:referer', headers.referer);
     // aws:RequestObjectTag - Used to limit putting object tags to specific
     // tag key and value. N/A here.
-    map.set('aws:RequestObjectTag', requestContext.getRequestObjTags());
-    // aws:RequestObjectTagKeys - Used to limit putting object tags to
-    // specific keys. N/A here.
-    map.set('aws:RequestObjectTagKeys', getTagKeys(requestContext.getRequestObjTags()));
+    // Requires information from CloudServer
+    // On first pass of policy evaluation, CloudServer information will not be included,
+    // so evaluation should be skipped
+    map.set('aws:RequestObjectTag', requestContext.getNeedTagEval() ? requestContext.getRequestObjTags() : undefined);
+    // aws:RequestObjectTagKeys - Used to limit putting object tags specific tag keys.
+    // Requires information from CloudServer.
+    // On first pass of policy evaluation, CloudServer information will not be included,
+    // so evaluation should be skipped
+    map.set('aws:RequestObjectTagKeys',
+        requestContext.getNeedTagEval() ? getTagKeys(requestContext.getRequestObjTags()) : undefined);
     // aws:SecureTransport – Used to check whether the request was sent
     // using SSL (see Boolean Condition Operators).
     map.set('aws:SecureTransport',
@@ -220,8 +228,6 @@ conditions.convertConditionOperator = operator => {
     // is only one of these strings so should not have undefined
     // or security issue with object assignment
     const operatorMap = {
-        // key = value contained in request or already existing <--- needs to be converted to query string from post xml in cloudserver
-        // value = value in policy
         StringEquals: function stringEquals(key, value) {
             return value.some(item => {
                 const swtichedOutChars = convertSpecialChars(item);
@@ -245,17 +251,20 @@ conditions.convertConditionOperator = operator => {
                 return !operatorMap.StringEqualsIgnoreCase(key, value);
             },
         StringLike: function stringLike(key, value, prefix) {
+            function policyValRegex(testKey) {
+                return value.some(item => {
+                    const wildItem = handleWildcards(item);
+                    const wildRegEx = new RegExp(wildItem);
+                    return wildRegEx.test(testKey);
+                });
+            }
             if (prefix === 'ForAnyValue') {
-
+                return key.some(k => policyValRegex(k));
             }
             if (prefix === 'ForAllValues') {
-                
+                return key.every(k => policyValRegex(k));
             }
-            return value.some(item => {
-                const wildItem = handleWildcards(item);
-                const wildRegEx = new RegExp(wildItem);
-                return wildRegEx.test(key);
-            });
+            return policyValRegex(key);
         },
         StringNotLike: function stringNotLike(key, value) {
             // eslint-disable-next-line new-cap

--- a/lib/policyEvaluator/utils/objectTags.js
+++ b/lib/policyEvaluator/utils/objectTags.js
@@ -1,0 +1,32 @@
+/**
+ * Removes tag key value from condition key and adds it to value if needed
+ * @param {string} key - condition key
+ * @param {string} value - condition value
+ * @return {array} key/value pair to use
+ */
+function transformTagKeyValue(key, value) {
+    if (!key.includes('/')) {
+        return [key, value];
+    }
+    // if key is RequestObjectTag or ExistingObjectTag,
+    // remove tag key from condition key and add to value
+    // and transform value into query string
+    const [conditionKey, tagKey] = key.split('/');
+    return [conditionKey, [tagKey, value].join('=')];
+}
+
+/**
+ * Gets array of tag key names from request tag query string
+ * @param {string} tagQuery - request tags in query string format
+ * @return {array} array of tag key names
+ */
+function getTagKeys(tagQuery) {
+    const tagsArray = tagQuery.split(',');
+    const keysArray = tagsArray.map(tag => tag.split('=')[0]);
+    return keysArray;
+}
+
+module.exports = {
+    transformTagKeyValue,
+    getTagKeys,
+};

--- a/lib/policyEvaluator/utils/objectTags.js
+++ b/lib/policyEvaluator/utils/objectTags.js
@@ -12,7 +12,8 @@ function transformTagKeyValue(key, value) {
     // remove tag key from condition key and add to value
     // and transform value into query string
     const [conditionKey, tagKey] = key.split('/');
-    return [conditionKey, [tagKey, value].join('=')];
+    const transformedValue = [tagKey, value].join('=');
+    return [conditionKey, [transformedValue]];
 }
 
 /**


### PR DESCRIPTION
In order for the policy condition keys `s3:ExistingObjectTag`, `s3:RequestObjectTagKey`, and `s3:RequestObjectTagKeys` to be evaluated, Arsenal requires information from CloudServer.
As such, the policy review process, if it includes any of these condition keys, will be as follows:
- Review policy as normal, but include information of whether any tag condition keys are in the policy
- Return to CloudServer, which will check whether a tag condition key was present and gather the necessary tag information, if needed
- Return to Arsenal with tag info for another complete policy evaluation, including tag condition keys
- Return auth results to Cloudserver and continue with request

I don't believe my solution is necessarily the most elegant, but it is the simplest I could come up with to change as little of the existing code as possible. Any feedback on logic or style or anything would be greatly appreciated! Tests to come.