### PR TITLE
INTEGRATION [PR#1403 > development/8.1] bf S3C-4239 log consumer callback error fix

### DIFF
--- a/lib/storage/metadata/bucketclient/LogConsumer.js
+++ b/lib/storage/metadata/bucketclient/LogConsumer.js
@@ -6,6 +6,7 @@ const jsonStream = require('JSONStream');
 const werelogs = require('werelogs');
 
 const errors = require('../../../errors');
+const jsutil = require('../../../jsutil');
 
 class ListRecordStream extends stream.Transform {
     constructor(logger) {
@@ -87,6 +88,7 @@ class LogConsumer {
     readRecords(params, cb) {
         const recordStream = new ListRecordStream(this.logger);
         const _params = params || {};
+        const cbOnce = jsutil.once(cb);
 
         this.bucketClient.getRaftLog(
             this.raftSession, _params.startSeq, _params.limit,
@@ -96,26 +98,26 @@ class LogConsumer {
                         // no such raft session, log and ignore
                         this.logger.warn('raft session does not exist yet',
                                          { raftId: this.raftSession });
-                        return cb(null, { info: { start: null,
+                        return cbOnce(null, { info: { start: null,
                             end: null } });
                     }
                     if (err.code === 416) {
                         // requested range not satisfiable
                         this.logger.debug('no new log record to process',
                                           { raftId: this.raftSession });
-                        return cb(null, { info: { start: null,
+                        return cbOnce(null, { info: { start: null,
                             end: null } });
                     }
                     this.logger.error(
                         'Error handling record log request', { error: err });
-                    return cb(err);
+                    return cbOnce(err);
                 }
                 // setup a temporary listener until the 'header' event
                 // is emitted
                 recordStream.on('error', err => {
                     this.logger.error('error receiving raft log',
                                       { error: err.message });
-                    return cb(errors.InternalError);
+                    return cbOnce(errors.InternalError);
                 });
                 const jsonResponse = stream.pipe(jsonStream.parse('log.*'));
                 jsonResponse.pipe(recordStream);
@@ -124,7 +126,7 @@ class LogConsumer {
                     .on('header', header => {
                         // remove temporary listener
                         recordStream.removeAllListeners('error');
-                        return cb(null, { info: header.info,
+                        return cbOnce(null, { info: header.info,
                                           log: recordStream });
                     })
                     .on('error', err => recordStream.emit('error', err));


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1403.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-4239-log-consumer-readrecords-callback-error`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-4239-log-consumer-readrecords-callback-error
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-4239-log-consumer-readrecords-callback-error
```

Please always comment pull request #1403 instead of this one.