### PR TITLE
bugfix: S3C-3388 network.http.Server.setKeepAliveTimeout()

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -72,4 +72,16 @@ module.exports = {
     permittedCapitalizedBuckets: {
         METADATA: true,
     },
+    // HTTP server keep-alive timeout is set to a higher value than
+    // client's free sockets timeout to avoid the risk of triggering
+    // ECONNRESET errors if the server closes the connection at the
+    // exact moment clients attempt to reuse an established connection
+    // for a new request.
+    //
+    // Note: the ability to close inactive connections on the client
+    // after httpClientFreeSocketsTimeout milliseconds requires the
+    // use of "agentkeepalive" module instead of the regular node.js
+    // http.Agent.
+    httpServerKeepAliveTimeout: 60000,
+    httpClientFreeSocketTimeout: 55000,
 };

--- a/lib/network/http/server.js
+++ b/lib/network/http/server.js
@@ -43,6 +43,7 @@ class Server {
         this._address = checkSupportIPv6() ? '::' : '0.0.0.0';
         this._server = null;
         this._logger = logger;
+        this._keepAliveTimeout = null; // null: use default node.js value
     }
 
     /**
@@ -54,6 +55,19 @@ class Server {
      */
     setNoDelay(value) {
         this._noDelay = value;
+        return this;
+    }
+
+    /**
+     * Set the keep-alive timeout after which inactive client
+     * connections are automatically closed (default should be
+     * 5 seconds in node.js)
+     *
+     * @param {number} keepAliveTimeout - keep-alive timeout in milliseconds
+     * @return {Server} - returns this
+     */
+    setKeepAliveTimeout(keepAliveTimeout) {
+        this._keepAliveTimeout = keepAliveTimeout;
         return this;
     }
 
@@ -400,6 +414,9 @@ class Server {
                 });
                 this._server = http.createServer(
                     (req, res) => this._onRequest(req, res));
+            }
+            if (this._keepAliveTimeout) {
+                this._server.keepAliveTimeout = this._keepAliveTimeout;
             }
 
             this._server.on('error', err => this._onError(err));


### PR DESCRIPTION
Add a helper function to set the keep-alive timeout of the node.js
HTTP server managed by the Server class.