### PR TITLE
ARSN-9 KMIP deep healthcheck

### DIFF
--- a/lib/network/kmip/Client.js
+++ b/lib/network/kmip/Client.js
@@ -574,6 +574,30 @@ class Client {
         });
     }
 
+    healthcheck(logger, cb) {
+        // the bucket does not have to exist, just passing a common bucket name here
+        this.createBucketKey('kmip-healthcheck-test-bucket', logger, (err, bucketKeyId) => {
+            if (err) {
+                logger.error('KMIP::healthcheck: failure to create a test bucket key', {
+                    error: err,
+                });
+                return cb(err);
+            }
+            logger.debug('KMIP::healthcheck: success creating a test bucket key');
+            this.destroyBucketKey(bucketKeyId, logger, err => {
+                if (err) {
+                    logger.error('KMIP::healthcheck: failure to remove the test bucket key', {
+                        bucketKeyId,
+                        error: err,
+                    });
+                }
+            });
+            // no need to have the healthcheck wait until the
+            // destroyBucketKey() call finishes, as the healthcheck
+            // already succeeded by creating the bucket key
+            return cb();
+        });
+    }
 }
 
 module.exports = Client;

--- a/lib/network/kmip/index.js
+++ b/lib/network/kmip/index.js
@@ -291,7 +291,7 @@ class KMIP {
             logger, encodedMessage,
             (err, conversation, rawResponse) => {
                 if (err) {
-                    logger.error('KMIP::request: Failed to encode message',
+                    logger.error('KMIP::request: Failed to send message',
                                  { error: err });
                     return cb(err);
                 }

--- a/tests/functional/kmip/highlevel.js
+++ b/tests/functional/kmip/highlevel.js
@@ -8,6 +8,8 @@ const LoopbackServerChannel =
       require('../../utils/kmip/LoopbackServerChannel.js');
 const TransportTemplate =
       require('../../../lib/network/kmip/transport/TransportTemplate.js');
+const TlsTransport =
+      require('../../../lib/network/kmip/transport/tls.js');
 const KMIP = require('../../../lib/network/kmip');
 const KMIPClient = require('../../../lib/network/kmip/Client.js');
 const {
@@ -63,6 +65,54 @@ describe('KMIP High Level Driver', () => {
                            kmipClient.destroyBucketKey(id, logger, next),
                    ], done);
                });
+        });
+    });
+    it('should succeed healthcheck with working KMIP client and server', done => {
+        const options = {
+            kmip: {
+                client: {
+                    bucketNameAttributeName: null,
+                    compoundCreateActivate: false,
+                },
+                codec: {},
+                transport: {
+                    pipelineDepth: 8,
+                    tls: {
+                        port: 5696,
+                    },
+                },
+            },
+        };
+        const kmipClient = new KMIPClient(options, TTLVCodec,
+                                          LoopbackServerTransport);
+        kmipClient.healthcheck(logger, err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+
+    it('should fail healthcheck with KMIP server not running', done => {
+        const options = {
+            kmip: {
+                client: {
+                    bucketNameAttributeName: null,
+                    compoundCreateActivate: false,
+                },
+                codec: {},
+                transport: {
+                    pipelineDepth: 8,
+                    tls: {
+                        port: 5696,
+                    },
+                },
+            },
+        };
+        const kmipClient = new KMIPClient(options, TTLVCodec, TlsTransport);
+        kmipClient.healthcheck(logger, err => {
+            assert(err);
+            assert(err.InternalError);
+            assert(err.description.includes('ECONNREFUSED'));
+            done();
         });
     });
 });


### PR DESCRIPTION
Add a healthcheck() function in the KMIP client that create a dummy
bucket key on the KMS then deletes it, to ensure basic functionality
is working