### PR TITLE
INTEGRATION [PR#1510 > development/8.1] improvement: S3C-4312 encryption info in ObjectMDLocation.setDataLocation

### DIFF
--- a/lib/models/ObjectMDLocation.js
+++ b/lib/models/ObjectMDLocation.js
@@ -33,9 +33,25 @@ class ObjectMDLocation {
         return this._data.dataStoreName;
     }
 
+    /**
+     * Update data location with new info
+     *
+     * @param {object} location - single data location info
+     * @param {string} location.key - data backend key
+     * @param {string} location.dataStoreName - type of data store
+     * @param {number} [location.cryptoScheme] - if location data is
+     * encrypted: the encryption scheme version
+     * @param {string} [location.cipheredDataKey] - if location data
+     * is encrypted: the base64-encoded ciphered data key
+     * @return {ObjectMDLocation} return this
+     */
     setDataLocation(location) {
         this._data.key = location.key;
         this._data.dataStoreName = location.dataStoreName;
+        if (location.cryptoScheme) {
+            this._data.cryptoScheme = location.cryptoScheme;
+            this._data.cipheredDataKey = location.cipheredDataKey;
+        }
         return this;
     }
 
@@ -62,6 +78,14 @@ class ObjectMDLocation {
     setPartSize(size) {
         this._data.size = size;
         return this;
+    }
+
+    getCryptoScheme() {
+        return this._data.cryptoScheme;
+    }
+
+    getCipheredDataKey() {
+        return this._data.cipheredDataKey;
     }
 
     getValue() {

--- a/tests/unit/models/object.js
+++ b/tests/unit/models/object.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const ObjectMD = require('../../../lib/models/ObjectMD');
+const ObjectMDLocation = require('../../../lib/models/ObjectMDLocation');
 const constants = require('../../../lib/constants');
 
 const retainDate = new Date();
@@ -307,7 +308,7 @@ describe('ObjectMD import from stored blob', () => {
     });
 });
 
-describe('getAttributes static method', () => {
+describe('ObjectMD.getAttributes static method', () => {
     it('should return object metadata attributes', () => {
         const attributes = ObjectMD.getAttributes();
         const expectedResult = {
@@ -342,5 +343,55 @@ describe('getAttributes static method', () => {
             'originOp': true,
         };
         assert.deepStrictEqual(attributes, expectedResult);
+    });
+});
+
+describe('ObjectMDLocation class', () => {
+    let mdLoc;
+    beforeEach(() => {
+        mdLoc = new ObjectMDLocation({
+            key: 'location-key',
+            start: 0,
+            size: 1000,
+            dataStoreName: 'location-name',
+            dataStoreETag: '1:location-etag',
+        });
+    });
+    it('should be able to create a location with standard fields', () => {
+        assert.strictEqual(mdLoc.getKey(), 'location-key');
+        assert.strictEqual(mdLoc.getDataStoreName(), 'location-name');
+        assert.strictEqual(mdLoc.getDataStoreETag(), '1:location-etag');
+        assert.strictEqual(mdLoc.getPartNumber(), 1);
+        assert.strictEqual(mdLoc.getPartETag(), 'location-etag');
+        assert.strictEqual(mdLoc.getPartStart(), 0);
+        assert.strictEqual(mdLoc.getPartSize(), 1000);
+        assert.strictEqual(mdLoc.getCryptoScheme(), undefined);
+        assert.strictEqual(mdLoc.getCipheredDataKey(), undefined);
+    });
+
+    it('should be able to update a location without encryption info', () => {
+        mdLoc.setDataLocation({
+            key: 'new-location-key',
+            dataStoreName: 'new-location-name',
+        });
+        assert.strictEqual(mdLoc.getKey(), 'new-location-key');
+        assert.strictEqual(mdLoc.getDataStoreName(), 'new-location-name');
+        assert.strictEqual(mdLoc.getDataStoreETag(), '1:location-etag');
+        assert.strictEqual(mdLoc.getCryptoScheme(), undefined);
+        assert.strictEqual(mdLoc.getCipheredDataKey(), undefined);
+    });
+
+    it('should be able to update a location with encryption info', () => {
+        mdLoc.setDataLocation({
+            key: 'new-location-key',
+            dataStoreName: 'new-location-name',
+            cryptoScheme: 1,
+            cipheredDataKey: 'CiPhErEdDaTaKeY',
+        });
+        assert.strictEqual(mdLoc.getKey(), 'new-location-key');
+        assert.strictEqual(mdLoc.getDataStoreName(), 'new-location-name');
+        assert.strictEqual(mdLoc.getDataStoreETag(), '1:location-etag');
+        assert.strictEqual(mdLoc.getCryptoScheme(), 1);
+        assert.strictEqual(mdLoc.getCipheredDataKey(), 'CiPhErEdDaTaKeY');
     });
 });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1510.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/improvement/S3C-4312-backbeatEncryptionSupport`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/improvement/S3C-4312-backbeatEncryptionSupport
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/improvement/S3C-4312-backbeatEncryptionSupport
```

Please always comment pull request #1510 instead of this one.