### PR TITLE
improvement: ARSN-197 implement object restore request xml parser

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -20,6 +20,7 @@ import SubStreamInterface from './lib/s3middleware/azureHelpers/SubStreamInterfa
 import { prepareStream } from './lib/s3middleware/prepareStream';
 import * as processMpuParts from './lib/s3middleware/processMpuParts';
 import * as retention from './lib/s3middleware/objectRetention';
+import * as objectRestore from './lib/s3middleware/objectRestore';
 import * as lifecycleHelpers from './lib/s3middleware/lifecycleHelpers';
 export { default as errors } from './lib/errors';
 export * as ipCheck from './lib/ipCheck';
@@ -97,6 +98,7 @@ export const s3middleware = {
     prepareStream,
     processMpuParts,
     retention,
+    objectRestore,
     lifecycleHelpers,
 };
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -153,3 +153,5 @@ export const supportedLifecycleRules = [
 // Maximum number of buckets to cache (bucket metadata)
 export const maxCachedBuckets = process.env.METADATA_MAX_CACHED_BUCKETS ?
     Number(process.env.METADATA_MAX_CACHED_BUCKETS) : 1000;
+
+export const validRestoreObjectTiers = new Set(['Expedited', 'Standard', 'Bulk']);

--- a/lib/s3middleware/objectRestore.ts
+++ b/lib/s3middleware/objectRestore.ts
@@ -59,9 +59,9 @@ function validateTier(tier?: string) {
 }
 
 /**
- * validate retention - validate retention xml
- * @param parsedXml - parsed retention xml object
- * @return - contains retention information on success,
+ * validate restore request xml
+ * @param parsedXml - parsed restore request xml object
+ * @return - contains restore request information on success,
  * error on failure
  */
 function validateRestoreRequestParameters(parsedXml?: any) {
@@ -88,12 +88,12 @@ function validateRestoreRequestParameters(parsedXml?: any) {
 }
 
 /**
- * parseRetentionXml - Parse and validate xml body, returning callback with
- * object retentionObj: { mode: <value>, date: <value> }
+ * parseRestoreRequestXml - Parse and validate xml body, returning callback with
+ * object restoreReqObj: { days: <value>, tier: <value> }
  * @param xml - xml body to parse and validate
  * @param log - Werelogs logger
  * @param cb - callback to server
- * @return - calls callback with object retention or error
+ * @return - calls callback with object restore request or error
  */
 export function parseRestoreRequestXml(
     xml: string,

--- a/lib/s3middleware/objectRestore.ts
+++ b/lib/s3middleware/objectRestore.ts
@@ -63,11 +63,11 @@ export async function parseRestoreRequestXml(
     try {
         result = await parseStringPromise(xml);
     } catch (err) {
-        log.trace('xml parsing failed', {
+        log.debug('xml parsing failed', {
             error: err,
             method: 'parseRestoreXml',
+            xml,
         });
-        log.debug('invalid xml', { xml });
         return cb(errors.MalformedXML);
     }
     if (!result) {
@@ -99,7 +99,7 @@ export async function parseRestoreRequestXml(
  */
 export function convertToXml(days: string, tier: string) {
     if (!(days && tier)) {
-        return ''
+        return '';
     }
     return [
         '<RestoreRequest xmlns="http://s3.amazonaws.com/doc/2006-03-01/">',

--- a/lib/s3middleware/objectRestore.ts
+++ b/lib/s3middleware/objectRestore.ts
@@ -1,0 +1,141 @@
+import { parseString } from 'xml2js';
+import errors, { ArsenalError } from '../errors';
+import * as werelogs from 'werelogs';
+
+/*
+    Format of xml request:
+    <RestoreRequest>
+      <Days>integer</Days>
+      <Tier>Standard|Bulk|Expedited</RetainUntilDate>
+    </RestoreRequest>
+*/
+
+/**
+ * validateDays - validate restore days
+ * @param days - parsed days string
+ * @return - contains days or error
+ */
+function validateDays(days?: string) {
+    if (!days || !days[0]) {
+        const desc = 'request xml does not contain RestoreRequest.Days';
+        const error = errors.MalformedXML.customizeDescription(desc);
+        return { error };
+    }
+    // RestoreRequest.Days must be greater than or equal to 1
+    const daysValue = Number.parseInt(days[0], 10);
+    if (Number.isNaN(daysValue)) {
+        const desc = `RestoreRequest.Days is invalid type. [${days}]`;
+        const error = errors.MalformedXML.customizeDescription(desc);
+        return { error };
+    }
+    if (daysValue < 1) {
+        const desc = `RestoreRequest.Days must be greater than 0. [${days}]`;
+        const error = errors.MalformedXML.customizeDescription(desc);
+        return { error };
+    }
+    if (daysValue > 2147483647) {
+        const desc = `RestoreRequest.Days must be less than 2147483648. [${days}]`;
+        const error = errors.MalformedXML.customizeDescription(desc);
+        return { error };
+    }
+    return { days: daysValue }
+}
+
+/**
+ * validateTier - validate retain until date
+ * @param tier - parsed tier string
+ * @return - contains retain until date or error
+ */
+function validateTier(tier?: string) {
+    // If Tier is specified, must be "Expedited" or "Standard" or "Bulk"
+    const tierList = ['Expedited', 'Standard', 'Bulk'];
+    if (tier && tier[0] && !tierList.includes(tier[0])) {
+        const desc = `RestoreRequest.Tier is invalid value. [${tier}]`;
+        const error = errors.MalformedXML.customizeDescription(desc);
+        return { error };
+    }
+    // If do not specify, set "Standard"
+    return { tier: tier && tier[0] ? tier[0] : 'Standard' };
+}
+
+/**
+ * validate retention - validate retention xml
+ * @param parsedXml - parsed retention xml object
+ * @return - contains retention information on success,
+ * error on failure
+ */
+function validateRestoreRequestParameters(parsedXml?: any) {
+    if (!parsedXml) {
+        const desc = 'request xml is undefined or empty';
+        const error = errors.MalformedXML.customizeDescription(desc);
+        return { error };
+    }
+    const restoreRequest = parsedXml.RestoreRequest;
+    if (!restoreRequest) {
+        const desc = 'request xml does not contain RestoreRequest';
+        const error = errors.MalformedXML.customizeDescription(desc);
+        return { error };
+    }
+    const daysObj = validateDays(restoreRequest.Days);
+    if (daysObj.error) {
+        return { error: daysObj.error };
+    }
+    const tierObj = validateTier(restoreRequest.Tier);
+    if (tierObj.error) {
+        return { error: tierObj.error };
+    }
+    return { days: daysObj.days, tier: tierObj.tier };
+}
+
+/**
+ * parseRetentionXml - Parse and validate xml body, returning callback with
+ * object retentionObj: { mode: <value>, date: <value> }
+ * @param xml - xml body to parse and validate
+ * @param log - Werelogs logger
+ * @param cb - callback to server
+ * @return - calls callback with object retention or error
+ */
+export function parseRestoreRequestXml(
+    xml: string,
+    log: werelogs.Logger,
+    cb: (err: ArsenalError | null, data?: any) => void,
+) {
+    parseString(xml, (err, result) => {
+        if (err) {
+            log.trace('xml parsing failed', {
+                error: err,
+                method: 'parseRestoreXml',
+            });
+            log.debug('invalid xml', { xml });
+            return cb(errors.MalformedXML);
+        }
+        const restoreReqObj = validateRestoreRequestParameters(result);
+        if (restoreReqObj.error) {
+            log.debug('restore request validation failed', {
+                error: restoreReqObj.error,
+                method: 'validateRestoreRequestParameters',
+                xml,
+            });
+            return cb(restoreReqObj.error);
+        }
+        return cb(null, restoreReqObj);
+    });
+}
+
+/**
+ * convertToXml - Convert restore request info object to xml
+ * @param days - restore days
+ * @param tier - restore tier
+ * @return - returns restore request information xml string
+ */
+export function convertToXml(days: string, tier: string) {
+    if (!(days && tier)) {
+        return ''
+    }
+    return [
+        '<RestoreRequest xmlns="http://s3.amazonaws.com/doc/2006-03-01/">',
+        `<Days>${days}</Days>`,
+        `<Tier>${tier}</Tier>`,
+        '</RestoreRequest>',
+    ].join('');
+}

--- a/tests/unit/s3middleware/objectRestore.spec.js
+++ b/tests/unit/s3middleware/objectRestore.spec.js
@@ -1,0 +1,146 @@
+const assert = require('assert');
+const { convertToXml, parseRestoreRequestXml } =
+    require('../../../lib/s3middleware/objectRestore');
+const DummyRequestLogger = require('../helpers').DummyRequestLogger;
+
+const log = new DummyRequestLogger();
+
+const generateXml = (days, tier) => {
+    const daysElement = days ? `<Days>${days}</Days>` : '';
+    const tierElement = tier ? `<Tier>${tier}</Tier>` : '';
+    return [
+        '<RestoreRequest xmlns="http://s3.amazonaws.com/doc/2006-03-01/">',
+        `${daysElement}`,
+        `${tierElement}`,
+        '</RestoreRequest>',
+    ].join('');
+};
+
+const validDay = '1';
+const invalidDays1 = 'abc';
+const invalidDays2 = '0';
+const invalidDays3 = '2147483648';
+const standardTier = 'Standard';
+const bulkTier = 'Bulk';
+const expedited = 'Expedited';
+const invalidTier = 'InvalidTier';
+
+const failTests = [
+    {
+        description: 'should fail with empty request xml',
+        requestXml: '',
+        error: 'MalformedXML',
+        errMessage: 'request xml is undefined or empty',
+    },
+    {
+        description: 'should fail without RestoreRequest param',
+        requestXml: '<OtherRequest></OtherRequest>',
+        error: 'MalformedXML',
+        errMessage: 'request xml does not contain RestoreRequest',
+    },
+    {
+        description: 'should fail without RestoreRequest.Days param',
+        requestXml: generateXml(null, null),
+        error: 'MalformedXML',
+        errMessage: 'request xml does not contain RestoreRequest.Days',
+    },
+    {
+        description: 'should fail with RestoreRequest.Days param is not integer',
+        requestXml: generateXml(invalidDays1, null),
+        error: 'MalformedXML',
+        errMessage: `RestoreRequest.Days is invalid type. [${invalidDays1}]`,
+    },
+    {
+        description: 'should fail with RestoreRequest.Days param is not greater than 0',
+        requestXml: generateXml(invalidDays2, null),
+        error: 'MalformedXML',
+        errMessage: `RestoreRequest.Days must be greater than 0. [${invalidDays2}]`,
+    },
+    {
+        description: 'should fail with RestoreRequest.Days param is not less than 2147483648',
+        requestXml: generateXml(invalidDays3, null),
+        error: 'MalformedXML',
+        errMessage: `RestoreRequest.Days must be less than 2147483648. [${invalidDays3}]`,
+    },
+    {
+        description: 'should fail with RestoreRequest.Tier not in [\'Expedited\', \'Standard\', \'Bulk\']',
+        requestXml: generateXml(validDay, invalidTier),
+        error: 'MalformedXML',
+        errMessage: `RestoreRequest.Tier is invalid value. [${invalidTier}]`,
+    },
+];
+
+
+describe('object restore: parseRestoreRequestXml', () => {
+    failTests.forEach(test => {
+        it(test.description, done => {
+            parseRestoreRequestXml(test.requestXml, log, err => {
+                assert(err.is[test.error]);
+                assert.strictEqual(err.description, test.errMessage);
+                done();
+            });
+        });
+    });
+
+    it('should pass with valid days and standard tier', done => {
+        parseRestoreRequestXml(generateXml(validDay, standardTier), log, (err, result) => {
+            assert.ifError(err);
+            assert.strictEqual(result.days, Number.parseInt(validDay, 10));
+            assert.strictEqual(result.tier, standardTier);
+            done();
+        });
+    });
+
+    it('should pass with valid days and bulk tier', done => {
+        parseRestoreRequestXml(generateXml(validDay, bulkTier), log, (err, result) => {
+            assert.ifError(err);
+            assert.strictEqual(result.days, Number.parseInt(validDay, 10));
+            assert.strictEqual(result.tier, bulkTier);
+            done();
+        });
+    });
+
+    it('should pass with valid days and expedited tier', done => {
+        parseRestoreRequestXml(generateXml(validDay, expedited), log, (err, result) => {
+            assert.ifError(err);
+            assert.strictEqual(result.days, Number.parseInt(validDay, 10));
+            assert.strictEqual(result.tier, expedited);
+            done();
+        });
+    });
+
+    it('should set tier to Standard if not specified', done => {
+        parseRestoreRequestXml(generateXml(validDay, null), log, (err, result) => {
+            assert.ifError(err);
+            assert.strictEqual(result.days, Number.parseInt(validDay, 10));
+            assert.strictEqual(result.tier, standardTier);
+            done();
+        });
+    });
+});
+
+describe('object restore: convertToXml', () => {
+    it('should return correct xml with both day and tier', () => {
+        const xml = convertToXml(validDay, standardTier);
+        const expextedXml = generateXml(validDay, standardTier);
+        assert.strictEqual(xml, expextedXml);
+    });
+
+    it('should return empty string when day not set', () => {
+        const xml = convertToXml(null, standardTier);
+        const expextedXml = '';
+        assert.strictEqual(xml, expextedXml);
+    });
+
+    it('should return empty string when tier not set', () => {
+        const xml = convertToXml(validDay, null);
+        const expextedXml = '';
+        assert.strictEqual(xml, expextedXml);
+    });
+
+    it('should return empty string when day and tier not set', () => {
+        const xml = convertToXml(null, null);
+        const expextedXml = '';
+        assert.strictEqual(xml, expextedXml);
+    });
+});

--- a/tests/unit/s3middleware/objectRestore.spec.js
+++ b/tests/unit/s3middleware/objectRestore.spec.js
@@ -6,14 +6,15 @@ const DummyRequestLogger = require('../helpers').DummyRequestLogger;
 const log = new DummyRequestLogger();
 
 const generateXml = (days, tier) => {
-    const daysElement = days ? `<Days>${days}</Days>` : '';
-    const tierElement = tier ? `<Tier>${tier}</Tier>` : '';
-    return [
-        '<RestoreRequest xmlns="http://s3.amazonaws.com/doc/2006-03-01/">',
-        `${daysElement}`,
-        `${tierElement}`,
-        '</RestoreRequest>',
-    ].join('');
+    const ret = ['<RestoreRequest xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'];
+    if (days) {
+        ret.push(`<Days>${days}</Days>`);
+    }
+    if (tier) {
+        ret.push(`<Tier>${tier}</Tier>`);
+    }
+    ret.push('</RestoreRequest>');
+    return ret.join('');
 };
 
 const validDay = '1';


### PR DESCRIPTION
add objectRestore api required request xml parser, for cloudserver side usage

although we don't support Bulk or Expedited Tier as per[ the design ](https://github.com/scality/citadel/blob/development/1.0/docs/design/cold-storage-s3-api.md#cloudserver-changes), we will have this limitation in cloudserver side(throw NotImplemented error if specified Bulk or Expited), here we keep it in line with aws, we allow Standard, Bulk and Expedited, otherwise throw MalformedXML error.