### PR TITLE
Bugfix: arsn 116 fix listing master returning phd

### DIFF
--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -16,6 +16,7 @@ const constants = require('../../../constants');
 const { reshapeExceptionError } = require('../../../errorUtils');
 const errors = require('../../../errors');
 const BucketInfo = require('../../../models/BucketInfo');
+const jsutil = require('../../../jsutil');
 
 const MongoClient = require('mongodb').MongoClient;
 const Uuid = require('uuid');
@@ -29,6 +30,8 @@ const MongoReadStream = require('./readStream');
 const MongoUtils = require('./utils');
 const Skip = require('../../../algos/list/skip');
 const MergeStream = require('../../../algos/stream/MergeStream');
+const { Transform } = require('stream');
+const { Version } = require('../../../versioning/Version');
 
 const { formatMasterKey, formatVersionKey } = require('./utils');
 
@@ -52,6 +55,8 @@ let uidCounter = 0;
 
 const BUCKET_VERSIONS = require('../../../versioning/constants')
     .VersioningConstants.BucketVersioningKeyFormat;
+const DB_PREFIXES = require('../../../versioning/constants')
+    .VersioningConstants.DbPrefixes;
 
 function generateVersionId(replicationGroupId) {
     // generate a unique number for each member of the nodejs cluster
@@ -1336,7 +1341,7 @@ class MongoClientInterface {
     }
 
     /**
-     * internal listing function
+     * internal listing function for buckets
      * @param {String} bucketName bucket name
      * @param {Object} params internal listing params
      * @param {Object} params.mainStreamParams internal listing param applied
@@ -1345,16 +1350,55 @@ class MongoClientInterface {
      * to the secondary stream (versionStream when having two streams) (is optional)
      * @param {Object} params.mongifiedSearch search options
      * @param {Object} extension listing extention
+     * @param {String} vFormat bucket format version
      * @param {Object} log logger
      * @param {Function} cb callback
      * @return {undefined}
      */
-    internalListObject(bucketName, params, extension, log, cb) {
+    internalListObject(bucketName, params, extension, vFormat, log, cb) {
         const c = this.getCollection(bucketName);
+        const getLatestVersion = this.getLatestVersion;
         let stream;
         if (!params.secondaryStreamParams) {
+            // listing masters only (DelimiterMaster)
             stream = new MongoReadStream(c, params.mainStreamParams, params.mongifiedSearch);
+            if (vFormat === BUCKET_VERSIONS.v1) {
+                /**
+                 * When listing masters only in v1 we can't just skip PHD
+                 * we have to replace them with the latest version of
+                 * the object.
+                 * Here we use a trasform stream that we pipe with the
+                 * mongo read steam and that checks and replaces the key
+                 * read if it's a PHD
+                 *  */
+                const resolvePhdKey = new Transform({
+                    objectMode: true,
+                    transform(obj, encoding, callback) {
+                        if (Version.isPHD(obj.value)) {
+                            const key = obj.key.slice(DB_PREFIXES.Master.length);
+                            getLatestVersion(c, key, BUCKET_VERSIONS.v1, log, (err, version) => {
+                                if (err) {
+                                    log.error(
+                                        'internalListObjectV1: error while getting latest version of PHD key');
+                                    return callback(errors.InternalError);
+                                }
+                                MongoUtils.unserialize(version);
+                                // we keep the master key and only replace the value
+                                const latestVersion = {
+                                    key: obj.key,
+                                    value: JSON.stringify(version),
+                                };
+                                return callback(null, latestVersion);
+                            });
+                        } else {
+                            callback(null, obj);
+                        }
+                    },
+                });
+                stream = stream.pipe(resolvePhdKey);
+            }
         } else {
+            // listing both master and version keys (delimiterVersion Algo)
             const masterStream = new MongoReadStream(c, params.mainStreamParams, params.mongifiedSearch);
             const versionStream = new MongoReadStream(c, params.secondaryStreamParams, params.mongifiedSearch);
             stream = new MergeStream(
@@ -1366,8 +1410,7 @@ class MongoClientInterface {
             extension,
             gte: gteParams,
         });
-        let cbDone = false;
-
+        const cbOnce = jsutil.once(cb);
         skip.setListingEndCb(() => {
             stream.emit('end');
             stream.destroy();
@@ -1393,28 +1436,22 @@ class MongoClientInterface {
             this.internalListObject(bucketName, newParams, extension, log, cb);
         });
         stream
-            .on('data', e => {
-                skip.filter(e);
+            .on('data', entry => {
+                skip.filter(entry);
             })
             .on('error', err => {
-                if (!cbDone) {
-                    cbDone = true;
-                    const logObj = {
-                        rawError: err,
-                        error: err.message,
-                        errorStack: err.stack,
-                    };
-                    log.error(
-                        'internalListObject: error listing objects', logObj);
-                    cb(errors.InternalError);
-                }
+                const logObj = {
+                    rawError: err,
+                    error: err.message,
+                    errorStack: err.stack,
+                };
+                log.error(
+                    'internalListObjectV1: error listing objects', logObj);
+                cbOnce(errors.InternalError);
             })
             .on('end', () => {
-                if (!cbDone) {
-                    cbDone = true;
-                    const data = extension.result();
-                    cb(null, data);
-                }
+                const data = extension.result();
+                cbOnce(null, data);
             });
         return undefined;
     }
@@ -1452,7 +1489,7 @@ class MongoClientInterface {
             };
             internalParams.mongifiedSearch = params.mongifiedSearch;
             return this.internalListObject(bucketName, internalParams, extension,
-                log, cb);
+                vFormat, log, cb);
         });
     }
 
@@ -1478,7 +1515,7 @@ class MongoClientInterface {
             mongifiedSearch: params.mongifiedSearch,
         };
         return this.internalListObject(bucketName, internalParams, extension,
-            log, cb);
+            BUCKET_VERSIONS.v0, log, cb);
     }
 
     checkHealth(implName, log, cb) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "8.1.36",
+  "version": "8.1.37",
   "description": "Common utilities for the S3 project components",
   "main": "index.js",
   "repository": {

--- a/tests/unit/storage/metadata/mongoclient/listObject.spec.js
+++ b/tests/unit/storage/metadata/mongoclient/listObject.spec.js
@@ -31,7 +31,7 @@ describe('MongoClientInterface:listObject', () => {
     it('should fail when internalListObject fails', done => {
         sinon.stub(client, 'getCollection').callsFake(() => null);
         sinon.stub(client, 'getBucketVFormat').callsFake((bucketName, log, cb) => cb(null, 'v0'));
-        sinon.stub(client, 'internalListObject').callsFake((...args) => args[4](errors.InternalError));
+        sinon.stub(client, 'internalListObject').callsFake((...args) => args[5](errors.InternalError));
         client.listObject('example-bucket', { listingType: 'DelimiterMaster' }, logger, err => {
             assert.deepStrictEqual(err, errors.InternalError);
             return done();


### PR DESCRIPTION
When the last version of an object is deleted a placeholder master key is created and is kept for 15 seconds before it gets repaired.

To avoid listing the PHD keys we added a transform stream that replaces PHD master keys with the last version of that object

For ease of readability, the internal listing function was divided into two functions one for each bucket version format