### PR TITLE
INTEGRATION [PR#1448 > development/8.1] bf: S3C-4358 add versioned object lock actions

### DIFF
--- a/lib/policyEvaluator/utils/actionMaps.js
+++ b/lib/policyEvaluator/utils/actionMaps.js
@@ -65,6 +65,8 @@ const actionMapRQ = Object.assign({
     objectPutTaggingVersion: 's3:PutObjectVersionTagging',
     serviceGet: 's3:ListAllMyBuckets',
     objectReplicate: 's3:ReplicateObject',
+    objectPutRetentionVersion: 's3:PutObjectVersionRetention',
+    objectPutLegalHoldVersion: 's3:PutObjectVersionLegalHold',
 }, sharedActionMap);
 
 // action map used for bucket policies


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1448.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-4358-add-versioned-obj-lock-actions`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-4358-add-versioned-obj-lock-actions
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-4358-add-versioned-obj-lock-actions
```

Please always comment pull request #1448 instead of this one.