### PR TITLE
INTEGRATION [PR#1846 > development/8.1] ARSN-175 Restores old behaviors of errors

### DIFF
--- a/lib/errors/index.ts
+++ b/lib/errors/index.ts
@@ -16,6 +16,12 @@ const isBase = Object.fromEntries(
     Object.keys(rawErrors).map(key => [key, false])
 ) as Is;
 
+// This allows to conditionally add the old behavior of errors to properly
+// test migration.
+// Activate CI tests with `ALLOW_UNSAFE_ERROR_COMPARISON=false yarn test`.
+// Remove this mechanism in ARSN-176.
+const allowUnsafeErrComp = (process.env.ALLOW_UNSAFE_ERROR_COMPARISON ?? 'true') === 'true'
+
 // This contains some metaprog. Be careful.
 // Proxy can be found on MDN.
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
@@ -46,6 +52,15 @@ export class ArsenalError extends Error {
         this.#description = description;
         this.#type = type;
         this.#is = createIs(type);
+
+        // This restores the old behavior of errors, to make sure they're now
+        // backward-compatible. Fortunately it's handled by TS, but it cannot
+        // be type-checked. This means we have to be extremely careful about
+        // what we're doing when using errors.
+        // Disables the feature when in CI tests but not in production.
+        if (allowUnsafeErrComp) {
+            this[type] = true;
+        }
     }
 
     /** Output the error as a JSON string */

--- a/lib/network/rpc/utils.ts
+++ b/lib/network/rpc/utils.ts
@@ -55,6 +55,9 @@ export function reconstructError(err: Error) {
     }
 
     const reconstructedErr = new Error(err.message);
+    // This restores the old behavior of errors. This should be removed as soon
+    // as all dependent codebases have been migrated to `is` accessors (ARSN-176).
+    reconstructedErr[err.message] = true;
     // @ts-expect-error
     reconstructedErr.is = {
         [err.message]: true,


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1846.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/feature/ARSN-175-fix-errors-backwards`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/feature/ARSN-175-fix-errors-backwards
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/feature/ARSN-175-fix-errors-backwards
```

Please always comment pull request #1846 instead of this one.