### PR TITLE
S3C-4110 Backport lifecycle expiration compatibility improvement

### DIFF
--- a/lib/models/LifecycleConfiguration.js
+++ b/lib/models/LifecycleConfiguration.js
@@ -313,7 +313,7 @@ class LifecycleConfiguration {
             return filterObj;
         }
         if (filter.Tag) {
-            const tagObj = this._parseTags(filter.Tag[0]);
+            const tagObj = this._parseTags(filter.Tag);
             if (tagObj.error) {
                 filterObj.error = tagObj.error;
                 return filterObj;
@@ -336,7 +336,7 @@ class LifecycleConfiguration {
                     return filterObj;
                 }
             }
-            const tagObj = this._parseTags(andF.Tag[0]);
+            const tagObj = this._parseTags(andF.Tag);
             if (tagObj.error) {
                 filterObj.error = tagObj.error;
                 return filterObj;
@@ -369,18 +369,15 @@ class LifecycleConfiguration {
         // reset _tagKeys to empty because keys cannot overlap within a rule,
         // but different rules can have the same tag keys
         this._tagKeys = [];
-        if (!tags.Key || !tags.Value) {
-            tagObj.error = errors.MissingRequiredParameter.customizeDescription(
-                'Tag XML does not contain both Key and Value');
-            return tagObj;
-        }
-        if (tags.Key.length !== tags.Value.length) {
-            tagObj.error = errors.MalformedXML.customizeDescription(
-                'Tag XML should contain same number of Keys and Values');
-            return tagObj;
-        }
-        for (let i = 0; i < tags.Key.length; i++) {
-            if (tags.Key[i].length < 1 || tags.Key[i].length > 128) {
+        for (let i = 0; i < tags.length; i++) {
+            if (!tags[i].Key || !tags[i].Value) {
+                tagObj.error =
+                    errors.MissingRequiredParameter.customizeDescription(
+                    'Tag XML does not contain both Key and Value');
+                break;
+            }
+
+            if (tags[i].Key[0].length < 1 || tags[i].Key[0].length > 128) {
                 tagObj.error = errors.InvalidRequest.customizeDescription(
                     'A Tag\'s Key must be a length between 1 and 128');
                 break;
@@ -390,15 +387,15 @@ class LifecycleConfiguration {
                     'A Tag\'s Value must be a length between 0 and 256');
                 break;
             }
-            if (this._tagKeys.includes(tags.Key[i])) {
+            if (this._tagKeys.includes(tags[i].Key[0])) {
                 tagObj.error = errors.InvalidRequest.customizeDescription(
                     'Tag Keys must be unique');
                 break;
             }
-            this._tagKeys.push(tags.Key[i]);
+            this._tagKeys.push(tags[i].Key[0]);
             const tag = {
-                key: tags.Key[i],
-                val: tags.Value[i],
+                key: tags[i].Key[0],
+                val: tags[i].Value[0],
             };
             tagObj.tags.push(tag);
         }
@@ -741,13 +738,12 @@ class LifecycleConfiguration {
                 `<Prefix>${rulePrefix}</Prefix>` : '';
             let tagXML = '';
             if (tags) {
-                const keysVals = tags.map(t => {
+                tagXML = tags.map(t => {
                     const { key, val } = t;
-                    const Tag = `<Key>${key}</Key>` +
-                        `<Value>${val}</Value>`;
+                    const Tag = `<Tag><Key>${key}</Key>` +
+                        `<Value>${val}</Value></Tag>`;
                     return Tag;
                 }).join('');
-                tagXML = `<Tag>${keysVals}</Tag>`;
             }
             let Filter;
             if (prefix !== undefined) {

--- a/lib/models/LifecycleConfiguration.js
+++ b/lib/models/LifecycleConfiguration.js
@@ -149,6 +149,36 @@ class LifecycleConfiguration {
     }
 
     /**
+     * Check that the prefix is valid
+     * @param {string} prefix - The prefix to check
+     * @return {object|null} - The error or null
+     */
+    _checkPrefix(prefix) {
+        if (prefix.length > 1024) {
+            const msg = 'The maximum size of a prefix is 1024';
+            return errors.InvalidRequest.customizeDescription(msg);
+        }
+        return null;
+    }
+
+    /**
+     * Parses the prefix of the config
+     * @param {string} prefix - The prefix to parse
+     * @return {object} - Contains error if parsing returned an error, otherwise
+     * it contains the parsed rule object
+     */
+    _parsePrefix(prefix) {
+        const error = this._checkPrefix(prefix);
+        if (error) {
+            return { error };
+        }
+        return {
+            propName: 'prefix',
+            prefix,
+        };
+    }
+
+    /**
      * Check that each xml rule is valid
      * @param {object} rule - a rule object from Rule array from this._parsedXml
      * @return {object} - contains error if any component returned an error
@@ -201,14 +231,18 @@ class LifecycleConfiguration {
                 customizeDescription('Rule xml does not include Status');
             return ruleObj;
         }
-        const subFilter = rule.Filter ? rule.Filter[0] : rule.Prefix;
-
         const id = this._parseID(rule.ID);
         const status = this._parseStatus(rule.Status[0]);
-        const filter = this._parseFilter(subFilter);
         const actions = this._parseAction(rule);
-
-        const rulePropArray = [id, status, filter, actions];
+        const rulePropArray = [id, status, actions];
+        if (rule.Prefix) {
+            // Backward compatibility with deprecated top-level prefix.
+            const prefix = this._parsePrefix(rule.Prefix[0]);
+            rulePropArray.push(prefix);
+        } else if (rule.Filter) {
+            const filter = this._parseFilter(rule.Filter[0]);
+            rulePropArray.push(filter);
+        }
         for (let i = 0; i < rulePropArray.length; i++) {
             const prop = rulePropArray[i];
             if (prop.error) {
@@ -218,7 +252,11 @@ class LifecycleConfiguration {
                 const propName = prop.propName;
                 // eslint-disable-next-line no-param-reassign
                 delete prop.propName;
-                ruleObj[propName] = prop[propName] || prop;
+                if (prop[propName] !== undefined) {
+                    ruleObj[propName] = prop[propName];
+                } else {
+                    ruleObj[propName] = prop;
+                }
             }
         }
         return ruleObj;
@@ -250,12 +288,14 @@ class LifecycleConfiguration {
     _parseFilter(filter) {
         const filterObj = {};
         filterObj.propName = 'filter';
-        // if no Rule Prefix or Filter, rulePrefix is empty string
-        filterObj.rulePrefix = '';
         if (Array.isArray(filter)) {
             // if Prefix was included, not Filter, filter will be Prefix array
             // if more than one Prefix is included, we ignore all but the last
-            filterObj.rulePrefix = filter.pop();
+            filterObj.rulePrefix = filter[filter.length - 1];
+            const error = this._checkPrefix(filterObj.rulePrefix);
+            if (error) {
+                filterObj.error = error;
+            }
             return filterObj;
         }
         if (filter.And && (filter.Prefix || filter.Tag) ||
@@ -265,7 +305,11 @@ class LifecycleConfiguration {
             return filterObj;
         }
         if (filter.Prefix) {
-            filterObj.rulePrefix = filter.Prefix.pop();
+            filterObj.rulePrefix = filter.Prefix[filter.Prefix.length - 1];
+            const error = this._checkPrefix(filterObj.rulePrefix);
+            if (error) {
+                filterObj.error = error;
+            }
             return filterObj;
         }
         if (filter.Tag) {
@@ -285,7 +329,12 @@ class LifecycleConfiguration {
                 return filterObj;
             }
             if (andF.Prefix && andF.Prefix.length >= 1) {
-                filterObj.rulePrefix = andF.Prefix.pop();
+                filterObj.rulePrefix = andF.Prefix[andF.Prefix.length - 1];
+                const error = this._checkPrefix(filterObj.rulePrefix);
+                if (error) {
+                    filterObj.error = error;
+                    return filterObj;
+                }
             }
             const tagObj = this._parseTags(andF.Tag[0]);
             if (tagObj.error) {
@@ -333,7 +382,12 @@ class LifecycleConfiguration {
         for (let i = 0; i < tags.Key.length; i++) {
             if (tags.Key[i].length < 1 || tags.Key[i].length > 128) {
                 tagObj.error = errors.InvalidRequest.customizeDescription(
-                    'Tag Key must be a length between 1 and 128 char');
+                    'A Tag\'s Key must be a length between 1 and 128');
+                break;
+            }
+            if (tags[i].Value[0].length < 0 || tags[i].Value[0].length > 256) {
+                tagObj.error = errors.InvalidRequest.customizeDescription(
+                    'A Tag\'s Value must be a length between 0 and 256');
                 break;
             }
             if (this._tagKeys.includes(tags.Key[i])) {
@@ -631,20 +685,24 @@ class LifecycleConfiguration {
         const rules = config.rules;
         assert.strictEqual(Array.isArray(rules), true);
         rules.forEach(rule => {
-            const { ruleID, ruleStatus, filter, actions } = rule;
+            const { ruleID, ruleStatus, prefix, filter, actions } = rule;
             assert.strictEqual(typeof ruleID, 'string');
             assert.strictEqual(typeof ruleStatus, 'string');
-            assert.strictEqual(typeof filter, 'object');
-            assert.strictEqual(Array.isArray(actions), true);
-            if (filter.rulePrefix) {
-                assert.strictEqual(typeof filter.rulePrefix, 'string');
-            }
-            if (filter.tags) {
-                assert.strictEqual(Array.isArray(filter.tags), true);
-                filter.tags.forEach(t => {
-                    assert.strictEqual(typeof t.key, 'string');
-                    assert.strictEqual(typeof t.val, 'string');
-                });
+            if (prefix !== undefined) {
+                assert.strictEqual(typeof prefix, 'string');
+            } else {
+                assert.strictEqual(typeof filter, 'object');
+                assert.strictEqual(Array.isArray(actions), true);
+                if (filter.rulePrefix) {
+                    assert.strictEqual(typeof filter.rulePrefix, 'string');
+                }
+                if (filter.tags) {
+                    assert.strictEqual(Array.isArray(filter.tags), true);
+                    filter.tags.forEach(t => {
+                        assert.strictEqual(typeof t.key, 'string');
+                        assert.strictEqual(typeof t.val, 'string');
+                    });
+                }
             }
             actions.forEach(a => {
                 assert.strictEqual(typeof a.actionName, 'string');
@@ -669,12 +727,18 @@ class LifecycleConfiguration {
     static getConfigXml(config) {
         const rules = config.rules;
         const rulesXML = rules.map(rule => {
-            const { ruleID, ruleStatus, filter, actions } = rule;
+            const { ruleID, ruleStatus, filter, actions, prefix } = rule;
             const ID = `<ID>${ruleID}</ID>`;
             const Status = `<Status>${ruleStatus}</Status>`;
-
-            const { rulePrefix, tags } = filter;
-            const Prefix = rulePrefix ? `<Prefix>${rulePrefix}</Prefix>` : '';
+            let rulePrefix;
+            if (prefix !== undefined) {
+                rulePrefix = prefix;
+            } else {
+                rulePrefix = filter.rulePrefix;
+            }
+            const tags = filter && filter.tags;
+            const Prefix = rulePrefix !== undefined ?
+                `<Prefix>${rulePrefix}</Prefix>` : '';
             let tagXML = '';
             if (tags) {
                 const keysVals = tags.map(t => {
@@ -686,9 +750,14 @@ class LifecycleConfiguration {
                 tagXML = `<Tag>${keysVals}</Tag>`;
             }
             let Filter;
-            if (rulePrefix && !tags) {
+            if (prefix !== undefined) {
+                // Prefix is in the top-level of the config, so we can skip the
+                // filter property.
                 Filter = Prefix;
-            } else if (tags && (rulePrefix || tags.length > 1)) {
+            } else if (filter.rulePrefix !== undefined && !tags) {
+                Filter = `<Filter>${Prefix}</Filter>`;
+            } else if (tags &&
+                (filter.rulePrefix !== undefined || tags.length > 1)) {
                 Filter = `<Filter><And>${Prefix}${tagXML}</And></Filter>`;
             } else {
                 // remaining condition is if only one or no tag

--- a/tests/unit/models/LifecycleConfiguration.js
+++ b/tests/unit/models/LifecycleConfiguration.js
@@ -162,6 +162,9 @@ function generateFilter(errorTag, tagObj) {
         if (tagObj.label === 'only-prefix') {
             middleTags = '<And><Prefix></Prefix></And>';
         }
+        if (tagObj.label === 'empty-prefix') {
+            middleTags = '<Prefix></Prefix>';
+        }
         if (tagObj.label === 'single-tag') {
             middleTags = '<And><Tags><Key>fo</Key><Value></Value></Tags></And>';
         }
@@ -190,6 +193,10 @@ function generateFilter(errorTag, tagObj) {
         if (tagObj.label === 'mult-tags') {
             middleTags = '<And><Tag><Key>color</Key><Value>blue</Value></Tag>' +
                 '<Tag><Key>shape</Key><Value>circle</Value></Tag></And>';
+        }
+        if (tagObj.label === 'not-unique-key-tag') {
+            middleTags = '<And><Tag><Key>color</Key><Value>blue</Value></Tag>' +
+                '<Tag><Key>color</Key><Value>red</Value></Tag></And>';
         }
         Filter = `<Filter>${middleTags}</Filter>`;
         if (tagObj.label === 'also-prefix') {
@@ -366,14 +373,22 @@ describe('LifecycleConfiguration class getLifecycleConfiguration', () => {
         });
     });
 
-    it('should apply all unique Key tags if multiple tags included', done => {
-        tagObj.label = 'mult-tags';
+    it('should return InvalidRequest is tag key is not unique', done => {
+        tagObj.label = 'not-unique-key-tag';
+        const errMessage = 'Tag Keys must be unique';
+        generateParsedXml('Filter', tagObj, parsedXml => {
+            checkError(parsedXml, 'InvalidRequest', errMessage, done);
+        });
+    });
+
+    it('should include prefix in the response even if it is an empty string', done => {
+        tagObj.label = 'empty-prefix';
+        const expectedPrefix = '';
         generateParsedXml('Filter', tagObj, parsedXml => {
             const lcConfig = new LifecycleConfiguration(parsedXml).
                 getLifecycleConfiguration();
-            const expected = [{ key: 'color', val: 'blue' },
-                { key: 'shape', val: 'circle' }];
-            assert.deepStrictEqual(expected, lcConfig.rules[0].filter.tags);
+            assert.strictEqual(expectedPrefix,
+                lcConfig.rules[0].filter.rulePrefix);
             done();
         });
     });

--- a/tests/unit/models/LifecycleConfiguration.js
+++ b/tests/unit/models/LifecycleConfiguration.js
@@ -187,6 +187,10 @@ function generateFilter(errorTag, tagObj) {
             middleTags = '<Prefix>foo</Prefix><Prefix>bar</Prefix>' +
                 `<Prefix>${tagObj.lastPrefix}</Prefix>`;
         }
+        if (tagObj.label === 'mult-tags') {
+            middleTags = '<And><Tag><Key>color</Key><Value>blue</Value></Tag>' +
+                '<Tag><Key>shape</Key><Value>circle</Value></Tag></And>';
+        }
         Filter = `<Filter>${middleTags}</Filter>`;
         if (tagObj.label === 'also-prefix') {
             Filter = '<Filter></Filter><Prefix></Prefix>';
@@ -358,6 +362,18 @@ describe('LifecycleConfiguration class getLifecycleConfiguration', () => {
                 getLifecycleConfiguration();
             assert.strictEqual(tagObj.lastPrefix,
                 lcConfig.rules[0].filter.rulePrefix);
+            done();
+        });
+    });
+
+    it('should apply all unique Key tags if multiple tags included', done => {
+        tagObj.label = 'mult-tags';
+        generateParsedXml('Filter', tagObj, parsedXml => {
+            const lcConfig = new LifecycleConfiguration(parsedXml).
+                getLifecycleConfiguration();
+            const expected = [{ key: 'color', val: 'blue' },
+                { key: 'shape', val: 'circle' }];
+            assert.deepStrictEqual(expected, lcConfig.rules[0].filter.tags);
             done();
         });
     });

--- a/tests/unit/models/LifecycleConfiguration.js
+++ b/tests/unit/models/LifecycleConfiguration.js
@@ -112,7 +112,11 @@ const invalidFilters = [
     { tag: 'Tag', label: 'no-value', error: 'MissingRequiredParameter',
         errMessage: 'Tag XML does not contain both Key and Value' },
     { tag: 'Tag', label: 'key-too-long', error: 'InvalidRequest',
-        errMessage: 'Tag Key must be a length between 1 and 128 char' }];
+        errMessage: 'A Tag\'s Key must be a length between 1 and 128' },
+    { tag: 'Tag', label: 'value-too-long', error: 'InvalidRequest',
+        errMessage: 'A Tag\'s Value must be a length between 0 and 256' },
+    { tag: 'Tag', label: 'prefix-too-long', error: 'InvalidRequest',
+        errMessage: 'The maximum size of a prefix is 1024' }];
 
 function generateAction(errorTag, tagObj) {
     const xmlObj = {};
@@ -170,6 +174,14 @@ function generateFilter(errorTag, tagObj) {
         if (tagObj.label === 'key-too-long') {
             const longKey = 'a'.repeat(129);
             middleTags = `<Tag><Key>${longKey}</Key><Value></Value></Tag>`;
+        }
+        if (tagObj.label === 'value-too-long') {
+            const longValue = 'b'.repeat(257);
+            middleTags = `<Tag><Key>a</Key><Value>${longValue}</Value></Tag>`;
+        }
+        if (tagObj.label === 'prefix-too-long') {
+            const longValue = 'a'.repeat(1025);
+            middleTags = `<Prefix>${longValue}</Prefix>`;
         }
         if (tagObj.label === 'mult-prefixes') {
             middleTags = '<Prefix>foo</Prefix><Prefix>bar</Prefix>' +


### PR DESCRIPTION
- Include the Prefix in the response even if it is an empty string.

- Check the max lengths of certain values (i.e. filter prefix length) to avoid DDOS-like attack surfaces where a very large value could be accepted by the API and pushed to Kafka.

- When setting multiple lifecycle filter tags, we previously only applied one tag.
This fix should apply all unique tags. If all tags are not unique, should error out.

More tests here: https://github.com/scality/cloudserver/pull/3659