### PR TITLE
ARSN-22 - Fix bug in `onPutObjectTagging` and `getObjectTagging`

### DIFF
--- a/lib/storage/data/external/AwsClient.js
+++ b/lib/storage/data/external/AwsClient.js
@@ -485,13 +485,14 @@ class AwsClient {
 
     objectPutTagging(key, bucket, objectMD, log, callback) {
         const awsBucket = this._awsBucketName;
-        const awsKey = this._createAwsKey(bucket, key, this._bucketMatch);
-        const dataStoreVersionId = objectMD.location[0].dataStoreVersionId;
+        const awsKey = this._createAwsKey(bucket.getName(), key, this._bucketMatch);
         const tagParams = {
             Bucket: awsBucket,
             Key: awsKey,
-            VersionId: dataStoreVersionId,
         };
+        if (objectMD.VersionId) {
+            tagParams.VersionId = objectMD.VersionId;
+        }
         const keyArray = Object.keys(objectMD.tags);
         tagParams.Tagging = {};
         tagParams.Tagging.TagSet = keyArray.map(key => {
@@ -514,13 +515,14 @@ class AwsClient {
 
     objectDeleteTagging(key, bucket, objectMD, log, callback) {
         const awsBucket = this._awsBucketName;
-        const awsKey = this._createAwsKey(bucket, key, this._bucketMatch);
-        const dataStoreVersionId = objectMD.location[0].dataStoreVersionId;
+        const awsKey = this._createAwsKey(bucket.getName(), key, this._bucketMatch);
         const tagParams = {
             Bucket: awsBucket,
             Key: awsKey,
-            VersionId: dataStoreVersionId,
         };
+        if (objectMD.versionId) {
+            tagParams.VersionId = objectMD.versionId;
+        }
         return this._client.deleteObjectTagging(tagParams, err => {
             if (err) {
                 logHelper(log, 'error', 'error from data backend on ' +

--- a/tests/unit/storage/data/external/ExternalClients.js
+++ b/tests/unit/storage/data/external/ExternalClients.js
@@ -48,6 +48,16 @@ const backendClients = [
 ];
 const log = new DummyRequestLogger();
 
+class DummyBucket {
+    constructor(name) {
+        this.name = name;
+    }
+
+    getName() {
+        return this.name;
+    }
+}
+
 describe('external backend clients', () => {
     backendClients.forEach(backend => {
         let testClient;
@@ -154,6 +164,73 @@ describe('external backend clients', () => {
                     });
             });
         });
+
+        if (backend.config.type !== 'azure') {
+            it(`${backend.name} objectPutTagging() then objectDeleteTagging() should set tags then delete it`, done => {
+                const key = {
+                    key: 'externalBackendTestBucket/externalBackendTestKey',
+                    dataStoreName: backend.config.dataStoreName,
+                    response: new stream.PassThrough(),
+                };
+                const bucket = new DummyBucket(backend.config.bucketName);
+                const objectMd = {
+                    tags: {
+                        Key1: 'value_1',
+                        Key2: 'value_2',
+                    },
+                };
+                testClient.objectPutTagging(
+                    key,
+                    bucket,
+                    objectMd,
+                    log,
+                    assert.ifError,
+                );
+                testClient.objectDeleteTagging(
+                    key,
+                    bucket,
+                    objectMd,
+                    log,
+                    (err) => {
+                        assert.ifError(err);
+                        done();
+                    },
+                );
+            });
+
+            it(`${backend.name} objectPutTagging() then objectDeleteTagging() with versionId`, done => {
+                const key = {
+                    key: 'externalBackendTestBucket/externalBackendTestKey',
+                    dataStoreName: backend.config.dataStoreName,
+                    response: new stream.PassThrough(),
+                };
+                const bucket = new DummyBucket(backend.config.bucketName);
+                const objectMd = {
+                    tags: {
+                        Key1: 'value_1',
+                        Key2: 'value_2',
+                    },
+                    versionId: 'latestversion',
+                };
+                testClient.objectPutTagging(
+                    key,
+                    bucket,
+                    objectMd,
+                    log,
+                    assert.ifError,
+                );
+                testClient.objectDeleteTagging(
+                    key,
+                    bucket,
+                    objectMd,
+                    log,
+                    (err) => {
+                        assert.ifError(err);
+                        done();
+                    },
+                );
+            });
+        }
         // To-Do: test the other external client methods (delete, createMPU ...)
     });
 });


### PR DESCRIPTION
do not use the version stored in the location object,
use the object version located in the object metadata.

quick fix on the way, use actual string instead of object
when building object key (for the bucket part).