### PR TITLE
feature S3C-4262 Backport zenko metrics

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,6 +118,7 @@ module.exports = {
         StatsClient: require('./lib/metrics/StatsClient'),
         StatsModel: require('./lib/metrics/StatsModel'),
         RedisClient: require('./lib/metrics/RedisClient'),
+        ZenkoMetrics: require('./lib/metrics/ZenkoMetrics'),
     },
     pensieve: {
         credentialUtils: require('./lib/executables/pensieveCreds/utils'),

--- a/lib/metrics/ZenkoMetrics.js
+++ b/lib/metrics/ZenkoMetrics.js
@@ -1,0 +1,40 @@
+const promClient = require('prom-client');
+
+const collectDefaultMetricsIntervalMs =
+      process.env.COLLECT_DEFAULT_METRICS_INTERVAL_MS !== undefined ?
+      Number.parseInt(process.env.COLLECT_DEFAULT_METRICS_INTERVAL_MS, 10) :
+      10000;
+
+promClient.collectDefaultMetrics({ timeout: collectDefaultMetricsIntervalMs });
+
+class ZenkoMetrics {
+    static createCounter(params) {
+        return new promClient.Counter(params);
+    }
+
+    static createGauge(params) {
+        return new promClient.Gauge(params);
+    }
+
+    static createHistogram(params) {
+        return new promClient.Histogram(params);
+    }
+
+    static createSummary(params) {
+        return new promClient.Summary(params);
+    }
+
+    static getMetric(name) {
+        return promClient.register.getSingleMetric(name);
+    }
+
+    static asPrometheus() {
+        return promClient.register.metrics();
+    }
+
+    static asPrometheusContentType() {
+        return promClient.register.contentType;
+    }
+}
+
+module.exports = ZenkoMetrics;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "level": "~5.0.1",
     "level-sublevel": "~6.6.5",
     "node-forge": "^0.7.1",
+    "prom-client": "10.2.3",
     "simple-glob": "^0.2",
     "socket.io": "~2.3.0",
     "socket.io-client": "~2.3.0",

--- a/tests/unit/metrics/ZenkoMetrics.spec.js
+++ b/tests/unit/metrics/ZenkoMetrics.spec.js
@@ -1,0 +1,106 @@
+const assert = require('assert');
+
+const ZenkoMetrics = require('../../../lib/metrics/ZenkoMetrics');
+
+describe('ZenkoMetrics', () => {
+    let counter;
+    let gauge;
+    let histogram;
+    let summary;
+    let petCounter;
+
+    before(() => {
+        counter = ZenkoMetrics.createCounter({
+            name: 'gizmo_counter',
+            help: 'Count gizmos',
+        });
+        counter.inc();
+        counter.inc(10);
+
+        gauge = ZenkoMetrics.createGauge({
+            name: 'gizmo_gauge',
+            help: 'Measure gizmos',
+        });
+        gauge.set(42);
+        gauge.inc();
+        gauge.dec(10);
+
+        histogram = ZenkoMetrics.createHistogram({
+            name: 'gizmo_histogram',
+            help: 'Make a histogram of gizmos',
+            buckets: [1, 10, 100],
+        });
+        histogram.observe(5);
+        histogram.observe(15);
+        histogram.observe(50);
+        histogram.observe(500);
+
+        summary = ZenkoMetrics.createSummary({
+            name: 'gizmo_summary',
+            help: 'Make a summary of gizmos',
+            percentiles: [0.05, 0.5, 0.95],
+        });
+        summary.observe(5);
+        summary.observe(50);
+        summary.observe(500);
+
+        petCounter = ZenkoMetrics.createCounter({
+            name: 'pet_counter',
+            help: 'Count pets',
+            labelNames: ['type'],
+        });
+        petCounter.inc({ type: 'kitten' });
+        petCounter.inc({ type: 'puppy' }, 2);
+    });
+
+    it('should keep created metrics objects in registry', () => {
+        const savedCounter = ZenkoMetrics.getMetric('gizmo_counter');
+        // check we get the same original counter object
+        assert.strictEqual(savedCounter, counter);
+
+        const savedGauge = ZenkoMetrics.getMetric('gizmo_gauge');
+        // check we get the same original gauge object
+        assert.strictEqual(savedGauge, gauge);
+
+        assert.strictEqual(ZenkoMetrics.getMetric('does_not_exist'), undefined);
+    });
+
+    it('should export metrics in prometheus format', () => {
+        const expectedLines = [
+            '# HELP gizmo_counter Count gizmos',
+            '# TYPE gizmo_counter counter',
+            'gizmo_counter 11',
+            '# HELP gizmo_gauge Measure gizmos',
+            '# TYPE gizmo_gauge gauge',
+            'gizmo_gauge 33',
+            '# HELP gizmo_histogram Make a histogram of gizmos',
+            '# TYPE gizmo_histogram histogram',
+            'gizmo_histogram_bucket{le="1"} 0',
+            'gizmo_histogram_bucket{le="10"} 1',
+            'gizmo_histogram_bucket{le="100"} 3',
+            'gizmo_histogram_bucket{le="+Inf"} 4',
+            'gizmo_histogram_sum 570',
+            'gizmo_histogram_count 4',
+            '# HELP gizmo_summary Make a summary of gizmos',
+            '# TYPE gizmo_summary summary',
+            'gizmo_summary{quantile="0.05"} 5',
+            'gizmo_summary{quantile="0.5"} 50',
+            'gizmo_summary{quantile="0.95"} 500',
+            'gizmo_summary_sum 555',
+            'gizmo_summary_count 3',
+            '# HELP pet_counter Count pets',
+            '# TYPE pet_counter counter',
+            'pet_counter{type="kitten"} 1',
+            'pet_counter{type="puppy"} 2',
+        ];
+        const lines = {};
+        ZenkoMetrics.asPrometheus().split('\n').forEach(line => {
+            lines[line.trimRight()] = true;
+        });
+        expectedLines.forEach(expectedLine => {
+            assert.notStrictEqual(
+                lines[expectedLine], undefined,
+                `missing expected line in Prometheus export '${expectedLine}'`);
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -216,6 +216,11 @@ bindings@^1.1.1:
   dependencies:
     file-uri-to-path "1.0.0"
 
+bintrees@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.1.tgz#0e655c9b9c2435eaab68bf4027226d2b55a34524"
+  integrity sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ=
+
 bl@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/bl/-/bl-0.8.2.tgz#c9b6bca08d1bc2ea00fc8afb4f1a5fd1e1c66e4e"
@@ -1472,6 +1477,13 @@ progress@^1.1.8:
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
   integrity sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=
 
+prom-client@10.2.3:
+  version "10.2.3"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-10.2.3.tgz#a51bf21c239c954a6c5be4b1361fdd380218bb41"
+  integrity sha512-Xboq5+TdUwuQtSSDRZRNnb5NprINlgQN999VqUjZxnLKydUNLeIPx6Eiahg6oJua3XBg2TGnh5Cth1s4I6+r7g==
+  dependencies:
+    tdigest "^0.1.1"
+
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
@@ -1827,6 +1839,13 @@ table@^3.7.8:
     lodash "^4.0.0"
     slice-ansi "0.0.4"
     string-width "^2.0.0"
+
+tdigest@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.1.tgz#2e3cb2c39ea449e55d1e6cd91117accca4588021"
+  integrity sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=
+  dependencies:
+    bintrees "1.0.1"
 
 temp@0.9.1:
   version "0.9.1"


### PR DESCRIPTION
Just including the zenko metrics in 7.4 so I can use it in backbeat 7.4, not sure if this is required but I didn't think it would be good to import the 8.x version in 7.4.