### PR TITLE
ARSN-62: include session token in v4 signature calculation

### DIFF
--- a/lib/auth/auth.js
+++ b/lib/auth/auth.js
@@ -154,10 +154,12 @@ function doAuth(request, log, cb, awsService, requestContexts) {
  * @param {string} secretKeyValue - the secretKey
  * @param {string} awsService - Aws service related
  * @param {sting} [proxyPath] - path that gets proxied by reverse proxy
+ * @param {string} [sessionToken] - security token if the access/secret keys
+ *                                are temporary credentials from STS
  * @return {undefined}
  */
 function generateV4Headers(request, data, accessKey, secretKeyValue,
-                           awsService, proxyPath) {
+                           awsService, proxyPath, sessionToken) {
     Object.assign(request, { headers: {} });
     const amzDate = convertUTCtoISO8601(Date.now());
     // get date without time
@@ -180,6 +182,11 @@ function generateV4Headers(request, data, accessKey, secretKeyValue,
     request.setHeader('host', request._headers.host);
     request.setHeader('x-amz-date', amzDate);
     request.setHeader('x-amz-content-sha256', payloadChecksum);
+
+    if (sessionToken) {
+        request.setHeader('x-amz-security-token', sessionToken);
+    }
+
     Object.assign(request.headers, request._headers);
     const signedHeaders = Object.keys(request._headers)
         .filter(headerName =>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.10.9",
+  "version": "7.10.11",
   "description": "Common utilities for the S3 project components",
   "main": "index.js",
   "repository": {

--- a/tests/unit/auth/v4/generateV4Headers.js
+++ b/tests/unit/auth/v4/generateV4Headers.js
@@ -1,0 +1,40 @@
+'use strict'; // eslint-disable-line strict
+
+const assert = require('assert');
+const http = require('http');
+
+const { generateV4Headers } = require('../../../../lib/auth/auth').client;
+
+const host = 'localhost:8000';
+const token = 'token';
+const data = 'data';
+
+describe('v4 header generation', () => {
+    it('should add x-amz-security-token if needed', done => {
+        const req = new http.OutgoingMessage();
+        req.setHeader('host', host);
+
+        generateV4Headers(req, data, 'accessKey', 'secretKey', 'iam', null, token);
+
+        try {
+            assert.deepStrictEqual(req.getHeader('x-amz-security-token'), token);
+            return done();
+        } catch (err) {
+            return done(err);
+        }
+    });
+
+    it('should not add x-amz-security-token by default', done => {
+        const req = new http.OutgoingMessage();
+        req.setHeader('host', host);
+
+        generateV4Headers(req, data, 'accessKey', 'secretKey', 'iam');
+
+        try {
+            assert.deepStrictEqual(req.getHeader('x-amz-security-token'), undefined);
+            return done();
+        } catch (err) {
+            return done(err);
+        }
+    });
+});


### PR DESCRIPTION
Adds STS session token to requests and generated AWSV4 signature when required. This will help vaultclient perform admin actions against Vault using assumed role credentials.