### PR TITLE
Feature: ARSN-280 abstract update

### DIFF
--- a/lib/storage/metadata/mongoclient/ListRecordStream.js
+++ b/lib/storage/metadata/mongoclient/ListRecordStream.js
@@ -108,9 +108,26 @@ class ListRecordStream extends stream.Readable {
             if (value && value.tags) {
                 value.tags = unescape(value.tags);
             }
+            // updates overwrite the whole metadata,
+            // so they are considered as puts
+            let type = 'put';
+            // When the object metadata contain the "deleted"
+            // flag, it means that the operation is the update
+            // we perform before the deletion of an object. We
+            // perform the update to keep all the metadata in the
+            // oplog. This update is what will be used by backbeat
+            // as the delete operation so we put the type of operation
+            // for this event to a delete.
+            // Backbeat still receives the actual delete operations
+            // but they are ignored as they don't contain any metadata.
+            // The delete operations are kept in case we want to listen
+            // to delete events comming from special collections other
+            // than "bucket" collections.
+            if (value && value.deleted) {
+                type = 'delete';
+            }
             entry = {
-                type: 'put', // updates overwrite the whole metadata,
-                // so they are considered as puts
+                type,
                 key: itemObj.o2._id,
                 // updated value may be either stored directly in 'o'
                 // attribute or in '$set' attribute (supposedly when

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "8.1.72",
+  "version": "8.1.73",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/storage/metadata/mongoclient/ListRecordStream.spec.js
+++ b/tests/unit/storage/metadata/mongoclient/ListRecordStream.spec.js
@@ -45,6 +45,22 @@ const mongoProcessedLogEntries = {
             _id: 'replicated-key\u000098467518084696999999RG001  19.3',
         },
     },
+    updateBeforeDeleteObject: {
+        h: -42,
+        ts: new Timestamp(1, 1651144629),
+        op: 'u',
+        ns: 'metadata.replicated-bucket',
+        o2: {
+            _id: 'replicated-key\u000098467518084696999999RG001  19.3',
+        },
+        o: {
+            $set: {
+                value: {
+                    deleted: true,
+                },
+            },
+        },
+    },
     putBucketAttributes: {
         h: -42,
         ts: new Timestamp(1, 1651144629),
@@ -126,6 +142,17 @@ const expectedStreamEntries = {
             {
                 key: 'replicated-key\u000098467518084696999999RG001  19.3',
                 type: 'delete',
+            },
+        ],
+        timestamp: new Date(1651144629 * 1000),
+    },
+    updateBeforeDeleteObject: {
+        db: 'replicated-bucket',
+        entries: [
+            {
+                key: 'replicated-key\u000098467518084696999999RG001  19.3',
+                type: 'delete',
+                value: '{"deleted":true}',
             },
         ],
         timestamp: new Date(1651144629 * 1000),


### PR DESCRIPTION
Issue: [ARSN-280](https://scality.atlassian.net/browse/ARSN-280)

**Context**
When deleting an object, and to keep the latest object's metadata in the oplog, we perform an update on the object, setting a deletion flag before actually deleting it.

Backbeat extensions will now use the update operation we do just before deleting an object as the new deletion event, the other "actual" delete will be ignored as it doesn't contain any metadata.

To do that we need to overwrite the event type at the logConsumer level.
