### PR TITLE
INTEGRATION [PR#1472 > development/8.1] bugfix: S3C-4257 Start Seq can be null

### DIFF
--- a/lib/storage/metadata/file/RecordLog.js
+++ b/lib/storage/metadata/file/RecordLog.js
@@ -30,7 +30,7 @@ class RecordLogProxy extends rpc.BaseClient {
 
 
 function formatSeq(seq) {
-    if (seq === undefined) {
+    if (!seq) {
         return undefined;
     }
     return `0000000000000000${seq.toString()}`.slice(-16);

--- a/tests/unit/storage/metadata/file/RecordLog.js
+++ b/tests/unit/storage/metadata/file/RecordLog.js
@@ -113,6 +113,24 @@ describe('record log - persistent log of metadata operations', () => {
                 recordStream.on('end', done);
             });
         });
+
+        it('should list an empty record log with null start', done => {
+            logProxy.readRecords({ startSeq: null }, (err, res) => {
+                assert.ifError(err);
+                const info = res.info;
+                const recordStream = res.log;
+
+                assert(info);
+                assert.strictEqual(info.start, null);
+                assert.strictEqual(info.end, null);
+                assert(recordStream);
+                recordStream.on('data', () => {
+                    assert.fail('unexpected data event');
+                });
+                recordStream.on('end', done);
+            });
+        });
+
         it('should be able to add records and list them thereafter', done => {
             debug('going to append records');
             const ops = [{ type: 'put', key: 'foo', value: 'bar',


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1472.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-4257_StartSeqCanBeNull`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-4257_StartSeqCanBeNull
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-4257_StartSeqCanBeNull
```

Please always comment pull request #1472 instead of this one.