### PR TITLE
bugfix: ZENKO-2866 abort request on backend if S3 client disconnects

### DIFF
--- a/lib/storage/data/external/AwsClient.js
+++ b/lib/storage/data/external/AwsClient.js
@@ -178,7 +178,18 @@ class AwsClient {
               { responseHeaders: response.httpResponse.headers,
                 backendType: this.clientType });
         });
-        const stream = request.createReadStream().on('error', err => {
+        const stream = request.createReadStream();
+
+        // modify the stream destroy() behavior to also abort the HTTP request
+        const streamDestroy = stream._destroy.bind(stream);
+        stream._destroy = (err, cb) => {
+            log.debug('aborting GET request in progress', { objectGetInfo });
+            request.abort();
+            if (streamDestroy) {
+                streamDestroy(err, cb);
+            }
+        };
+        stream.on('error', err => {
             let logLevel;
             if (err.code === 'NotFound') {
                 logLevel = 'info';
@@ -189,7 +200,11 @@ class AwsClient {
               `error streaming data from ${this.type}`,
               err, this._dataStoreName, this.clientType);
         });
-        return callback(null, stream);
+        // Always call the callback asynchronously: the caller may
+        // destroy the stream with destroy(), which MUST be
+        // asynchronous wrt. request.createReadStream() to avoid
+        // socket leaks, notably because of the request.abort() call.
+        return process.nextTick(() => callback(null, stream));
     }
     delete(objectGetInfo, reqUids, callback) {
         const { key, dataStoreVersionId, deleteVersion } = objectGetInfo;

--- a/tests/unit/s3routes/routesUtils/responseStreamData.js
+++ b/tests/unit/s3routes/routesUtils/responseStreamData.js
@@ -1,0 +1,80 @@
+const assert = require('assert');
+const http = require('http');
+
+const werelogs = require('werelogs');
+const logger = new werelogs.Logger('test:routesUtils.responseStreamData');
+
+const { responseStreamData } = require('../../../../lib/s3routes/routesUtils.js');
+const AwsClient = require('../../../../lib/storage/data/external/AwsClient');
+const DummyObjectStream = require('../../storage/data/DummyObjectStream');
+
+werelogs.configure({
+    level: 'debug',
+    dump: 'error',
+});
+
+describe('routesUtils.responseStreamData', () => {
+    const awsAgent = new http.Agent({
+        keepAlive: true,
+    });
+    const awsConfig = {
+        s3Params: {
+            endpoint: 'http://localhost:8888',
+            maxRetries: 0,
+            s3ForcePathStyle: true,
+            accessKeyId: 'accessKey',
+            secretAccessKey: 'secretKey',
+            httpOptions: {
+                agent: awsAgent,
+            },
+        },
+        bucketName: 'awsTestBucketName',
+        dataStoreName: 'awsDataStore',
+        serverSideEncryption: false,
+        type: 'aws',
+    };
+    let httpServer;
+    let awsClient;
+
+    before(done => {
+        awsClient = new AwsClient(awsConfig);
+        httpServer = http.createServer((req, res) => {
+            const objStream = new DummyObjectStream(0, 10000000);
+            res.setHeader('content-length', 10000000);
+            objStream.pipe(res);
+        }).listen(8888);
+        httpServer.on('listening', done);
+        httpServer.on('error', err => assert.ifError(err));
+    });
+
+    after(() => {
+        httpServer.close();
+    });
+
+    it('should not leak socket if client closes the connection before ' +
+    'data backend starts streaming', done => {
+        responseStreamData(undefined, {}, {}, [{
+            key: 'foo',
+            size: 10000000,
+        }], {
+            client: awsClient,
+            implName: 'impl',
+            config: {},
+            locStorageCheckFn: () => {},
+        }, {
+            setHeader: () => {},
+            writeHead: () => {},
+            on: () => {},
+            once: () => {},
+            emit: () => {},
+            write: () => {},
+            end: () => setTimeout(() => {
+                const nOpenSockets = Object.keys(awsAgent.sockets).length;
+                assert.strictEqual(nOpenSockets, 0);
+                done();
+            }, 1000),
+            // fake a connection close from the S3 client by setting the "isclosed" flag
+            isclosed: true,
+        }, undefined, logger.newRequestLogger());
+    });
+});

--- a/tests/unit/storage/data/DummyObjectStream.js
+++ b/tests/unit/storage/data/DummyObjectStream.js
@@ -1,4 +1,3 @@
-const assert = require('assert');
 const stream = require('stream');
 
 /**
@@ -59,75 +58,26 @@ class DummyObjectStream extends stream.Readable {
     }
 
     _read(size) {
-        while (this.pendingSize < size && this.remainingSize > 0) {
-            this._pushNextChunk();
-        }
-        let consolidated = this.pendingChunks.join('');
-        if (this.remainingSize < 0) {
-            // remove as many bytes from the end as remainingSize overflowed
-            consolidated = consolidated.slice(0, this.remainingSize);
-            this.remainingSize = 0;
-        }
-        if (this.pendingSize > size) {
-            this.push(consolidated.slice(0, size));
-            this.pendingChunks = [consolidated.slice(size)];
-            this.pendingSize -= size;
-        } else {
-            this.push(consolidated);
-            this.push(null);
+        let cont = true;
+        while (cont) {
+            while (this.pendingSize < size && this.remainingSize > 0) {
+                this._pushNextChunk();
+            }
+            let consolidated = this.pendingChunks.join('');
+            if (this.remainingSize < 0) {
+                // remove as many bytes from the end as remainingSize overflowed
+                consolidated = consolidated.slice(0, this.remainingSize);
+                this.remainingSize = 0;
+            }
+            cont = this.push(consolidated);
             this.pendingChunks = [];
             this.pendingSize = 0;
+            if (this.remainingSize === 0) {
+                this.push(null);
+                cont = false;
+            }
         }
     }
 }
-
-async function testStream(startByteOffset, streamSize, expectedData) {
-    const p = new Promise((resolve, reject) => {
-        const dos = new DummyObjectStream(startByteOffset, streamSize);
-        const readChunks = [];
-        dos
-            .on('data', chunk => readChunks.push(chunk))
-            .on('error', err => reject(err))
-            .on('end', () => {
-                assert.strictEqual(readChunks.join(''), expectedData);
-                resolve();
-            });
-    });
-    return p;
-}
-
-describe('DummyObjectStream', () => {
-    it('should return a stream of 8-byte hex-encoded blocks', async () => {
-        // FIXME we likely need an eslint update
-        /* eslint-disable no-unused-expressions */
-        await testStream(0, 0, '');
-        await testStream(50, 0, '');
-        await testStream(0, 1, ' ');
-        await testStream(1, 1, '0');
-        await testStream(1, 7, '0000000');
-        await testStream(0, 8, ' 0000000');
-        await testStream(1, 8, '0000000 ');
-        await testStream(0, 10, ' 0000000 0');
-        await testStream(1, 10, '0000000 00');
-        await testStream(7, 5, '0 000');
-        await testStream(7, 12, '0 0000008 00');
-        await testStream(8, 12, ' 0000008 000');
-        await testStream(9, 12, '0000008 0000');
-        await testStream(40, 16, ' 0000028 0000030');
-        // check that offsets wrap around after 256MB
-        await testStream(256 * 1024 * 1024 - 8, 16, ' ffffff8 0000000');
-        await testStream(567890123, 30, '950c8 1d950d0 1d950d8 1d950e0 ');
-
-        // test a larger stream with slightly more than 8MiB of contents
-        const expectedLarge =
-              ['950c8']
-              .concat(new Array(1024 * 1024).fill()
-                      .map((x, i) => ` ${Number(0x1d950d0 + i * 8).toString(16)}`))
-              .concat([' 25'])
-              .join('');
-        await testStream(567890123, 5 + 8 * 1024 * 1024 + 3, expectedLarge);
-        /* eslint-enable no-unused-expressions */
-    }).timeout(30000);
-});
 
 module.exports = DummyObjectStream;

--- a/tests/unit/storage/data/DummyObjectStream.spec.js
+++ b/tests/unit/storage/data/DummyObjectStream.spec.js
@@ -1,0 +1,57 @@
+const assert = require('assert');
+const DummyObjectStream = require('./DummyObjectStream');
+
+async function testStream(startByteOffset, streamSize, expectedData) {
+    const p = new Promise((resolve, reject) => {
+        const dos = new DummyObjectStream(startByteOffset, streamSize);
+        const readChunks = [];
+        dos
+            .on('data', chunk => readChunks.push(chunk))
+            .on('error', err => reject(err))
+            .on('end', () => {
+                assert.strictEqual(readChunks.join(''), expectedData);
+                resolve();
+            });
+    });
+    return p;
+}
+
+describe('DummyObjectStream', () => {
+    it('should return a stream of 8-byte hex-encoded blocks', async () => {
+        // FIXME we likely need an eslint update
+        /* eslint-disable no-unused-expressions */
+        await testStream(0, 0, '');
+        await testStream(50, 0, '');
+        await testStream(0, 1, ' ');
+        await testStream(1, 1, '0');
+        await testStream(1, 7, '0000000');
+        await testStream(0, 8, ' 0000000');
+        await testStream(1, 8, '0000000 ');
+        await testStream(0, 10, ' 0000000 0');
+        await testStream(1, 10, '0000000 00');
+        await testStream(7, 5, '0 000');
+        await testStream(7, 12, '0 0000008 00');
+        await testStream(8, 12, ' 0000008 000');
+        await testStream(9, 12, '0000008 0000');
+        await testStream(40, 16, ' 0000028 0000030');
+        // check that offsets wrap around after 256MB
+        await testStream(256 * 1024 * 1024 - 8, 16, ' ffffff8 0000000');
+        await testStream(567890123, 30, '950c8 1d950d0 1d950d8 1d950e0 ');
+
+        // test larger streams with 8MiB of contents
+        const expectedLarge =
+              new Array(1024 * 1024).fill()
+              .map((x, i) => ` ${`000000${Number(i * 8).toString(16)}`.slice(-7)}`)
+              .join('');
+        await testStream(0, 8 * 1024 * 1024, expectedLarge);
+
+        const expectedLarge2 =
+              ['950c8']
+              .concat(new Array(1024 * 1024).fill()
+                      .map((x, i) => ` ${Number(0x1d950d0 + i * 8).toString(16)}`))
+              .concat([' 25'])
+              .join('');
+        await testStream(567890123, 5 + 8 * 1024 * 1024 + 3, expectedLarge2);
+        /* eslint-enable no-unused-expressions */
+    }).timeout(30000);
+});


### PR DESCRIPTION
Call request.abort() on the backend side when an S3 client disconnects, to avoid leaking sockets. Also make sure request.abort() through the stream destroy() call is called asynchronously from the stream creation.

Add a unit test counting the number of open sockets after an S3 client closes the connection before the data backend has sent a GET request: with the fix, there should be none remaining open.

Also in this PR: fix DummyObjectStream

- fix the DummyObjectStream test helper _read implementation

- separate tests of the helper itself into a separate file to ease reuse outside the mocha test framework

**Note to reviewers:** it can be easier to review individual commits.