### PR TITLE
INTEGRATION [PR#1399 > development/8.1] bugfix: S3C-4275 enable skip-scan for DelimiterVersions with a delimiter

### DIFF
--- a/lib/algos/list/delimiterMaster.js
+++ b/lib/algos/list/delimiterMaster.js
@@ -80,13 +80,13 @@ class DelimiterMaster extends Delimiter {
              *   when a listing page ends on an accepted obj and the next page
              *   starts with a version of this object.
              *   In that case prvKey is default set to undefined
-             *   in the constructor) and comparing to NextMarker is the only
+             *   in the constructor and comparing to NextMarker is the only
              *   way to know  we should not accept this version. This test is
              *   not redundant with the one at the beginning of this function,
              *   we are comparing here the key without the version suffix,
              * - key startsWith the previous NextMarker happens because we set
              *   NextMarker to the common prefix instead of the whole key
-             *   value. (TODO: remove this test once ZENKO-1048 is fixed. ).
+             *   value. (TODO: remove this test once ZENKO-1048 is fixed)
              *   */
             if (key === this.prvKey || key === this[this.nextContinueMarker] ||
                 (this.delimiter &&

--- a/lib/algos/list/delimiterVersions.js
+++ b/lib/algos/list/delimiterVersions.js
@@ -164,7 +164,8 @@ class DelimiterVersions extends Delimiter {
      */
     filterV0(obj) {
         if (Version.isPHD(obj.value)) {
-            return FILTER_ACCEPT; // trick repd to not increase its streak
+            // return accept to avoid skipping the next values in range
+            return FILTER_ACCEPT;
         }
         return this.filterCommon(obj.key, obj.value);
     }
@@ -205,8 +206,9 @@ class DelimiterVersions extends Delimiter {
         } else {
             nonversionedKey = key.slice(0, versionIdIndex);
             versionId = key.slice(versionIdIndex + 1);
+            // skip a version key if it is the master version
             if (this.masterKey === nonversionedKey && this.masterVersionId === versionId) {
-                return FILTER_ACCEPT; // trick repd to not increase its streak
+                return FILTER_SKIP;
             }
             this.masterKey = undefined;
             this.masterVersionId = undefined;

--- a/tests/unit/algos/list/delimiterMaster.js
+++ b/tests/unit/algos/list/delimiterMaster.js
@@ -64,7 +64,6 @@ function getListingKey(key, vFormat) {
                                                   fakeLogger, vFormat);
 
             /* Filter a master version to set NextMarker. */
-            // TODO: useless once S3C-1628 is fixed.
             const listingKey = getListingKey(key, vFormat);
             delimiter.filter({ key: listingKey, value: '' });
             assert.strictEqual(delimiter.NextMarker, key);
@@ -215,8 +214,8 @@ function getListingKey(key, vFormat) {
                     value: Version.generatePHDVersion(generateVersionId('', '')),
                 };
 
-                /* When filtered, it should return FILTER_ACCEPT and set the prvKey.
-                 * to undefined. It should not be added to result the content or common
+                /* When filtered, it should return FILTER_ACCEPT and set the prvKey
+                 * to undefined. It should not be added to the result content or common
                  * prefixes. */
                 assert.strictEqual(delimiter.filter(objPHD), FILTER_ACCEPT);
                 assert.strictEqual(delimiter.prvKey, undefined);
@@ -238,7 +237,7 @@ function getListingKey(key, vFormat) {
                  * and element in result content. */
                 delimiter.filter({ key, value });
 
-                /* When filtered, it should return FILTER_ACCEPT and set the prvKey.
+                /* When filtered, it should return FILTER_ACCEPT and set the prvKey
                  * to undefined. It should not be added to the result content or common
                  * prefixes. */
                 assert.strictEqual(delimiter.filter(objPHD), FILTER_ACCEPT);
@@ -283,7 +282,7 @@ function getListingKey(key, vFormat) {
                 });
             });
 
-            it('should accept a delete marker', () => {
+            it('should skip a delete marker version', () => {
                 const delimiter = new DelimiterMaster({}, fakeLogger, vFormat);
                 const version = new Version({ isDeleteMarker: true });
                 const key = 'key';
@@ -300,7 +299,7 @@ function getListingKey(key, vFormat) {
                 assert.deepStrictEqual(delimiter.result(), EmptyResult);
             });
 
-            it('should skip version after a delete marker', () => {
+            it('should skip version after a delete marker master', () => {
                 const delimiter = new DelimiterMaster({}, fakeLogger, vFormat);
                 const version = new Version({ isDeleteMarker: true });
                 const key = 'key';
@@ -316,7 +315,7 @@ function getListingKey(key, vFormat) {
                 assert.deepStrictEqual(delimiter.result(), EmptyResult);
             });
 
-            it('should accept a new key after a delete marker', () => {
+            it('should accept a new master key after a delete marker master', () => {
                 const delimiter = new DelimiterMaster({}, fakeLogger, vFormat);
                 const version = new Version({ isDeleteMarker: true });
                 const key1 = 'key1';

--- a/tests/unit/algos/list/delimiterVersions.js
+++ b/tests/unit/algos/list/delimiterVersions.js
@@ -3,14 +3,29 @@
 const assert = require('assert');
 const DelimiterVersions =
     require('../../../../lib/algos/list/delimiterVersions').DelimiterVersions;
+const {
+    FILTER_ACCEPT,
+    FILTER_SKIP,
+    SKIP_NONE,
+} = require('../../../../lib/algos/list/tools');
 const Werelogs = require('werelogs').Logger;
 const logger = new Werelogs('listTest');
 const performListing = require('../../../utils/performListing');
 const zpad = require('../../helpers').zpad;
 const { inc } = require('../../../../lib/algos/list/tools');
 const VSConst = require('../../../../lib/versioning/constants').VersioningConstants;
+const Version = require('../../../../lib/versioning/Version').Version;
+const { generateVersionId } = require('../../../../lib/versioning/VersionID');
 const { DbPrefixes } = VSConst;
 const VID_SEP = VSConst.VersionId.Separator;
+const EmptyResult = {
+    Versions: [],
+    CommonPrefixes: [],
+    IsTruncated: false,
+    NextKeyMarker: undefined,
+    NextVersionIdMarker: undefined,
+    Delimiter: undefined,
+};
 
 class Test {
     constructor(name, input, genMDParams, output, filter) {
@@ -264,7 +279,7 @@ const tests = [
         NextKeyMarker: undefined,
         NextVersionIdMarker: undefined,
     }),
-    new Test('bad key marker and good prefix', {
+    new Test('with bad key marker and good prefix', {
         delimiter: '/',
         prefix: 'notes/summer/',
         keyMarker: 'notes/summer0',
@@ -288,7 +303,7 @@ const tests = [
         NextKeyMarker: undefined,
         NextVersionIdMarker: undefined,
     }, (e, input) => e.key > input.keyMarker),
-    new Test('delimiter and prefix (related to #147)', {
+    new Test('with delimiter and prefix (related to #147)', {
         delimiter: '/',
         prefix: 'notes/',
     }, {
@@ -318,7 +333,7 @@ const tests = [
         NextKeyMarker: undefined,
         NextVersionIdMarker: undefined,
     }),
-    new Test('delimiter, prefix and marker (related to #147)', {
+    new Test('with delimiter, prefix and marker (related to #147)', {
         delimiter: '/',
         prefix: 'notes/',
         keyMarker: 'notes/year.txt',
@@ -346,7 +361,7 @@ const tests = [
         NextKeyMarker: undefined,
         NextVersionIdMarker: undefined,
     }, (e, input) => e.key > input.keyMarker),
-    new Test('all parameters 1/3', {
+    new Test('with all parameters 1/3', {
         delimiter: '/',
         prefix: 'notes/',
         keyMarker: 'notes/',
@@ -372,7 +387,7 @@ const tests = [
         NextVersionIdMarker: undefined,
     }, (e, input) => e.key > input.keyMarker),
 
-    new Test('all parameters 2/3', {
+    new Test('with all parameters 2/3', {
         delimiter: '/',
         prefix: 'notes/', // prefix
         keyMarker: 'notes/spring/',
@@ -398,7 +413,7 @@ const tests = [
         NextVersionIdMarker: undefined,
     }, (e, input) => e.key > input.keyMarker),
 
-    new Test('all parameters 3/3', {
+    new Test('with all parameters 3/3', {
         delimiter: '/',
         prefix: 'notes/', // prefix
         keyMarker: 'notes/summer/',
@@ -426,7 +441,7 @@ const tests = [
         NextVersionIdMarker: receivedData[19].versionId,
     }, (e, input) => e.key > input.keyMarker),
 
-    new Test('all parameters 4/3', {
+    new Test('with all parameters 4/3', {
         delimiter: '/',
         prefix: 'notes/', // prefix
         keyMarker: 'notes/year.txt',
@@ -454,7 +469,7 @@ const tests = [
         NextVersionIdMarker: receivedData[20].versionId,
     }, (e, input) => e.key > input.keyMarker),
 
-    new Test('all parameters 5/3', {
+    new Test('with all parameters 5/3', {
         delimiter: '/',
         prefix: 'notes/',
         keyMarker: 'notes/yore.rs',
@@ -481,23 +496,25 @@ const tests = [
     }, (e, input) => e.key > input.keyMarker),
 ];
 
+function getListingKey(key, vFormat) {
+    if (vFormat === 'v0') {
+        return key;
+    }
+    if (vFormat === 'v1') {
+        const keyPrefix = key.includes(VID_SEP) ?
+              DbPrefixes.Version : DbPrefixes.Master;
+        return `${keyPrefix}${key}`;
+    }
+    return assert.fail(`bad format ${vFormat}`);
+}
+
 function getTestListing(test, data, vFormat) {
     return data
         .filter(e => test.filter(e, test.input))
-        .map(e => {
-            if (vFormat === 'v0') {
-                return e;
-            }
-            if (vFormat === 'v1') {
-                const keyPrefix = e.key.includes(VID_SEP) ?
-                      DbPrefixes.Version : DbPrefixes.Master;
-                return {
-                    key: `${keyPrefix}${e.key}`,
-                    value: e.value,
-                };
-            }
-            return assert.fail(`bad format ${vFormat}`);
-        });
+        .map(e => ({
+            key: getListingKey(e.key, vFormat),
+            value: e.value,
+        }));
 }
 
 ['v0', 'v1'].forEach(vFormat => {
@@ -527,5 +544,364 @@ function getTestListing(test, data, vFormat) {
                 assert.deepStrictEqual(res, test.output);
             });
         });
+
+        it('skipping() should return SKIP_NONE when NextMarker is undefined', () => {
+            const delimiter = new DelimiterVersions({ delimiter: '/' }, logger, vFormat);
+
+            assert.strictEqual(delimiter.NextMarker, undefined);
+            assert.strictEqual(delimiter.skipping(), SKIP_NONE);
+        });
+
+        it('skipping() should return SKIP_NONE when marker is set and ' +
+        'does not contain the delimiter', () => {
+            const key = 'foo';
+            const delimiter = new DelimiterVersions({ delimiter: '/', marker: key },
+                                                    logger, vFormat);
+
+            /* Filter a master version to set NextMarker. */
+            const listingKey = getListingKey(key, vFormat);
+            delimiter.filter({ key: listingKey, value: '' });
+            assert.strictEqual(delimiter.NextMarker, 'foo');
+            assert.strictEqual(delimiter.skipping(), SKIP_NONE);
+        });
+
+        it('skipping() should return prefix to skip when marker is set and ' +
+        'contains the delimiter', () => {
+            const key = 'foo/bar';
+            const delimiter = new DelimiterVersions({ delimiter: '/', marker: key },
+                                                    logger, vFormat);
+
+            /* Filter a master version to set NextMarker. */
+            const listingKey = getListingKey(key, vFormat);
+            delimiter.filter({ key: listingKey, value: '' });
+            assert.strictEqual(delimiter.NextMarker, 'foo/');
+
+            if (vFormat === 'v0') {
+                assert.strictEqual(delimiter.skipping(), 'foo/');
+            } else {
+                assert.deepStrictEqual(delimiter.skipping(), [
+                    `${DbPrefixes.Master}foo/`,
+                    `${DbPrefixes.Version}foo/`,
+                ]);
+            }
+        });
+
+        it('skipping() should return prefix when marker is set and ' +
+        'ends with the delimiter', () => {
+            const key = 'foo/';
+            const delimiter = new DelimiterVersions({ delimiter: '/', marker: key },
+                                                    logger, vFormat);
+
+            /* Filter a master version to set NextMarker. */
+            const listingKey = getListingKey(key, vFormat);
+            delimiter.filter({ key: listingKey, value: '' });
+            assert.strictEqual(delimiter.NextMarker, 'foo/');
+
+            if (vFormat === 'v0') {
+                assert.strictEqual(delimiter.skipping(), 'foo/');
+            } else {
+                assert.deepStrictEqual(delimiter.skipping(), [
+                    `${DbPrefixes.Master}foo/`,
+                    `${DbPrefixes.Version}foo/`,
+                ]);
+            }
+        });
+
+        it('should skip entries not starting with prefix', () => {
+            const delimiter = new DelimiterVersions({ prefix: 'prefix' }, logger, vFormat);
+
+            const listingKey = getListingKey('wrong', vFormat);
+            assert.strictEqual(delimiter.filter({ key: listingKey, value: '' }), FILTER_SKIP);
+            assert.strictEqual(delimiter.NextMarker, undefined);
+            assert.strictEqual(delimiter.prvKey, undefined);
+            assert.deepStrictEqual(delimiter.result(), EmptyResult);
+        });
+
+        it('should accept a master version', () => {
+            const delimiter = new DelimiterVersions({}, logger, vFormat);
+            const key = 'key';
+            const value = '';
+
+            const listingKey = getListingKey(key, vFormat);
+            assert.strictEqual(delimiter.filter({ key: listingKey, value }), FILTER_ACCEPT);
+            assert.strictEqual(delimiter.NextMarker, key);
+            assert.deepStrictEqual(delimiter.result(), {
+                CommonPrefixes: [],
+                Versions: [{
+                    key: 'key',
+                    value: '',
+                    versionId: 'null',
+                }],
+                Delimiter: undefined,
+                IsTruncated: false,
+                NextKeyMarker: undefined,
+                NextVersionIdMarker: undefined,
+            });
+        });
+
+        it('should return good values for entries with different common prefixes', () => {
+            const delimiter = new DelimiterVersions({ delimiter: '/' },
+                                                    logger, vFormat);
+
+            /* Filter the first entry with a common prefix. It should be
+             * accepted and added to the result. */
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey('commonPrefix1/key1', vFormat),
+                value: '',
+            }),
+                               FILTER_ACCEPT);
+            assert.deepStrictEqual(delimiter.result(), {
+                CommonPrefixes: ['commonPrefix1/'],
+                Versions: [],
+                Delimiter: '/',
+                IsTruncated: false,
+                NextKeyMarker: undefined,
+                NextVersionIdMarker: undefined,
+            });
+
+            /* Filter the second entry with the same common prefix than the
+             * first entry. It should be skipped and not added to the result. */
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey('commonPrefix1/key2', vFormat),
+                value: '',
+            }),
+                               FILTER_SKIP);
+            assert.deepStrictEqual(delimiter.result(), {
+                CommonPrefixes: ['commonPrefix1/'],
+                Versions: [],
+                Delimiter: '/',
+                IsTruncated: false,
+                NextKeyMarker: undefined,
+                NextVersionIdMarker: undefined,
+            });
+
+            /* Filter an entry with a new common prefix. It should be accepted
+             * and not added to the result. */
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey('commonPrefix2/key1', vFormat),
+                value: '',
+            }),
+                               FILTER_ACCEPT);
+            assert.deepStrictEqual(delimiter.result(), {
+                CommonPrefixes: ['commonPrefix1/', 'commonPrefix2/'],
+                Versions: [],
+                Delimiter: '/',
+                IsTruncated: false,
+                NextKeyMarker: undefined,
+                NextVersionIdMarker: undefined,
+            });
+        });
+
+        it('should accept a delete marker version', () => {
+            const delimiter = new DelimiterVersions({}, logger, vFormat);
+            const version = new Version({ isDeleteMarker: true });
+            const key = 'key';
+            const obj = {
+                key: getListingKey(`${key}${VID_SEP}version`, vFormat),
+                value: version.toString(),
+            };
+
+            /* When filtered, it should return FILTER_ACCEPT and
+             * should be added to the result content. */
+            assert.strictEqual(delimiter.filter(obj), FILTER_ACCEPT);
+            assert.strictEqual(delimiter.NextMarker, key);
+            assert.deepStrictEqual(delimiter.result(), {
+                CommonPrefixes: [],
+                Versions: [{
+                    key: 'key',
+                    value: version.toString(),
+                    versionId: 'version',
+                }],
+                Delimiter: undefined,
+                IsTruncated: false,
+                NextKeyMarker: undefined,
+                NextVersionIdMarker: undefined,
+            });
+        });
+
+        it('should accept a version after a delete marker master', () => {
+            const delimiter = new DelimiterVersions({}, logger, vFormat);
+            const version = new Version({ isDeleteMarker: true });
+            const key = 'key';
+            const versionKey = `${key}${VID_SEP}version`;
+
+            delimiter.filter({ key: getListingKey(key, vFormat), value: version.toString() });
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey, vFormat),
+                value: 'value',
+            }), FILTER_ACCEPT);
+            assert.strictEqual(delimiter.NextMarker, key);
+            assert.deepStrictEqual(delimiter.result(), {
+                CommonPrefixes: [],
+                Versions: [{
+                    key: 'key',
+                    value: version.toString(),
+                    versionId: 'null',
+                }, {
+                    key: 'key',
+                    value: 'value',
+                    versionId: 'version',
+                }],
+                Delimiter: undefined,
+                IsTruncated: false,
+                NextKeyMarker: undefined,
+                NextVersionIdMarker: undefined,
+            });
+        });
+
+        it('should accept a new master key w/ version after a delete marker master', () => {
+            const delimiter = new DelimiterVersions({}, logger, vFormat);
+            const version = new Version({ isDeleteMarker: true });
+            const key1 = 'key1';
+            const key2 = 'key2';
+            const value2 = '{"versionId":"version"}';
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(key1, vFormat),
+                value: version.toString(),
+            }), FILTER_ACCEPT);
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(key2, vFormat),
+                value: value2,
+            }), FILTER_ACCEPT);
+            assert.strictEqual(delimiter.NextMarker, key2);
+            assert.deepStrictEqual(delimiter.result(), {
+                CommonPrefixes: [],
+                Delimiter: undefined,
+                IsTruncated: false,
+                NextKeyMarker: undefined,
+                NextVersionIdMarker: undefined,
+                Versions: [{
+                    key: 'key1',
+                    value: '{"isDeleteMarker":true}',
+                    versionId: 'null',
+                }, {
+                    key: 'key2',
+                    value: '{"versionId":"version"}',
+                    versionId: 'version',
+                }],
+            });
+        });
+
+        it('should accept a version after skipping an object because of its commonPrefix', () => {
+            const commonPrefix1 = 'commonPrefix1/';
+            const commonPrefix2 = 'commonPrefix2/';
+            const prefix1Key1 = 'commonPrefix1/key1';
+            const prefix1Key2 = 'commonPrefix1/key2';
+            const prefix2VersionKey1 = `commonPrefix2/key1${VID_SEP}version`;
+            const value = '{"versionId":"version"}';
+
+            const delimiter = new DelimiterVersions({ delimiter: '/' },
+                                                    logger, vFormat);
+
+            /* Filter the two first entries with the same common prefix to add
+             * it to the result and reach the state where an entry is skipped
+             * because of an already present common prefix in the result. */
+            delimiter.filter({ key: getListingKey(prefix1Key1, vFormat), value });
+            delimiter.filter({ key: getListingKey(prefix1Key2, vFormat), value });
+
+            /* Filter an object with a key containing a version part and a new
+             * common prefix. It should be accepted and the new common prefix
+             * added to the result. */
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(prefix2VersionKey1, vFormat),
+                value,
+            }), FILTER_ACCEPT);
+            assert.deepStrictEqual(delimiter.result(), {
+                CommonPrefixes: [commonPrefix1, commonPrefix2],
+                Versions: [],
+                Delimiter: '/',
+                IsTruncated: false,
+                NextKeyMarker: undefined,
+                NextVersionIdMarker: undefined,
+            });
+        });
+
+        if (vFormat === 'v0') {
+            it('should accept a PHD version as first input', () => {
+                const delimiter = new DelimiterVersions({}, logger, vFormat);
+                const keyPHD = 'keyPHD';
+                const objPHD = {
+                    key: keyPHD,
+                    value: Version.generatePHDVersion(generateVersionId('', '')),
+                };
+
+                /* When filtered, it should return FILTER_ACCEPT and set the prvKey
+                 * to undefined. It should not be added to the result content or common
+                 * prefixes. */
+                assert.strictEqual(delimiter.filter(objPHD), FILTER_ACCEPT);
+                assert.strictEqual(delimiter.prvKey, undefined);
+                assert.strictEqual(delimiter.NextMarker, undefined);
+                assert.deepStrictEqual(delimiter.result(), EmptyResult);
+            });
+
+            it('should accept a PHD version', () => {
+                const delimiter = new DelimiterVersions({}, logger, vFormat);
+                const key = 'keyA';
+                const value = '';
+                const keyPHD = 'keyBPHD';
+                const objPHD = {
+                    key: keyPHD,
+                    value: Version.generatePHDVersion(generateVersionId('', '')),
+                };
+
+                /* Filter a master version to set the NextMarker and add
+                 * and element in result content. */
+                delimiter.filter({ key, value });
+
+                /* When filtered, it should return FILTER_ACCEPT. It
+                 * should not be added to the result content or common
+                 * prefixes. */
+                assert.strictEqual(delimiter.filter(objPHD), FILTER_ACCEPT);
+                assert.strictEqual(delimiter.prvKey, undefined);
+                assert.strictEqual(delimiter.NextMarker, key);
+                assert.deepStrictEqual(delimiter.result(), {
+                    CommonPrefixes: [],
+                    Versions: [{
+                        key: 'keyA',
+                        value: '',
+                        versionId: 'null',
+                    }],
+                    Delimiter: undefined,
+                    IsTruncated: false,
+                    NextKeyMarker: undefined,
+                    NextVersionIdMarker: undefined,
+                });
+            });
+
+            it('should accept a version after a PHD', () => {
+                const delimiter = new DelimiterVersions({}, logger, vFormat);
+                const masterKey = 'key';
+                const keyVersion = `${masterKey}${VID_SEP}version`;
+                const value = '';
+                const objPHD = {
+                    key: masterKey,
+                    value: Version.generatePHDVersion(generateVersionId('', '')),
+                };
+
+                /* Filter the PHD object. */
+                delimiter.filter(objPHD);
+
+                /* The filtering of the PHD object has no impact, the version is
+                 * accepted and added to the result. */
+                assert.strictEqual(delimiter.filter({
+                    key: keyVersion,
+                    value,
+                }), FILTER_ACCEPT);
+                assert.strictEqual(delimiter.NextMarker, masterKey);
+                assert.deepStrictEqual(delimiter.result(), {
+                    CommonPrefixes: [],
+                    Versions: [{
+                        key: 'key',
+                        value: '',
+                        versionId: 'version',
+                    }],
+                    Delimiter: undefined,
+                    IsTruncated: false,
+                    NextKeyMarker: undefined,
+                    NextVersionIdMarker: undefined,
+                });
+            });
+        }
     });
 });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1399.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-4275-versionListingWithDelimiterInefficiency`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-4275-versionListingWithDelimiterInefficiency
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-4275-versionListingWithDelimiterInefficiency
```

Please always comment pull request #1399 instead of this one.