### PR TITLE
feature: S3C-3185-CredentialReport-policy-check

### DIFF
--- a/errors/arsenalErrors.json
+++ b/errors/arsenalErrors.json
@@ -475,6 +475,18 @@
     "code": 400,
     "description": "This policy contains invalid Json"
   },
+  "ReportExpired": {
+    "code": 410,
+    "description": "The request was rejected because the most recent credential report has expired. To generate a new credential report, use GenerateCredentialReport."
+  },
+  "ReportInProgress": {
+    "code": 404,
+    "description": "The request was rejected because the credential report is still being generated."
+  },
+  "ReportNotPresent": {
+    "code": 410,
+    "description": "The request was rejected because the credential report does not exist. To generate a credential report, use GenerateCredentialReport."
+  },
   "_comment": "-------------- Special non-AWS S3 errors --------------",
   "MPUinProgress": {
     "code": 409,

--- a/lib/policyEvaluator/RequestContext.js
+++ b/lib/policyEvaluator/RequestContext.js
@@ -106,6 +106,8 @@ const _actionMapIAM = {
     updateGroup: 'iam:UpdateGroup',
     updateUser: 'iam:UpdateUser',
     getAccessKeyLastUsed: 'iam:GetAccessKeyLastUsed',
+    generateCredentialReport: 'iam:GenerateCredentialReport',
+    getCredentialReport: 'iam:GetCredentialReport',
 };
 
 const _actionMapSSO = {


### PR DESCRIPTION
Adds support for IAM calls, `GenerateCredentialReport` and `GetCredentialReport` to be called using policies.

Also has errors:

``
ReportExpired
The request was rejected because the most recent credential report has expired. To generate a new credential report, use GenerateCredentialReport.

HTTP Status Code: 410
ReportInProgress
The request was rejected because the credential report is still being generated.

HTTP Status Code: 404
ReportNotPresent
The request was rejected because the credential report does not exist. To generate a credential report, use GenerateCredentialReport.

HTTP Status Code: 410
ServiceFailure
The request processing has failed because of an unknown error, exception or failure.

HTTP Status Code: 500
```