### PR TITLE
ARSN-40: fix count-items helper to parse content-length as number

### DIFF
--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -1458,14 +1458,21 @@ class MongoClientInterface {
      */
     _processEntryData(entry, isTransient) {
         const results = {};
+
+        const size = Number.parseInt(entry.value['content-length'], 10);
+        if (Number.isNaN(size)) {
+            return {
+                data: {},
+                error: new Error('invalid content length'),
+            };
+        }
+
         if (!isTransient ||
             entry.value.replicationInfo.status !== 'COMPLETED') {
             if (results[entry.value.dataStoreName]) {
-                results[entry.value.dataStoreName] +=
-                    entry.value['content-length'];
+                results[entry.value.dataStoreName] += size;
             } else {
-                results[entry.value.dataStoreName] =
-                    entry.value['content-length'];
+                results[entry.value.dataStoreName] = size;
             }
         } else {
             if (!results[entry.value.dataStoreName]) {
@@ -1475,13 +1482,16 @@ class MongoClientInterface {
         entry.value.replicationInfo.backends.forEach(rep => {
             if (rep.status === 'COMPLETED') {
                 if (results[rep.site]) {
-                    results[rep.site] += entry.value['content-length'];
+                    results[rep.site] += size;
                 } else {
-                    results[rep.site] = entry.value['content-length'];
+                    results[rep.site] = size;
                 }
             }
         });
-        return results;
+        return {
+            data: results,
+            error: null,
+        };
     }
 
     /**
@@ -1531,7 +1541,16 @@ class MongoClientInterface {
 
         cursor.forEach(
             res => {
-                const data = this._processEntryData(res, isTransient);
+                const { data, error } = this._processEntryData(res, isTransient);
+
+                if (error) {
+                    log.error('Failed to process entry data', {
+                        method: 'getObjectMDStats',
+                        entry: res,
+                        error,
+                    });
+                }
+
                 let targetCount;
                 let targetData;
                 if (res._id.indexOf('\0') !== -1) {

--- a/tests/unit/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/tests/unit/storage/metadata/mongoclient/MongoClientInterface.js
@@ -128,7 +128,10 @@ describe('MongoClientInterface::_processEntryData', () => {
                 },
             },
             {
-                'us-east-1': 42,
+                data: {
+                    'us-east-1': 42,
+                },
+                error: null,
             },
         ],
         [
@@ -156,7 +159,10 @@ describe('MongoClientInterface::_processEntryData', () => {
                 },
             },
             {
-                'us-east-1': 0,
+                data: {
+                    'us-east-1': 0,
+                },
+                error: null,
             },
         ],
         [
@@ -184,7 +190,10 @@ describe('MongoClientInterface::_processEntryData', () => {
                 },
             },
             {
-                'us-east-1': 42,
+                data: {
+                    'us-east-1': 42,
+                },
+                error: null,
             },
         ],
         [
@@ -212,7 +221,10 @@ describe('MongoClientInterface::_processEntryData', () => {
                 },
             },
             {
-                'us-east-1': 42,
+                data: {
+                    'us-east-1': 42,
+                },
+                error: null,
             },
         ],
         [
@@ -253,10 +265,13 @@ describe('MongoClientInterface::_processEntryData', () => {
                 },
             },
             {
-                'us-east-1': 0,
-                'completed-1': 42,
-                'completed-2': 42,
-                'completed-3': 42,
+                data: {
+                    'us-east-1': 0,
+                    'completed-1': 42,
+                    'completed-2': 42,
+                    'completed-3': 42,
+                },
+                error: null,
             },
         ],
         [
@@ -297,9 +312,83 @@ describe('MongoClientInterface::_processEntryData', () => {
                 },
             },
             {
-                'us-east-1': 42,
-                'completed-1': 42,
-                'completed-2': 42,
+                data: {
+                    'us-east-1': 42,
+                    'completed-1': 42,
+                    'completed-2': 42,
+                },
+                error: null,
+            },
+        ],
+        [
+            'should error if content-length is invalid',
+            true,
+            {
+                _id: 'testkey',
+                value: {
+                    'last-modified': new Date(),
+                    'replicationInfo': {
+                        status: 'PENDING',
+                        backends: [
+                            {
+                                status: 'PENDING',
+                                site: 'not-completed',
+                            },
+                            {
+                                status: 'COMPLETED',
+                                site: 'completed-1',
+                            },
+                            {
+                                status: 'COMPLETED',
+                                site: 'completed-2',
+                            },
+                        ],
+                        content: [],
+                        destination: '',
+                        storageClass: '',
+                        role: '',
+                        storageType: '',
+                        dataStoreVersionId: '',
+                        isNFS: null,
+                    },
+                    'dataStoreName': 'us-east-1',
+                    'content-length': 'not-a-number',
+                    'versionId': '0123456789abcdefg',
+                },
+            },
+            {
+                data: {},
+                error: new Error('invalid content length'),
+            },
+        ],
+        [
+            'should correctly process entry with string typed content-length',
+            true,
+            {
+                _id: 'testkey',
+                value: {
+                    'last-modified': new Date(),
+                    'replicationInfo': {
+                        status: 'PENDING',
+                        backends: [],
+                        content: [],
+                        destination: '',
+                        storageClass: '',
+                        role: '',
+                        storageType: '',
+                        dataStoreVersionId: '',
+                        isNFS: null,
+                    },
+                    'dataStoreName': 'us-east-1',
+                    'content-length': '42',
+                    'versionId': '0123456789abcdefg',
+                },
+            },
+            {
+                data: {
+                    'us-east-1': 42,
+                },
+                error: null,
             },
         ],
     ];


### PR DESCRIPTION
Update `MongoClientInterface::getObjectMDStats` to parse entries'
`content-length` as numbers. This is needed to avoid performing
calcuulation with poosible mixed types.

The ticket [ZENKO-3711](https://scality.atlassian.net/browse/ZENKO-3711)
tracks the source of the string typed `content-length` insert.