### PR TITLE
bugfix: ARSN-293 DelimiterMaster: default to vFormat=v0

### DIFF
--- a/lib/algos/list/delimiterMaster.ts
+++ b/lib/algos/list/delimiterMaster.ts
@@ -60,7 +60,7 @@ export class DelimiterMaster extends Delimiter {
             },
         }[this.vFormat]);
 
-        if (vFormat === BucketVersioningKeyFormat.v0) {
+        if (this.vFormat === BucketVersioningKeyFormat.v0) {
             // override Delimiter's implementation of NotSkipping for
             // DelimiterMaster logic (skipping versions and special
             // handling of delete markers and PHDs)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.10.39",
+  "version": "7.10.40",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/algos/list/delimiterMaster.spec.js
+++ b/tests/unit/algos/list/delimiterMaster.spec.js
@@ -354,6 +354,36 @@ function getListingKey(key, vFormat) {
                 });
             });
 
+            it('should assume vFormat=v0 when not passed explicitly', () => {
+                // this test is identical to the above one "should
+                // accept the master version and skip the other ones",
+                // which checks that the listing algo effectively
+                // behaves as if it is a v0 format
+                const delimiter = new DelimiterMaster({}, fakeLogger);
+                const masterKey = 'key';
+                const masterValue = 'value';
+                const versionKey = `${masterKey}${VID_SEP}version`;
+                const versionValue = 'versionvalue';
+
+                /* Filter the master version. */
+                delimiter.filter({ key: masterKey, value: masterValue });
+
+                /* Version is skipped, not added to the result. The delimiter
+                 * NextMarker is unmodified and set to the masterKey. */
+                assert.strictEqual(delimiter.filter({
+                    key: versionKey,
+                    value: versionValue,
+                }), FILTER_SKIP);
+                assert.strictEqual(delimiter.nextMarker, masterKey);
+                assert.deepStrictEqual(delimiter.result(), {
+                    CommonPrefixes: [],
+                    Contents: [{ key: masterKey, value: masterValue }],
+                    IsTruncated: false,
+                    NextMarker: undefined,
+                    Delimiter: undefined,
+                });
+            });
+
             it('should return good listing result for version', () => {
                 const delimiter = new DelimiterMaster({}, fakeLogger, vFormat);
                 const masterKey = 'key';


### PR DESCRIPTION
The BucketFile interface (open-source) does not pass an explicit vFormat to the constructor of the listing algorithm. DelimiterMaster does not interpret it correctly and uses vFormat=v1 logic in this case, resulting in wrong listing results.

Fix it by checking against `this.vFormat` that was set with a default value by the Delimiter class, instead of directly using the constructor parameter `vFormat`.
