### PR TITLE
[HOTFIX 7.4.9.4] feature: ARSN-37 ObjectMD getUploadId/setUploadId

### DIFF
--- a/lib/models/ObjectMD.js
+++ b/lib/models/ObjectMD.js
@@ -112,6 +112,7 @@ class ObjectMD {
             'nullVersionId': undefined,
             'isDeleteMarker': undefined,
             'versionId': undefined,
+            'uploadId': undefined,
             'tags': {},
             'replicationInfo': {
                 status: '',
@@ -678,6 +679,26 @@ class ObjectMD {
      */
     getEncodedVersionId() {
         return VersionIDUtils.encode(this.getVersionId());
+    }
+
+    /**
+     * Set metadata uploadId value
+     *
+     * @param {string} uploadId - The upload ID used to complete the MPU object
+     * @return {ObjectMD} itself
+     */
+    setUploadId(uploadId) {
+        this._data.uploadId = uploadId;
+        return this;
+    }
+
+    /**
+     * Get metadata uploadId value
+     *
+     * @return {string|undefined} The object uploadId
+     */
+    getUploadId() {
+        return this._data.uploadId;
     }
 
     /**

--- a/tests/unit/models/object.js
+++ b/tests/unit/models/object.js
@@ -73,6 +73,8 @@ describe('ObjectMD class setters/getters', () => {
             key: 'value',
         }],
         ['Tags', null, {}],
+        ['UploadId', null, undefined],
+        ['UploadId', 'abcdefghi'],
         ['ReplicationInfo', null, {
             status: '',
             backends: [],
@@ -310,6 +312,7 @@ describe('getAttributes static method', () => {
             'isDeleteMarker': true,
             'versionId': true,
             'tags': true,
+            'uploadId': true,
             'replicationInfo': true,
             'dataStoreName': true,
             'last-modified': true,


### PR DESCRIPTION
Add getter/setter for the "uploadId" field, used for MPUs in progress.

(cherry picked from commit b1c9474159579d4f8487d2b9d8cbc73402a2c3d9)