### PR TITLE
INTEGRATION [PR#1897 > development/8.1] ARSN-97 Stop ignoring build errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "lint_yml": "yamllint $(git ls-files '*.yml')",
     "test": "jest tests/unit",
     "build": "tsc",
-    "prepare": "yarn build || true",
+    "prepare": "yarn build",
     "ft_test": "jest tests/functional --testTimeout=120000 --forceExit"
   },
   "private": true,


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1897.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/ARSN-97-stop-ignoring-ts-errors-in-yarn-install`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/ARSN-97-stop-ignoring-ts-errors-in-yarn-install
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/ARSN-97-stop-ignoring-ts-errors-in-yarn-install
```

Please always comment pull request #1897 instead of this one.