### PR TITLE
bugfix: ARSN-4 rework KMIP connection handling

### DIFF
--- a/lib/network/kmip/transport/TransportTemplate.js
+++ b/lib/network/kmip/transport/TransportTemplate.js
@@ -70,58 +70,59 @@ class TransportTemplate {
                 this.options.tls.port || DEFAULT_KMIP_PORT,
                 this.options.tls,
                 () => {
-                    socket.on('data', data => {
-                        const queuedCallback = this.callbackPipeline.shift();
-                        queuedCallback(null, socket, data);
-
-                        if (this.callbackPipeline.length <
-                            this.pipelineDepth &&
-                            this.deferedRequests.length > 0) {
-                            const deferedRequest = this.deferedRequests.shift();
-                            process.nextTick(() => {
-                                this.send(logger,
-                                          deferedRequest.encodedMessage,
-                                          deferedRequest.cb);
-                            });
-                        } else if (this.callbackPipeline.length === 0 &&
-                                   this.deferedRequests.length === 0 &&
-                                   this.pipelineDrainedCallback) {
-                            this.pipelineDrainedCallback();
-                            this.pipelineDrainedCallback = null;
-                        }
-                    });
-                    socket.on('end', () => {
-                        const error = Error('Conversation interrupted');
-                        this._drainQueuesWithError(error);
-                        this.socket = null;
-                    });
-                    socket.on('error', err => {
-                        this._drainQueuesWithError(err);
-                    });
                     if (this.handshakeFunction) {
                         this.handshakeFunction(logger, readyCallback);
                     } else {
                         readyCallback(null);
                     }
                 });
+            socket.on('data', data => {
+                const queuedCallback = this.callbackPipeline.shift();
+                queuedCallback(null, socket, data);
+
+                if (this.callbackPipeline.length <
+                    this.pipelineDepth &&
+                    this.deferedRequests.length > 0) {
+                    const deferedRequest = this.deferedRequests.shift();
+                    process.nextTick(() => {
+                        this.send(logger,
+                                  deferedRequest.encodedMessage,
+                                  deferedRequest.cb);
+                    });
+                } else if (this.callbackPipeline.length === 0 &&
+                           this.deferedRequests.length === 0 &&
+                           this.pipelineDrainedCallback) {
+                    this.pipelineDrainedCallback();
+                    this.pipelineDrainedCallback = null;
+                }
+            });
+            socket.on('end', () => {
+                const error = Error('Conversation interrupted');
+                this.socket = null;
+                this._drainQueuesWithError(error);
+            });
+            socket.on('error', err => {
+                this._drainQueuesWithError(err);
+            });
             this.socket = socket;
         } catch (err) {
-            logger.error();
+            logger.error(err);
+            this._drainQueuesWithError(err);
             readyCallback(err);
         }
     }
 
     _doSend(logger, encodedMessage, cb) {
-        const socket = this.socket;
-        if (!socket || socket.destroyed) {
-            const error = new Error('Socket to server not available');
-            logger.error('TransportTemplate::_doSend', { error });
-            return cb(error);
-        }
         this.callbackPipeline.push(cb);
-        socket.cork();
-        socket.write(encodedMessage);
-        socket.uncork();
+        if (this.socket === null || this.socket.destroyed) {
+            this._createConversation(logger, () => {});
+        }
+        const socket = this.socket;
+        if (socket) {
+            socket.cork();
+            socket.write(encodedMessage);
+            socket.uncork();
+        }
         return undefined;
     }
 
@@ -138,14 +139,6 @@ class TransportTemplate {
             return this.deferedRequests.push({ encodedMessage, cb });
         }
         assert(encodedMessage.length !== 0);
-        if (this.socket === null || this.socket.destroyed) {
-            return this._createConversation(logger, err => {
-                if (err) {
-                    return cb(err);
-                }
-                return this._doSend(logger, encodedMessage, cb);
-            });
-        }
         return this._doSend(logger, encodedMessage, cb);
     }
 

--- a/tests/functional/kmip/tls.js
+++ b/tests/functional/kmip/tls.js
@@ -1,0 +1,43 @@
+const assert = require('assert');
+const net = require('net');
+const tls = require('tls');
+const TransportTemplate =
+      require('../../../lib/network/kmip/transport/TransportTemplate.js');
+const { logger } = require('../../utils/kmip/ersatz.js');
+
+describe('KMIP Connection Management', () => {
+    let server;
+    before(done => {
+        server = net.createServer(conn => {
+            // abort the connection as soon as it is accepted
+            conn.destroy();
+        });
+        server.listen(5696);
+        server.on('listening', done);
+    });
+    after(done => {
+        server.close(done);
+    });
+
+    it('should gracefully handle connection errors', done => {
+        const transport = new TransportTemplate(
+            tls,
+            {
+                pipelineDepth: 1,
+                tls: {
+                    port: 5696,
+                },
+            });
+        const request = Buffer.alloc(10).fill(6);
+        /* Using a for loop here instead of anything
+         * asynchronous, the callbacks get stuck in
+         * the conversation queue and are unwind with
+         * an error. It is the purpose of this test */
+        transport.send(logger, request, (err, conversation, response) => {
+            assert(err);
+            assert(!response);
+            done();
+        });
+        transport.end();
+    });
+});


### PR DESCRIPTION
Rework KMIP connection handling to catch all errors, including before the connection is established, and return the error to each pending command response.

In particular, setup the 'error' listener (also 'data' and 'end' listeners) as soon as the TLS client socket is created instead of
waiting for the connection to be established to set the listeners.
