### PR TITLE
Feature/s3 c 1801 policy tag condition keys

### DIFF
--- a/lib/policyEvaluator/RequestContext.js
+++ b/lib/policyEvaluator/RequestContext.js
@@ -235,7 +235,7 @@ class RequestContext {
         requesterIp, sslEnabled, apiMethod,
         awsService, locationConstraint, requesterInfo,
         signatureVersion, authType, signatureAge, securityToken, policyArn,
-        action) {
+        action, postXml) {
         this._headers = headers;
         this._query = query;
         this._requesterIp = requesterIp;
@@ -264,6 +264,10 @@ class RequestContext {
         this._policyArn = policyArn;
         this._action = action;
         this._needQuota = _actionNeedQuotaCheck[apiMethod] === true;
+        this._postXml = postXml;
+        this._requestObjTags = null;
+        this._existingObjTag = null;
+        this._needTagEval = false;
         return this;
     }
 
@@ -292,6 +296,10 @@ class RequestContext {
             securityToken: this._securityToken,
             policyArn: this._policyArn,
             action: this._action,
+            postXml: this._postXml,
+            requestObjTags: this._requestObjTags,
+            existingObjTag: this._existingObjTag,
+            needTagEval: this._needTagEval,
         };
         return JSON.stringify(requestInfo);
     }
@@ -317,7 +325,7 @@ class RequestContext {
             obj.apiMethod, obj.awsService, obj.locationConstraint,
             obj.requesterInfo, obj.signatureVersion,
             obj.authType, obj.signatureAge, obj.securityToken, obj.policyArn,
-            obj.action);
+            obj.action, obj.postXml);
     }
 
     /**
@@ -659,6 +667,86 @@ class RequestContext {
      */
     isQuotaCheckNeeded() {
         return this._needQuota;
+    }
+
+    /**
+     * Set request post
+     *
+     * @param {string} postXml - request post
+     * @return {RequestContext} itself
+     */
+    setPostXml(postXml) {
+        this._postXml = postXml;
+        return this;
+    }
+
+    /**
+     * Get request post
+     *
+     * @return {string} request post
+     */
+    getPostXml() {
+        return this._postXml;
+    }
+
+    /**
+     * Set request object tags
+     *
+     * @param {string} requestObjTags - object tag(s) included in request in query string form
+     * @return {RequestContext} itself
+     */
+    setRequestObjTags(requestObjTags) {
+        this._requestObjTags = requestObjTags;
+        return this;
+    }
+
+    /**
+     * Get request object tags
+     *
+     * @return {string} request object tag(s)
+     */
+    getRequestObjTags() {
+        return this._requestObjTags;
+    }
+
+    /**
+     * Set info on existing tag on object included in request
+     *
+     * @param {string} existingObjTag - existing object tag in query string form
+     * @return {RequestContext} itself
+     */
+    setExistingObjTag(existingObjTag) {
+        this._existingObjTag = existingObjTag;
+        return this;
+    }
+
+    /**
+     * Get existing object tag
+     *
+     * @return {string} existing object tag
+     */
+    getExistingObjTag() {
+        return this._existingObjTag;
+    }
+
+    /**
+     * Set whether IAM policy tag condition keys should be evaluated
+     *
+     * @param {boolean} needTagEval - whether to evaluate tags
+     * @return {RequestContext} itself
+     */
+    setNeedTagEval(needTagEval) {
+        this._needTagEval = needTagEval;
+        return this;
+    }
+
+    /**
+     * Get needTagEval param
+     *
+     * @return {boolean} needTagEval - whether IAM policy tags condition keys should be evaluated
+     */
+    getNeedTagEval() {
+        return this._needTagEval;
     }
 }
 

--- a/lib/policyEvaluator/evaluator.js
+++ b/lib/policyEvaluator/evaluator.js
@@ -6,6 +6,7 @@ const conditions = require('./utils/conditions.js');
 const findConditionKey = conditions.findConditionKey;
 const convertConditionOperator = conditions.convertConditionOperator;
 const checkArnMatch = require('./utils/checkArnMatch.js');
+const { transformTagKeyValue } = require('./utils/objectTags');
 
 const evaluators = {};
 
@@ -16,6 +17,7 @@ const operatorsWithVariables = ['StringEquals', 'StringNotEquals',
 const operatorsWithNegation = ['StringNotEquals',
     'StringNotEqualsIgnoreCase', 'StringNotLike', 'ArnNotEquals',
     'ArnNotLike', 'NumericNotEquals'];
+const tagConditions = new Set(['s3:ExistingObjectTag', 's3:RequestObjectTagKey', 's3:RequestObjectTagKeys']);
 
 
 /**
@@ -96,20 +98,27 @@ evaluators.isActionApplicable = (requestAction, statementAction, log) => {
  * @param {RequestContext} requestContext - info about request
  * @param {Object} statementCondition - Condition statement from policy
  * @param {Object} log - logger
- * @return {boolean} true if meet conditions, false if not
+ * @return {Object} contains whether conditions are allowed and whether they
+ * contain any tag condition keys
  */
 evaluators.meetConditions = (requestContext, statementCondition, log) => {
     // The Condition portion of a policy is an object with different
     // operators as keys
+    const conditionEval = {};
     const operators = Object.keys(statementCondition);
     const length = operators.length;
     for (let i = 0; i < length; i++) {
         const operator = operators[i];
+        const hasPrefix = operator.includes(':');
         const hasIfExistsCondition = operator.endsWith('IfExists');
-        // If has "IfExists" added to operator name, find operator name
-        // without "IfExists"
-        const bareOperator = hasIfExistsCondition ? operator.slice(0, -8) :
+        // If has "IfExists" added to operator name, or operator has "ForAnyValue" or
+        // "For All Values" prefix, find operator name without "IfExists" or prefix
+        let bareOperator = hasIfExistsCondition ? operator.slice(0, -8) :
             operator;
+        let prefix;
+        if (hasPrefix) {
+            [prefix, bareOperator] = bareOperator.split(':');
+        }
         const operatorCanHaveVariables =
             operatorsWithVariables.indexOf(bareOperator) > -1;
         const isNegationOperator =
@@ -118,6 +127,9 @@ evaluators.meetConditions = (requestContext, statementCondition, log) => {
         // Note: this should be the actual operator name, not the bareOperator
         const conditionsWithSameOperator = statementCondition[operator];
         const conditionKeys = Object.keys(conditionsWithSameOperator);
+        if (conditionKeys.some(key => tagConditions.has(key)) && !requestContext.getNeedTagEval()) {
+            conditionEval.tagConditions = true;
+        }
         const conditionKeysLength = conditionKeys.length;
         for (let j = 0; j < conditionKeysLength; j++) {
             const key = conditionKeys[j];
@@ -130,14 +142,18 @@ evaluators.meetConditions = (requestContext, statementCondition, log) => {
                 value = value.map(item =>
                     substituteVariables(item, requestContext));
             }
+            // if condition key is RequestObjectTag or ExistingObjectTag,
+            // tag key is included in condition key and needs to be
+            // moved to value for evaluation, otherwise key/value are unchanged
+            const [transformedKey, transformedValue] = transformTagKeyValue(key, value);
             // Pull key using requestContext
             // TODO: If applicable to S3, handle policy set operations
             // where a keyBasedOnRequestContext returns multiple values and
             // condition has "ForAnyValue" or "ForAllValues".
             // (see http://docs.aws.amazon.com/IAM/latest/UserGuide/
             // reference_policies_multi-value-conditions.html)
-            const keyBasedOnRequestContext =
-                findConditionKey(key, requestContext);
+            let keyBasedOnRequestContext =
+                findConditionKey(transformedKey, requestContext);
             // Handle IfExists and negation operators
             if ((keyBasedOnRequestContext === undefined ||
                 keyBasedOnRequestContext === null) &&
@@ -154,22 +170,27 @@ evaluators.meetConditions = (requestContext, statementCondition, log) => {
                 bareOperator !== 'Null') {
                 log.trace('condition not satisfied due to ' +
                 'missing info', { operator,
-                    conditionKey: key, policyValue: value });
-                return false;
+                    conditionKey: transformedKey, policyValue: transformedValue });
+                return { allow: false };
+            }
+            // If condition operator prefix is included, the key should be an array
+            if (prefix && !Array.isArray(keyBasedOnRequestContext)) {
+                keyBasedOnRequestContext = [keyBasedOnRequestContext];
             }
             // Transalate operator into function using bareOperator
             const operatorFunction = convertConditionOperator(bareOperator);
             // Note: Wildcards are handled in the comparison operator function
             // itself since StringLike, StringNotLike, ArnLike and ArnNotLike
             // are the only operators where wildcards are allowed
-            if (!operatorFunction(keyBasedOnRequestContext, value)) {
+            if (!operatorFunction(keyBasedOnRequestContext, transformedValue, prefix)) {
                 log.trace('did not satisfy condition', { operator: bareOperator,
-                    keyBasedOnRequestContext, policyValue: value });
-                return false;
+                    keyBasedOnRequestContext, policyValue: transformedValue });
+                return { allow: false };
             }
         }
     }
-    return true;
+    conditionEval.allow = true;
+    return conditionEval;
 };
 
 /**
@@ -220,10 +241,11 @@ evaluators.evaluatePolicy = (requestContext, policy, log) => {
             currentStatement.NotAction, log)) {
             continue;
         }
+        const conditionEval = currentStatement.Condition ?
+            evaluators.meetConditions(requestContext, currentStatement.Condition, log) :
+            null;
         // If do not meet conditions move on to next statement
-        if (currentStatement.Condition &&
-            !evaluators.meetConditions(requestContext,
-            currentStatement.Condition, log)) {
+        if (conditionEval && !conditionEval.allow) {
             continue;
         }
         if (currentStatement.Effect === 'Deny') {
@@ -235,6 +257,9 @@ evaluators.evaluatePolicy = (requestContext, policy, log) => {
         // If statement is applicable, conditions are met and Effect is
         // to Allow, set verdict to Allow
         verdict = 'Allow';
+        if (conditionEval && conditionEval.tagConditions) {
+            verdict = 'NeedTagConditionEval';
+        }
     }
     log.trace('result of evaluating single policy', { verdict });
     return verdict;

--- a/lib/policyEvaluator/principal.js
+++ b/lib/policyEvaluator/principal.js
@@ -35,7 +35,8 @@ class Principal {
                 // In case of anonymous NotPrincipal, this will neutral everyone
                 return 'Neutral';
             }
-            if (!Principal._evaluateCondition(params, statement)) {
+            const conditionEval = Principal._evaluateCondition(params, statement);
+            if (!conditionEval || conditionEval.allow === false) {
                 return 'Neutral';
             }
             return statement.Effect;
@@ -65,7 +66,8 @@ class Principal {
             if (reverse) {
                 return 'Neutral';
             }
-            if (!Principal._evaluateCondition(params, statement)) {
+            const conditionEval = Principal._evaluateCondition(params, statement);
+            if (!conditionEval || conditionEval.allow === false) {
                 return 'Neutral';
             }
             return statement.Effect;
@@ -76,7 +78,8 @@ class Principal {
                 if (reverse) {
                     return 'Neutral';
                 }
-                if (!Principal._evaluateCondition(params, statement)) {
+                const conditionEval = Principal._evaluateCondition(params, statement);
+                if (!conditionEval || conditionEval.allow === false) {
                     return 'Neutral';
                 }
                 return statement.Effect;

--- a/lib/policyEvaluator/utils/conditions.js
+++ b/lib/policyEvaluator/utils/conditions.js
@@ -4,6 +4,7 @@
 const checkIPinRangeOrMatch = require('../../ipCheck').checkIPinRangeOrMatch;
 const handleWildcards = require('./wildcards.js').handleWildcards;
 const checkArnMatch = require('./checkArnMatch.js');
+const { getTagKeys } = require('./objectTags');
 const conditions = {};
 
 /**
@@ -146,6 +147,25 @@ conditions.findConditionKey = (key, requestContext) => {
         headers['x-amz-meta-scal-location-constraint']);
     map.set('sts:ExternalId', requestContext.getRequesterExternalId());
     map.set('iam:PolicyArn', requestContext.getPolicyArn());
+    // s3:ExistingObjectTag - Used to check that existing object tag has
+    // specific tag key and value. Extraction of correct tag key is done in CloudServer.
+    // On first pass of policy evaluation, CloudServer information will not be included,
+    // so evaluation should be skipped
+    map.set('s3:ExistingObjectTag', requestContext.getNeedTagEval() ? requestContext.getExistingObjTag() : undefined);
+    // s3:RequestObjectTag - Used to limit putting object tags to specific
+    // tag key and value. N/A here.
+    // Requires information from CloudServer
+    // On first pass of policy evaluation, CloudServer information will not be included,
+    // so evaluation should be skipped
+    map.set('s3:RequestObjectTagKey', requestContext.getNeedTagEval() ? requestContext.getRequestObjTags() : undefined);
+    // s3:RequestObjectTagKeys - Used to limit putting object tags specific tag keys.
+    // Requires information from CloudServer.
+    // On first pass of policy evaluation, CloudServer information will not be included,
+    // so evaluation should be skipped
+    map.set('s3:RequestObjectTagKeys',
+        requestContext.getNeedTagEval() && requestContext.getRequestObjTags()
+        ? getTagKeys(requestContext.getRequestObjTags())
+        : undefined);
     return map.get(key);
 };
 
@@ -232,12 +252,21 @@ conditions.convertConditionOperator = operator => {
                 // eslint-disable-next-line new-cap
                 return !operatorMap.StringEqualsIgnoreCase(key, value);
             },
-        StringLike: function stringLike(key, value) {
-            return value.some(item => {
-                const wildItem = handleWildcards(item);
-                const wildRegEx = new RegExp(wildItem);
-                return wildRegEx.test(key);
-            });
+        StringLike: function stringLike(key, value, prefix) {
+            function policyValRegex(testKey) {
+                return value.some(item => {
+                    const wildItem = handleWildcards(item);
+                    const wildRegEx = new RegExp(wildItem);
+                    return wildRegEx.test(testKey);
+                });
+            }
+            if (prefix === 'ForAnyValue') {
+                return key.some(policyValRegex);
+            }
+            if (prefix === 'ForAllValues') {
+                return key.every(policyValRegex);
+            }
+            return policyValRegex(key);
         },
         StringNotLike: function stringNotLike(key, value) {
             // eslint-disable-next-line new-cap

--- a/lib/policyEvaluator/utils/objectTags.js
+++ b/lib/policyEvaluator/utils/objectTags.js
@@ -1,0 +1,33 @@
+/**
+ * Removes tag key value from condition key and adds it to value if needed
+ * @param {string} key - condition key
+ * @param {string} value - condition value
+ * @return {array} key/value pair to use
+ */
+function transformTagKeyValue(key, value) {
+    const patternKeys = ['s3:ExistingObjectTag/', 's3:RequestObjectTagKey/'];
+    if (!patternKeys.some(k => key.includes(k))) {
+        return [key, value];
+    }
+    // if key is RequestObjectTag or ExistingObjectTag,
+    // remove tag key from condition key and add to value
+    // and transform value into query string
+    const [conditionKey, tagKey] = key.split('/');
+    const transformedValue = [tagKey, value].join('=');
+    return [conditionKey, [transformedValue]];
+}
+
+/**
+ * Gets array of tag key names from request tag query string
+ * @param {string} tagQuery - request tags in query string format
+ * @return {array} array of tag key names
+ */
+function getTagKeys(tagQuery) {
+    return tagQuery.split('&')
+        .map(tag => tag.split('=')[0]);
+}
+
+module.exports = {
+    transformTagKeyValue,
+    getTagKeys,
+};

--- a/tests/unit/policyEvaluator.js
+++ b/tests/unit/policyEvaluator.js
@@ -1161,6 +1161,85 @@ describe('policyEvaluator', () => {
                 };
                 check(requestContext, rcModifiers, policy, 'Neutral');
             });
+
+            it('should allow with StringEquals operator and ExistingObjectTag ' +
+            'key if meet condition', () => {
+                policy.Statement.Condition = {
+                    StringEquals: { 's3:ExistingObjectTag/tagKey': 'tagValue' },
+                };
+                const rcModifiers = {
+                    _existingObjTag: 'tagKey=tagValue',
+                    _needTagEval: true,
+                };
+                check(requestContext, rcModifiers, policy, 'Allow');
+            });
+
+            it('should allow StringEquals operator and RequestObjectTag ' +
+            'key if meet condition', () => {
+                policy.Statement.Condition = {
+                    StringEquals: { 's3:RequestObjectTagKey/tagKey': 'tagValue' },
+                };
+                const rcModifiers = {
+                    _requestObjTags: 'tagKey=tagValue',
+                    _needTagEval: true,
+                };
+                check(requestContext, rcModifiers, policy, 'Allow');
+            });
+
+            it('should allow with ForAnyValue prefix if meet condition', () => {
+                policy.Statement.Condition = {
+                    'ForAnyValue:StringLike': { 's3:RequestObjectTagKeys': ['tagOne', 'tagTwo'] },
+                };
+                const rcModifiers = {
+                    _requestObjTags: 'tagOne=keyOne&tagThree=keyThree',
+                    _needTagEval: true,
+                };
+                check(requestContext, rcModifiers, policy, 'Allow');
+            });
+
+            it('should allow with ForAllValues prefix if meet condition', () => {
+                policy.Statement.Condition = {
+                    'ForAllValues:StringLike': { 's3:RequestObjectTagKeys': ['tagOne', 'tagTwo'] },
+                };
+                const rcModifiers = {
+                    _requestObjTags: 'tagOne=keyOne&tagTwo=keyTwo',
+                    _needTagEval: true,
+                };
+                check(requestContext, rcModifiers, policy, 'Allow');
+            });
+
+            it('should not allow with ForAnyValue prefix if do not meet condition', () => {
+                policy.Statement.Condition = {
+                    'ForAnyValue:StringLike': { 's3:RequestObjectTagKeys': ['tagOne', 'tagTwo'] },
+                };
+                const rcModifiers = {
+                    _requestObjTags: 'tagThree=keyThree&tagFour=keyFour',
+                    _needTagEval: true,
+                };
+                check(requestContext, rcModifiers, policy, 'Neutral');
+            });
+
+            it('should not allow with ForAllValues prefix if do not meet condition', () => {
+                policy.Statement.Condition = {
+                    'ForAllValues:StringLike': { 's3:RequestObjectTagKeys': ['tagOne', 'tagTwo'] },
+                };
+                const rcModifiers = {
+                    _requestObjTags: 'tagThree=keyThree&tagFour=keyFour',
+                    _needTagEval: true,
+                };
+                check(requestContext, rcModifiers, policy, 'Neutral');
+            });
+
+            it('should be neutral with StringEquals if condition key does not exist', () => {
+                policy.Statement.Condition = {
+                    StringEquals: { 's3:Foobar/tagKey': 'tagValue' },
+                };
+                const rcModifiers = {
+                    _requestObjTags: 'tagKey=tagValue',
+                    _needTagEval: true,
+                };
+                check(requestContext, rcModifiers, policy, 'Neutral');
+            });
         });
     });
 


### PR DESCRIPTION
In order for the policy condition keys s3:ExistingObjectTag, s3:RequestObjectTagKey, and s3:RequestObjectTagKeys to be evaluated, Arsenal requires information from CloudServer.
As such, the policy review process, if it includes any of these condition keys, will be as follows:

Review policy as normal, but include information of whether any tag condition keys are in the policy
Return to CloudServer, which will check whether a tag condition key was present and gather the necessary tag information, if needed
Return to Arsenal with tag info for another complete policy evaluation, including tag condition keys
Return auth results to Cloudserver and continue with request
I don't believe my solution is necessarily the most elegant, but it is the simplest I could come up with to change as little of the existing code as possible. Any feedback on logic or style or anything would be greatly appreciated! ~Tests in progress.~ Tests included :)