### PR TITLE
INTEGRATION [PR#1846 > development/8.1] ARSN-175 Restores old behaviors of errors

### DIFF
--- a/lib/errors/index.ts
+++ b/lib/errors/index.ts
@@ -16,6 +16,13 @@ const isBase = Object.fromEntries(
     Object.keys(rawErrors).map(key => [key, false])
 ) as Is;
 
+// This allows to conditionally add the old behavior of errors to properly
+// test migration.
+// Activate CI tests with `ALLOW_UNSAFE_ERROR_COMPARISON=false yarn test`.
+// Remove this mechanism in ARSN-176.
+export const allowUnsafeErrComp = (
+    process.env.ALLOW_UNSAFE_ERROR_COMPARISON ?? 'true') === 'true'
+
 // This contains some metaprog. Be careful.
 // Proxy can be found on MDN.
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
@@ -46,6 +53,15 @@ export class ArsenalError extends Error {
         this.#description = description;
         this.#type = type;
         this.#is = createIs(type);
+
+        // This restores the old behavior of errors, to make sure they're now
+        // backward-compatible. Fortunately it's handled by TS, but it cannot
+        // be type-checked. This means we have to be extremely careful about
+        // what we're doing when using errors.
+        // Disables the feature when in CI tests but not in production.
+        if (allowUnsafeErrComp) {
+            this[type] = true;
+        }
     }
 
     /** Output the error as a JSON string */

--- a/lib/network/rpc/utils.ts
+++ b/lib/network/rpc/utils.ts
@@ -1,4 +1,4 @@
-import { ArsenalError } from '../../errors';
+import { ArsenalError, allowUnsafeErrComp } from '../../errors';
 
  // eslint-disable-line
 
@@ -55,10 +55,13 @@ export function reconstructError(err: Error) {
     }
 
     const reconstructedErr = new Error(err.message);
-    // @ts-expect-error
-    reconstructedErr.is = {
-        [err.message]: true,
-    };
+    // This restores the old behavior of errors. This should be removed as soon
+    // as all dependent codebases have been migrated to `is` accessors (ARSN-176).
+    reconstructedErr[err.message] = true;
+    if (allowUnsafeErrComp){
+        // @ts-expect-error
+        reconstructedErr.is = { [err.message]: true };
+    }
     Object.keys(err).forEach(k => {
         reconstructedErr[k] = err[k];
     });

--- a/tests/unit/errors.spec.ts
+++ b/tests/unit/errors.spec.ts
@@ -37,3 +37,61 @@ describe('Errors: ', () => {
         });
     });
 });
+
+describe('Backward compatibility flag', () => {
+
+    const env = process.env;
+
+    beforeEach(() => {
+        jest.resetModules();
+        process.env = { ...env };
+    });
+
+    afterEach(() => {
+        process.env = { ...env };
+    })
+
+    it('should be enabled when no env variable is present', () => {
+        const errors = require('../../lib/errors');
+        const err = errors.default.InternalError;
+        expect(errors.allowUnsafeErrComp).toBe(true);
+        expect(err.InternalError).toBe(true);
+        expect(err.is.InternalError).toBe(true);
+    });
+
+    it('should be enabled when `true` is specified', () => {
+        process.env = {
+            ALLOW_UNSAFE_ERROR_COMPARISON: 'true',
+            ...env
+        };
+        const errors = require('../../lib/errors');
+        const err = errors.default.InternalError;
+        expect(errors.allowUnsafeErrComp).toBe(true);
+        expect(err.InternalError).toBe(true);
+        expect(err.is.InternalError).toBe(true);
+    });
+
+    it('should be disabled when `false` is specified', () => {
+        process.env = {
+            ALLOW_UNSAFE_ERROR_COMPARISON: 'false',
+            ...env
+        };
+        const errors = require('../../lib/errors');
+        const err = errors.default.InternalError;
+        expect(errors.allowUnsafeErrComp).toBe(false);
+        expect(err).not.toHaveProperty(err.type);
+        expect(err.is.InternalError).toBe(true);
+    });
+
+    it('should be disabled when `foo` is specified', () => {
+        process.env = {
+            ALLOW_UNSAFE_ERROR_COMPARISON: 'foo',
+            ...env
+        };
+        const errors = require('../../lib/errors');
+        const err = errors.default.InternalError;
+        expect(errors.allowUnsafeErrComp).toBe(false);
+        expect(err).not.toHaveProperty(err.type);
+        expect(err.is.InternalError).toBe(true);
+    });
+});


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1846.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/feature/ARSN-175-fix-errors-backwards`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/feature/ARSN-175-fix-errors-backwards
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/feature/ARSN-175-fix-errors-backwards
```

Please always comment pull request #1846 instead of this one.