### PR TITLE
improvement: S3C-4312 encryption info in ObjectMDLocation.setDataLocation

### DIFF
--- a/lib/models/ObjectMDLocation.js
+++ b/lib/models/ObjectMDLocation.js
@@ -22,6 +22,8 @@ class ObjectMDLocation {
             size: locationObj.size,
             dataStoreName: locationObj.dataStoreName,
             dataStoreETag: locationObj.dataStoreETag,
+            cryptoScheme: locationObj.cryptoScheme,
+            cipheredDataKey: locationObj.cipheredDataKey,
         };
     }
 
@@ -33,9 +35,27 @@ class ObjectMDLocation {
         return this._data.dataStoreName;
     }
 
+    /**
+     * Update data location with new info
+     *
+     * @param {object} location - single data location info
+     * @param {string} location.key - data backend key
+     * @param {string} location.dataStoreName - type of data store
+     * @param {number} [location.cryptoScheme] - if location data is
+     * encrypted: the encryption scheme version
+     * @param {string} [location.cipheredDataKey] - if location data
+     * is encrypted: the base64-encoded ciphered data key
+     * @return {ObjectMDLocation} return this
+     */
     setDataLocation(location) {
-        this._data.key = location.key;
-        this._data.dataStoreName = location.dataStoreName;
+        [
+            'key',
+            'dataStoreName',
+            'cryptoScheme',
+            'cipheredDataKey',
+        ].forEach(attrName => {
+            this._data[attrName] = location[attrName];
+        });
         return this;
     }
 
@@ -62,6 +82,14 @@ class ObjectMDLocation {
     setPartSize(size) {
         this._data.size = size;
         return this;
+    }
+
+    getCryptoScheme() {
+        return this._data.cryptoScheme;
+    }
+
+    getCipheredDataKey() {
+        return this._data.cipheredDataKey;
     }
 
     getValue() {

--- a/tests/unit/models/ObjectMDLocation.js
+++ b/tests/unit/models/ObjectMDLocation.js
@@ -1,0 +1,57 @@
+const assert = require('assert');
+const ObjectMDLocation = require('../../../lib/models/ObjectMDLocation');
+
+describe('ObjectMDLocation', () => {
+    it('class getters/setters', () => {
+        const locValue = {
+            key: 'fookey',
+            start: 42,
+            size: 100,
+            dataStoreName: 'awsbackend',
+            dataStoreETag: '2:abcdefghi',
+            cryptoScheme: 1,
+            cipheredDataKey: 'CiPhErEdDaTaKeY',
+        };
+        const location = new ObjectMDLocation(locValue);
+        assert.strictEqual(location.getKey(), 'fookey');
+        assert.strictEqual(location.getDataStoreName(), 'awsbackend');
+        assert.strictEqual(location.getDataStoreETag(), '2:abcdefghi');
+        assert.strictEqual(location.getPartNumber(), 2);
+        assert.strictEqual(location.getPartETag(), 'abcdefghi');
+        assert.strictEqual(location.getPartStart(), 42);
+        assert.strictEqual(location.getPartSize(), 100);
+        assert.strictEqual(location.getCryptoScheme(), 1);
+        assert.strictEqual(location.getCipheredDataKey(), 'CiPhErEdDaTaKeY');
+
+        assert.deepStrictEqual(location.getValue(), locValue);
+
+        location.setPartSize(200);
+        assert.strictEqual(location.getPartSize(), 200);
+    });
+
+    it('ObjectMDLocation::setDataLocation()', () => {
+        const location = new ObjectMDLocation({
+            key: 'fookey',
+            start: 42,
+            size: 100,
+            dataStoreName: 'awsbackend',
+            dataStoreETag: '2:abcdefghi',
+            cryptoScheme: 1,
+            cipheredDataKey: 'CiPhErEdDaTaKeY',
+        });
+        location.setDataLocation({ key: 'secondkey',
+                                   dataStoreName: 'gcpbackend' });
+        assert.strictEqual(location.getKey(), 'secondkey');
+        assert.strictEqual(location.getDataStoreName(), 'gcpbackend');
+        assert.strictEqual(location.getCryptoScheme(), undefined);
+        assert.strictEqual(location.getCipheredDataKey(), undefined);
+        location.setDataLocation({ key: 'thirdkey',
+                                   dataStoreName: 'azurebackend',
+                                   cryptoScheme: 1,
+                                   cipheredDataKey: 'NeWcIpHeReDdAtAkEy' });
+        assert.strictEqual(location.getKey(), 'thirdkey');
+        assert.strictEqual(location.getDataStoreName(), 'azurebackend');
+        assert.strictEqual(location.getCryptoScheme(), 1);
+        assert.strictEqual(location.getCipheredDataKey(), 'NeWcIpHeReDdAtAkEy');
+    });
+});


### PR DESCRIPTION
Support setting encryption info in ObjectMDLocation with the method
setDataLocation(), used by backbeat to set the new target location
before writing metadata on the target.