### PR TITLE
bf: S3C-4358 add versioned object lock actions

### DIFF
--- a/lib/policyEvaluator/utils/actionMaps.js
+++ b/lib/policyEvaluator/utils/actionMaps.js
@@ -65,6 +65,8 @@ const actionMapRQ = Object.assign({
     objectPutTaggingVersion: 's3:PutObjectVersionTagging',
     serviceGet: 's3:ListAllMyBuckets',
     objectReplicate: 's3:ReplicateObject',
+    objectPutRetentionVersion: 's3:PutObjectVersionRetention',
+    objectPutLegalHoldVersion: 's3:PutObjectVersionLegalHold',
 }, sharedActionMap);
 
 // action map used for bucket policies


### PR DESCRIPTION
Adds `objectPutRetentionVersion` and `objectPutLegalHoldVersion` into the request-context action-map in order to support `objectPutRetention` and `objectPutLegalHold` requests with versionId.