### PR TITLE
feature: ARSN-256 support tagging and ACL events

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -96,6 +96,10 @@ export const supportedNotificationEvents = new Set([
     's3:ObjectRemoved:*',
     's3:ObjectRemoved:Delete',
     's3:ObjectRemoved:DeleteMarkerCreated',
+    's3:ObjectTagging:*',
+    's3:ObjectTagging:Put',
+    's3:ObjectTagging:Delete',
+    's3:ObjectAcl:Put',
 ]);
 export const notificationArnPrefix = 'arn:scality:bucketnotif';
 // some of the available data backends  (if called directly rather

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.10.29",
+  "version": "7.10.30",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {


### PR DESCRIPTION
Add to the list of supported event types for bucket notification
purpose, the tagging and ACL-related events that can be set in bucket
notification

Reference: https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-how-to-event-types-and-destinations.html#supported-notification-event-types