### PR TITLE
INTEGRATION [PR#1611 > development/7.10] bugfix: ARSN-35 add http header too large error

### DIFF
--- a/errors/arsenalErrors.json
+++ b/errors/arsenalErrors.json
@@ -56,6 +56,10 @@
     "code": 400,
     "description": "The provided token has expired."
   },
+  "HttpHeadersTooLarge": {
+    "code": 400,
+    "description": "Your http headers exceed the maximum allowed http headers size."
+  },
   "IllegalVersioningConfigurationException": {
     "code": 400,
     "description": "Indicates that the versioning configuration specified in the request is invalid."


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1611.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.10/bugfix/ARSN-35/add-http-header-too-large-error`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.10/bugfix/ARSN-35/add-http-header-too-large-error
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.10/bugfix/ARSN-35/add-http-header-too-large-error
```

Please always comment pull request #1611 instead of this one.