### PR TITLE
bugfix: ARSN-294 use CommonPrefix for NextMarker

### DIFF
--- a/lib/algos/list/delimiter.ts
+++ b/lib/algos/list/delimiter.ts
@@ -214,7 +214,7 @@ export class Delimiter extends Extension {
         // add the new prefix to the list
         this.CommonPrefixes.push(commonPrefix);
         ++this.keys;
-        this.nextMarker = key;
+        this.nextMarker = commonPrefix;
     }
 
     addCommonPrefixOrContents(key: string, value: string): string | undefined {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.10.40",
+  "version": "7.10.41",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/algos/list/delimiter.spec.js
+++ b/tests/unit/algos/list/delimiter.spec.js
@@ -292,13 +292,13 @@ const tests = [
         CommonPrefixes: ['notes/spring/'],
         Delimiter: '/',
         IsTruncated: true,
-        NextMarker: 'notes/spring/1.txt',
+        NextMarker: 'notes/spring/',
     }),
 
     new Test('all parameters 2/5', {
         delimiter: '/',
         prefix: 'notes/',
-        marker: 'notes/spring/1.txt',
+        marker: 'notes/spring/',
         maxKeys: 1,
     }, {
         v0: {
@@ -314,13 +314,13 @@ const tests = [
         CommonPrefixes: ['notes/summer/'],
         Delimiter: '/',
         IsTruncated: true,
-        NextMarker: 'notes/summer/1.txt',
+        NextMarker: 'notes/summer/',
     }),
 
     new Test('all parameters 3/5', {
         delimiter: '/',
         prefix: 'notes/',
-        marker: 'notes/summer/1.txt',
+        marker: 'notes/summer/',
         maxKeys: 1,
     }, {
         v0: {
@@ -385,6 +385,28 @@ const tests = [
         Delimiter: '/',
         IsTruncated: false,
         NextMarker: undefined,
+    }),
+
+    new Test('marker inside common prefix', {
+        delimiter: '/',
+        prefix: 'notes/',
+        marker: 'notes/spring/1.txt',
+        maxKeys: 1,
+    }, {
+        v0: {
+            gte: 'notes/spring0',
+            lt: 'notes0',
+        },
+        v1: {
+            gte: `${DbPrefixes.Master}notes/spring0`,
+            lt: `${DbPrefixes.Master}notes0`,
+        },
+    }, {
+        Contents: [],
+        CommonPrefixes: ['notes/summer/'],
+        Delimiter: '/',
+        IsTruncated: true,
+        NextMarker: 'notes/summer/',
     }),
 
     new Test('all elements v2', {
@@ -573,13 +595,13 @@ const tests = [
         CommonPrefixes: ['notes/spring/'],
         Delimiter: '/',
         IsTruncated: true,
-        NextContinuationToken: 'notes/spring/1.txt',
+        NextContinuationToken: 'notes/spring/',
     }),
 
     new Test('all parameters v2 2/5', {
         delimiter: '/',
         prefix: 'notes/',
-        continuationToken: 'notes/spring/1.txt',
+        continuationToken: 'notes/spring/',
         maxKeys: 1,
         v2: true,
     }, {
@@ -596,13 +618,13 @@ const tests = [
         CommonPrefixes: ['notes/summer/'],
         Delimiter: '/',
         IsTruncated: true,
-        NextContinuationToken: 'notes/summer/1.txt',
+        NextContinuationToken: 'notes/summer/',
     }),
 
     new Test('all parameters v2 3/5', {
         delimiter: '/',
         prefix: 'notes/',
-        continuationToken: 'notes/summer/1.txt',
+        continuationToken: 'notes/summer/',
         maxKeys: 1,
         v2: true,
     }, {

--- a/tests/unit/algos/list/delimiterMaster.spec.js
+++ b/tests/unit/algos/list/delimiterMaster.spec.js
@@ -162,7 +162,7 @@ function getListingKey(key, vFormat) {
                 Contents: [],
                 Delimiter: '/',
                 IsTruncated: true,
-                NextMarker: 'prefix2/key1',
+                NextMarker: 'prefix2/',
             });
         });
 


### PR DESCRIPTION
Revert behavior introduced for S3C-7274 that changed NextMarker to an object key instead of a common prefix, the ticket was invalid as AWS does use a CommonPrefix.
