### PR TITLE
ARSN-252 - listing bug in DelimisterMaster

### DIFF
--- a/lib/algos/list/delimiter.js
+++ b/lib/algos/list/delimiter.js
@@ -271,4 +271,4 @@ class Delimiter extends Extension {
     }
 }
 
-module.exports = { Delimiter };
+module.exports = { Delimiter, getCommonPrefix };

--- a/lib/algos/list/delimiterMaster.js
+++ b/lib/algos/list/delimiterMaster.js
@@ -62,6 +62,10 @@ class DelimiterMaster extends Delimiter {
         let key = obj.key;
         const value = obj.value;
 
+        if (key === this.prefix) {
+            return this.addContents(key, value);
+        }
+
         if (key.startsWith(DbPrefixes.Replay)) {
             this.inReplayPrefix = true;
             return FILTER_SKIP;
@@ -96,8 +100,7 @@ class DelimiterMaster extends Delimiter {
              *   value. (TODO: remove this test once ZENKO-1048 is fixed)
              *   */
             if (key === this.prvKey || key === this[this.nextContinueMarker] ||
-                (this.delimiter &&
-                key.startsWith(this[this.nextContinueMarker]))) {
+                (this.delimiter && key.startsWith(this[this.nextContinueMarker]))) {
                 /* master version already filtered */
                 return FILTER_SKIP;
             }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.21",
     "@types/xml2js": "^0.4.11",
+    "chance": "^1.1.8",
     "eslint": "^8.12.0",
     "eslint-config-airbnb": "6.2.0",
     "eslint-config-scality": "scality/Guidelines#7.10.2",

--- a/tests/unit/algos/list/delimiterMaster.spec.js
+++ b/tests/unit/algos/list/delimiterMaster.spec.js
@@ -1,7 +1,9 @@
 'use strict'; // eslint-disable-line strict
 
 const assert = require('assert');
+const chance = require('chance').Chance(); // eslint-disable-line
 
+const { getCommonPrefix } = require('../../../../lib/algos/list/delimiter');
 const DelimiterMaster =
     require('../../../../lib/algos/list/delimiterMaster').DelimiterMaster;
 const {
@@ -16,8 +18,6 @@ const Version = require('../../../../lib/versioning/Version').Version;
 const { generateVersionId } = require('../../../../lib/versioning/VersionID');
 const { DbPrefixes } = VSConst;
 const zpad = require('../../helpers').zpad;
-
-
 const VID_SEP = VSConst.VersionId.Separator;
 const EmptyResult = {
     CommonPrefixes: [],
@@ -46,6 +46,111 @@ function getListingKey(key, vFormat) {
     return assert.fail(`bad vFormat ${vFormat}`);
 }
 
+const MAX_STREAK_LENGTH = 100;
+
+function createStreakState(prefix, vFormat) {
+    return {
+        vFormat,
+        prefix,
+        prefixes: new Set(),
+        params: {},
+        streakLength: 0,
+        gteparams: null,
+    };
+}
+
+/**
+ * Simplified version of logic found in Metadata's RepdServer. When MAX_STREAK_LENGTH (typically 100)
+ * is reached, we attempt to skip to the next listing range as a performance optimization.
+ * @param {Integer} filteringResult - 0, 1, -1 indicating if we can skip to the next character range.
+ * @param {String} skippingRange - lower bound that the listing can begin from.
+ * @returns {undefined}
+ */
+/* eslint-disable no-param-reassign */
+function handleStreak(filteringResult, skippingRange, state) {
+    if (filteringResult < 0) {
+        // readStream would be destroyed. In this mock, we just continue.
+    } else if (filteringResult === 0 && skippingRange) {
+        // check if MAX_STREAK_LENGTH consecutive keys have been
+        // skipped
+        if (++state.streakLength === MAX_STREAK_LENGTH) {
+            if (Array.isArray(skippingRange)) {
+                // With synchronized listing, the listing
+                // algo backend skipping() function must
+                // return as many skip keys as listing
+                // param sets.
+                for (let i = 0; i < skippingRange.length; ++i) {
+                    state.params[i].gte = inc(skippingRange[i]);
+                }
+            } else {
+                state.params.gte = inc(skippingRange);
+            }
+            if (state.gteparams && state.gteparams === state.params.gte) {
+                state.streakLength = 1;
+            } else {
+                // stop listing this key range
+                state.gteparams = state.params.gte;
+            }
+        }
+    } else {
+        state.streakLength = 1;
+    }
+}/* eslint-enable */
+
+/**
+ * Generate a random number of versioned keys.
+ * @param {String} masterKey - base key used to derive version keys
+ * @param {Integer} numKeys - how many versioned keys to generate
+ * @param {Object} state - test case state
+ * @yields {Object} - { key, isDeleteMarker }
+ * @returns {undefined}
+ */
+function *generateVersionedKeys(masterKey, numKeys, state) {
+    for (let i = 0; i < numKeys; i++) {
+        yield {
+            key: `${masterKey}${VID_SEP}${zpad(i)}`,
+            isDeleteMarker: state.vFormat === 'v0' && chance.bool(),
+            canSkip: true,
+        };
+    }
+}
+
+/**
+ * Generate raw listing keys in alphabetical order.
+ * @param {Integer} count - how many keys to generate.
+ * @param {Object} state - state for test run.
+ * @yields {Object} - { key, isDeleteMarker }
+ */
+
+function *generateKeys(count, state) {
+    let idx = 0;
+    let masterKey = '_Common-Prefix/';
+    yield { key: masterKey, isDeleteMarker: false, canSkip: false };
+
+    idx++;
+    while (idx < count) {
+        masterKey = `_Common-Prefix/${zpad(idx)}`;
+        const masterKeyWithSubprefix = `_Common-Prefix/${zpad(idx)}/${zpad(idx)}`;
+
+        const hasSubprefix = chance.bool();
+        const isDeleteMarker = state.vFormat === 'v0' && chance.bool();
+        const baseKey = hasSubprefix ? masterKeyWithSubprefix : masterKey;
+
+        let canSkip = isDeleteMarker;
+        if (hasSubprefix || state.prefix[state.prefix.length - 1] !== '/') {
+            canSkip = canSkip || state.handleSubprefixKey(baseKey);
+        }
+
+        yield { key: baseKey, isDeleteMarker, canSkip };
+        idx++;
+
+        const versioned = chance.integer({ min: 0, max: 200 });
+        const allowedVersionedKeys = Math.min(count - idx, versioned);
+        yield* generateVersionedKeys(baseKey, allowedVersionedKeys, state);
+        idx += allowedVersionedKeys;
+    }
+}
+
 ['v0', 'v1'].forEach(vFormat => {
     describe(`Delimiter All masters listing algorithm vFormat=${vFormat}`, () => {
         it('should return SKIP_NONE for DelimiterMaster when both NextMarker ' +
@@ -57,6 +162,70 @@ function getListingKey(key, vFormat) {
             // When there is no NextMarker or NextContinuationToken, it should
             // return SKIP_NONE
             assert.strictEqual(delimiter.skipping(), SKIP_NONE);
+        });
+
+        it('should list all subprefixes when handleStreak is applied as in RepdServer', () => {
+            ['_Common-Prefix', '_Common-Prefix/'].forEach(prefix => {
+                const state = createStreakState(prefix, vFormat);
+                state.handleSubprefixKey = baseKey => {
+                    const isLastDelim = state.prefix[state.prefix.length - 1] === '/';
+                    const lastIdx = isLastDelim ? baseKey.lastIndexOf('/') : state.prefix.length;
+                    const prefix = isLastDelim ? getCommonPrefix(baseKey, '/', lastIdx) : baseKey.slice(0, lastIdx);
+                    if (state.prefixes.has(prefix) || (!isLastDelim && baseKey.length > lastIdx)) {
+                        return true;
+                    }
+
+                    state.prefixes.add(prefix);
+                    return false;
+                };
+
+                const maxKeys = 1000000;
+                const delimiter = new DelimiterMaster({
+                    maxKeys,
+                    prefix,
+                    delimiter: '/',
+                    startAfter: '',
+                    continuationToken: '',
+                    v2: true,
+                    fetchOwner: false }, fakeLogger, vFormat);
+
+                [...generateKeys(maxKeys, state)].forEach(ob => {
+                    const { key, isDeleteMarker, canSkip } = ob;
+                    // simulate not doing a raw listing when key < params.gte
+                    // this represents a key not reaching the read stream from leveldb
+                    if (state.params.gte && key < state.params.gte) {
+                        return;
+                    }
+
+                    if (!key.includes(VID_SEP)) { // master key
+                        const version = new Version({ isDeleteMarker });
+                        const obj = {
+                            key: getListingKey(key, vFormat),
+                            value: version.toString(),
+                        };
+
+                        const res = delimiter.filter(obj);
+                        const skippingRange = delimiter.skipping();
+                        handleStreak(res, skippingRange, state);
+
+                        const expected = canSkip ? FILTER_SKIP : FILTER_ACCEPT;
+                        assert.strictEqual(res, expected);
+                    } else { // versioned key
+                        if (vFormat === 'v0') {
+                            const vid = key.split(VID_SEP).slice(-1)[0];
+                            const version = new Version({ versionId: vid, isDeleteMarker });
+                            const obj2 = {
+                                key: getListingKey(key, vFormat),
+                                value: version.toString(),
+                            };
+                            const res = delimiter.filter(obj2);
+                            const skippingRange = delimiter.skipping();
+                            handleStreak(res, skippingRange, state);
+                            assert.strictEqual(res, FILTER_SKIP);
+                        }
+                    }
+                });
+            });
         });
 
         it('should return <key><VersionIdSeparator> for DelimiterMaster when ' +

--- a/tests/unit/network/http/server.spec.js
+++ b/tests/unit/network/http/server.spec.js
@@ -166,7 +166,7 @@ describe('network.Server: ', () => {
                 if (err) {
                     return ws.onStop(() => {
                         clearTimeout(requestTimeout);
-                        if (err.code === 'EPROTO') {
+                        if (err.code === 'EPROTO' || err.code === 'ECONNRESET') {
                             return done();
                         }
                         return done(err);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2144,6 +2144,11 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chance@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/chance/-/chance-1.1.8.tgz#5d6c2b78c9170bf6eb9df7acdda04363085be909"
+  integrity sha512-v7fi5Hj2VbR6dJEGRWLmJBA83LJMS47pkAbmROFxHWd9qmE1esHRZW8Clf1Fhzr3rjxnNZVCjOEv/ivFxeIMtg==
+
 char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"


### PR DESCRIPTION
DelimiterMaster.filter is used to determine when a key range can be skipped in Metadata:RepdServer to optimize listing performance. When a bucket is created with vFormat=v0, and subsequently a listing is done with a prefix, DelimiterMaster.filter was incorrectly determining that a range could be skipped if a key was listed such that key == prefix. This case is now correctly handled in filterV0.

(cherry picked from commit f62c3d22edf84a47c85fa7753f80bedeeec19636)