### PR TITLE
bugfix: S3C-4257 Start Seq can be null

### DIFF
--- a/lib/storage/metadata/file/RecordLog.js
+++ b/lib/storage/metadata/file/RecordLog.js
@@ -30,7 +30,7 @@ class RecordLogProxy extends rpc.BaseClient {
 
 
 function formatSeq(seq) {
-    if (seq === undefined) {
+    if (!seq) {
         return undefined;
     }
     return `0000000000000000${seq.toString()}`.slice(-16);

--- a/tests/unit/storage/metadata/file/RecordLog.js
+++ b/tests/unit/storage/metadata/file/RecordLog.js
@@ -113,6 +113,24 @@ describe('record log - persistent log of metadata operations', () => {
                 recordStream.on('end', done);
             });
         });
+
+        it('should list an empty record log with null start', done => {
+            logProxy.readRecords({ startSeq: null }, (err, res) => {
+                assert.ifError(err);
+                const info = res.info;
+                const recordStream = res.log;
+
+                assert(info);
+                assert.strictEqual(info.start, null);
+                assert.strictEqual(info.end, null);
+                assert(recordStream);
+                recordStream.on('data', () => {
+                    assert.fail('unexpected data event');
+                });
+                recordStream.on('end', done);
+            });
+        });
+
         it('should be able to add records and list them thereafter', done => {
             debug('going to append records');
             const ops = [{ type: 'put', key: 'foo', value: 'bar',


### PR DESCRIPTION
* Return undefined if start seq is falsey
* This seems to occur whenever I start a fresh queue populator