### PR TITLE
Bugfix/arsn 269 listing bug versioned bucket edge case

### DIFF
--- a/lib/algos/list/delimiterMaster.js
+++ b/lib/algos/list/delimiterMaster.js
@@ -33,6 +33,8 @@ class DelimiterMaster extends Delimiter {
         this.prvKey = undefined;
         this.prvPHDKey = undefined;
         this.inReplayPrefix = false;
+        this.prefixKeySeen = false;
+        this.prefixEndsWithDelim = this.prefix && this.prefix.endsWith(this.delimiter);
 
         Object.assign(this, {
             [BucketVersioningKeyFormat.v0]: {
@@ -63,7 +65,7 @@ class DelimiterMaster extends Delimiter {
         const value = obj.value;
 
         if (key === this.prefix) {
-            return this.addContents(key, value);
+            this.prefixKeySeen = true;
         }
 
         if (key.startsWith(DbPrefixes.Replay)) {
@@ -99,8 +101,8 @@ class DelimiterMaster extends Delimiter {
              *   NextMarker to the common prefix instead of the whole key
              *   value. (TODO: remove this test once ZENKO-1048 is fixed)
              *   */
-            if (key === this.prvKey || key === this[this.nextContinueMarker] ||
-                (this.delimiter && key.startsWith(this[this.nextContinueMarker]))) {
+            if (key === this.prvKey || key === this[this.nextContinueMarker]
+                || (this.delimiter && key.startsWith(this[this.nextContinueMarker]))) {
                 /* master version already filtered */
                 return FILTER_SKIP;
             }
@@ -130,6 +132,14 @@ class DelimiterMaster extends Delimiter {
                 return FILTER_ACCEPT;
             }
             this.prvKey = key;
+            if (this.prefixEndsWithDelim) {
+                /* When the prefix ends with a delimiter, update nextContinueMarker
+                 * to be able to skip ranges of the form prefix/subprefix/ as an optimization.
+                 * The marker may also end up being prefix/, in which case .skipping will determine
+                 * if a skip over the full range is allowed or a smaller skipping range of prefix/{VID_SEP}
+                 * must be used. */
+                this[this.nextContinueMarker] = key.slice(0, key.lastIndexOf(this.delimiter) + 1);
+            }
             return FILTER_SKIP;
         }
 
@@ -165,6 +175,27 @@ class DelimiterMaster extends Delimiter {
         return super.filter(obj);
     }
 
+    /**
+     * Determine if a nextContinueMarker ending with a delimiter
+     * can be skipped.
+     * @returns {bool}
+     */
+
+    allowDelimiterRangeSkip() {
+        if (!this.prefixKeySeen) {
+            // A prefix key is a master key equal to the prefix. If it has
+            // not been encountered, can skip.
+            return true;
+        }
+        const marker = this[this.nextContinueMarker];
+        // prefix = prefix, key = prefix/. Can skip since key will be part of commonPrefixes.
+        if (marker.length > this.prefix.length && marker.startsWith(this.prefix)) {
+            return true;
+        }
+        const lastIdx = marker.lastIndexOf(this.delimiter); // prefix/foo is a masterKey following a prefix key.
+        return marker.slice(0, lastIdx + 1) !== this.prefix; // cannot skip the full range prefix/ range.
+    }
+
     skippingBase() {
         if (this[this.nextContinueMarker]) {
             // next marker or next continuation token:
@@ -172,7 +203,7 @@ class DelimiterMaster extends Delimiter {
             // - foo  : skipping foo.
             const index = this[this.nextContinueMarker].
                 lastIndexOf(this.delimiter);
-            if (index === this[this.nextContinueMarker].length - 1) {
+            if (index === this[this.nextContinueMarker].length - 1 && this.allowDelimiterRangeSkip()) {
                 return this[this.nextContinueMarker];
             }
             return this[this.nextContinueMarker] + VID_SEP;


### PR DESCRIPTION
address https://scality.atlassian.net/browse/S3C-4682 and corrects missed faulty logic in  [ARSN-262](https://scality.atlassian.net/browse/ARSN-262)

Simplifies testing that was used in [ARSN-262](https://scality.atlassian.net/browse/ARSN-262). 
Adds a function allowDelimiterRangeSkip to determine when a nextContinueMarker range can be skipped when .skipping is called. This function uses a new state variable prefixKeySeen and the nextContinueMarker to determine if a range of the form prefix/ can be skipped. An additional check is added when processing delete markers of the form prefix/foo/(bar) so that the prefix/foo/ range can still be skipped as an optimization.