### PR TITLE
bugfix: ARSN-191 fix wrong notification type when master version is d…

### DIFF
--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -1033,6 +1033,7 @@ class MongoClientInterface {
         const masterKey = formatMasterKey(objName, vFormat);
         MongoUtils.serialize(objVal);
         // eslint-disable-next-line
+        objVal.originOp = 's3:ObjectRemoved:Delete';
         c.findOneAndReplace({
             '_id': masterKey,
             'value.isPHD': true,

--- a/tests/unit/storage/metadata/mongoclient/delObject.spec.js
+++ b/tests/unit/storage/metadata/mongoclient/delObject.spec.js
@@ -202,4 +202,25 @@ describe('MongoClientInterface:delObject', () => {
             return done();
         });
     });
+
+    it('repair:: should set correct originOp', done => {
+        const collection = {
+            findOneAndReplace: sinon.stub().callsArgWith(3, null, { ok: 1 }),
+        };
+        const master = {
+            versionId: '1234',
+        };
+        const objVal = {
+            originOp: 's3:ObjectCreated:Put',
+        };
+        client.repair(collection, 'example-bucket', 'example-object', objVal, master, 'v0', logger, () => {
+            assert.deepEqual(collection.findOneAndReplace.args[0][1], {
+                _id: 'example-object',
+                value: {
+                    originOp: 's3:ObjectRemoved:Delete',
+                },
+            });
+            return done();
+        });
+    });
 });


### PR DESCRIPTION
…eleted

Ticket: [ARSN-191](https://scality.atlassian.net/browse/ARSN-191)

Issue:
When the last version of an object is deleted, the master gets updated with the metadata of the new last version of the object. The originOp is kept the same during this update, however it should be updated into a "delete operation"