### PR TITLE
ARSN-44 Expose backbeat metrics on standard path

### DIFF
--- a/lib/network/probe/ProbeServer.js
+++ b/lib/network/probe/ProbeServer.js
@@ -4,7 +4,7 @@ const errors = require('../../errors');
 
 const DEFAULT_LIVE_ROUTE = '/_/live';
 const DEFAULT_READY_ROUTE = '/_/ready';
-const DEFAULT_METRICS_ROUTE = '/_/metrics';
+const DEFAULT_METRICS_ROUTE = '/metrics';
 
 /**
  * ProbeDelegate is used to handle probe checks.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=8"
   },
-  "version": "8.1.15",
+  "version": "8.1.17",
   "description": "Common utilities for the S3 project components",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Update `DEFAULT_METRICS_ROUTE` to `/metrics`.
Right now, `DEFAULT_METRICS_ROUTE` is only used in backbeat for the following processes:

BackbeatIngestionProcessor "npm run mongo_queue_processor"
BackbeatIngestionProducer "npm run ingestion_populator"

BackbeatReplicationDataProcessor "npm run queue_processor"
BackbeatReplicationProducer "npm run queue_populator"
BackbeatReplicationStatusProcessor "npm run replication_status_processor"

BackbeatLifecycleConductor "npm run lifecycle_conductor"
BackbeatLifecycleBucketProcessor "npm run lifecycle_bucket_processor"
BackbeatLifecycleObjectProcessor "npm run lifecycle_object_processor"
BackbeatGC "npm run garbage_collector"