### PR TITLE
bf S3C-4239 log consumer callback error fix

### DIFF
--- a/lib/storage/metadata/bucketclient/LogConsumer.js
+++ b/lib/storage/metadata/bucketclient/LogConsumer.js
@@ -6,6 +6,7 @@ const jsonStream = require('JSONStream');
 const werelogs = require('werelogs');
 
 const errors = require('../../../errors');
+const jsutil = require('../../../jsutil');
 
 class ListRecordStream extends stream.Transform {
     constructor(logger) {
@@ -87,6 +88,7 @@ class LogConsumer {
     readRecords(params, cb) {
         const recordStream = new ListRecordStream(this.logger);
         const _params = params || {};
+        const cbOnce = jsutil.once(cb);
 
         this.bucketClient.getRaftLog(
             this.raftSession, _params.startSeq, _params.limit,
@@ -96,26 +98,26 @@ class LogConsumer {
                         // no such raft session, log and ignore
                         this.logger.warn('raft session does not exist yet',
                                          { raftId: this.raftSession });
-                        return cb(null, { info: { start: null,
+                        return cbOnce(null, { info: { start: null,
                             end: null } });
                     }
                     if (err.code === 416) {
                         // requested range not satisfiable
                         this.logger.debug('no new log record to process',
                                           { raftId: this.raftSession });
-                        return cb(null, { info: { start: null,
+                        return cbOnce(null, { info: { start: null,
                             end: null } });
                     }
                     this.logger.error(
                         'Error handling record log request', { error: err });
-                    return cb(err);
+                    return cbOnce(err);
                 }
                 // setup a temporary listener until the 'header' event
                 // is emitted
                 recordStream.on('error', err => {
                     this.logger.error('error receiving raft log',
                                       { error: err.message });
-                    return cb(errors.InternalError);
+                    return cbOnce(errors.InternalError);
                 });
                 const jsonResponse = stream.pipe(jsonStream.parse('log.*'));
                 jsonResponse.pipe(recordStream);
@@ -124,7 +126,7 @@ class LogConsumer {
                     .on('header', header => {
                         // remove temporary listener
                         recordStream.removeAllListeners('error');
-                        return cb(null, { info: header.info,
+                        return cbOnce(null, { info: header.info,
                                           log: recordStream });
                     })
                     .on('error', err => recordStream.emit('error', err));


### PR DESCRIPTION
A guard is added to ensure that the callback is called only once in the
event of an error while reading records in log consumer.

(cherry picked from commit 941b644e9ebdbe6e02671fbeabd76816d2629056)