### PR TITLE
INTEGRATION [PR#1970 > development/8.1] bf(ARSN-250): Fix getByteRangeFromSpec when range is 0-0

### DIFF
--- a/lib/network/http/utils.ts
+++ b/lib/network/http/utils.ts
@@ -77,10 +77,11 @@ export function getByteRangeFromSpec(
             objectSize - 1] };
     }
     if (rangeSpec.start < objectSize) {
-        // test is false if end is undefined
-        return { range: [rangeSpec.start,
-            ((rangeSpec.end && (rangeSpec.end < objectSize)) ?
-            rangeSpec.end : objectSize - 1)] };
+        // test is false if end is undefined or end is greater than objectSize
+        const end: number = rangeSpec.end !== undefined && rangeSpec.end < objectSize
+            ? rangeSpec.end
+            : objectSize - 1;
+        return { range: [rangeSpec.start, end] };
     }
     return { error: errors.InvalidRange };
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.10.28",
+  "version": "7.10.29",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/network/http/utils.spec.js
+++ b/tests/unit/network/http/utils.spec.js
@@ -64,6 +64,8 @@ describe('getByteRangeFromSpec function', () => {
         expectedByteRange: { } },
     { rangeSpec: { suffix: 0 }, objectSize: 0,
         expectedByteRange: { error: errors.InvalidRange } },
+    { rangeSpec: { start: 0, end: 0 }, objectSize: 7340032,
+        expectedByteRange: { range: [0, 0] } },
     ].forEach(testCase => {
         const { rangeSpec, objectSize, expectedByteRange } = testCase;
 


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1970.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/ARSN-250/fix_getByteRangeFromSpec_edgecase`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/ARSN-250/fix_getByteRangeFromSpec_edgecase
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/ARSN-250/fix_getByteRangeFromSpec_edgecase
```

Please always comment pull request #1970 instead of this one.