### PR TITLE
Fix unsafe path construction in DataFileStore.js

### DIFF
--- a/lib/storage/data/file/DataFileStore.js
+++ b/lib/storage/data/file/DataFileStore.js
@@ -121,6 +121,9 @@ class DataFileStore {
      *   object contents
      */
     getFilePath(key) {
+        if (key.includes(path.sep) || key === '..' || key === '.') {
+            return '';
+        }
         if (this.isPassthrough) {
             const dirname = path.resolve(this.dataPath);
             const filePath = path.resolve(dirname, key);


### PR DESCRIPTION
Fix unsafe path construction in DataFileStore.js. Ensure that `key` is a single path component. 
Otherwise it could be vulnerable to [path traversal attack](https://owasp.org/www-community/attacks/Path_Traversal).