### PR TITLE
INTEGRATION [PR#1916 > development/8.1] ARSN-212 remove assert in decoder in favor of returning an error.

### DIFF
--- a/lib/versioning/VersionID.ts
+++ b/lib/versioning/VersionID.ts
@@ -8,7 +8,6 @@
 
 import base62Integer from 'base62';
 import baseX from 'base-x';
-import assert from 'assert/strict';
 const BASE62 = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 const base62String = baseX(BASE62);
 
@@ -242,7 +241,7 @@ export function base62Decode(str: string): string | Error {
         );
     } catch (err) {
         // in case of exceptions caused by base62 libs
-        return err as any;
+        return err as Error;
     }
 }
 
@@ -275,9 +274,9 @@ export function encode(str: string): string {
 export function decode(str: string): string | Error {
     // default format is exactly 32 characters when encoded
     if (str.length === 32) {
-        const decoded = base62Decode(str);
-        if (typeof decoded === 'string') {
-            assert.strictEqual(decoded.length, 27);
+        const decoded: string | Error = base62Decode(str);
+        if (typeof decoded === 'string' && decoded.length !== 27) {
+            return new Error(`decoded ${str} is not length 27`);
         }
         return decoded;
     }

--- a/tests/unit/versioning/VersionID.spec.js
+++ b/tests/unit/versioning/VersionID.spec.js
@@ -23,6 +23,16 @@ function generateRandomVIDs(count) {
 const count = 1000000;
 
 describe('test generating versionIds', () => {
+    describe('invalid IDs', () => {
+        // A client can use the CLI to send requests with arbitrary version IDs.
+        // These IDs may contain invalid characters and should be handled gracefully.
+        it('should return an error when an ID has unsupported characters', () => {
+            const encoded = 'wHtI53.S4ApsYLRI5VZZ3Iw.7ny4NgQz';
+            const decoded = VID.decode(encoded);
+            assert(decoded instanceof Error);
+            assert.strictEqual(decoded.message, 'Non-base62 character');
+        });
+    });
     describe('legaxy hex encoding', () => {
         env.S3_VERSION_ID_ENCODING_TYPE = 'hex';
         const vids = generateRandomVIDs(count);


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1916.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/ARSN-212-remove-assert-in-decoder`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/ARSN-212-remove-assert-in-decoder
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/ARSN-212-remove-assert-in-decoder
```

Please always comment pull request #1916 instead of this one.