### PR TITLE
bugfix: ARSN-45-mergePolicy-ignore-versionId

### DIFF
--- a/lib/auth/backends/ChainBackend.js
+++ b/lib/auth/backends/ChainBackend.js
@@ -120,22 +120,24 @@ class ChainBackend extends BaseBackend {
             }
 
             resp.message.body.forEach(policy => {
-                const arn = policy.arn || '';
-                if (!policyMap[arn]) {
-                    policyMap[arn] = policy.isAllowed;
+                const key = (policy.arn || '') + (policy.versionId || '');
+                if (!policyMap[key] || !policyMap[key].isAllowed) {
+                    policyMap[key] = policy;
                 }
                 // else is duplicate policy
             });
         });
 
-        const policyList = Object.keys(policyMap).map(arn => {
-            if (arn === '') {
-                return { isAllowed: policyMap[arn] };
+        return Object.keys(policyMap).map(key => {
+            const policyRes = { isAllowed: policyMap[key].isAllowed };
+            if (policyMap[key].arn !== '') {
+                policyRes.arn = policyMap[key].arn;
             }
-            return { isAllowed: policyMap[arn], arn };
+            if (policyMap[key].versionId) {
+                policyRes.versionId = policyMap[key].versionId;
+            }
+            return policyRes;
         });
-
-        return policyList;
     }
 
     /*

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=8"
   },
-  "version": "8.1.17",
+  "version": "8.1.18",
   "description": "Common utilities for the S3 project components",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
In cloudserver, for auth ChainBackend,  while merging policies, it de-duplicates policies with the same resource arn, but for s3 multiObjectDelete operation, if we try to delete the same object with different versionIds, it will still de-duplicate policies into one policy which cause vault can't receive the correct number of result.

So now we need to de-duplicate policies by a unique key arn+versionId and also return versionId as part of policy result.