### PR TITLE
bugfix: ARSN-278 handle getting versionId when object is versioning suspended

### DIFF
--- a/lib/models/ObjectMD.ts
+++ b/lib/models/ObjectMD.ts
@@ -1,6 +1,7 @@
 import * as crypto from 'crypto';
 import * as constants from '../constants';
 import * as VersionIDUtils from '../versioning/VersionID';
+import { VersioningConstants } from '../versioning/constants';
 import ObjectMDLocation, {
     ObjectMDLocationData,
     Location,
@@ -901,6 +902,9 @@ export default class ObjectMD {
      * @return The object versionId
      */
     getVersionId() {
+        if (this.getIsNull()) {
+            return VersioningConstants.ExternalNullVersionId;
+        }
         return this._data.versionId;
     }
 
@@ -908,13 +912,16 @@ export default class ObjectMD {
      * Get metadata versionId value in encoded form (the one visible
      * to the S3 API user)
      *
-     * @return The encoded object versionId
+     * @return {undefined|string} The encoded object versionId
      */
     getEncodedVersionId() {
         const versionId = this.getVersionId();
-        if (versionId) {
+        if (versionId === VersioningConstants.ExternalNullVersionId) {
+            return versionId;
+        } else if (versionId) {
             return VersionIDUtils.encode(versionId);
         }
+        return undefined;
     }
 
     /**

--- a/lib/versioning/constants.ts
+++ b/lib/versioning/constants.ts
@@ -15,4 +15,5 @@ export const VersioningConstants = {
         v1mig: 'v1mig',
         v1: 'v1',
     },
+    ExternalNullVersionId: 'null',
 };

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "8.1.75",
+  "version": "8.1.76",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/models/ObjectMD.spec.js
+++ b/tests/unit/models/ObjectMD.spec.js
@@ -1,6 +1,8 @@
 const assert = require('assert');
 const ObjectMD = require('../../../lib/models/ObjectMD').default;
 const constants = require('../../../lib/constants');
+const ExternalNullVersionId = require('../../../lib/versioning/constants')
+    .VersioningConstants.ExternalNullVersionId;
 
 const retainDate = new Date();
 retainDate.setDate(retainDate.getDate() + 1);
@@ -770,5 +772,46 @@ describe('ObjectMD::getReducedLocations', () => {
                 blockId: 'someBlockId4',
             },
         ]);
+    });
+});
+
+describe('ObjectMD::getVersionId', () => {
+    let objMd = null;
+    const versionId = '98451712418844999999RG001  22019.0';
+    beforeEach(() => {
+        objMd = new ObjectMD();
+    });
+    it('should return undefined when object is non versioned', () => {
+        assert.strictEqual(objMd.getVersionId(), undefined);
+    });
+    it('should return versionId when object versioned', () => {
+        objMd.setVersionId(versionId);
+        assert.strictEqual(objMd.getVersionId(), versionId);
+    });
+    it('should return "null" when object is in versioning suspended mode', () => {
+        objMd.setVersionId(versionId);
+        objMd.setIsNull(true);
+        assert.strictEqual(objMd.getVersionId(), ExternalNullVersionId);
+    });
+});
+
+describe('ObjectMD::getEncodedVersionId', () => {
+    let objMd = null;
+    const versionId = '98451712418844999999RG001  22019.0';
+    const encodedVersionId = '39383435313731323431383834343939393939395247303031202032323031392e30';
+    beforeEach(() => {
+        objMd = new ObjectMD();
+    });
+    it('should return undefined when object is non versioned', () => {
+        assert.strictEqual(objMd.getEncodedVersionId(), undefined);
+    });
+    it('should return versionId when object versioned', () => {
+        objMd.setVersionId(versionId);
+        assert.strictEqual(objMd.getEncodedVersionId(), encodedVersionId);
+    });
+    it('should return "null" when object is in versioning suspended mode', () => {
+        objMd.setVersionId(versionId);
+        objMd.setIsNull(true);
+        assert.strictEqual(objMd.getEncodedVersionId(), ExternalNullVersionId);
     });
 });


### PR DESCRIPTION
…uspended

When replicating a versioning suspended object, we need to specify 'null' as the encoded versionId as the versionId contained within the object's metadata is strictly internal

In the replication processor we use getVersionId() when putting/deleting a tag. It's used by the mongoClient to fetch the object from MongoDB. Here again we need to specify 'null' to get the versioning suspended object (Cloudserver already knows how to handle 'null' versionId and transforms it to undefined before giving it to the mongoClient)

https://github.com/scality/cloudserver/blob/2c8968ef4a0d6f44f10222c90d2ae3066ce04068/lib/metadata/metadataUtils.js#L94-L96

Linked to: https://github.com/scality/backbeat/pull/2306