### PR TITLE
bugfix: S3C-3402 remove wrong error log

### DIFF
--- a/lib/network/http/server.js
+++ b/lib/network/http/server.js
@@ -330,7 +330,7 @@ class Server {
      * @return {undefined}
      */
     _onSecureConnection(sock) {
-        if (!sock.authorized) {
+        if (this._https.requestCert && !sock.authorized) {
             this._logger.error('rejected secure connection', {
                 address: sock.address(),
                 authorized: false,


### PR DESCRIPTION
Remove the error log 'rejected secure connection' when client
certificate checks are disabled in the HTTPS server, since the
connection is accepted although the client is not authenticated but is
still allowed to request the server.