### PR TITLE
bugfix: S3C-3904: better-s3-action-logs

### DIFF
--- a/lib/policyEvaluator/utils/actionMaps.js
+++ b/lib/policyEvaluator/utils/actionMaps.js
@@ -29,6 +29,12 @@ const sharedActionMap = {
     objectPutTagging: 's3:PutObjectTagging',
 };
 
+// Meant to override shared action map values with fakes name for monitoring of s3
+const sharedMonitoringMap = {
+    bucketGet: 's3:GetBucket',
+    bucketHead: 's3:HeadBucket',
+};
+
 // action map used for request context
 const actionMapRQ = Object.assign({
     bucketPut: 's3:CreateBucket',
@@ -53,6 +59,15 @@ const actionMapRQ = Object.assign({
     objectReplicate: 's3:ReplicateObject',
 }, sharedActionMap);
 
+// Meant to override shared action map values with fakes name for moniroting of s3
+const actionMonitoringMapRQ = Object.assign({
+    bucketDeleteCors: 's3:DeleteBucketCORS',
+    completeMultipartUpload: 's3:CompleteMultipartUpload',
+    initiateMultipartUpload: 's3:InitiateMultipartUpload',
+    objectHead: 's3:HeadObject',
+    objectPutPart: 's3:PutPartObject',
+}, sharedMonitoringMap);
+
 // action map used for bucket policies
 const actionMapBP = Object.assign({
     bucketDeletePolicy: 's3:DeleteBucketPolicy',
@@ -66,11 +81,27 @@ const actionMapBP = Object.assign({
     objectPutRetention: 's3:PutObjectRetention',
 }, sharedActionMap);
 
+// Meant to override shared action map values with fakes name for moniroting of s3
+const actionMonitoringMapBP = Object.assign(
+    {},
+    sharedMonitoringMap,
+);
+
 // action map for all relevant s3 actions
 const actionMapS3 = Object.assign({
     bucketGetNotification: 's3:GetBucketNotification',
     bucketPutNotification: 's3:PutBucketNotification',
 }, sharedActionMap, actionMapRQ, actionMapBP);
+
+// Meant to override shared action map values with fakes name for moniroting of s3
+const actionMonitoringMapS3 = Object.assign(
+    {},
+    sharedMonitoringMap,
+    actionMonitoringMapRQ,
+    actionMonitoringMapBP,
+);
+
+// Action monitoring
 
 const actionMapIAM = {
     attachGroupPolicy: 'iam:AttachGroupPolicy',
@@ -119,8 +150,11 @@ const actionMapMetadata = {
 
 module.exports = {
     actionMapRQ,
+    actionMonitoringMapRQ,
     actionMapBP,
+    actionMonitoringMapBP,
     actionMapS3,
+    actionMonitoringMapS3,
     actionMapIAM,
     actionMapSSO,
     actionMapSTS,


### PR DESCRIPTION
Introduce a map meant to override default
actionMap values for S3, will be used in logs
to monitor the s3 actions instead of the iam
permissions needed for that action