### PR TITLE
INTEGRATION [PR#1866 > development/8.1] bugfix: ARSN-191 fix wrong notification type when master version is d…

### DIFF
--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -1032,7 +1032,7 @@ class MongoClientInterface {
     repair(c, bucketName, objName, objVal, mst, vFormat, log, cb) {
         const masterKey = formatMasterKey(objName, vFormat);
         MongoUtils.serialize(objVal);
-        // eslint-disable-next-line
+        objVal.originOp = 's3:ObjectRemoved:Delete';
         c.findOneAndReplace({
             '_id': masterKey,
             'value.isPHD': true,

--- a/tests/unit/storage/metadata/mongoclient/delObject.spec.js
+++ b/tests/unit/storage/metadata/mongoclient/delObject.spec.js
@@ -202,4 +202,25 @@ describe('MongoClientInterface:delObject', () => {
             return done();
         });
     });
+
+    it('repair:: should set correct originOp', done => {
+        const collection = {
+            findOneAndReplace: sinon.stub().callsArgWith(3, null, { ok: 1 }),
+        };
+        const master = {
+            versionId: '1234',
+        };
+        const objVal = {
+            originOp: 's3:ObjectCreated:Put',
+        };
+        client.repair(collection, 'example-bucket', 'example-object', objVal, master, 'v0', logger, () => {
+            assert.deepEqual(collection.findOneAndReplace.args[0][1], {
+                _id: 'example-object',
+                value: {
+                    originOp: 's3:ObjectRemoved:Delete',
+                },
+            });
+            return done();
+        });
+    });
 });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1866.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/ARSN-191-getting-wrong-notification-type-when-master-version-deleted`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/ARSN-191-getting-wrong-notification-type-when-master-version-deleted
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/ARSN-191-getting-wrong-notification-type-when-master-version-deleted
```

Please always comment pull request #1866 instead of this one.