### PR TITLE
bugfix: ARSN-262 fixes/tests in RequestContext

### DIFF
--- a/lib/policyEvaluator/RequestContext.ts
+++ b/lib/policyEvaluator/RequestContext.ts
@@ -166,7 +166,6 @@ export default class RequestContext {
     _policyArn: string;
     _action?: string;
     _needQuota: boolean;
-    _postXml?: string;
     _requestObjTags: string | null;
     _existingObjTag: string | null;
     _needTagEval: boolean;
@@ -190,7 +189,9 @@ export default class RequestContext {
         securityToken: string,
         policyArn: string,
         action?: string,
-        postXml?: string,
+        requestObjTags?: string,
+        existingObjTag?: string,
+        needTagEval?: false,
     ) {
         this._headers = headers;
         this._query = query;
@@ -220,10 +221,9 @@ export default class RequestContext {
         this._policyArn = policyArn;
         this._action = action;
         this._needQuota = _actionNeedQuotaCheck[apiMethod] === true;
-        this._postXml = postXml;
-        this._requestObjTags = null;
-        this._existingObjTag = null;
-        this._needTagEval = false;
+        this._requestObjTags = requestObjTags || null;
+        this._existingObjTag = existingObjTag || null;
+        this._needTagEval = needTagEval || false;
         return this;
     }
 
@@ -236,7 +236,7 @@ export default class RequestContext {
             apiMethod: this._apiMethod,
             headers: this._headers,
             query: this._query,
-            requersterInfo: this._requesterInfo,
+            requesterInfo: this._requesterInfo,
             requesterIp: this._requesterIp,
             sslEnabled: this._sslEnabled,
             awsService: this._awsService,
@@ -252,7 +252,6 @@ export default class RequestContext {
             securityToken: this._securityToken,
             policyArn: this._policyArn,
             action: this._action,
-            postXml: this._postXml,
             requestObjTags: this._requestObjTags,
             existingObjTag: this._existingObjTag,
             needTagEval: this._needTagEval,
@@ -276,12 +275,27 @@ export default class RequestContext {
         if (resource) {
             obj.specificResource = resource;
         }
-        return new RequestContext(obj.headers, obj.query, obj.generalResource,
-            obj.specificResource, obj.requesterIp, obj.sslEnabled,
-            obj.apiMethod, obj.awsService, obj.locationConstraint,
-            obj.requesterInfo, obj.signatureVersion,
-            obj.authType, obj.signatureAge, obj.securityToken, obj.policyArn,
-            obj.action, obj.postXml);
+        return new RequestContext(
+            obj.headers,
+            obj.query,
+            obj.generalResource,
+            obj.specificResource,
+            obj.requesterIp,
+            obj.sslEnabled,
+            obj.apiMethod,
+            obj.awsService,
+            obj.locationConstraint,
+            obj.requesterInfo,
+            obj.signatureVersion,
+            obj.authType,
+            obj.signatureAge,
+            obj.securityToken,
+            obj.policyArn,
+            obj.action,
+            obj.requestObjTags,
+            obj.existingObjTag,
+            obj.needTagEval,
+        );
     }
 
     /**
@@ -623,26 +637,6 @@ export default class RequestContext {
      */
     isQuotaCheckNeeded() {
         return this._needQuota;
-    }
-
-    /**
-     * Set request post
-     *
-     * @param postXml - request post
-     * @return itself
-     */
-    setPostXml(postXml: string) {
-        this._postXml = postXml;
-        return this;
-    }
-
-    /**
-     * Get request post
-     *
-     * @return request post
-     */
-    getPostXml() {
-        return this._postXml;
     }
 
     /**

--- a/tests/unit/policyEvaluator/RequestContext.spec.js
+++ b/tests/unit/policyEvaluator/RequestContext.spec.js
@@ -1,0 +1,128 @@
+const assert = require('assert');
+
+const RequestContext = require('../../../lib/policyEvaluator/RequestContext').default;
+
+describe('RequestContext', () => {
+    const constructorParams = [
+        { 'some-header': 'some-value' }, // headers
+        { q1: 'v1', q2: 'v2' }, // query
+        'general-resource', // generalResource
+        'specific-resource', // specificResource
+        '127.0.0.1', // requesterIp
+        true, // sslEnabled
+        'GET', // apiMethod
+        's3', // awsService
+        'us-east-1', // locationConstraint
+        { // requesterInfo
+            arn: 'arn:aws:iam::user/johndoe',
+            accountId: 'JOHNACCOUNT',
+            username: 'John Doe',
+            principalType: 'user',
+        },
+        'v4', // signatureVersion
+        'REST-HEADER', // authType
+        123456, // signatureAge
+        'security-token', // securityToken
+        'arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess', // policyArn
+        'objectGet', // action
+        'reqTagOne=valueOne&reqTagTwo=valueTwo', // requestObjTags
+        'existingTagOne=valueOne&existingTagTwo=valueTwo', // existingObjTag
+        true, // needTagEval
+    ];
+    const rc = new RequestContext(...constructorParams);
+
+    const GetterTests = [
+        { name: 'getAction', expectedValue: 'objectGet' },
+        { name: 'getResource', expectedValue: 'arn:aws:s3:::general-resource/specific-resource' },
+        { name: 'getHeaders', expectedValue: { 'some-header': 'some-value' } },
+        { name: 'getQuery', expectedValue: { q1: 'v1', q2: 'v2' } },
+        {
+            name: 'getRequesterInfo',
+            expectedValue: {
+                accountId: 'JOHNACCOUNT',
+                arn: 'arn:aws:iam::user/johndoe',
+                username: 'John Doe',
+                principalType: 'user',
+            },
+        },
+        { name: 'getRequesterIp', expectedValueToString: '127.0.0.1' },
+        { name: 'getRequesterAccountId', expectedValue: undefined },
+        { name: 'getRequesterEndArn', expectedValue: 'arn:aws:iam::user/johndoe' },
+        { name: 'getRequesterExternalId', expectedValue: undefined },
+        { name: 'getRequesterPrincipalArn', expectedValue: 'arn:aws:iam::user/johndoe' },
+        { name: 'getRequesterType', expectedValue: 'user' },
+        { name: 'getSslEnabled', expectedValue: true },
+        { name: 'getSignatureVersion', expectedValue: 'v4' },
+        { name: 'getAuthType', expectedValue: 'REST-HEADER' },
+        { name: 'getSignatureAge', expectedValue: 123456 },
+        { name: 'getLocationConstraint', expectedValue: 'us-east-1' },
+        { name: 'getAwsService', expectedValue: 's3' },
+        { name: 'getTokenIssueTime', expectedValue: null },
+        { name: 'getMultiFactorAuthPresent', expectedValue: null },
+        { name: 'getMultiFactorAuthAge', expectedValue: null },
+        { name: 'getSecurityToken', expectedValue: 'security-token' },
+        { name: 'getPolicyArn', expectedValue: 'arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess' },
+        { name: 'isQuotaCheckNeeded', expectedValue: false },
+        { name: 'getRequestObjTags', expectedValue: 'reqTagOne=valueOne&reqTagTwo=valueTwo' },
+        { name: 'getExistingObjTag', expectedValue: 'existingTagOne=valueOne&existingTagTwo=valueTwo' },
+        { name: 'getNeedTagEval', expectedValue: true },
+    ];
+    GetterTests.forEach(testCase => {
+        it(`getter:${testCase.name}`, () => {
+            const getterResult = rc[testCase.name]();
+            if (testCase.expectedValueToString) {
+                assert.strictEqual(getterResult.toString(), testCase.expectedValueToString);
+            } else {
+                assert.deepStrictEqual(getterResult, testCase.expectedValue);
+            }
+        });
+    });
+
+    const SerializedFields = {
+        action: 'objectGet',
+        apiMethod: 'GET',
+        authType: 'REST-HEADER',
+        awsService: 's3',
+        existingObjTag: 'existingTagOne=valueOne&existingTagTwo=valueTwo',
+        generalResource: 'general-resource',
+        headers: {
+            'some-header': 'some-value',
+        },
+        locationConstraint: 'us-east-1',
+        multiFactorAuthAge: null,
+        multiFactorAuthPresent: null,
+        needTagEval: true,
+        policyArn: 'arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess',
+        query: {
+            q1: 'v1',
+            q2: 'v2',
+        },
+        requesterInfo: {
+            accountId: 'JOHNACCOUNT',
+            arn: 'arn:aws:iam::user/johndoe',
+            principalType: 'user',
+            username: 'John Doe',
+        },
+        requestObjTags: 'reqTagOne=valueOne&reqTagTwo=valueTwo',
+        requesterIp: '127.0.0.1',
+        securityToken: 'security-token',
+        signatureAge: 123456,
+        signatureVersion: 'v4',
+        specificResource: 'specific-resource',
+        sslEnabled: true,
+        tokenIssueTime: null,
+    };
+    it('serialize()', () => {
+        assert.deepStrictEqual(JSON.parse(rc.serialize()), SerializedFields);
+    });
+    it('deSerialize()', () => {
+        // check that everything that was serialized is deserialized
+        // properly into a new RequestContext object by making sure
+        // the serialized version of the latter corresponds to the
+        // input
+        const serialized = JSON.stringify(SerializedFields);
+        const deserializedRC = RequestContext.deSerialize(serialized);
+        const newSerialized = JSON.parse(deserializedRC.serialize());
+        assert.deepStrictEqual(newSerialized, SerializedFields);
+    });
+});


### PR DESCRIPTION
- remove "postXml" field, as it was a left-over from prototyping

- handle fields related to tag conditions: requestObjTags,
  existingObjTag, needTagEval, those were missing from constructor
  params

- fix a typo in serialization: requersterInfo -> requesterInfo

- new unit tests for RequestContext
  constructor/serialize/deserialize/getters