### PR TITLE
bf: S3C-3581 add bucket notification apis to iam policy eval

### DIFF
--- a/lib/policyEvaluator/utils/actionMaps.js
+++ b/lib/policyEvaluator/utils/actionMaps.js
@@ -7,6 +7,7 @@ const sharedActionMap = {
     bucketGetCors: 's3:GetBucketCORS',
     bucketGetLifecycle: 's3:GetLifecycleConfiguration',
     bucketGetLocation: 's3:GetBucketLocation',
+    bucketGetNotification: 's3:GetBucketNotification',
     bucketGetObjectLock: 's3:GetBucketObjectLockConfiguration',
     bucketGetPolicy: 's3:GetBucketPolicy',
     bucketGetReplication: 's3:GetReplicationConfiguration',
@@ -16,6 +17,7 @@ const sharedActionMap = {
     bucketPutACL: 's3:PutBucketAcl',
     bucketPutCors: 's3:PutBucketCORS',
     bucketPutLifecycle: 's3:PutLifecycleConfiguration',
+    bucketPutNotification: 's3:PutBucketNotification',
     bucketPutObjectLock: 's3:PutBucketObjectLockConfiguration',
     bucketPutPolicy: 's3:PutBucketPolicy',
     bucketPutReplication: 's3:PutReplicationConfiguration',
@@ -67,8 +69,6 @@ const actionMapBP = Object.assign({}, sharedActionMap);
 
 // action map for all relevant s3 actions
 const actionMapS3 = Object.assign({
-    bucketGetNotification: 's3:GetBucketNotification',
-    bucketPutNotification: 's3:PutBucketNotification',
 }, sharedActionMap, actionMapRQ, actionMapBP);
 
 const actionMapIAM = {


### PR DESCRIPTION
With my previous PR for creating the action maps, a rebase and Berte reset caused me to lose changes on the upstream 7.8 PR which I forgot to add again. This PR adds the change, which adds bucket notification APIs into policy evaluation. 