### PR TITLE
INTEGRATION [PR#1482 > development/8.1] build(deps): Bump ipaddr.js from 1.9.1 to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "debug": "~2.6.9",
     "diskusage": "^1.1.1",
     "ioredis": "4.9.5",
-    "ipaddr.js": "1.9.1",
+    "ipaddr.js": "2.0.1",
     "level": "~5.0.1",
     "level-sublevel": "~6.6.5",
     "node-forge": "^0.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1190,10 +1190,10 @@ ioredis@4.9.5:
     redis-parser "^3.0.0"
     standard-as-callback "^2.0.1"
 
-ipaddr.js@1.9.1:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
-  integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
+ipaddr.js@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-2.0.1.tgz#eca256a7a877e917aeb368b0a7497ddf42ef81c0"
+  integrity sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==
 
 is-arguments@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1482.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/dependabot/npm_and_yarn/development/7.4/ipaddr.js-2.0.1`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/dependabot/npm_and_yarn/development/7.4/ipaddr.js-2.0.1
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/dependabot/npm_and_yarn/development/7.4/ipaddr.js-2.0.1
```

Please always comment pull request #1482 instead of this one.