### PR TITLE
INTEGRATION [PR#1674 > development/8.1] bf: ARSN-50 object retention date with sub seconds should not fail

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -75,9 +75,6 @@ module.exports = {
     // Default expiration value of the S3 pre-signed URL duration
     // 604800 seconds (seven days).
     defaultPreSignedURLExpiry: 7 * 24 * 60 * 60,
-    // Regex for ISO-8601 formatted date
-    shortIso8601Regex: /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/,
-    longIso8601Regex: /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/,
     supportedNotificationEvents: new Set([
         's3:ObjectCreated:*',
         's3:ObjectCreated:Put',

--- a/lib/s3middleware/objectRetention.js
+++ b/lib/s3middleware/objectRetention.js
@@ -50,13 +50,13 @@ function validateRetainDate(retainDate) {
             'request xml does not contain RetainUntilDate');
         return dateObj;
     }
-    if (!constants.shortIso8601Regex.test(retainDate[0]) &&
-        !constants.longIso8601Regex.test(retainDate[0])) {
+    const retentionDate = Date.parse(retainDate[0]);
+    if (isNaN(retentionDate)) {
         dateObj.error = errors.InvalidRequest.customizeDescription(
-            'RetainUntilDate timestamp must be ISO-8601 format');
+            'RetainUntilDate is not a valid timestamp');
         return dateObj;
     }
-    const date = new Date(retainDate[0]);
+    const date = new Date(retentionDate);
     if (date < Date.now()) {
         dateObj.error = errors.InvalidRequest.customizeDescription(
             'RetainUntilDate must be in the future');


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1674.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/ARSN-50-object-retention-date-with-sub-seconds-fails`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/ARSN-50-object-retention-date-with-sub-seconds-fails
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/ARSN-50-object-retention-date-with-sub-seconds-fails
```

Please always comment pull request #1674 instead of this one.