### PR TITLE
INTEGRATION [PR#1538 > development/8.1] ARSN-11 update werelogs to tagged version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "socket.io-client": "~2.3.0",
     "utf8": "2.1.2",
     "uuid": "^3.0.1",
-    "werelogs": "scality/werelogs#0ff7ec82",
+    "werelogs": "scality/werelogs#8.1.0",
     "xml2js": "~0.4.23"
   },
   "optionalDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2506,9 +2506,9 @@ uuid@^3.0.1:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
-werelogs@scality/werelogs#0ff7ec82:
-  version "7.4.0"
-  resolved "https://codeload.github.com/scality/werelogs/tar.gz/0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61"
+werelogs@scality/werelogs#8.1.0:
+  version "8.1.0"
+  resolved "https://codeload.github.com/scality/werelogs/tar.gz/e8f828725642c54c511cdbe580b18f43d3589313"
   dependencies:
     safe-json-stringify "1.0.3"
 


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1538.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/feature/ARSN-11-bump-werelogs`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/feature/ARSN-11-bump-werelogs
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/feature/ARSN-11-bump-werelogs
```

Please always comment pull request #1538 instead of this one.