### PR TITLE
S3C-656: Remove the expect header hack

### DIFF
--- a/lib/auth/v4/createCanonicalRequest.js
+++ b/lib/auth/v4/createCanonicalRequest.js
@@ -71,11 +71,6 @@ function createCanonicalRequest(params) {
                 .trim().replace(/\s+/g, ' ');
             return `${signedHeader}:${trimmedHeader}\n`;
         }
-        // nginx will strip the actual expect header so add value of
-        // header back here if it was included as a signed header
-        if (signedHeader === 'expect') {
-            return `${signedHeader}:100-continue\n`;
-        }
         // handle case where signed 'header' is actually query param
         return `${signedHeader}:${pQuery[signedHeader]}\n`;
     });


### PR DESCRIPTION
See [Federation PR](https://github.com/scality/Federation/pull/3701) that correctly sets the Expect HTTP header. We don't need the dirty hack on Arsenal anymore.