### PR TITLE
feature: ARSN-160 add support for invalid arguments in errors

### DIFF
--- a/lib/s3routes/routesUtils.js
+++ b/lib/s3routes/routesUtils.js
@@ -116,6 +116,15 @@ const XMLResponseBackend = {
             '<Error>',
             `<Code>${errCode.message}</Code>`,
             `<Message>${errCode.description}</Message>`,
+        );
+        let counter = 1;
+        const invalidArguments = errCode.metadata.get('invalidArguments') || [];
+        invalidArguments.forEach(invalidArgument => {
+            xml.push(`<ArgumentName${counter}>${invalidArgument.ArgumentName}</ArgumentName${counter}>`);
+            xml.push(`<ArgumentValue${counter}>${invalidArgument.ArgumentValue}</ArgumentValue${counter}>`);
+            counter++;
+        });
+        xml.push(
             '<Resource></Resource>',
             `<RequestId>${log.getSerializedUids()}</RequestId>`,
             '</Error>',
@@ -176,9 +185,20 @@ const JSONResponseBackend = {
              "requestId": "4442587FB7D0A2F9"
          }
          */
+        let invalidArgumentsStr = '';
+        let counter = 1;
+        const invalidArguments = errCode.metadata.get('invalidArguments') || [];
+        invalidArguments.forEach(invalidArgument => {
+            invalidArgumentsStr = invalidArgumentsStr.concat(`"ArgumentName${counter}":\
+            "${invalidArgument.ArgumentName}",`);
+            invalidArgumentsStr = invalidArgumentsStr.concat(`"ArgumentValue${counter}":\
+            "${invalidArgument.ArgumentValue}",`);
+            counter++;
+        });
         const jsonStr =
                   `{"code":"${errCode.message}",` +
                   `"message":"${errCode.description}",` +
+                  `${invalidArgumentsStr}` +
                   '"resource":null,' +
                   `"requestId":"${log.getSerializedUids()}"}`;
         const bytesSent = Buffer.byteLength(jsonStr);
@@ -409,7 +429,7 @@ function _contentLengthMatchesLocations(contentLength, dataLocations) {
 
 const routesUtils = {
     /**
-     * @param {string} errCode - S3 error Code
+     * @param {ArsenalError} errCode - error object
      * @param {string} xml - xml body as string conforming to S3's spec.
      * @param {object} response - router's response object
      * @param {object} log - Werelogs logger
@@ -423,7 +443,7 @@ const routesUtils = {
     },
 
     /**
-     * @param {string} errCode - S3 error Code
+     * @param {ArsenalError} errCode - error object
      * @param {string} json - JSON body as string conforming to S3's spec.
      * @param {object} response - router's response object
      * @param {object} log - Werelogs logger

--- a/tests/unit/errors.spec.ts
+++ b/tests/unit/errors.spec.ts
@@ -22,6 +22,22 @@ describe('Errors: ', () => {
         expect(custom.is).toHaveProperty('NoSuchEntity', true);
     });
 
+    it('should allow additional metadata fields', () => {
+        const error = errors.InvalidArgument;
+        const originDescription = error.description;
+        const origincode = error.code;
+        const origintype = error.type; // InvalidArgument
+        const custom = error.addMetadataEntry('fieldName', [{ key: 'value' }]);
+        expect(custom.metadata.get('fieldName')).toEqual([{ key: 'value' }]);
+        // Other properties should not change
+        expect(custom.is[origintype]).toBeTruthy()
+        expect(custom.description).toStrictEqual(originDescription);
+        expect(custom.code).toStrictEqual(origincode);
+        expect(custom.type).toStrictEqual(origintype);
+        // The original error should not be modified
+        expect(error.metadata.get('fieldName')).toBeUndefined()
+    });
+
     it('can be used as an http response', () => {
         // @ts-expect-errors
         errors.NoSuchEntity.writeResponse({

--- a/tests/unit/s3routes/routesUtils/responseBody.spec.ts
+++ b/tests/unit/s3routes/routesUtils/responseBody.spec.ts
@@ -1,0 +1,89 @@
+import { errors } from '../../../../index';
+import { responseXMLBody, responseJSONBody } from '../../../../lib/s3routes/routesUtils';
+
+import werelogs from 'werelogs';
+const logger = new werelogs.Logger('test:routesUtils.responseStreamData');
+
+describe('responseXMLBody: ', () => {
+    it('Should include invalid arguments in reponse body', done => {
+        const invalidArgument1 = { ArgumentName: 'argumentName1', ArgumentValue: 'argumentValue1' };
+        const invalidArgument2 = { ArgumentName: 'argumentName2', ArgumentValue: 'argumentValue2' };
+        const error = errors.InvalidArgument.addMetadataEntry('invalidArguments',
+            [invalidArgument1, invalidArgument2]);
+        responseXMLBody(error, '', {
+            setHeader: () => {},
+            writeHead: () => {},
+            on: () => {},
+            once: () => {},
+            emit: () => {},
+            write: () => {},
+            end: (xmlStr) => {
+                expect(xmlStr.includes('<ArgumentName1>argumentName1</ArgumentName1>'));
+                expect(xmlStr.includes('<ArgumentValue1>argumentValue1</ArgumentValue1>'));
+                expect(xmlStr.includes('<ArgumentName2>argumentName2</ArgumentName2>'));
+                expect(xmlStr.includes('<ArgumentValue2>argumentValue1</ArgumentValue2>'));
+                return done();
+            },
+        }, logger.newRequestLogger());
+    })
+
+    it('Should not include invalid arguments in reponse body', done => {
+        const error = errors.InvalidArgument;
+        responseXMLBody(error, '', {
+            setHeader: () => {},
+            writeHead: () => {},
+            on: () => {},
+            once: () => {},
+            emit: () => {},
+            write: () => {},
+            end: (xmlStr) => {
+                expect(xmlStr.includes('<ArgumentName1></ArgumentName1>'));
+                expect(xmlStr.includes('<ArgumentValue1></ArgumentValue1>'));
+                return done();
+            },
+        }, logger.newRequestLogger());
+    })
+});
+
+describe('JSONResponseBackend: ', () => {
+    it('Should include invalid arguments in reponse body', done => {
+        const invalidArgument1 = { ArgumentName: 'argumentName1', ArgumentValue: 'argumentValue1' };
+        const invalidArgument2 = { ArgumentName: 'argumentName2', ArgumentValue: 'argumentValue2' };
+        const error = errors.InvalidArgument.addMetadataEntry('invalidArguments',
+            [invalidArgument1, invalidArgument2]);
+        responseJSONBody(error, '', {
+            setHeader: () => {},
+            writeHead: () => {},
+            on: () => {},
+            once: () => {},
+            emit: () => {},
+            write: () => {},
+            end: (jsonStr) => {
+                const response = JSON.parse(jsonStr);
+                expect(response).toHaveProperty('ArgumentName1', 'argumentName1');
+                expect(response).toHaveProperty('ArgumentValue1', 'argumentValue1');
+                expect(response).toHaveProperty('ArgumentName2', 'argumentName2');
+                expect(response).toHaveProperty('ArgumentValue2', 'argumentValue2');
+                return done();
+            },
+        }, logger.newRequestLogger());
+    })
+
+    it('Should not include invalid arguments in reponse body', done => {
+        const error = errors.InvalidArgument;
+        responseJSONBody(error, '', {
+            setHeader: () => {},
+            writeHead: () => {},
+            on: () => {},
+            once: () => {},
+            emit: () => {},
+            write: () => {},
+            end: (jsonStr) => {
+                const response = JSON.parse(jsonStr);
+                expect(response.ArgumentName1).toBeFalsy();
+                expect(response.ArgumentValue1).toBeFalsy();
+                return done();
+            },
+        }, logger.newRequestLogger());
+    })
+});


### PR DESCRIPTION
Issue: [ARSN-160](https://scality.atlassian.net/browse/ARSN-160)
This will be used [here](https://github.com/scality/cloudserver/blob/ffd1fcd2c173b77d716567fc8b412af0484b081f/lib/api/apiUtils/bucket/getNotificationConfiguration.js#L18-L22), where for each invalid destination in the target we should add an invalid argument. This is done to match the AWS's error