### PR TITLE
INTEGRATION [PR#1508 > development/8.1] ARSN-3: Remove the expect header hack

### DIFF
--- a/lib/auth/v4/createCanonicalRequest.js
+++ b/lib/auth/v4/createCanonicalRequest.js
@@ -71,11 +71,6 @@ function createCanonicalRequest(params) {
                 .trim().replace(/\s+/g, ' ');
             return `${signedHeader}:${trimmedHeader}\n`;
         }
-        // nginx will strip the actual expect header so add value of
-        // header back here if it was included as a signed header
-        if (signedHeader === 'expect') {
-            return `${signedHeader}:100-continue\n`;
-        }
         // handle case where signed 'header' is actually query param
         return `${signedHeader}:${pQuery[signedHeader]}\n`;
     });

--- a/tests/unit/auth/v4/createCanonicalRequest.js
+++ b/tests/unit/auth/v4/createCanonicalRequest.js
@@ -231,29 +231,6 @@ describe('createCanonicalRequest function', () => {
         assert.strictEqual(actualOutput, expectedOutput);
     });
 
-    it('should construct a canonical request that contains a ' +
-        'signed expect header even if expect header value was ' +
-        'stripped by the load balancer', () => {
-        const params = {
-            pHttpVerb: 'PUT',
-            pResource: '/test.txt',
-            pQuery: {},
-            pHeaders: {
-                host: 'examplebucket.s3.amazonaws.com',
-            },
-            pSignedHeaders: 'expect;host',
-            payloadChecksum: 'UNSIGNED-PAYLOAD',
-        };
-        const expectedOutput = 'PUT\n' +
-            '/test.txt\n\n' +
-            'expect:100-continue\n' +
-            'host:examplebucket.s3.amazonaws.com\n\n' +
-            'expect;host\n' +
-            'UNSIGNED-PAYLOAD';
-        const actualOutput = createCanonicalRequest(params);
-        assert.strictEqual(actualOutput, expectedOutput);
-    });
-
     it('should trim white space in a canonical header value so that ' +
         'there is no white space before or after a value and any sequential ' +
         'white space becomes a single space', () => {


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1508.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/ARSN-3/remove-dirty-old-expect-header-fix`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/ARSN-3/remove-dirty-old-expect-header-fix
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/ARSN-3/remove-dirty-old-expect-header-fix
```

Please always comment pull request #1508 instead of this one.