### PR TITLE
INTEGRATION [PR#1602 > development/7.10] Bugfix/arsn 31 invalid query params

### DIFF
--- a/lib/auth/v4/awsURIencode.js
+++ b/lib/auth/v4/awsURIencode.js
@@ -35,6 +35,13 @@ function _toHexUTF8(char) {
 function awsURIencode(input, encodeSlash, noEncodeStar) {
     const encSlash = encodeSlash === undefined ? true : encodeSlash;
     let encoded = '';
+    /**
+     * Duplicate query params are not suppported by AWS S3 APIs. These params
+     * are parsed as Arrays by Node.js HTTP parser which breaks this method
+    */
+    if (typeof input !== 'string') {
+        return encoded;
+    }
     for (let i = 0; i < input.length; i++) {
         const ch = input.charAt(i);
         if ((ch >= 'A' && ch <= 'Z') ||

--- a/tests/unit/auth/v4/awsURIencode.js
+++ b/tests/unit/auth/v4/awsURIencode.js
@@ -53,4 +53,12 @@ describe('should URIencode in accordance with AWS rules', () => {
         const actualOutput = awsURIencode(input);
         assert.strictEqual(actualOutput, expectedOutput);
     });
+
+    it('should skip invalid query params', () => {
+        const input = ['s3:ObjectCreated:*', 's3:ObjectRemoved:*',
+            's3:BucketCreated:*', 's3:BucketRemoved:*'];
+        const expectedOutput = '';
+        const actualOutput = awsURIencode(input);
+        assert.strictEqual(actualOutput, expectedOutput);
+    });
 });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1602.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.10/bugfix/ARSN-31-invalid-query-params`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.10/bugfix/ARSN-31-invalid-query-params
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.10/bugfix/ARSN-31-invalid-query-params
```

Please always comment pull request #1602 instead of this one.