### PR TITLE
feature: ARSN-2 fix renamed encryption helper

### DIFF
--- a/lib/storage/data/external/AwsClient.js
+++ b/lib/storage/data/external/AwsClient.js
@@ -554,7 +554,7 @@ class AwsClient {
             MetadataDirective: metadataDirective,
         };
         if (destLocationConstraintName &&
-        config.isAWSServerSideEncrytion(destLocationConstraintName)) {
+        config.isAWSServerSideEncryption(destLocationConstraintName)) {
             awsParams.ServerSideEncryption = 'AES256';
         }
         this._client.copyObject(awsParams, (err, copyResult) => {


### PR DESCRIPTION
The name of the Cloudserver config helper "isAWSServerSideEncrytion"
has been renamed to "isAWSServerSideEncryption" to fix a typo, in commit
https://github.com/scality/cloudserver/pull/3708/commits/f336541f6acd0226eab26bd668dea921f8c5d69c

This new name needs to be fixed in the AwsBackend data location.