### PR TITLE
INTEGRATION [PR#1615 > development/7.10] feature: ARSN-38 introduce replay prefix hidden in listings

### DIFF
--- a/lib/algos/list/delimiterMaster.js
+++ b/lib/algos/list/delimiterMaster.js
@@ -32,6 +32,7 @@ class DelimiterMaster extends Delimiter {
         // non-PHD master version or a version whose master is a PHD version
         this.prvKey = undefined;
         this.prvPHDKey = undefined;
+        this.inReplayPrefix = false;
 
         Object.assign(this, {
             [BucketVersioningKeyFormat.v0]: {
@@ -60,6 +61,12 @@ class DelimiterMaster extends Delimiter {
     filterV0(obj) {
         let key = obj.key;
         const value = obj.value;
+
+        if (key.startsWith(DbPrefixes.Replay)) {
+            this.inReplayPrefix = true;
+            return FILTER_SKIP;
+        }
+        this.inReplayPrefix = false;
 
         /* Skip keys not starting with the prefix or not alphabetically
          * ordered. */
@@ -155,7 +162,7 @@ class DelimiterMaster extends Delimiter {
         return super.filter(obj);
     }
 
-    skippingV0() {
+    skippingBase() {
         if (this[this.nextContinueMarker]) {
             // next marker or next continuation token:
             // - foo/ : skipping foo/
@@ -170,8 +177,15 @@ class DelimiterMaster extends Delimiter {
         return SKIP_NONE;
     }
 
+    skippingV0() {
+        if (this.inReplayPrefix) {
+            return DbPrefixes.Replay;
+        }
+        return this.skippingBase();
+    }
+
     skippingV1() {
-        const skipTo = this.skippingV0();
+        const skipTo = this.skippingBase();
         if (skipTo === SKIP_NONE) {
             return SKIP_NONE;
         }

--- a/lib/algos/list/delimiterVersions.js
+++ b/lib/algos/list/delimiterVersions.js
@@ -33,6 +33,7 @@ class DelimiterVersions extends Delimiter {
         // listing results
         this.NextMarker = parameters.keyMarker;
         this.NextVersionIdMarker = undefined;
+        this.inReplayPrefix = false;
 
         Object.assign(this, {
             [BucketVersioningKeyFormat.v0]: {
@@ -163,6 +164,12 @@ class DelimiterVersions extends Delimiter {
      *  @return {number}          - indicates if iteration should continue
      */
     filterV0(obj) {
+        if (obj.key.startsWith(DbPrefixes.Replay)) {
+            this.inReplayPrefix = true;
+            return FILTER_SKIP;
+        }
+        this.inReplayPrefix = false;
+
         if (Version.isPHD(obj.value)) {
             // return accept to avoid skipping the next values in range
             return FILTER_ACCEPT;
@@ -224,6 +231,9 @@ class DelimiterVersions extends Delimiter {
     }
 
     skippingV0() {
+        if (this.inReplayPrefix) {
+            return DbPrefixes.Replay;
+        }
         if (this.NextMarker) {
             const index = this.NextMarker.lastIndexOf(this.delimiter);
             if (index === this.NextMarker.length - 1) {

--- a/lib/versioning/constants.js
+++ b/lib/versioning/constants.js
@@ -5,6 +5,7 @@ module.exports.VersioningConstants = {
     DbPrefixes: {
         Master: '\x7fM',
         Version: '\x7fV',
+        Replay: '\x7fR',
     },
     BucketVersioningKeyFormat: {
         current: 'v1',


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1615.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.10/feature/ARSN-38-replayPrefixHiddenInListings`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.10/feature/ARSN-38-replayPrefixHiddenInListings
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.10/feature/ARSN-38-replayPrefixHiddenInListings
```

Please always comment pull request #1615 instead of this one.