### PR TITLE
INTEGRATION [PR#1315 > development/8.1] bf: S3C-3425 extract client ip from header if available

### DIFF
--- a/lib/policyEvaluator/requestUtils.js
+++ b/lib/policyEvaluator/requestUtils.js
@@ -1,6 +1,16 @@
 const ipCheck = require('../ipCheck');
 
 /**
+ * Extracts the ip from the header, returns the
+ * first ip when there are multiple ip addresses
+ * @param {string} values - comma separated ip addresses
+ * @return {string} - ip address
+ */
+function _extractIpFromHeader(values) {
+    return values.split(',')[0].trim();
+}
+
+/**
  * getClientIp - Gets the client IP from the request
  * @param {object} request - http request object
  * @param {object} s3config - s3 config
@@ -18,14 +28,17 @@ function getClientIp(request, s3config) {
         if (ipCheck.ipMatchCidrList(requestConfig.trustedProxyCIDRs,
             clientIp)) {
             const ipFromHeader
-            // eslint-disable-next-line operator-linebreak
                 = request.headers[requestConfig.extractClientIPFromHeader];
             if (ipFromHeader && ipFromHeader.trim().length) {
-                return ipFromHeader.split(',')[0].trim();
+                return _extractIpFromHeader(ipFromHeader);
             }
         }
+    } else {
+        const ipFromHeader = request.headers['x-forwarded-for'];
+        if (ipFromHeader && ipFromHeader.trim().length) {
+            return _extractIpFromHeader(ipFromHeader);
+        }
     }
-
     return clientIp;
 }
 

--- a/tests/unit/policyEvaluator/requestUtils.js
+++ b/tests/unit/policyEvaluator/requestUtils.js
@@ -28,9 +28,9 @@ describe('requestUtils.getClientIp', () => {
         assert.strictEqual(result, testClientIp1);
     });
 
-    it('should not return client Ip address from header ' +
-        'if the request is not forwarded from proxies or ' +
-        'fails ip check', () => {
+    it('should extract client Ip address from x-forwarded-for header ' +
+        'when the header is present and has valid ip address(es) if the ' +
+        'request is not forwarded via proxy', () => {
         const request = new DummyRequest({
             headers: {
                 'x-forwarded-for': [testClientIp1, testProxyIp].join(','),
@@ -42,11 +42,11 @@ describe('requestUtils.getClientIp', () => {
             },
         });
         const result = requestUtils.getClientIp(request, configWithoutProxy);
-        assert.strictEqual(result, testClientIp2);
+        assert.strictEqual(result, testClientIp1);
     });
 
     it('should not return client Ip address from header ' +
-        'if the request is forwarded from proxies, but the request' +
+        'if the request is forwarded from proxies, but the request ' +
         'has no expected header or the header value is empty', () => {
         const request = new DummyRequest({
             headers: {


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1315.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-3425-extract-client-ip-from-header`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-3425-extract-client-ip-from-header
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-3425-extract-client-ip-from-header
```

Please always comment pull request #1315 instead of this one.