### PR TITLE
Bugfix/ARSN-22 fix put delete tagging

### DIFF
--- a/lib/storage/data/external/AwsClient.js
+++ b/lib/storage/data/external/AwsClient.js
@@ -485,7 +485,7 @@ class AwsClient {
 
     objectPutTagging(key, bucket, objectMD, log, callback) {
         const awsBucket = this._awsBucketName;
-        const awsKey = this._createAwsKey(bucket, key, this._bucketMatch);
+        const awsKey = this._createAwsKey(bucket.getName(), key, this._bucketMatch);
         const dataStoreVersionId = objectMD.location[0].dataStoreVersionId;
         const tagParams = {
             Bucket: awsBucket,
@@ -514,7 +514,7 @@ class AwsClient {
 
     objectDeleteTagging(key, bucket, objectMD, log, callback) {
         const awsBucket = this._awsBucketName;
-        const awsKey = this._createAwsKey(bucket, key, this._bucketMatch);
+        const awsKey = this._createAwsKey(bucket.getName(), key, this._bucketMatch);
         const dataStoreVersionId = objectMD.location[0].dataStoreVersionId;
         const tagParams = {
             Bucket: awsBucket,

--- a/tests/unit/storage/data/external/ExternalClients.js
+++ b/tests/unit/storage/data/external/ExternalClients.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const async = require('async');
 const stream = require('stream');
 
 const AwsClient = require('../../../../../lib/storage/data/external/AwsClient');
@@ -7,6 +8,7 @@ const AzureClient =
     require('../../../../../lib/storage/data/external/AzureClient');
 const DummyService = require('../DummyService');
 const { DummyRequestLogger } = require('../../../helpers');
+const BucketInfo = require('../../../../../lib/models/BucketInfo');
 
 const backendClients = [
     {
@@ -154,6 +156,68 @@ describe('external backend clients', () => {
                     });
             });
         });
+
+        if (backend.config.type !== 'azure') {
+            it(`${backend.name} should set tags and then delete it`, done => {
+                const key = 'externalBackendTestKey';
+                const bucketData = {
+                    _name: 'externalBackendTestBucket',
+                    _owner: 'abcdef0123456789',
+                    _ownerDisplayName: 'UnitTestOwner',
+                    _creationDate: '2021-10-05T08:59:12.546Z',
+                };
+                const bucket = BucketInfo.fromObj(bucketData);
+                const objectMd = {
+                    tags: {
+                        Key1: 'value_1',
+                        Key2: 'value_2',
+                    },
+                    location: [
+                        {
+                            dataStoreVersionId: 'latestversion',
+                        },
+                    ],
+                };
+                async.series([
+                    next => testClient.objectPutTagging(key.key, bucket, objectMd, log, next),
+                    next => testClient.objectDeleteTagging(key.Key, bucket, objectMd, log, next),
+                ], done);
+            });
+
+            it(`${backend.name} should fail to set tag on missing key`, done => {
+                const key = 'externalBackendMissingKey';
+                const bucketData = {
+                    _name: 'externalBackendTestBucket',
+                    _owner: 'abcdef0123456789',
+                    _ownerDisplayName: 'UnitTestOwner',
+                    _creationDate: '2021-10-05T08:59:12.546Z',
+                };
+                const bucket = BucketInfo.fromObj(bucketData);
+                const objectMD = {
+                    tags: {
+                        Key1: 'value_1',
+                    },
+                    location: [
+                        {
+                            dataStoreVersionId: 'latestversion',
+                        },
+                    ],
+                };
+                async.series(
+                    [
+                        next => testClient.objectPutTagging(key, bucket, objectMD, log, (err) => {
+                            assert(err.ServiceUnavailable);
+                            next();
+                        }),
+                        next => testClient.objectDeleteTagging(key, bucket, objectMD, log, (err) => {
+                            assert(err.ServiceUnavailable);
+                            next();
+                        }),
+                    ],
+                    done,
+                );
+            });
+        }
         // To-Do: test the other external client methods (delete, createMPU ...)
     });
 });


### PR DESCRIPTION
when sending command (put|delete)-object-tagging AWS interface receives a bucket as argument and
when creating the key should only send the name of the bucket and not the whole bucket object.

Added a test on put/delete tagging methods.