### PR TITLE
Allow AssumeRole from user in different account

### DIFF
--- a/lib/policyEvaluator/principal.js
+++ b/lib/policyEvaluator/principal.js
@@ -143,6 +143,7 @@ class Principal {
                 AWS: [
                     account,
                     accountArn,
+                    requesterArn,
                 ],
             };
             checkAction = true;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=6.9.5"
   },
-  "version": "7.7.0",
+  "version": "7.7.1",
   "description": "Common utilities for the S3 project components",
   "main": "index.js",
   "repository": {

--- a/tests/unit/policy/test_principalEvaluator.js
+++ b/tests/unit/policy/test_principalEvaluator.js
@@ -472,7 +472,7 @@ describe('Principal evaluator', () => {
             },
         },
         {
-            name: 'should deny user as principal if account is different',
+            name: 'should allow user as principal if account is different',
             statement: [
                 {
                     Principal: {
@@ -491,7 +491,7 @@ describe('Principal evaluator', () => {
                 accountId: defaultAccountId,
             },
             result: {
-                result: 'Deny',
+                result: 'Allow',
                 checkAction: true,
             },
         },


### PR DESCRIPTION
The policy evaluator did not pass the requester ARN in the different accounts case, so there could not be a match against a user principal in the trust policy.