### PR TITLE
improvement: S3C-4312 fix ObjectMDLocation.setDataLocation()

### DIFF
--- a/lib/models/ObjectMDLocation.js
+++ b/lib/models/ObjectMDLocation.js
@@ -14,6 +14,10 @@ class ObjectMDLocation {
      * @param {string} locationObj.dataStoreName - type of data store
      * @param {string} locationObj.dataStoreETag - internal ETag of
      *   data part
+     * @param {number} [location.cryptoScheme] - if location data is
+     * encrypted: the encryption scheme version
+     * @param {string} [location.cipheredDataKey] - if location data
+     * is encrypted: the base64-encoded ciphered data key
      */
     constructor(locationObj) {
         this._data = {
@@ -22,9 +26,11 @@ class ObjectMDLocation {
             size: locationObj.size,
             dataStoreName: locationObj.dataStoreName,
             dataStoreETag: locationObj.dataStoreETag,
-            cryptoScheme: locationObj.cryptoScheme,
-            cipheredDataKey: locationObj.cipheredDataKey,
         };
+        if (locationObj.cryptoScheme) {
+            this._data.cryptoScheme = locationObj.cryptoScheme;
+            this._data.cipheredDataKey = locationObj.cipheredDataKey;
+        }
     }
 
     getKey() {
@@ -54,7 +60,11 @@ class ObjectMDLocation {
             'cryptoScheme',
             'cipheredDataKey',
         ].forEach(attrName => {
-            this._data[attrName] = location[attrName];
+            if (location[attrName] !== undefined) {
+                this._data[attrName] = location[attrName];
+            } else {
+                delete this._data[attrName];
+            }
         });
         return this;
     }

--- a/tests/unit/models/ObjectMDLocation.js
+++ b/tests/unit/models/ObjectMDLocation.js
@@ -45,6 +45,13 @@ describe('ObjectMDLocation', () => {
         assert.strictEqual(location.getDataStoreName(), 'gcpbackend');
         assert.strictEqual(location.getCryptoScheme(), undefined);
         assert.strictEqual(location.getCipheredDataKey(), undefined);
+        assert.deepStrictEqual(location.getValue(), {
+            dataStoreETag: '2:abcdefghi',
+            dataStoreName: 'gcpbackend',
+            key: 'secondkey',
+            size: 100,
+            start: 42,
+        });
         location.setDataLocation({ key: 'thirdkey',
                                    dataStoreName: 'azurebackend',
                                    cryptoScheme: 1,


### PR DESCRIPTION
Fix ObjectMDLocation.setDataLocation() behavior when cryptoScheme and
cipheredDataKey location params are undefined: instead of setting the
attributes as undefined, remove the attributes.

The previous situation made some backbeat tests fail due to those
attributes existing, and it's cleaner this way.