### PR TITLE
INTEGRATION [PR#1283 > development/7.9] bugfix: S3C-3388 network.http.Server.setKeepAliveTimeout()

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -72,4 +72,16 @@ module.exports = {
     permittedCapitalizedBuckets: {
         METADATA: true,
     },
+    // HTTP server keep-alive timeout is set to a higher value than
+    // client's free sockets timeout to avoid the risk of triggering
+    // ECONNRESET errors if the server closes the connection at the
+    // exact moment clients attempt to reuse an established connection
+    // for a new request.
+    //
+    // Note: the ability to close inactive connections on the client
+    // after httpClientFreeSocketsTimeout milliseconds requires the
+    // use of "agentkeepalive" module instead of the regular node.js
+    // http.Agent.
+    httpServerKeepAliveTimeout: 60000,
+    httpClientFreeSocketTimeout: 55000,
 };

--- a/lib/network/http/server.js
+++ b/lib/network/http/server.js
@@ -43,6 +43,7 @@ class Server {
         this._address = checkSupportIPv6() ? '::' : '0.0.0.0';
         this._server = null;
         this._logger = logger;
+        this._keepAliveTimeout = null; // null: use default node.js value
     }
 
     /**
@@ -54,6 +55,19 @@ class Server {
      */
     setNoDelay(value) {
         this._noDelay = value;
+        return this;
+    }
+
+    /**
+     * Set the keep-alive timeout after which inactive client
+     * connections are automatically closed (default should be
+     * 5 seconds in node.js)
+     *
+     * @param {number} keepAliveTimeout - keep-alive timeout in milliseconds
+     * @return {Server} - returns this
+     */
+    setKeepAliveTimeout(keepAliveTimeout) {
+        this._keepAliveTimeout = keepAliveTimeout;
         return this;
     }
 
@@ -400,6 +414,9 @@ class Server {
                 });
                 this._server = http.createServer(
                     (req, res) => this._onRequest(req, res));
+            }
+            if (this._keepAliveTimeout) {
+                this._server.keepAliveTimeout = this._keepAliveTimeout;
             }
 
             this._server.on('error', err => this._onError(err));


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1283.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.9/bugfix/S3C-3388-httpServerKeepAliveTimeoutOption`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.9/bugfix/S3C-3388-httpServerKeepAliveTimeoutOption
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.9/bugfix/S3C-3388-httpServerKeepAliveTimeoutOption
```

Please always comment pull request #1283 instead of this one.