### PR TITLE
ARSN-276: putObjectVerCase3 -add case for v1 and versioned entry update

### DIFF
--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -492,6 +492,7 @@ class MongoClientInterface {
                 },
             };
         }
+
         // in v0 or if the version is not a delete marker the master
         // simply gets updated
         return {
@@ -678,6 +679,29 @@ class MongoClientInterface {
         objVal.versionId = params.versionId;
         const versionKey = formatVersionKey(objName, params.versionId, params.vFormat);
         const masterKey = formatMasterKey(objName, params.vFormat);
+
+        const putObjectEntry = (ops, callback) => {
+            c.bulkWrite(ops, {
+                ordered: true,
+            }, err => {
+                if (err) {
+                    log.error(
+                        'putObjectVerCase3: error putting object version',
+                        { error: err.message });
+                    if (err.code === 11000) {
+                        // We want duplicate key error logged however in
+                        // case of the race condition mentioned above, the
+                        // InternalError will allow for automatic retries
+                        log.error(
+                            'putObjectVerCase3:', errors.KeyAlreadyExists);
+                        return callback(errors.InternalError);
+                    }
+                    return callback(errors.NoSuchVersion);
+                }
+                return callback(null, `{"versionId": "${objVal.versionId}"}`);
+            });
+        };
+
         c.findOne({ _id: masterKey }, (err, checkObj) => {
             if (err) {
                 log.error('putObjectVerCase3: mongoDB error finding object');
@@ -708,29 +732,33 @@ class MongoClientInterface {
             const update = {
                 $set: { _id: masterKey, value: objVal },
             };
-            // updating or deleting master depending on the last version put
-            // in v0 the master gets updated, in v1 the master gets deleted if version is
-            // a delete marker or updated otherwise.
-            const masterOp = this.updateDeleteMaster(objVal.isDeleteMarker, params.vFormat, filter, update, objUpsert);
-            ops.push(masterOp);
-            c.bulkWrite(ops, {
-                ordered: true,
-            }, err => {
+
+            c.findOne({ _id: versionKey }, (err, verObj) => {
                 if (err) {
-                    log.error(
-                        'putObjectVerCase3: error putting object version',
-                        { error: err.message });
-                    if (err.code === 11000) {
-                        // We want duplicate key error logged however in
-                        // case of the race condition mentioned above, the
-                        // InternalError will allow for automatic retries
-                        log.error(
-                            'putObjectVerCase3:', errors.KeyAlreadyExists);
-                        return cb(errors.InternalError);
-                    }
-                    return cb(errors.NoSuchVersion);
+                    log.error('putObjectVerCase3: mongoDB error finding object');
+                    return cb(errors.InternalError);
                 }
-                return cb(null, `{"versionId": "${objVal.versionId}"}`);
+
+                // existing versioned entry update.
+                // if master entry doesn't exists, skip upsert of master
+                if (verObj && !checkObj) {
+                    putObjectEntry(ops, cb);
+                    return null;
+                }
+
+                // updating or deleting master depending on the last version put
+                // in v0 the master gets updated, in v1 the master gets deleted if version is
+                // a delete marker or updated otherwise.
+                const masterOp = this.updateDeleteMaster(
+                    objVal.isDeleteMarker,
+                    params.vFormat,
+                    filter,
+                    update,
+                    objUpsert,
+                );
+                ops.push(masterOp);
+                putObjectEntry(ops, cb);
+                return null;
             });
             return null;
         });

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "8.1.70",
+  "version": "8.1.71",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {


### PR DESCRIPTION
add condition check in putObjectVerCase3 to avoid creating erroneous master entry for v1 format and versioned updates.
sequence:
* check if master entry exists
* check if version entry exists
* new condition: if version exists and master entry doesn't, update only the versioned entry