### PR TITLE
Bugfix/arsn 31 invalid query params

### DIFF
--- a/lib/auth/v4/awsURIencode.js
+++ b/lib/auth/v4/awsURIencode.js
@@ -35,6 +35,13 @@ function _toHexUTF8(char) {
 function awsURIencode(input, encodeSlash, noEncodeStar) {
     const encSlash = encodeSlash === undefined ? true : encodeSlash;
     let encoded = '';
+    /**
+     * Duplicate query params are not suppported by AWS S3 APIs. These params
+     * are parsed as Arrays by Node.js HTTP parser which breaks this method
+    */
+    if (typeof input !== 'string') {
+        return encoded;
+    }
     for (let i = 0; i < input.length; i++) {
         const ch = input.charAt(i);
         if ((ch >= 'A' && ch <= 'Z') ||

--- a/tests/unit/auth/v4/awsURIencode.js
+++ b/tests/unit/auth/v4/awsURIencode.js
@@ -53,4 +53,12 @@ describe('should URIencode in accordance with AWS rules', () => {
         const actualOutput = awsURIencode(input);
         assert.strictEqual(actualOutput, expectedOutput);
     });
+
+    it('should skip invalid query params', () => {
+        const input = ['s3:ObjectCreated:*', 's3:ObjectRemoved:*',
+            's3:BucketCreated:*', 's3:BucketRemoved:*'];
+        const expectedOutput = '';
+        const actualOutput = awsURIencode(input);
+        assert.strictEqual(actualOutput, expectedOutput);
+    });
 });


### PR DESCRIPTION
-  test: test for invalid type for encoding strings 
-  bugfix: ARSN-31 return empty string for invalid requests