### PR TITLE
bugfix: ARSN-115 Fix listing algo returning phd

### DIFF
--- a/lib/algos/list/delimiterVersions.js
+++ b/lib/algos/list/delimiterVersions.js
@@ -190,6 +190,10 @@ class DelimiterVersions extends Delimiter {
      *  @return {number}          - indicates if iteration should continue
      */
     filterV1(obj) {
+        if (Version.isPHD(obj.value)) {
+            // return accept to avoid skipping the next values in range
+            return FILTER_ACCEPT;
+        }
         // this function receives both M and V keys, but their prefix
         // length is the same so we can remove their prefix without
         // looking at the type of key

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "8.1.33",
+  "version": "8.1.34",
   "description": "Common utilities for the S3 project components",
   "main": "index.js",
   "repository": {

--- a/tests/unit/algos/list/delimiterVersions.spec.js
+++ b/tests/unit/algos/list/delimiterVersions.spec.js
@@ -933,91 +933,92 @@ function getTestListing(test, data, vFormat) {
             });
         });
 
-        if (vFormat === 'v0') {
-            it('should accept a PHD version as first input', () => {
-                const delimiter = new DelimiterVersions({}, logger, vFormat);
-                const keyPHD = 'keyPHD';
-                const objPHD = {
-                    key: keyPHD,
-                    value: Version.generatePHDVersion(generateVersionId('', '')),
-                };
+        it('should accept a PHD version as first input', () => {
+            const delimiter = new DelimiterVersions({}, logger, vFormat);
+            const keyPHD = 'keyPHD';
+            const objPHD = {
+                key: getListingKey(keyPHD, vFormat),
+                value: Version.generatePHDVersion(generateVersionId('', '')),
+            };
 
-                /* When filtered, it should return FILTER_ACCEPT and set the prvKey
-                 * to undefined. It should not be added to the result content or common
-                 * prefixes. */
-                assert.strictEqual(delimiter.filter(objPHD), FILTER_ACCEPT);
-                assert.strictEqual(delimiter.prvKey, undefined);
-                assert.strictEqual(delimiter.NextMarker, undefined);
-                assert.deepStrictEqual(delimiter.result(), EmptyResult);
+            /* When filtered, it should return FILTER_ACCEPT and set the prvKey
+                * to undefined. It should not be added to the result content or common
+                * prefixes. */
+            assert.strictEqual(delimiter.filter(objPHD), FILTER_ACCEPT);
+            assert.strictEqual(delimiter.prvKey, undefined);
+            assert.strictEqual(delimiter.NextMarker, undefined);
+            assert.deepStrictEqual(delimiter.result(), EmptyResult);
+        });
+
+        it('should accept a PHD version', () => {
+            const delimiter = new DelimiterVersions({}, logger, vFormat);
+            const key = 'keyA';
+            const value = '';
+            const keyPHD = 'keyBPHD';
+            const objPHD = {
+                key: getListingKey(keyPHD, vFormat),
+                value: Version.generatePHDVersion(generateVersionId('', '')),
+            };
+
+            /* Filter a master version to set the NextMarker and add
+                * and element in result content. */
+            delimiter.filter({
+                key: getListingKey(key, vFormat),
+                value,
             });
 
-            it('should accept a PHD version', () => {
-                const delimiter = new DelimiterVersions({}, logger, vFormat);
-                const key = 'keyA';
-                const value = '';
-                const keyPHD = 'keyBPHD';
-                const objPHD = {
-                    key: keyPHD,
-                    value: Version.generatePHDVersion(generateVersionId('', '')),
-                };
-
-                /* Filter a master version to set the NextMarker and add
-                 * and element in result content. */
-                delimiter.filter({ key, value });
-
-                /* When filtered, it should return FILTER_ACCEPT. It
-                 * should not be added to the result content or common
-                 * prefixes. */
-                assert.strictEqual(delimiter.filter(objPHD), FILTER_ACCEPT);
-                assert.strictEqual(delimiter.prvKey, undefined);
-                assert.strictEqual(delimiter.NextMarker, key);
-                assert.deepStrictEqual(delimiter.result(), {
-                    CommonPrefixes: [],
-                    Versions: [{
-                        key: 'keyA',
-                        value: '',
-                        versionId: 'null',
-                    }],
-                    Delimiter: undefined,
-                    IsTruncated: false,
-                    NextKeyMarker: undefined,
-                    NextVersionIdMarker: undefined,
-                });
+            /* When filtered, it should return FILTER_ACCEPT. It
+                * should not be added to the result content or common
+                * prefixes. */
+            assert.strictEqual(delimiter.filter(objPHD), FILTER_ACCEPT);
+            assert.strictEqual(delimiter.prvKey, undefined);
+            assert.strictEqual(delimiter.NextMarker, key);
+            assert.deepStrictEqual(delimiter.result(), {
+                CommonPrefixes: [],
+                Versions: [{
+                    key: 'keyA',
+                    value: '',
+                    versionId: 'null',
+                }],
+                Delimiter: undefined,
+                IsTruncated: false,
+                NextKeyMarker: undefined,
+                NextVersionIdMarker: undefined,
             });
+        });
 
-            it('should accept a version after a PHD', () => {
-                const delimiter = new DelimiterVersions({}, logger, vFormat);
-                const masterKey = 'key';
-                const keyVersion = `${masterKey}${VID_SEP}version`;
-                const value = '';
-                const objPHD = {
-                    key: masterKey,
-                    value: Version.generatePHDVersion(generateVersionId('', '')),
-                };
+        it('should accept a version after a PHD', () => {
+            const delimiter = new DelimiterVersions({}, logger, vFormat);
+            const masterKey = 'key';
+            const keyVersion = `${masterKey}${VID_SEP}version`;
+            const value = '';
+            const objPHD = {
+                key: getListingKey(masterKey, vFormat),
+                value: Version.generatePHDVersion(generateVersionId('', '')),
+            };
 
-                /* Filter the PHD object. */
-                delimiter.filter(objPHD);
+            /* Filter the PHD object. */
+            delimiter.filter(objPHD);
 
-                /* The filtering of the PHD object has no impact, the version is
-                 * accepted and added to the result. */
-                assert.strictEqual(delimiter.filter({
-                    key: keyVersion,
-                    value,
-                }), FILTER_ACCEPT);
-                assert.strictEqual(delimiter.NextMarker, masterKey);
-                assert.deepStrictEqual(delimiter.result(), {
-                    CommonPrefixes: [],
-                    Versions: [{
-                        key: 'key',
-                        value: '',
-                        versionId: 'version',
-                    }],
-                    Delimiter: undefined,
-                    IsTruncated: false,
-                    NextKeyMarker: undefined,
-                    NextVersionIdMarker: undefined,
-                });
+            /* The filtering of the PHD object has no impact, the version is
+                * accepted and added to the result. */
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(keyVersion, vFormat),
+                value,
+            }), FILTER_ACCEPT);
+            assert.strictEqual(delimiter.NextMarker, masterKey);
+            assert.deepStrictEqual(delimiter.result(), {
+                CommonPrefixes: [],
+                Versions: [{
+                    key: 'key',
+                    value: '',
+                    versionId: 'version',
+                }],
+                Delimiter: undefined,
+                IsTruncated: false,
+                NextKeyMarker: undefined,
+                NextVersionIdMarker: undefined,
             });
-        }
+        });
     });
 });


### PR DESCRIPTION
In the metadata backend, PHD master is not created in v1 hence
it wasn't considered in the skipping method, in the Mongo implementation
however the PHD keys need to be taken into consideration as they are still
created