### PR TITLE
INTEGRATION [PR#1726 > development/7.10] ft: ARSN-87 some versioning exports are still missing for Armory

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,9 @@ module.exports = {
             .VersioningConstants,
         Version: require('./lib/versioning/Version.js').Version,
         VersionID: require('./lib/versioning/VersionID.js'),
+        WriteGatheringManager: require('./lib/versioning/WriteGatheringManager.js'),
+        WriteCache: require('./lib/versioning/WriteCache.js'),
+        VersioningRequestProcessor: require('./lib/versioning/VersioningRequestProcessor.js'),
     },
     network: {
         http: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.4.16",
+  "version": "7.4.17",
   "description": "Common utilities for the S3 project components",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1726.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.10/feature/ARSN-87-versioning-exports-missing`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.10/feature/ARSN-87-versioning-exports-missing
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.10/feature/ARSN-87-versioning-exports-missing
```

Please always comment pull request #1726 instead of this one.