### PR TITLE
ARSN-149 Release new versions for Arsenal

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.10.17",
+  "version": "7.10.18",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {


### PR DESCRIPTION
# `7.10.18` & `8.1.41`
This PR releases two new versions: `7.10.18` and `8.1.41`.

## Breaking changes: errors

Instead of testing for errors with `err.InternalError`, we got `err.is.InternalError`. Moreover, we changed the error generation, which means `err.InternalError === err.InternalError` is now `false`. This can be a little bit painful, but it allows to have correct stacktraces, which should improve debugging process. Beside that, the API hasn’t changed.

On an other subject, due to the switch to TS, the dependency requirement has changed. Instead of specifying in `package.json` something like `"arsenal": "scality/arsenal#[version-number]"` , you have to switch to `git+https` that way: `"arsenal": "git+https://github.com/scality/Arsenal#[version-number]"`.
It can feels weird at first, but it ensures the TS sources are compiled, and it is subject to change in a near future.

## Timeline

We’ve merged the new format today. You can expect to get the modification as soon as you jump from your actual Arsenal version to `7.10.18` and `8.1.41`. By that time, fix the version number of Arsenal below that version while working on the migration process.