### PR TITLE
ARSN-310 Add logic to list current/master versions for Lifecycle

### DIFF
--- a/lib/algos/list/delimiterCurrent.ts
+++ b/lib/algos/list/delimiterCurrent.ts
@@ -1,0 +1,54 @@
+const { Delimiter } = require('./delimiter');
+
+type ResultObject = {
+    Contents: {
+        key: string;
+        value: string;
+    }[];
+    IsTruncated: boolean;
+    NextMarker ?: string;
+};
+
+/**
+ * Handle object listing with parameters. This extends the base class Delimiter
+ * to return the master/current versions.
+ */
+class DelimiterCurrent extends Delimiter {
+    /**
+     * Delimiter listing of current versions.
+     * @param {Object}  parameters            - listing parameters
+     * @param {String}  parameters.beforeDate - limit the response to keys older than beforeDate
+     * @param {RequestLogger} logger          - The logger of the request
+     * @param {String} [vFormat]              - versioning key format
+     */
+    constructor(parameters, logger, vFormat) {
+        super(parameters, logger, vFormat);
+
+        this.beforeDate = parameters.beforeDate;
+    }
+
+    genMDParamsV1() {
+        const params = super.genMDParamsV1();
+ 
+        if (this.beforeDate) {
+            params.lastModified = {
+                lt: this.beforeDate,
+            };
+        }
+        return params;
+    }
+
+    result(): ResultObject {
+        const result: ResultObject = {
+            Contents: this.Contents,
+            IsTruncated: this.IsTruncated,
+        };
+
+        if (this.IsTruncated) {
+            result.NextMarker = this.NextMarker;
+        }
+
+        return result;
+    }
+}
+module.exports = { DelimiterCurrent };

--- a/lib/algos/list/exportAlgos.js
+++ b/lib/algos/list/exportAlgos.js
@@ -6,4 +6,5 @@ module.exports = {
     DelimiterMaster: require('./delimiterMaster')
         .DelimiterMaster,
     MPU: require('./MPU').MultipartUploads,
+    DelimiterCurrent: require('./delimiterCurrent').DelimiterCurrent,
 };

--- a/lib/storage/metadata/MetadataWrapper.js
+++ b/lib/storage/metadata/MetadataWrapper.js
@@ -51,6 +51,35 @@ function _parseListEntries(entries) {
     });
 }
 
+/** _parseLifecycleListEntries - parse the values returned in a lifeycle listing by metadata
+ * @param {object[]} entries - Version or Content entries in a metadata listing
+ * @param {string} entries[].key - metadata key
+ * @param {string} entries[].value - stringified object metadata
+ * @return {object} - mapped array with parsed value or JSON parsing err
+ */
+function _parseLifecycleListEntries(entries) {
+    return entries.map(entry => {
+        const tmp = JSON.parse(entry.value);
+        return {
+            key: entry.key,
+            value: {
+                Size: tmp['content-length'],
+                ETag: tmp['content-md5'],
+                VersionId: tmp.versionId,
+                LastModified: tmp['last-modified'],
+                Owner: {
+                    DisplayName: tmp['owner-display-name'],
+                    ID: tmp['owner-id'],
+                },
+                StorageClass: tmp['x-amz-storage-class'],
+                tags: tmp.tags,
+                staleDate: tmp.staleDate,
+                dataStoreName: tmp.dataStoreName,
+            },
+        };
+    });
+}
+
 /** parseListEntries - parse the values returned in a listing by metadata
  * @param {object[]} entries - Version or Content entries in a metadata listing
  * @param {string} entries[].key - metadata key
@@ -272,6 +301,29 @@ class MetadataWrapper {
                     error: data.Contents,
                     listingType: listingParams.listingType,
                     method: 'listObject',
+                });
+                return cb(errors.InternalError);
+            }
+            return cb(null, data);
+        });
+    }
+
+    listLifecycleObject(bucketName, listingParams, log, cb) {
+        log.debug('getting object listing for lifecycle from metadata');
+        this.client.listLifecycleObject(bucketName, listingParams, log, (err, data) => {
+            if (err) {
+                log.error('error from metadata', { implName: this.implName,
+                    err });
+                return cb(err);
+            }
+            log.debug('object listing for lifecycle retrieved from metadata');
+            // eslint-disable-next-line no-param-reassign
+            data.Contents = parseListEntries(data.Contents, _parseLifecycleListEntries);
+            if (data.Contents instanceof Error) {
+                log.error('error parsing metadata listing for lifecycle', {
+                    error: data.Contents,
+                    listingType: listingParams.listingType,
+                    method: 'listLifecycleObject',
                 });
                 return cb(errors.InternalError);
             }

--- a/lib/storage/metadata/bucketclient/BucketClientInterface.js
+++ b/lib/storage/metadata/bucketclient/BucketClientInterface.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 
+const errors = require('../../../errors').default;
 const BucketInfo = require('../../../models/BucketInfo').default;
 
 class BucketClientInterface {
@@ -108,6 +109,10 @@ class BucketClientInterface {
                 return cb(err, JSON.parse(data));
             });
         return null;
+    }
+
+    listLifecycleObject(bucketName, params, log, cb) {
+        return process.nextTick(cb, errors.NotImplemented);
     }
 
     listMultipartUploads(bucketName, params, log, cb) {

--- a/lib/storage/metadata/file/BucketFileInterface.js
+++ b/lib/storage/metadata/file/BucketFileInterface.js
@@ -325,6 +325,10 @@ class BucketFileInterface {
         return this.internalListObject(bucketName, params, log, cb);
     }
 
+    listLifecycleObject(bucketName, params, log, cb) {
+        return process.nextTick(cb, errors.NotImplemented);
+    }
+
     listMultipartUploads(bucketName, params, log, cb) {
         return this.internalListObject(bucketName, params, log, cb);
     }

--- a/lib/storage/metadata/in_memory/metastore.js
+++ b/lib/storage/metadata/in_memory/metastore.js
@@ -318,6 +318,10 @@ const metastore = {
         });
     },
 
+    listLifecycleObject(bucketName, params, log, cb) {
+        return process.nextTick(cb, errors.NotImplemented);
+    },
+
     listMultipartUploads(bucketName, listingParams, log, cb) {
         process.nextTick(() => {
             metastore.getBucketAttributes(bucketName, log, (err, bucket) => {

--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -1651,6 +1651,42 @@ class MongoClientInterface {
     }
 
     /**
+     * lists current version, non-current version and orphan delete markers in a bucket
+     * @param {String} bucketName bucket name
+     * @param {Object} params params
+     * @param {String} params.listingType type of algorithm to use
+     * @param {Number} [params.maxKeys] maximum number of keys to list
+     * @param {String} [params.prefix] prefix of objects to use
+     * @param {Object} log logger
+     * @param {Function} cb callback
+     * @return {undefined}
+     */
+    listLifecycleObject(bucketName, params, log, cb) {
+        return this.getBucketVFormat(bucketName, log, (err, vFormat) => {
+            if (err) {
+                return cb(err);
+            }
+
+            if (vFormat !== BUCKET_VERSIONS.v1) {
+                log.error('not supported bucket format version',
+                    { method: 'listLifecycleObject', bucket: bucketName, vFormat });
+                return cb(errors.NotImplemented.customizeDescription('Not supported bucket format version'));
+            }
+
+            const extName = params.listingType;
+
+            const extension = new listAlgos[extName](params, log, vFormat);
+            const mainStreamParams = extension.genMDParams();
+
+            const internalParams = {
+                mainStreamParams,
+            };
+
+            return this.internalListObject(bucketName, internalParams, extension, vFormat, log, cb);
+        });
+    }
+
+    /**
      * lists versionned and non versionned objects in a bucket
      * @param {String} bucketName bucket name
      * @param {Object} params params

--- a/lib/storage/metadata/mongoclient/readStream.js
+++ b/lib/storage/metadata/mongoclient/readStream.js
@@ -55,6 +55,14 @@ class MongoReadStream extends Readable {
             }
         }
 
+        if (options.lastModified) {
+            query['value.last-modified'] = {};
+
+            if (options.lastModified.lt) {
+                query['value.last-modified'].$lt = options.lastModified.lt;
+            }
+        }
+
         if (!Object.keys(query._id).length) {
             delete query._id;
         }

--- a/tests/functional/metadata/mongodb/listLifecycleObject/current.spec.js
+++ b/tests/functional/metadata/mongodb/listLifecycleObject/current.spec.js
@@ -1,0 +1,409 @@
+const async = require('async');
+const assert = require('assert');
+const werelogs = require('werelogs');
+const { MongoMemoryReplSet } = require('mongodb-memory-server');
+const logger = new werelogs.Logger('MongoClientInterface', 'debug', 'debug');
+const MetadataWrapper =
+require('../../../../../lib/storage/metadata/MetadataWrapper');
+const { versioning } = require('../../../../../index');
+const { BucketVersioningKeyFormat } = versioning.VersioningConstants;
+const { flagObjectForDeletion, makeBucketMD, putBulkObjectVersions } = require('./utils');
+
+const IMPL_NAME = 'mongodb';
+const DB_NAME = 'metadata';
+const BUCKET_NAME = 'test-lifecycle-list-current-bucket';
+
+const mongoserver = new MongoMemoryReplSet({
+    debug: false,
+    instanceOpts: [
+        { port: 27020 },
+    ],
+    replSet: {
+        name: 'rs0',
+        count: 1,
+        DB_NAME,
+        storageEngine: 'ephemeralForTest',
+    },
+});
+
+describe('MongoClientInterface::metadata.listLifecycleObject::current', () => {
+    let metadata;
+    let collection;
+
+    beforeAll(done => {
+        mongoserver.waitUntilRunning().then(() => {
+            const opts = {
+                mongodb: {
+                    replicaSetHosts: 'localhost:27020',
+                    writeConcern: 'majority',
+                    replicaSet: 'rs0',
+                    readPreference: 'primary',
+                    database: DB_NAME,
+                },
+            };
+            metadata = new MetadataWrapper(IMPL_NAME, opts, null, logger);
+            metadata.client.defaultBucketKeyFormat = BucketVersioningKeyFormat.v1;
+            metadata.setup(done);
+        });
+    });
+
+    afterAll(done => {
+        async.series([
+            next => metadata.close(next),
+            next => mongoserver.stop()
+                .then(() => next())
+                .catch(next),
+        ], done);
+    });
+
+    beforeEach(done => {
+        const bucketMD = makeBucketMD(BUCKET_NAME);
+        const versionParams = {
+            versioning: true,
+            versionId: null,
+            repairMaster: null,
+        };
+        async.series([
+            next => metadata.createBucket(BUCKET_NAME, bucketMD, logger, err => {
+                if (err) {
+                    return next(err);
+                }
+
+                collection = metadata.client.getCollection(BUCKET_NAME);
+                return next();
+            }),
+            next => {
+                const params = {
+                    objName: 'pfx1-test-object',
+                    objVal: {
+                        key: 'pfx1-test-object',
+                        versionId: 'null',
+                    },
+                    nbVersions: 5,
+                };
+                const timestamp = 0;
+                putBulkObjectVersions(metadata, BUCKET_NAME, params.objName, params.objVal, versionParams,
+                    params.nbVersions, timestamp, logger, next);
+                /* eslint-disable max-len */
+                // The following versions are created:
+                // { "_id" : "Mpfx1-test-object", "value" : { "key" : "pfx1-test-object", "versionId" : "vid4", "last-modified" : "1970-01-01T00:00:00.005Z" } }
+                // { "_id" : "Vpfx1-test-object{sep}id4", "value" : { "key" : "pfx1-test-object", "versionId" : "vid4", "last-modified" : "1970-01-01T00:00:00.005Z" } }
+                // { "_id" : "Vpfx1-test-object{sep}id3", "value" : { "key" : "pfx1-test-object", "versionId" : "vid3", "last-modified" : "1970-01-01T00:00:00.004Z" } }
+                // { "_id" : "Vpfx1-test-object{sep}id2", "value" : { "key" : "pfx1-test-object", "versionId" : "vid2", "last-modified" : "1970-01-01T00:00:00.003Z" } }
+                // { "_id" : "Vpfx1-test-object{sep}id1", "value" : { "key" : "pfx1-test-object", "versionId" : "vid1", "last-modified" : "1970-01-01T00:00:00.002Z" } }
+                // { "_id" : "Vpfx1-test-object{sep}id0", "value" : { "key" : "pfx1-test-object", "versionId" : "vid0", "last-modified" : "1970-01-01T00:00:00.001Z" } }
+                /* eslint-enable max-len */
+            },
+            next => {
+                const params = {
+                    objName: 'pfx2-test-object',
+                    objVal: {
+                        key: 'pfx2-test-object',
+                        versionId: 'null',
+                    },
+                    nbVersions: 5,
+                };
+                const timestamp = 2000;
+                putBulkObjectVersions(metadata, BUCKET_NAME, params.objName, params.objVal, versionParams,
+                    params.nbVersions, timestamp, logger, next);
+                /* eslint-disable max-len */
+                // The following versions are created:
+                // { "_id" : "Mpfx2-test-object", "value" : { "key" : "pfx2-test-object", "versionId" : "vid4", "last-modified" : "1970-01-01T00:00:02.005Z" } }
+                // { "_id" : "Vpfx2-test-object{sep}id4", "value" : { "key" : "pfx2-test-object", "versionId" : "vid4", "last-modified" : "1970-01-01T00:00:02.005Z" } }
+                // { "_id" : "Vpfx2-test-object{sep}id3", "value" : { "key" : "pfx2-test-object", "versionId" : "vid3", "last-modified" : "1970-01-01T00:00:02.004Z" } }
+                // { "_id" : "Vpfx2-test-object{sep}id2", "value" : { "key" : "pfx2-test-object", "versionId" : "vid2", "last-modified" : "1970-01-01T00:00:02.003Z" } }
+                // { "_id" : "Vpfx2-test-object{sep}id1", "value" : { "key" : "pfx2-test-object", "versionId" : "vid1", "last-modified" : "1970-01-01T00:00:02.002Z" } }
+                // { "_id" : "Vpfx1-test-object{sep}id0", "value" : { "key" : "pfx2-test-object", "versionId" : "vid0", "last-modified" : "1970-01-01T00:00:02.001Z" } }
+                /* eslint-enable max-len */
+            },
+            next => {
+                const params = {
+                    objName: 'pfx3-test-object',
+                    objVal: {
+                        key: 'pfx3-test-object',
+                        versionId: 'null',
+                    },
+                    nbVersions: 5,
+                };
+                const timestamp = 1000;
+                putBulkObjectVersions(metadata, BUCKET_NAME, params.objName, params.objVal, versionParams,
+                    params.nbVersions, timestamp, logger, next);
+                /* eslint-disable max-len */
+                // The following versions are created:
+                // { "_id" : "Mpfx3-test-object", "value" : { "key" : "pfx3-test-object", "versionId" : "vid4", "last-modified" : "1970-01-01T00:00:01.005Z" } }
+                // { "_id" : "Vpfx3-test-object{sep}id4", "value" : { "key" : "pfx3-test-object", "versionId" : "vid4", "last-modified" : "1970-01-01T00:00:01.005Z" } }
+                // { "_id" : "Vpfx3-test-object{sep}id3", "value" : { "key" : "pfx3-test-object", "versionId" : "vid3", "last-modified" : "1970-01-01T00:00:01.004Z" } }
+                // { "_id" : "Vpfx3-test-object{sep}id2", "value" : { "key" : "pfx3-test-object", "versionId" : "vid2", "last-modified" : "1970-01-01T00:00:01.003Z" } }
+                // { "_id" : "Vpfx3-test-object{sep}id1", "value" : { "key" : "pfx3-test-object", "versionId" : "vid1", "last-modified" : "1970-01-01T00:00:01.002Z" } }
+                // { "_id" : "Vpfx3-test-object{sep}id0", "value" : { "key" : "pfx3-test-object", "versionId" : "vid0", "last-modified" : "1970-01-01T00:00:01.001Z" } }
+                /* eslint-enable max-len */
+            },
+        ], done);
+    });
+
+    afterEach(done => {
+        metadata.deleteBucket(BUCKET_NAME, logger, done);
+    });
+
+    it('Should list current versions of objects', done => {
+        const params = {
+            listingType: 'DelimiterCurrent',
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.ifError(err);
+            assert.strictEqual(data.IsTruncated, false);
+            assert.strictEqual(data.Contents.length, 3);
+            assert.strictEqual(data.Contents[0].key, 'pfx1-test-object');
+            assert.strictEqual(data.Contents[1].key, 'pfx2-test-object');
+            assert.strictEqual(data.Contents[2].key, 'pfx3-test-object');
+
+            return done();
+        });
+    });
+
+    it('Should return empty list when beforeDate is before the objects creation date', done => {
+        const params = {
+            listingType: 'DelimiterCurrent',
+            beforeDate: '1970-01-01T00:00:00.000Z',
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.ifError(err);
+            assert.strictEqual(data.IsTruncated, false);
+            assert.strictEqual(data.Contents.length, 0);
+
+            return done();
+        });
+    });
+
+    it('Should return the current version modified before 1970-01-01T00:00:00.010Z', done => {
+        const params = {
+            listingType: 'DelimiterCurrent',
+            beforeDate: '1970-01-01T00:00:00.10Z',
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.ifError(err);
+            assert.strictEqual(data.IsTruncated, false);
+            assert.strictEqual(data.Contents.length, 1);
+            assert.strictEqual(data.Contents[0].key, 'pfx1-test-object');
+
+            return done();
+        });
+    });
+
+    it('Should return the current versions modified before 1970-01-01T00:00:01.010Z', done => {
+        const params = {
+            listingType: 'DelimiterCurrent',
+            beforeDate: '1970-01-01T00:00:01.010Z',
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.ifError(err);
+            assert.strictEqual(data.IsTruncated, false);
+            assert.strictEqual(data.Contents.length, 2);
+            assert.strictEqual(data.Contents[0].key, 'pfx1-test-object');
+            assert.strictEqual(data.Contents[1].key, 'pfx3-test-object');
+
+            return done();
+        });
+    });
+
+    it('Should return the current versions modified before 1970-01-01T00:00:02.010Z', done => {
+        const params = {
+            listingType: 'DelimiterCurrent',
+            beforeDate: '1970-01-01T00:00:02.010Z',
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.ifError(err);
+            assert.strictEqual(data.IsTruncated, false);
+            assert.strictEqual(data.Contents.length, 3);
+            assert.strictEqual(data.Contents[0].key, 'pfx1-test-object');
+            assert.strictEqual(data.Contents[1].key, 'pfx2-test-object');
+            assert.strictEqual(data.Contents[2].key, 'pfx3-test-object');
+
+            return done();
+        });
+    });
+
+    it('Should truncate the list of current versions modified before 1970-01-01T00:00:01.010Z', done => {
+        const params = {
+            listingType: 'DelimiterCurrent',
+            beforeDate: '1970-01-01T00:00:01.010Z',
+            maxKeys: 1,
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.ifError(err);
+            assert.strictEqual(data.IsTruncated, true);
+            assert.strictEqual(data.Contents.length, 1);
+            assert.strictEqual(data.Contents[0].key, 'pfx1-test-object');
+            assert.strictEqual(data.NextMarker, 'pfx1-test-object');
+
+            params.marker = 'pfx1-test-object';
+
+            return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+                assert.ifError(err);
+                assert.strictEqual(data.IsTruncated, false);
+                assert.strictEqual(data.Contents.length, 1);
+                assert.strictEqual(data.Contents[0].key, 'pfx3-test-object');
+
+                return done();
+            });
+        });
+    });
+
+    it('Should truncate list of current versions of objects', done => {
+        const params = {
+            listingType: 'DelimiterCurrent',
+            maxKeys: 2,
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.ifError(err);
+            assert.strictEqual(data.IsTruncated, true);
+            assert.strictEqual(data.NextMarker, 'pfx2-test-object');
+            assert.strictEqual(data.Contents.length, 2);
+            assert.strictEqual(data.Contents[0].key, 'pfx1-test-object');
+            assert.strictEqual(data.Contents[1].key, 'pfx2-test-object');
+
+            return done();
+        });
+    });
+
+    it('Should list the following current versions of objects', done => {
+        const params = {
+            listingType: 'DelimiterCurrent',
+            marker: 'pfx2-test-object',
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.ifError(err);
+            assert.strictEqual(data.IsTruncated, false);
+            assert.strictEqual(data.Contents.length, 1);
+            assert.strictEqual(data.Contents[0].key, 'pfx3-test-object');
+
+            return done();
+        });
+    });
+
+    it('Should list current versions that start with prefix', done => {
+        const params = {
+            listingType: 'DelimiterCurrent',
+            prefix: 'pfx2',
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.ifError(err);
+            assert.strictEqual(data.IsTruncated, false);
+            assert.strictEqual(data.Contents.length, 1);
+            assert.strictEqual(data.Contents[0].key, 'pfx2-test-object');
+
+            return done();
+        });
+    });
+
+    it('Should return the list of current versions modified before 1970-01-01T00:00:01.010Z with prefix pfx1', done => {
+        const params = {
+            listingType: 'DelimiterCurrent',
+            beforeDate: '1970-01-01T00:00:01.010Z',
+            maxKeys: 1,
+            prefix: 'pfx1',
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.ifError(err);
+            assert.strictEqual(data.IsTruncated, false);
+            assert.strictEqual(data.Contents.length, 1);
+            assert.strictEqual(data.Contents[0].key, 'pfx1-test-object');
+
+            return done();
+        });
+    });
+
+    it('Should not list deleted object', done => {
+        const objVal = {
+            'key': 'pfx4-test-object',
+            'last-modified': new Date(0).toISOString(),
+        };
+        const versionParams = {
+            versioning: true,
+        };
+        const params = {
+            listingType: 'DelimiterCurrent',
+        };
+        async.series([
+            next => metadata.putObjectMD(BUCKET_NAME, objVal.key, objVal, versionParams,
+                logger, next),
+            next => metadata.deleteObjectMD(BUCKET_NAME, objVal.key, null, logger, next),
+            next => metadata.listObject(BUCKET_NAME, params, logger, (err, data) => {
+                assert.ifError(err);
+                assert.strictEqual(data.Contents.length, 3);
+                assert.strictEqual(data.Contents[0].key, 'pfx1-test-object');
+                assert.strictEqual(data.Contents[1].key, 'pfx2-test-object');
+                assert.strictEqual(data.Contents[2].key, 'pfx3-test-object');
+                return next();
+            }),
+        ], done);
+    });
+
+    it('Should not list phd master key when listing current versions', done => {
+        const objVal = {
+            'key': 'pfx4-test-object',
+            'versionId': 'null',
+            'last-modified': new Date(0).toISOString(),
+        };
+        const versionParams = {
+            versioning: true,
+        };
+        const params = {
+            listingType: 'DelimiterCurrent',
+            prefix: 'pfx4',
+        };
+        let versionId;
+        let lastVersionId;
+        async.series([
+            next => metadata.putObjectMD(BUCKET_NAME, 'pfx4-test-object', objVal, versionParams,
+                logger, (err, res) => {
+                    if (err) {
+                        return next(err);
+                    }
+                    versionId = JSON.parse(res).versionId;
+                    return next(null);
+                }),
+            next => metadata.putObjectMD(BUCKET_NAME, 'pfx4-test-object', objVal, versionParams,
+                logger, (err, res) => {
+                    if (err) {
+                        return next(err);
+                    }
+                    lastVersionId = JSON.parse(res).versionId;
+                    return next(null);
+                }),
+            next => metadata.deleteObjectMD(BUCKET_NAME, 'pfx4-test-object', { versionId: lastVersionId },
+                logger, next),
+            next => metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+                assert.ifError(err);
+                assert.strictEqual(data.Contents[0].value.VersionId, versionId);
+                return next();
+            }),
+        ], done);
+    });
+
+    it('Should not list the current version tagged for deletion', done => {
+        const objVal = {
+            'key': 'pfx4-test-object',
+            'last-modified': new Date(0).toISOString(),
+        };
+        const versionParams = {
+            versioning: true,
+        };
+        const params = {
+            listingType: 'DelimiterCurrent',
+        };
+        async.series([
+            next => metadata.putObjectMD(BUCKET_NAME, objVal.key, objVal, versionParams,
+                logger, next),
+            next => flagObjectForDeletion(collection, objVal.key, next),
+            next => metadata.listObject(BUCKET_NAME, params, logger, (err, data) => {
+                assert.ifError(err);
+                assert.strictEqual(data.Contents.length, 3);
+                assert.strictEqual(data.Contents[0].key, 'pfx1-test-object');
+                assert.strictEqual(data.Contents[1].key, 'pfx2-test-object');
+                assert.strictEqual(data.Contents[2].key, 'pfx3-test-object');
+                return next();
+            }),
+        ], done);
+    });
+});

--- a/tests/functional/metadata/mongodb/listLifecycleObject/global.spec.js
+++ b/tests/functional/metadata/mongodb/listLifecycleObject/global.spec.js
@@ -1,0 +1,78 @@
+const async = require('async');
+const assert = require('assert');
+const werelogs = require('werelogs');
+const { MongoMemoryReplSet } = require('mongodb-memory-server');
+const logger = new werelogs.Logger('MongoClientInterface', 'debug', 'debug');
+const MetadataWrapper =
+require('../../../../../lib/storage/metadata/MetadataWrapper');
+const { versioning } = require('../../../../../index');
+const { BucketVersioningKeyFormat } = versioning.VersioningConstants;
+const { makeBucketMD } = require('./utils');
+
+const IMPL_NAME = 'mongodb';
+const DB_NAME = 'metadata';
+const BUCKET_NAME = 'test-lifecycle-list-bucket-v0';
+
+const mongoserver = new MongoMemoryReplSet({
+    debug: false,
+    instanceOpts: [
+        { port: 27020 },
+    ],
+    replSet: {
+        name: 'rs0',
+        count: 1,
+        DB_NAME,
+        storageEngine: 'ephemeralForTest',
+    },
+});
+
+describe('MongoClientInterface::metadata.listLifecycleObject::global', () => {
+    let metadata;
+
+    beforeAll(done => {
+        mongoserver.waitUntilRunning().then(() => {
+            const opts = {
+                mongodb: {
+                    replicaSetHosts: 'localhost:27020',
+                    writeConcern: 'majority',
+                    replicaSet: 'rs0',
+                    readPreference: 'primary',
+                    database: DB_NAME,
+                },
+            };
+            metadata = new MetadataWrapper(IMPL_NAME, opts, null, logger);
+            metadata.client.defaultBucketKeyFormat = BucketVersioningKeyFormat.v0;
+            metadata.setup(done);
+        });
+    });
+
+    afterAll(done => {
+        async.series([
+            next => metadata.close(next),
+            next => mongoserver.stop()
+                .then(() => next())
+                .catch(next),
+        ], done);
+    });
+
+    beforeEach(done => {
+        const bucketMD = makeBucketMD(BUCKET_NAME);
+        return metadata.createBucket(BUCKET_NAME, bucketMD, logger, done);
+    });
+
+    afterEach(done => {
+        metadata.deleteBucket(BUCKET_NAME, logger, done);
+    });
+
+    it('Should return error listing current versions if v0 key format', done => {
+        const params = {
+            listingType: 'DelimiterCurrent',
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert(err.NotImplemented);
+            assert(!data);
+
+            return done();
+        });
+    });
+});

--- a/tests/functional/metadata/mongodb/listLifecycleObject/utils.js
+++ b/tests/functional/metadata/mongodb/listLifecycleObject/utils.js
@@ -1,0 +1,88 @@
+const async = require('async');
+const BucketInfo = require('../../../../../lib/models/BucketInfo').default;
+const assert = require('assert');
+
+/**
+    * Puts multpile versions of an object
+    * @param {Object} metadata - metadata client
+    * @param {String} bucketName - bucket name
+    * @param {String} objName - object key
+    * @param {Object} objVal - object metadata
+    * @param {Object} params - versioning parameters
+    * @param {number} versionNb - number of versions to put
+    * @param {number} timestamp - used for last-modified
+    * @param {Object} logger - a Logger instance
+    * @param {Function} cb - callback
+    * @returns {undefined}
+*/
+function putBulkObjectVersions(metadata, bucketName, objName, objVal, params, versionNb, timestamp, logger, cb) {
+    let count = 0;
+    return async.whilst(
+        () => count < versionNb,
+        cbIterator => {
+            count++;
+            const lastModified = new Date(timestamp + count).toISOString();
+            const finalObjectVal = Object.assign(objVal, { 'last-modified': lastModified });
+            return metadata.putObjectMD(bucketName, objName, finalObjectVal, params,
+                logger, cbIterator);
+        }, cb);
+}
+
+function makeBucketMD(bucketName) {
+    return BucketInfo.fromObj({
+        _name: bucketName,
+        _owner: 'testowner',
+        _ownerDisplayName: 'testdisplayname',
+        _creationDate: new Date().toJSON(),
+        _acl: {
+            Canned: 'private',
+            FULL_CONTROL: [],
+            WRITE: [],
+            WRITE_ACP: [],
+            READ: [],
+            READ_ACP: [],
+        },
+        _mdBucketModelVersion: 10,
+        _transient: false,
+        _deleted: false,
+        _serverSideEncryption: null,
+        _versioningConfiguration: null,
+        _locationConstraint: 'us-east-1',
+        _readLocationConstraint: null,
+        _cors: null,
+        _replicationConfiguration: null,
+        _lifecycleConfiguration: null,
+        _uid: '',
+        _isNFS: null,
+        ingestion: null,
+    });
+}
+
+function assertContents(contents, expected) {
+    contents.forEach((c, i) => {
+        assert.strictEqual(c.key, expected[i].key);
+        assert.strictEqual(c.value.LastModified, expected[i].LastModified);
+        assert.strictEqual(c.value.staleDate, expected[i].staleDate);
+    });
+}
+
+/**
+* Sets the "deleted" property to true
+* @param {Object} collection - collection to be updated
+* @param {string} key - object name
+* @param {Function} cb - callback
+* @return {undefined}
+*/
+function flagObjectForDeletion(collection, key, cb) {
+    collection.updateMany(
+        { 'value.key': key },
+        { $set: { 'value.deleted': true } },
+        { upsert: false }, cb);
+}
+
+module.exports = {
+    putBulkObjectVersions,
+    makeBucketMD,
+    assertContents,
+    flagObjectForDeletion,
+};

--- a/tests/unit/algos/list/delimiterCurrent.spec.js
+++ b/tests/unit/algos/list/delimiterCurrent.spec.js
@@ -1,0 +1,128 @@
+'use strict'; // eslint-disable-line strict
+
+const assert = require('assert');
+
+const DelimiterCurrent =
+    require('../../../../lib/algos/list/delimiterCurrent').DelimiterCurrent;
+const {
+    FILTER_ACCEPT,
+    FILTER_SKIP,
+    FILTER_END,
+} = require('../../../../lib/algos/list/tools');
+const VSConst =
+    require('../../../../lib/versioning/constants').VersioningConstants;
+const { DbPrefixes } = VSConst;
+
+const VID_SEP = VSConst.VersionId.Separator;
+const EmptyResult = {
+    Contents: [],
+    IsTruncated: false,
+};
+
+const fakeLogger = {
+    trace: () => {},
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    fatal: () => {},
+};
+
+function makeV1Key(key) {
+    const keyPrefix = key.includes(VID_SEP) ?
+        DbPrefixes.Version : DbPrefixes.Master;
+    return `${keyPrefix}${key}`;
+}
+
+describe('DelimiterCurrent', () => {
+    it('should accept entry starting with prefix', () => {
+        const delimiter = new DelimiterCurrent({ prefix: 'prefix' }, fakeLogger, 'v1');
+
+        const masterKey = 'prefix1';
+        const date1 = '1970-01-01T00:00:00.001Z';
+        const value1 = `{"last-modified": "${date1}"}`;
+        assert.strictEqual(delimiter.filter({ key: makeV1Key(masterKey), value: value1 }), FILTER_ACCEPT);
+
+        const expectedResult = {
+            Contents: [
+                {
+                    key: masterKey,
+                    value: value1,
+                },
+            ],
+            IsTruncated: false,
+        };
+
+        assert.deepStrictEqual(delimiter.result(), expectedResult);
+    });
+
+    it('should skip entry not starting with prefix', () => {
+        const delimiter = new DelimiterCurrent({ prefix: 'prefix' }, fakeLogger, 'v1');
+
+        const listingKey = makeV1Key('noprefix');
+        assert.strictEqual(delimiter.filter({ key: listingKey, value: '' }), FILTER_SKIP);
+
+        assert.deepStrictEqual(delimiter.result(), EmptyResult);
+    });
+
+    it('should accept a master and return it', () => {
+        const delimiter = new DelimiterCurrent({ }, fakeLogger, 'v1');
+
+        const masterKey = 'key';
+
+        const date1 = '1970-01-01T00:00:00.001Z';
+        const value1 = `{"last-modified": "${date1}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(masterKey),
+            value: value1,
+        }), FILTER_ACCEPT);
+
+        const expectedResult = {
+            Contents: [
+                {
+                    key: masterKey,
+                    value: value1,
+                },
+            ],
+            IsTruncated: false,
+        };
+
+        assert.deepStrictEqual(delimiter.result(), expectedResult);
+    });
+
+    it('should accept the first master and return the truncated content', () => {
+        const delimiter = new DelimiterCurrent({ maxKeys: 1 }, fakeLogger, 'v1');
+
+        const masterKey1 = 'key1';
+        const date1 = '1970-01-01T00:00:00.001Z';
+        const value1 = `{"last-modified": "${date1}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(masterKey1),
+            value: value1,
+        }), FILTER_ACCEPT);
+
+        const masterKey2 = 'key2';
+        const date2 = '1970-01-01T00:00:00.000Z';
+        const value2 = `{"last-modified": "${date2}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(masterKey2),
+            value: value2,
+        }), FILTER_END);
+
+        const expectedResult = {
+            Contents: [
+                {
+                    key: masterKey1,
+                    value: value1,
+                },
+            ],
+            NextMarker: masterKey1,
+            IsTruncated: true,
+        };
+
+        assert.deepStrictEqual(delimiter.result(), expectedResult);
+    });
+});


### PR DESCRIPTION
DelimiterCurrent is used for listing current versions. 
The Metadata call returns the masters (M prefix) younger than a defined date: `beforeDate`. 
No extra filtering action is needed on the Metadata call response.