### PR TITLE
ARSN-3: Remove the expect header hack

### DIFF
--- a/lib/auth/v4/createCanonicalRequest.js
+++ b/lib/auth/v4/createCanonicalRequest.js
@@ -71,11 +71,6 @@ function createCanonicalRequest(params) {
                 .trim().replace(/\s+/g, ' ');
             return `${signedHeader}:${trimmedHeader}\n`;
         }
-        // nginx will strip the actual expect header so add value of
-        // header back here if it was included as a signed header
-        if (signedHeader === 'expect') {
-            return `${signedHeader}:100-continue\n`;
-        }
         // handle case where signed 'header' is actually query param
         return `${signedHeader}:${pQuery[signedHeader]}\n`;
     });

--- a/tests/unit/auth/v4/createCanonicalRequest.js
+++ b/tests/unit/auth/v4/createCanonicalRequest.js
@@ -231,29 +231,6 @@ describe('createCanonicalRequest function', () => {
         assert.strictEqual(actualOutput, expectedOutput);
     });
 
-    it('should construct a canonical request that contains a ' +
-        'signed expect header even if expect header value was ' +
-        'stripped by the load balancer', () => {
-        const params = {
-            pHttpVerb: 'PUT',
-            pResource: '/test.txt',
-            pQuery: {},
-            pHeaders: {
-                host: 'examplebucket.s3.amazonaws.com',
-            },
-            pSignedHeaders: 'expect;host',
-            payloadChecksum: 'UNSIGNED-PAYLOAD',
-        };
-        const expectedOutput = 'PUT\n' +
-            '/test.txt\n\n' +
-            'expect:100-continue\n' +
-            'host:examplebucket.s3.amazonaws.com\n\n' +
-            'expect;host\n' +
-            'UNSIGNED-PAYLOAD';
-        const actualOutput = createCanonicalRequest(params);
-        assert.strictEqual(actualOutput, expectedOutput);
-    });
-
     it('should trim white space in a canonical header value so that ' +
         'there is no white space before or after a value and any sequential ' +
         'white space becomes a single space', () => {


### PR DESCRIPTION
See [Federation PR](https://github.com/scality/Federation/pull/3701) that correctly sets the Expect HTTP header. We don't need the dirty hack on Arsenal anymore.