### PR TITLE
feature: ARSN-18 and ARSN-19

### DIFF
--- a/lib/network/probe/HealthProbeServer.js
+++ b/lib/network/probe/HealthProbeServer.js
@@ -2,28 +2,7 @@ const httpServer = require('../http/server');
 const werelogs = require('werelogs');
 const errors = require('../../errors');
 const ZenkoMetrics = require('../../metrics/ZenkoMetrics');
-
-function sendError(res, log, error, optMessage) {
-    res.writeHead(error.code);
-    let message;
-    if (optMessage) {
-        message = optMessage;
-    } else {
-        message = error.description || '';
-    }
-    log.debug('sending back error response', { httpCode: error.code,
-        errorType: error.message,
-        error: message });
-    res.end(`${JSON.stringify({ errorType: error.message,
-        errorMessage: message })}\n`);
-}
-
-function sendSuccess(res, log, msg) {
-    res.writeHead(200);
-    log.debug('replying with success');
-    const message = msg || 'OK';
-    res.end(message);
-}
+const { sendSuccess, sendError } = require('./Utils');
 
 function checkStub(log) { // eslint-disable-line
     return true;

--- a/lib/network/probe/ProbeServer.js
+++ b/lib/network/probe/ProbeServer.js
@@ -3,19 +3,17 @@ const werelogs = require('werelogs');
 const errors = require('../../errors');
 
 const DEFAULT_LIVE_ROUTE = '/_/live';
-const DEFAULT_READY_ROUTE = '/_/live';
+const DEFAULT_READY_ROUTE = '/_/ready';
 const DEFAULT_METRICS_ROUTE = '/_/metrics';
 
 /**
- * ProbeDelegate is used to determine if a probe is successful or
- * if any errors are present.
- * If everything is working as intended, it is a no-op.
- * Otherwise, return a string representing what is failing.
+ * ProbeDelegate is used to handle probe checks.
+ * You can sendSuccess and sendError from Utils to handle success
+ * and failure conditions.
  * @callback ProbeDelegate
  * @param { import('http').ServerResponse } res - HTTP response for writing
  * @param {werelogs.Logger} log - Werelogs instance for logging if you choose to
- * @return {(string|undefined)} String representing issues to report. An empty
- * string or undefined is used to represent no issues.
+ * @return {undefined}
  */
 
 /**
@@ -91,13 +89,7 @@ class ProbeServer extends httpServer {
             return;
         }
 
-        const probeResponse = this._handlers.get(req.url)(res, log);
-        if (probeResponse !== undefined && probeResponse !== '') {
-            // Return an internal error with the response
-            errors.InternalError
-                .customizeDescription(probeResponse)
-                .writeResponse(res);
-        }
+        this._handlers.get(req.url)(res, log);
     }
 }
 

--- a/lib/network/probe/Utils.js
+++ b/lib/network/probe/Utils.js
@@ -1,0 +1,41 @@
+/**
+ * Send a successful HTTP response of 200 OK
+ * @param {http.ServerResponse} res - HTTP response for writing
+ * @param {werelogs.Logger} log - Werelogs instance for logging if you choose to
+ * @param {string} [message] - Message to send as response, defaults to OK
+ * @returns {undefined}
+ */
+function sendSuccess(res, log, message = 'OK') {
+    log.debug('replying with success');
+    res.writeHead(200);
+    res.end(message);
+}
+
+/**
+ * Send an Arsenal Error response
+ * @param {http.ServerResponse} res - HTTP response for writing
+ * @param {werelogs.Logger} log - Werelogs instance for logging if you choose to
+ * @param {ArsenalError} error - Error to send back to the user
+ * @param {string} [optMessage] - Message to use instead of the errors message
+ * @returns {undefined}
+ */
+function sendError(res, log, error, optMessage) {
+    const message = optMessage || error.description || '';
+    log.debug('sending back error response',
+        {
+            httpCode: error.code,
+            errorType: error.message,
+            error: message,
+        }
+    );
+    res.writeHead(error.code);
+    res.end(JSON.stringify({
+        errorType: error.message,
+        errorMessage: message,
+    }));
+}
+
+module.exports = {
+    sendSuccess,
+    sendError,
+};

--- a/tests/unit/network/probe/ProbeServer.spec.js
+++ b/tests/unit/network/probe/ProbeServer.spec.js
@@ -52,7 +52,7 @@ describe('network.probe.ProbeServer', () => {
         });
     });
 
-    it('does nothing if probe successful', done => {
+    it('allows probe to handle requests', done => {
         server.addHandler('/check', res => {
             res.writeHead(200);
             res.end();
@@ -85,22 +85,6 @@ describe('network.probe.ProbeServer', () => {
             if (calls === 2) {
                 done();
             }
-        });
-    });
-
-    it('500 response on bad probe', done => {
-        server.addHandler('/check', () => 'check failed');
-        makeRequest('GET', '/check', (err, res) => {
-            assert.ifError(err);
-            assert.strictEqual(res.statusCode, 500);
-            res.setEncoding('utf8');
-            res.on('data', body => {
-                assert.strictEqual(
-                    body,
-                    '{"errorType":"InternalError","errorMessage":"check failed"}',
-                );
-                done();
-            });
         });
     });
 });

--- a/tests/unit/network/probe/Utils.spec.js
+++ b/tests/unit/network/probe/Utils.spec.js
@@ -1,0 +1,74 @@
+const assert = require('assert');
+const errors = require('../../../../lib/errors');
+const { sendError, sendSuccess } = require('../../../../lib/network/probe/Utils');
+const sinon = require('sinon');
+
+describe('network.probe.Utils', () => {
+    let mockLogger;
+
+    beforeEach(() => {
+        mockLogger = {
+            debug: sinon.fake(),
+        };
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('send success will return 200 OK', done => {
+        const mockRes = {
+            writeHead: sinon.fake(status => assert.strictEqual(200, status)),
+            end: sinon.fake(msg => {
+                assert.strictEqual(msg, 'OK');
+                done();
+            }),
+        };
+        sendSuccess(mockRes, mockLogger);
+    });
+
+    it('send success will return 200 and optional message', done => {
+        const mockRes = {
+            writeHead: sinon.fake(status => assert.strictEqual(200, status)),
+            end: sinon.fake(msg => {
+                assert.strictEqual(msg, 'Granted');
+                done();
+            }),
+        };
+        sendSuccess(mockRes, mockLogger, 'Granted');
+    });
+
+    it('send error will return send an Arsenal Error and code', done => {
+        const mockRes = {
+            writeHead: sinon.fake(status => assert.strictEqual(405, status)),
+            end: sinon.fake(msg => {
+                assert.deepStrictEqual(
+                    JSON.parse(msg),
+                    {
+                        errorType: 'MethodNotAllowed',
+                        errorMessage: errors.MethodNotAllowed.description,
+                    }
+                );
+                done();
+            }),
+        };
+        sendError(mockRes, mockLogger, errors.MethodNotAllowed);
+    });
+
+    it('send error will return send an Arsenal Error and code using optional message', done => {
+        const mockRes = {
+            writeHead: sinon.fake(status => assert.strictEqual(405, status)),
+            end: sinon.fake(msg => {
+                assert.deepStrictEqual(
+                    JSON.parse(msg),
+                    {
+                        errorType: 'MethodNotAllowed',
+                        errorMessage: 'Very much not allowed',
+                    }
+                );
+                done();
+            }),
+        };
+        sendError(mockRes, mockLogger, errors.MethodNotAllowed, 'Very much not allowed');
+    });
+});


### PR DESCRIPTION
* Probe server should not check for strings to handle 500
* Move sendError and sendSuccess to Util.js
* Export sendError and sendSuccess for public uses