### PR TITLE
ARSN-311 Add logic to list non-current versions for Lifecycle

### DIFF
--- a/lib/algos/list/delimiterNonCurrent.js
+++ b/lib/algos/list/delimiterNonCurrent.js
@@ -1,0 +1,213 @@
+'use strict'; // eslint-disable-line strict
+const Delimiter = require('./delimiter').Delimiter;
+const VSConst = require('../../versioning/constants').VersioningConstants;
+const { inc, FILTER_ACCEPT, FILTER_END, SKIP_NONE } = require('./tools');
+const VID_SEP = VSConst.VersionId.Separator;
+const { DbPrefixes } = VSConst;
+
+// TODO: find an acceptable timeout value.
+const DELIMITER_TIMEOUT_MS = 10 * 1000; // 10s
+const TRIM_METADATA_MIN_BLOB_SIZE = 10000;
+
+/**
+ * Handle object listing with parameters. This extends the base class Delimiter
+ * to return the raw non-current versions objects.
+ */
+class DelimiterNonCurrent extends Delimiter {
+    /**
+     * Delimiter listing of non-current versions.
+     * @param {Object}  parameters                  - listing parameters
+     * @param {String}  parameters.versionIdMarker  - version id marker
+     * @param {String}  parameters.beforeDate       - limit the response to keys with stale date older than beforeDate
+     * “stale date” is the date on when a version becomes non-current.
+     * @param {String}  parameters.keyMarker        - key marker
+     * @param {RequestLogger} logger                - The logger of the request
+     * @param {String} [vFormat]                    - versioning key format
+     */
+    constructor(parameters, logger, vFormat) {
+        super(parameters, logger, vFormat);
+
+        this.versionIdMarker = parameters.versionIdMarker;
+        this.beforeDate = parameters.beforeDate;
+        this.keyMarker = parameters.keyMarker;
+        this.NextKeyMarker = null;
+
+        this.skipping = this.skippingV1;
+        this.genMDParams = this.genMDParamsV1;
+
+        this.keyName = null;
+        this.staleDate = null;
+
+        // used for monitoring
+        this.evaluatedKeys = 0;
+    }
+
+    skippingV1() {
+        return SKIP_NONE;
+    }
+
+    genMDParamsV1() {
+        const params = {
+            gte: DbPrefixes.Version,
+            lt: inc(DbPrefixes.Version),
+        };
+
+        if (this.prefix) {
+            params.gte = `${DbPrefixes.Version}${this.prefix}`;
+            params.lt = `${DbPrefixes.Version}${inc(this.prefix)}`;
+        }
+
+        if (this.keyMarker && `${DbPrefixes.Version}${this.keyMarker}` >= params.gte) {
+            if (this.versionIdMarker) {
+                // versionIdMarker should always come with keyMarker but may not be the other way around.
+                // NOTE: "gte" (instead of "gt") is used to include the last version of the "previous"
+                // truncated listing when a versionId marker is specified.
+                // This "previous"/"already evaluated" version will be used to retrieve the stale date and
+                // skipped to not evaluate the same key twice in the addContents() method.
+                params.gte = DbPrefixes.Version
+                    + this.keyMarker
+                    + VID_SEP
+                    + this.versionIdMarker;
+            } else {
+                delete params.gte;
+                params.gt = DbPrefixes.Version + inc(this.keyMarker + VID_SEP);
+            }
+        }
+
+        this.start = Date.now();
+
+        return params;
+    }
+
+    getLastModified(value) {
+        let lastModified;
+        try {
+            const v = JSON.parse(value);
+            lastModified = v['last-modified'];
+        } catch (e) {
+            this.logger.warn('could not parse Object Metadata while listing',
+                {
+                    method: 'getLastModified',
+                    err: e.toString(),
+                });
+        }
+        return lastModified;
+    }
+
+    /**
+     * NOTE: Each version of a specific key is sorted from the latest to the oldest
+     * thanks to the way version ids are generated.
+     * DESCRIPTION: For a given key, the latest version is skipped since it represents the current version or
+     * the last version of the previous truncated listing.
+     * The current last-modified date is kept in memory and used as a "stale date" for the following version.
+     * The following version is pushed only if the "stale date" (picked up from the previous version)
+     * is available (JSON.parse has not failed), if the "beforeDate" argument is specified, and
+     * the "stale date" is older than the "beforeDate".
+     * The in-memory "stale date" is then updated with the version's last-modified date to be used for
+     * the following version.
+     * The process stops and returns the available results if either:
+     * - no more metadata key is left to be processed
+     * - the listing reaches the maximum number of key to be returned
+     * - the internal timeout is reached
+     *  @param {String} keyVersionSuffix   - The key to add
+     *  @param {String} value - The value of the key
+     *  @return {number}      - indicates if iteration should continue
+     */
+    addContents(keyVersionSuffix, value) {
+        if (this._reachedMaxKeys()) {
+            return FILTER_END;
+        }
+
+        if (this.start && Date.now() - this.start > DELIMITER_TIMEOUT_MS) {
+            this.IsTruncated = true;
+            this.logger.info('listing stopped after expected internal timeout',
+                {
+                    timeoutMs: DELIMITER_TIMEOUT_MS,
+                    evaluatedKeys: this.evaluatedKeys,
+                });
+            return FILTER_END;
+        }
+        ++this.evaluatedKeys;
+
+        const versionIdIndex = keyVersionSuffix.indexOf(VID_SEP);
+        const key = keyVersionSuffix.slice(0, versionIdIndex);
+        const versionId = keyVersionSuffix.slice(versionIdIndex + 1);
+
+        this.NextKeyMarker = key;
+        this.NextVersionIdMarker = versionId;
+
+        // For a given key, the latest version is skipped since it represents either:
+        // - the current version or
+        // - the last version of the previous truncated listing
+        const isLatestVersion = key !== this.keyName;
+
+        if (isLatestVersion) {
+            this.keyName = key;
+            // The current last-modified date is kept in memory and used as a "stale date" for the following version.
+            this.staleDate = this.getLastModified(value);
+            return FILTER_ACCEPT;
+        }
+
+        // The following version is pushed only if the "stale date" (picked up from the previous version)
+        // is available (JSON.parse has not failed) and, if the "beforeDate" argument is specified,
+        // the "stale date" is older than the "beforeDate".
+        let lastModified;
+        if (this.staleDate && (!this.beforeDate || this.staleDate < this.beforeDate)) {
+            const v = this.trimMetadataAddStaleDate(value, this.staleDate);
+            lastModified = v.lastModified;
+            const { contentValue } = v;
+            // check that trimMetadataAddStaleDate succeeds to only push objects with a defined staleDate.
+            if (contentValue) {
+                this.Contents.push({ key, value: contentValue });
+                ++this.keys;
+            }
+        }
+
+        // The in-memory "stale date" is then updated with the version's last-modified date to be used for
+        // the following version.
+        this.staleDate = lastModified || this.getLastModified(value);
+
+        return FILTER_ACCEPT;
+    }
+
+    trimMetadataAddStaleDate(value, staleDate) {
+        let ret = undefined;
+        let lastModified = undefined;
+        try {
+            ret = JSON.parse(value);
+            ret.staleDate = staleDate;
+            lastModified = ret['last-modified'];
+            if (value.length >= TRIM_METADATA_MIN_BLOB_SIZE) {
+                delete ret.location;
+            }
+            ret = JSON.stringify(ret);
+        } catch (e) {
+            // Prefer returning an unfiltered data rather than
+            // stopping the service in case of parsing failure.
+            // The risk of this approach is a potential
+            // reproduction of MD-692, where too much memory is
+            // used by repd.
+            this.logger.warn('could not parse Object Metadata while listing',
+                {
+                    method: 'trimMetadataAddStaleDate',
+                    err: e.toString(),
+                });
+        }
+        return { contentValue: ret, lastModified };
+    }
+
+    result() {
+        const result = {
+            Contents: this.Contents,
+            IsTruncated: this.IsTruncated,
+        };
+
+        if (this.IsTruncated) {
+            result.NextKeyMarker = this.NextKeyMarker;
+            result.NextVersionIdMarker = this.NextVersionIdMarker;
+        }
+
+        return result;
+    }
+}
+module.exports = { DelimiterNonCurrent };

--- a/lib/algos/list/exportAlgos.js
+++ b/lib/algos/list/exportAlgos.js
@@ -7,4 +7,5 @@ module.exports = {
         .DelimiterMaster,
     MPU: require('./MPU').MultipartUploads,
     DelimiterCurrent: require('./delimiterCurrent').DelimiterCurrent,
+    DelimiterNonCurrent: require('./delimiterNonCurrent').DelimiterNonCurrent,
 };

--- a/tests/functional/metadata/mongodb/listLifecycleObject/global.spec.js
+++ b/tests/functional/metadata/mongodb/listLifecycleObject/global.spec.js
@@ -75,4 +75,16 @@ describe('MongoClientInterface::metadata.listLifecycleObject::global', () => {
             return done();
         });
     });
+
+    it('Should return error listing non-current versions if v0 key format', done => {
+        const params = {
+            listingType: 'DelimiterNonCurrent',
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert(err.NotImplemented);
+            assert(!data);
+
+            return done();
+        });
+    });
 });

--- a/tests/functional/metadata/mongodb/listLifecycleObject/noncurrent.spec.js
+++ b/tests/functional/metadata/mongodb/listLifecycleObject/noncurrent.spec.js
@@ -1,0 +1,827 @@
+const async = require('async');
+const assert = require('assert');
+const werelogs = require('werelogs');
+const { MongoMemoryReplSet } = require('mongodb-memory-server');
+const logger = new werelogs.Logger('MongoClientInterface', 'debug', 'debug');
+const MetadataWrapper =
+require('../../../../../lib/storage/metadata/MetadataWrapper');
+const { versioning } = require('../../../../../index');
+const { BucketVersioningKeyFormat } = versioning.VersioningConstants;
+const { assertContents, makeBucketMD, putBulkObjectVersions, flagObjectForDeletion } = require('./utils');
+
+const IMPL_NAME = 'mongodb';
+const DB_NAME = 'metadata';
+const BUCKET_NAME = 'test-lifecycle-list-non-current-bucket';
+
+const mongoserver = new MongoMemoryReplSet({
+    debug: false,
+    instanceOpts: [
+        { port: 27020 },
+    ],
+    replSet: {
+        name: 'rs0',
+        count: 1,
+        DB_NAME,
+        storageEngine: 'ephemeralForTest',
+    },
+});
+
+describe('MongoClientInterface::metadata.listLifecycleObject::noncurrent', () => {
+    let metadata;
+    let collection;
+    const expectedVersionIds = {};
+    const key1 = 'pfx1-test-object';
+    const key2 = 'pfx2-test-object';
+    const key3 = 'pfx3-test-object';
+
+    beforeAll(done => {
+        mongoserver.waitUntilRunning().then(() => {
+            const opts = {
+                mongodb: {
+                    replicaSetHosts: 'localhost:27020',
+                    writeConcern: 'majority',
+                    replicaSet: 'rs0',
+                    readPreference: 'primary',
+                    database: DB_NAME,
+                },
+            };
+            metadata = new MetadataWrapper(IMPL_NAME, opts, null, logger);
+            metadata.client.defaultBucketKeyFormat = BucketVersioningKeyFormat.v1;
+            metadata.setup(done);
+        });
+    });
+
+    afterAll(done => {
+        async.series([
+            next => metadata.close(next),
+            next => mongoserver.stop()
+                .then(() => next())
+                .catch(next),
+        ], done);
+    });
+
+    beforeEach(done => {
+        const bucketMD = makeBucketMD(BUCKET_NAME);
+        const versionParams = {
+            versioning: true,
+            versionId: null,
+            repairMaster: null,
+        };
+        async.series([
+            next => metadata.createBucket(BUCKET_NAME, bucketMD, logger, err => {
+                if (err) {
+                    return next(err);
+                }
+
+                collection = metadata.client.getCollection(BUCKET_NAME);
+                return next();
+            }),
+            next => {
+                const params = {
+                    objName: key1,
+                    objVal: {
+                        key: key1,
+                        versionId: 'null',
+                    },
+                    nbVersions: 5,
+                };
+                const timestamp = 0;
+                putBulkObjectVersions(metadata, BUCKET_NAME, params.objName, params.objVal, versionParams,
+                    params.nbVersions, timestamp, logger, (err, data) => {
+                        expectedVersionIds[key1] = data;
+                        return next(err);
+                    });
+                /* eslint-disable max-len */
+                // { "_id" : "Mpfx1-test-object", "value" : { "key" : "pfx1-test-object", "versionId" : "vid4", "last-modified" : "1970-01-01T00:00:00.005Z" } }
+                // { "_id" : "Vpfx1-test-object{sep}id4", "value" : { "key" : "pfx1-test-object", "versionId" : "vid4", "last-modified" : "1970-01-01T00:00:00.005Z" } }
+                // { "_id" : "Vpfx1-test-object{sep}id3", "value" : { "key" : "pfx1-test-object", "versionId" : "vid3", "last-modified" : "1970-01-01T00:00:00.004Z" } }
+                // { "_id" : "Vpfx1-test-object{sep}id2", "value" : { "key" : "pfx1-test-object", "versionId" : "vid2", "last-modified" : "1970-01-01T00:00:00.003Z" } }
+                // { "_id" : "Vpfx1-test-object{sep}id1", "value" : { "key" : "pfx1-test-object", "versionId" : "vid1", "last-modified" : "1970-01-01T00:00:00.002Z" } }
+                // { "_id" : "Vpfx1-test-object{sep}id0", "value" : { "key" : "pfx1-test-object", "versionId" : "vid0", "last-modified" : "1970-01-01T00:00:00.001Z" } }
+                /* eslint-enable max-len */
+            },
+            next => {
+                const params = {
+                    objName: key2,
+                    objVal: {
+                        key: key2,
+                        versionId: 'null',
+                    },
+                    nbVersions: 5,
+                };
+                const timestamp = 0;
+                putBulkObjectVersions(metadata, BUCKET_NAME, params.objName, params.objVal, versionParams,
+                    params.nbVersions, timestamp, logger, (err, data) => {
+                        expectedVersionIds[key2] = data;
+                        return next(err);
+                    });
+                /* eslint-disable max-len */
+                // { "_id" : "Mpfx2-test-object", "value" : { "key" : "pfx2-test-object", "versionId" : "vid4", "last-modified" : "1970-01-01T00:00:00.005Z" } }
+                // { "_id" : "Vpfx2-test-object{sep}id4", "value" : { "key" : "pfx2-test-object", "versionId" : "vid4", "last-modified" : "1970-01-01T00:00:00.005Z" } }
+                // { "_id" : "Vpfx2-test-object{sep}id3", "value" : { "key" : "pfx2-test-object", "versionId" : "vid3", "last-modified" : "1970-01-01T00:00:00.004Z" } }
+                // { "_id" : "Vpfx2-test-object{sep}id2", "value" : { "key" : "pfx2-test-object", "versionId" : "vid2", "last-modified" : "1970-01-01T00:00:00.003Z" } }
+                // { "_id" : "Vpfx2-test-object{sep}id1", "value" : { "key" : "pfx2-test-object", "versionId" : "vid1", "last-modified" : "1970-01-01T00:00:00.002Z" } }
+                // { "_id" : "Vpfx1-test-object{sep}id0", "value" : { "key" : "pfx2-test-object", "versionId" : "vid0", "last-modified" : "1970-01-01T00:00:00.001Z" } }
+                /* eslint-enable max-len */
+            },
+            next => {
+                const params = {
+                    objName: key3,
+                    objVal: {
+                        key: key3,
+                        versionId: 'null',
+                    },
+                    nbVersions: 5,
+                };
+                const timestamp = 0;
+                putBulkObjectVersions(metadata, BUCKET_NAME, params.objName, params.objVal, versionParams,
+                    params.nbVersions, timestamp, logger, (err, data) => {
+                        expectedVersionIds[key3] = data;
+                        return next(err);
+                    });
+                /* eslint-disable max-len */
+                // { "_id" : "Mpfx3-test-object", "value" : { "key" : "pfx3-test-object", "versionId" : "vid4", "last-modified" : "1970-01-01T00:00:00.005Z" } }
+                // { "_id" : "Vpfx3-test-object{sep}id4", "value" : { "key" : "pfx3-test-object", "versionId" : "vid4", "last-modified" : "1970-01-01T00:00:00.005Z" } }
+                // { "_id" : "Vpfx3-test-object{sep}id3", "value" : { "key" : "pfx3-test-object", "versionId" : "vid3", "last-modified" : "1970-01-01T00:00:00.004Z" } }
+                // { "_id" : "Vpfx3-test-object{sep}id2", "value" : { "key" : "pfx3-test-object", "versionId" : "vid2", "last-modified" : "1970-01-01T00:00:00.003Z" } }
+                // { "_id" : "Vpfx3-test-object{sep}id1", "value" : { "key" : "pfx3-test-object", "versionId" : "vid1", "last-modified" : "1970-01-01T00:00:00.002Z" } }
+                // { "_id" : "Vpfx3-test-object{sep}id0", "value" : { "key" : "pfx3-test-object", "versionId" : "vid0", "last-modified" : "1970-01-01T00:00:00.001Z" } }
+                /* eslint-enable max-len */
+            },
+        ], done);
+    });
+
+    afterEach(done => metadata.deleteBucket(BUCKET_NAME, logger, done));
+
+    it('Should list non-current versions', done => {
+        const params = {
+            listingType: 'DelimiterNonCurrent',
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(data.IsTruncated, false);
+            assert.strictEqual(data.Contents.length, 12);
+            const expected = [
+                {
+                    key: key1,
+                    LastModified: '1970-01-01T00:00:00.004Z',
+                    staleDate: '1970-01-01T00:00:00.005Z',
+                },
+                {
+                    key: key1,
+                    LastModified: '1970-01-01T00:00:00.003Z',
+                    staleDate: '1970-01-01T00:00:00.004Z',
+                },
+                {
+                    key: key1,
+                    LastModified: '1970-01-01T00:00:00.002Z',
+                    staleDate: '1970-01-01T00:00:00.003Z',
+                },
+                {
+                    key: key1,
+                    LastModified: '1970-01-01T00:00:00.001Z',
+                    staleDate: '1970-01-01T00:00:00.002Z',
+                },
+                {
+                    key: key2,
+                    LastModified: '1970-01-01T00:00:00.004Z',
+                    staleDate: '1970-01-01T00:00:00.005Z',
+                },
+                {
+                    key: key2,
+                    LastModified: '1970-01-01T00:00:00.003Z',
+                    staleDate: '1970-01-01T00:00:00.004Z',
+                },
+                {
+                    key: key2,
+                    LastModified: '1970-01-01T00:00:00.002Z',
+                    staleDate: '1970-01-01T00:00:00.003Z',
+                },
+                {
+                    key: key2,
+                    LastModified: '1970-01-01T00:00:00.001Z',
+                    staleDate: '1970-01-01T00:00:00.002Z',
+                },
+                {
+                    key: key3,
+                    LastModified: '1970-01-01T00:00:00.004Z',
+                    staleDate: '1970-01-01T00:00:00.005Z',
+                },
+                {
+                    key: key3,
+                    LastModified: '1970-01-01T00:00:00.003Z',
+                    staleDate: '1970-01-01T00:00:00.004Z',
+                },
+                {
+                    key: key3,
+                    LastModified: '1970-01-01T00:00:00.002Z',
+                    staleDate: '1970-01-01T00:00:00.003Z',
+                },
+                {
+                    key: key3,
+                    LastModified: '1970-01-01T00:00:00.001Z',
+                    staleDate: '1970-01-01T00:00:00.002Z',
+                },
+            ];
+            assertContents(data.Contents, expected);
+
+            const key1VersionIds = data.Contents.filter(k => k.key === key1).map(k => k.value.VersionId);
+            assert.deepStrictEqual(key1VersionIds, expectedVersionIds[key1]);
+
+            const key2VersionIds = data.Contents.filter(k => k.key === key2).map(k => k.value.VersionId);
+            assert.deepStrictEqual(key2VersionIds, expectedVersionIds[key2]);
+
+            const key3VersionIds = data.Contents.filter(k => k.key === key2).map(k => k.value.VersionId);
+            assert.deepStrictEqual(key3VersionIds, expectedVersionIds[key2]);
+
+            return done();
+        });
+    });
+
+    it('Should return empty list when beforeDate is before the objects stale date', done => {
+        const params = {
+            listingType: 'DelimiterNonCurrent',
+            beforeDate: '1970-01-01T00:00:00.000Z',
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(data.IsTruncated, false);
+            assert.strictEqual(data.Contents.length, 0);
+
+            return done();
+        });
+    });
+
+    it('Should return the non-current versions with stale date older than 1970-01-01T00:00:00.003Z', done => {
+        const params = {
+            listingType: 'DelimiterNonCurrent',
+            beforeDate: '1970-01-01T00:00:00.003Z',
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(data.IsTruncated, false);
+            assert.strictEqual(data.Contents.length, 3);
+            const expected = [
+                {
+                    key: key1,
+                    LastModified: '1970-01-01T00:00:00.001Z',
+                    staleDate: '1970-01-01T00:00:00.002Z',
+                    VersionId: expectedVersionIds[key1][3],
+                },
+                {
+                    key: key2,
+                    LastModified: '1970-01-01T00:00:00.001Z',
+                    staleDate: '1970-01-01T00:00:00.002Z',
+                    VersionId: expectedVersionIds[key2][3],
+                },
+                {
+                    key: key3,
+                    LastModified: '1970-01-01T00:00:00.001Z',
+                    staleDate: '1970-01-01T00:00:00.002Z',
+                    VersionId: expectedVersionIds[key3][3],
+                },
+            ];
+            assertContents(data.Contents, expected);
+
+            return done();
+        });
+    });
+
+    it('Should list non-current versions three by three', done => {
+        const params = {
+            listingType: 'DelimiterNonCurrent',
+            maxKeys: 3,
+        };
+
+        return async.series([
+            next => metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+                assert.deepStrictEqual(err, null);
+                assert.strictEqual(data.IsTruncated, true);
+                assert.strictEqual(data.NextKeyMarker, key1);
+                assert.strictEqual(data.NextVersionIdMarker, data.Contents[2].value.VersionId);
+                assert.strictEqual(data.Contents.length, 3);
+                const expected = [
+                    {
+                        key: key1,
+                        LastModified: '1970-01-01T00:00:00.004Z',
+                        staleDate: '1970-01-01T00:00:00.005Z',
+                        VersionId: expectedVersionIds[key1][0],
+                    },
+                    {
+                        key: key1,
+                        LastModified: '1970-01-01T00:00:00.003Z',
+                        staleDate: '1970-01-01T00:00:00.004Z',
+                        VersionId: expectedVersionIds[key1][1],
+                    },
+                    {
+                        key: key1,
+                        LastModified: '1970-01-01T00:00:00.002Z',
+                        staleDate: '1970-01-01T00:00:00.003Z',
+                        VersionId: expectedVersionIds[key1][2],
+                    },
+                ];
+                assertContents(data.Contents, expected);
+
+                params.keyMarker = data.NextKeyMarker;
+                params.versionIdMarker = data.NextVersionIdMarker;
+
+                return next();
+            }),
+            next => metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+                assert.deepStrictEqual(err, null);
+                assert.strictEqual(data.IsTruncated, true);
+                assert.strictEqual(data.NextKeyMarker, key2);
+                assert.strictEqual(data.NextVersionIdMarker, data.Contents[2].value.VersionId);
+                assert.strictEqual(data.Contents.length, 3);
+                const expected = [
+                    {
+                        key: key1,
+                        LastModified: '1970-01-01T00:00:00.001Z',
+                        staleDate: '1970-01-01T00:00:00.002Z',
+                        VersionId: expectedVersionIds[key1][3],
+                    },
+                    {
+                        key: key2,
+                        LastModified: '1970-01-01T00:00:00.004Z',
+                        staleDate: '1970-01-01T00:00:00.005Z',
+                        VersionId: expectedVersionIds[key2][0],
+                    },
+                    {
+                        key: key2,
+                        LastModified: '1970-01-01T00:00:00.003Z',
+                        staleDate: '1970-01-01T00:00:00.004Z',
+                        VersionId: expectedVersionIds[key2][1],
+                    },
+                ];
+                assertContents(data.Contents, expected);
+
+                params.keyMarker = data.NextKeyMarker;
+                params.versionIdMarker = data.NextVersionIdMarker;
+
+                return next();
+            }),
+            next => metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+                assert.deepStrictEqual(err, null);
+                assert.strictEqual(data.IsTruncated, true);
+                assert.strictEqual(data.NextKeyMarker, key3);
+                assert.strictEqual(data.NextVersionIdMarker, data.Contents[2].value.VersionId);
+                assert.strictEqual(data.Contents.length, 3);
+                const expected = [
+                    {
+                        key: key2,
+                        LastModified: '1970-01-01T00:00:00.002Z',
+                        staleDate: '1970-01-01T00:00:00.003Z',
+                        VersionId: expectedVersionIds[key2][2],
+                    },
+                    {
+                        key: key2,
+                        LastModified: '1970-01-01T00:00:00.001Z',
+                        staleDate: '1970-01-01T00:00:00.002Z',
+                        VersionId: expectedVersionIds[key2][3],
+                    },
+                    {
+                        key: key3,
+                        LastModified: '1970-01-01T00:00:00.004Z',
+                        staleDate: '1970-01-01T00:00:00.005Z',
+                        VersionId: expectedVersionIds[key3][0],
+                    },
+                ];
+                assertContents(data.Contents, expected);
+
+                params.keyMarker = data.NextKeyMarker;
+                params.versionIdMarker = data.NextVersionIdMarker;
+
+                return next();
+            }),
+            next => metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+                assert.deepStrictEqual(err, null);
+                assert.strictEqual(data.IsTruncated, false);
+                assert.strictEqual(data.Contents.length, 3);
+                const expected = [
+                    {
+                        key: key3,
+                        LastModified: '1970-01-01T00:00:00.003Z',
+                        staleDate: '1970-01-01T00:00:00.004Z',
+                        VersionId: expectedVersionIds[key3][1],
+                    },
+                    {
+                        key: key3,
+                        LastModified: '1970-01-01T00:00:00.002Z',
+                        staleDate: '1970-01-01T00:00:00.003Z',
+                        VersionId: expectedVersionIds[key3][2],
+                    },
+                    {
+                        key: key3,
+                        LastModified: '1970-01-01T00:00:00.001Z',
+                        staleDate: '1970-01-01T00:00:00.002Z',
+                        VersionId: expectedVersionIds[key3][3],
+                    },
+                ];
+                assertContents(data.Contents, expected);
+
+                return next();
+            }),
+        ], done);
+    });
+
+    it('Should list non-current versions four by four', done => {
+        const params = {
+            listingType: 'DelimiterNonCurrent',
+            maxKeys: 4,
+        };
+
+        return async.series([
+            next => metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+                assert.deepStrictEqual(err, null);
+
+                assert.strictEqual(data.IsTruncated, true);
+                assert.strictEqual(data.NextKeyMarker, key1);
+                assert.strictEqual(data.NextVersionIdMarker, data.Contents[3].value.VersionId);
+                assert.strictEqual(data.Contents.length, 4);
+
+                const expected = [
+                    {
+                        key: key1,
+                        LastModified: '1970-01-01T00:00:00.004Z',
+                        staleDate: '1970-01-01T00:00:00.005Z',
+                    },
+                    {
+                        key: key1,
+                        LastModified: '1970-01-01T00:00:00.003Z',
+                        staleDate: '1970-01-01T00:00:00.004Z',
+                    },
+                    {
+                        key: key1,
+                        LastModified: '1970-01-01T00:00:00.002Z',
+                        staleDate: '1970-01-01T00:00:00.003Z',
+                    },
+                    {
+                        key: key1,
+                        LastModified: '1970-01-01T00:00:00.001Z',
+                        staleDate: '1970-01-01T00:00:00.002Z',
+                    },
+                ];
+
+                assertContents(data.Contents, expected);
+
+                const key1VersionIds = data.Contents.filter(k => k.key === key1).map(k => k.value.VersionId);
+                assert.deepStrictEqual(key1VersionIds, expectedVersionIds[key1]);
+
+                params.keyMarker = data.NextKeyMarker;
+                params.versionIdMarker = data.NextVersionIdMarker;
+
+                return next();
+            }),
+            next => metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+                assert.deepStrictEqual(err, null);
+                assert.strictEqual(data.IsTruncated, true);
+                assert.strictEqual(data.NextKeyMarker, key2);
+                assert.strictEqual(data.NextVersionIdMarker, data.Contents[3].value.VersionId);
+                assert.strictEqual(data.Contents.length, 4);
+                const expected = [
+                    {
+                        key: key2,
+                        LastModified: '1970-01-01T00:00:00.004Z',
+                        staleDate: '1970-01-01T00:00:00.005Z',
+                    },
+                    {
+                        key: key2,
+                        LastModified: '1970-01-01T00:00:00.003Z',
+                        staleDate: '1970-01-01T00:00:00.004Z',
+                    },
+                    {
+                        key: key2,
+                        LastModified: '1970-01-01T00:00:00.002Z',
+                        staleDate: '1970-01-01T00:00:00.003Z',
+                    },
+                    {
+                        key: key2,
+                        LastModified: '1970-01-01T00:00:00.001Z',
+                        staleDate: '1970-01-01T00:00:00.002Z',
+                    },
+                ];
+                assertContents(data.Contents, expected);
+
+                const key2VersionIds = data.Contents.filter(k => k.key === key2).map(k => k.value.VersionId);
+                assert.deepStrictEqual(key2VersionIds, expectedVersionIds[key2]);
+
+                params.keyMarker = data.NextKeyMarker;
+                params.versionIdMarker = data.NextVersionIdMarker;
+
+                return next();
+            }),
+            next => metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+                assert.deepStrictEqual(err, null);
+                assert.strictEqual(data.IsTruncated, false);
+                assert.strictEqual(data.Contents.length, 4);
+                const expected = [
+                    {
+                        key: key3,
+                        LastModified: '1970-01-01T00:00:00.004Z',
+                        staleDate: '1970-01-01T00:00:00.005Z',
+                    },
+                    {
+                        key: key3,
+                        LastModified: '1970-01-01T00:00:00.003Z',
+                        staleDate: '1970-01-01T00:00:00.004Z',
+                    },
+                    {
+                        key: key3,
+                        LastModified: '1970-01-01T00:00:00.002Z',
+                        staleDate: '1970-01-01T00:00:00.003Z',
+                    },
+                    {
+                        key: key3,
+                        LastModified: '1970-01-01T00:00:00.001Z',
+                        staleDate: '1970-01-01T00:00:00.002Z',
+                    },
+                ];
+                assertContents(data.Contents, expected);
+
+                const key3VersionIds = data.Contents.filter(k => k.key === key3).map(k => k.value.VersionId);
+                assert.deepStrictEqual(key3VersionIds, expectedVersionIds[key3]);
+
+                return next();
+            }),
+        ], done);
+    });
+
+    it('Should list non-current versions with a specific prefix two by two', done => {
+        const params = {
+            listingType: 'DelimiterNonCurrent',
+            maxKeys: 2,
+            prefix: 'pfx2',
+        };
+
+        return async.series([
+            next => metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+                assert.deepStrictEqual(err, null);
+
+                assert.strictEqual(data.IsTruncated, true);
+                assert.strictEqual(data.NextKeyMarker, key2);
+                assert.strictEqual(data.NextVersionIdMarker, data.Contents[1].value.VersionId);
+                assert.strictEqual(data.Contents.length, 2);
+
+                const expected = [
+                    {
+                        key: key2,
+                        LastModified: '1970-01-01T00:00:00.004Z',
+                        staleDate: '1970-01-01T00:00:00.005Z',
+                        VersionId: expectedVersionIds[key2][0],
+                    },
+                    {
+                        key: key2,
+                        LastModified: '1970-01-01T00:00:00.003Z',
+                        staleDate: '1970-01-01T00:00:00.004Z',
+                        VersionId: expectedVersionIds[key2][1],
+                    },
+                ];
+
+                assertContents(data.Contents, expected);
+
+                params.keyMarker = data.NextKeyMarker;
+                params.versionIdMarker = data.NextVersionIdMarker;
+
+                return next();
+            }),
+            next => metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+                assert.deepStrictEqual(err, null);
+                assert.strictEqual(data.IsTruncated, false);
+                assert.strictEqual(data.Contents.length, 2);
+                const expected = [
+                    {
+                        key: key2,
+                        LastModified: '1970-01-01T00:00:00.002Z',
+                        staleDate: '1970-01-01T00:00:00.003Z',
+                        VersionId: expectedVersionIds[key2][2],
+                    },
+                    {
+                        key: key2,
+                        LastModified: '1970-01-01T00:00:00.001Z',
+                        staleDate: '1970-01-01T00:00:00.002Z',
+                        VersionId: expectedVersionIds[key2][3],
+                    },
+                ];
+                assertContents(data.Contents, expected);
+
+                params.keyMarker = data.NextKeyMarker;
+                params.versionIdMarker = data.NextVersionIdMarker;
+
+                return next();
+            }),
+        ], done);
+    });
+
+    it('Should return truncated list of non-current versions after pfx1-test-object key marker', done => {
+        const params = {
+            listingType: 'DelimiterNonCurrent',
+            maxKeys: 4,
+            keyMarker: key1,
+        };
+
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(data.IsTruncated, true);
+            assert.strictEqual(data.NextKeyMarker, key2);
+            assert.strictEqual(data.NextVersionIdMarker, data.Contents[3].value.VersionId);
+            assert.strictEqual(data.Contents.length, 4);
+            const expected = [
+                {
+                    key: key2,
+                    LastModified: '1970-01-01T00:00:00.004Z',
+                    staleDate: '1970-01-01T00:00:00.005Z',
+                },
+                {
+                    key: key2,
+                    LastModified: '1970-01-01T00:00:00.003Z',
+                    staleDate: '1970-01-01T00:00:00.004Z',
+                },
+                {
+                    key: key2,
+                    LastModified: '1970-01-01T00:00:00.002Z',
+                    staleDate: '1970-01-01T00:00:00.003Z',
+                },
+                {
+                    key: key2,
+                    LastModified: '1970-01-01T00:00:00.001Z',
+                    staleDate: '1970-01-01T00:00:00.002Z',
+                },
+            ];
+            assertContents(data.Contents, expected);
+
+            const key2VersionIds = data.Contents.filter(k => k.key === key2).map(k => k.value.VersionId);
+            assert.deepStrictEqual(key2VersionIds, expectedVersionIds[key2]);
+
+            return done();
+        });
+    });
+
+    it('Should list non-current versions that start with prefix', done => {
+        const params = {
+            listingType: 'DelimiterNonCurrent',
+            prefix: 'pfx2',
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(data.IsTruncated, false);
+            assert.strictEqual(data.Contents.length, 4);
+            const expected = [{
+                key: key2,
+                LastModified: '1970-01-01T00:00:00.004Z',
+                staleDate: '1970-01-01T00:00:00.005Z',
+            },
+            {
+                key: key2,
+                LastModified: '1970-01-01T00:00:00.003Z',
+                staleDate: '1970-01-01T00:00:00.004Z',
+            },
+            {
+                key: key2,
+                LastModified: '1970-01-01T00:00:00.002Z',
+                staleDate: '1970-01-01T00:00:00.003Z',
+            },
+            {
+                key: key2,
+                LastModified: '1970-01-01T00:00:00.001Z',
+                staleDate: '1970-01-01T00:00:00.002Z',
+            }];
+            assertContents(data.Contents, expected);
+
+            const key2VersionIds = data.Contents.filter(k => k.key === key2).map(k => k.value.VersionId);
+            assert.deepStrictEqual(key2VersionIds, expectedVersionIds[key2]);
+
+            return done();
+        });
+    });
+
+    it('Should list non-current version that start with prefix and older than beforedate', done => {
+        const params = {
+            listingType: 'DelimiterNonCurrent',
+            prefix: 'pfx2',
+            maxKeys: 1,
+            beforeDate: '1970-01-01T00:00:00.003Z',
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(data.IsTruncated, false);
+            assert.strictEqual(data.Contents.length, 1);
+            const expected = [{
+                key: key2,
+                LastModified: '1970-01-01T00:00:00.001Z',
+                staleDate: '1970-01-01T00:00:00.002Z',
+                VersionId: expectedVersionIds[key2][3],
+            }];
+            assertContents(data.Contents, expected);
+
+            return done();
+        });
+    });
+
+    it('Should truncate list of non-current versions that start with prefix and older than beforedate', done => {
+        const params = {
+            listingType: 'DelimiterNonCurrent',
+            prefix: 'pfx2',
+            maxKeys: 2,
+            beforeDate: '1970-01-01T00:00:00.005Z',
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(data.IsTruncated, true);
+            assert.strictEqual(data.NextKeyMarker, key2);
+            assert.strictEqual(data.NextVersionIdMarker, data.Contents[1].value.VersionId);
+            const expected = [
+                {
+                    key: key2,
+                    LastModified: '1970-01-01T00:00:00.003Z',
+                    staleDate: '1970-01-01T00:00:00.004Z',
+                    VersionId: expectedVersionIds[key2][1],
+                },
+                {
+                    key: key2,
+                    LastModified: '1970-01-01T00:00:00.002Z',
+                    staleDate: '1970-01-01T00:00:00.003Z',
+                    VersionId: expectedVersionIds[key2][2],
+                },
+            ];
+            assert.strictEqual(data.Contents.length, 2);
+            assertContents(data.Contents, expected);
+
+            return done();
+        });
+    });
+
+    it('Should not take phd master key into account when listing non-current versions', done => {
+        const objVal = {
+            'key': 'pfx4-test-object',
+            'versionId': 'null',
+            'last-modified': new Date(10000).toISOString(),
+        };
+        const versionParams = {
+            versioning: true,
+        };
+        const params = {
+            listingType: 'DelimiterNonCurrent',
+            prefix: 'pfx4',
+        };
+        let earlyVersionId;
+        let lastVersionId;
+        async.series([
+            next => metadata.putObjectMD(BUCKET_NAME, 'pfx4-test-object', objVal, versionParams,
+                logger, (err, res) => {
+                    if (err) {
+                        return next(err);
+                    }
+                    earlyVersionId = JSON.parse(res).versionId;
+                    return next(null);
+                }),
+            next => metadata.putObjectMD(BUCKET_NAME, 'pfx4-test-object', objVal, versionParams,
+                logger, next),
+            next => metadata.putObjectMD(BUCKET_NAME, 'pfx4-test-object', objVal, versionParams,
+                logger, (err, res) => {
+                    if (err) {
+                        return next(err);
+                    }
+                    lastVersionId = JSON.parse(res).versionId;
+                    return next(null);
+                }),
+            next => metadata.deleteObjectMD(BUCKET_NAME, 'pfx4-test-object', { versionId: lastVersionId },
+                logger, next),
+            next => metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+                assert.ifError(err);
+                assert.strictEqual(data.Contents.length, 1);
+                assert.strictEqual(data.Contents[0].value.VersionId, earlyVersionId);
+
+                return next();
+            }),
+        ], done);
+    });
+
+    it('Should not list non current versions tagged for deletion', done => {
+        const objVal = {
+            'key': 'pfx4-test-object',
+            'versionId': 'null',
+            'last-modified': new Date(10000).toISOString(),
+        };
+        const versionParams = {
+            versioning: true,
+        };
+        const params = {
+            listingType: 'DelimiterNonCurrent',
+            prefix: 'pfx4',
+        };
+
+        async.series([
+            next => metadata.putObjectMD(BUCKET_NAME, 'pfx4-test-object', objVal, versionParams,
+                logger, next),
+            next => metadata.putObjectMD(BUCKET_NAME, 'pfx4-test-object', objVal, versionParams,
+                logger, next),
+            next => flagObjectForDeletion(collection, 'pfx4-test-object', next),
+            next => metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+                assert.ifError(err);
+                assert.strictEqual(data.IsTruncated, false);
+                assert.strictEqual(data.Contents.length, 0);
+                return next();
+            }),
+        ], done);
+    });
+});

--- a/tests/functional/metadata/mongodb/listLifecycleObject/utils.js
+++ b/tests/functional/metadata/mongodb/listLifecycleObject/utils.js
@@ -17,15 +17,24 @@ const assert = require('assert');
 */
 function putBulkObjectVersions(metadata, bucketName, objName, objVal, params, versionNb, timestamp, logger, cb) {
     let count = 0;
+    const versionIds = [];
     return async.whilst(
         () => count < versionNb,
         cbIterator => {
             count++;
             const lastModified = new Date(timestamp + count).toISOString();
             const finalObjectVal = Object.assign(objVal, { 'last-modified': lastModified });
-            return metadata.putObjectMD(bucketName, objName, finalObjectVal, params,
-                logger, cbIterator);
-        }, cb);
+            return metadata.putObjectMD(bucketName, objName, finalObjectVal, params, logger, (err, data) => {
+                versionIds.push(JSON.parse(data).versionId);
+                return cbIterator(err, versionIds);
+            });
+        }, (err, expectedVersionIds) => {
+            // The last version is removed since it represents the current version.
+            expectedVersionIds.pop();
+            // array is reversed to be alligned with the version order (latest to oldest).
+            expectedVersionIds.reverse();
+            return cb(err, expectedVersionIds);
+        });
 }
 
 function makeBucketMD(bucketName) {
@@ -63,6 +72,9 @@ function assertContents(contents, expected) {
         assert.strictEqual(c.key, expected[i].key);
         assert.strictEqual(c.value.LastModified, expected[i].LastModified);
         assert.strictEqual(c.value.staleDate, expected[i].staleDate);
+        if (expected[i].VersionId) {
+            assert.strictEqual(c.value.VersionId, expected[i].VersionId);
+        }
     });
 }
 

--- a/tests/unit/algos/list/delimiterNonCurrent.spec.js
+++ b/tests/unit/algos/list/delimiterNonCurrent.spec.js
@@ -1,0 +1,372 @@
+'use strict'; // eslint-disable-line strict
+
+const assert = require('assert');
+
+const DelimiterNonCurrent =
+    require('../../../../lib/algos/list/delimiterNonCurrent').DelimiterNonCurrent;
+const {
+    FILTER_ACCEPT,
+    FILTER_SKIP,
+    FILTER_END,
+} = require('../../../../lib/algos/list/tools');
+const VSConst =
+    require('../../../../lib/versioning/constants').VersioningConstants;
+const { DbPrefixes } = VSConst;
+
+// TODO: find an acceptable timeout value.
+const DELIMITER_TIMEOUT_MS = 10 * 1000; // 10s
+
+const VID_SEP = VSConst.VersionId.Separator;
+const EmptyResult = {
+    Contents: [],
+    IsTruncated: false,
+};
+
+const fakeLogger = {
+    trace: () => {},
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    fatal: () => {},
+};
+
+function makeV1Key(key) {
+    const keyPrefix = key.includes(VID_SEP) ?
+        DbPrefixes.Version : DbPrefixes.Master;
+    return `${keyPrefix}${key}`;
+}
+
+describe('DelimiterNonCurrent', () => {
+    it('should accept entry starting with prefix', () => {
+        const delimiter = new DelimiterNonCurrent({ prefix: 'prefix' }, fakeLogger, 'v1');
+
+        const listingKey = makeV1Key('prefix1');
+        assert.strictEqual(delimiter.filter({ key: listingKey, value: '' }), FILTER_ACCEPT);
+
+        assert.deepStrictEqual(delimiter.result(), EmptyResult);
+    });
+
+    it('should skip entry not starting with prefix', () => {
+        const delimiter = new DelimiterNonCurrent({ prefix: 'prefix' }, fakeLogger, 'v1');
+
+        const listingKey = makeV1Key('noprefix');
+        assert.strictEqual(delimiter.filter({ key: listingKey, value: '' }), FILTER_SKIP);
+
+        assert.deepStrictEqual(delimiter.result(), EmptyResult);
+    });
+
+    it('should accept a version and return an empty content', () => {
+        const delimiter = new DelimiterNonCurrent({ }, fakeLogger, 'v1');
+
+        const masterKey = 'key';
+
+        const versionId1 = 'version1';
+        const versionKey1 = `${masterKey}${VID_SEP}${versionId1}`;
+        const date1 = '1970-01-01T00:00:00.001Z';
+        const value1 = `{"versionId":"${versionId1}", "last-modified": "${date1}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey1),
+            value: value1,
+        }), FILTER_ACCEPT);
+
+        assert.deepStrictEqual(delimiter.result(), EmptyResult);
+    });
+
+    it('should accept two versions and return the non current version', () => {
+        const delimiter = new DelimiterNonCurrent({ }, fakeLogger, 'v1');
+
+        const masterKey = 'key';
+
+        // filter first version
+        const versionId1 = 'version1';
+        const versionKey1 = `${masterKey}${VID_SEP}${versionId1}`;
+        const date1 = '1970-01-01T00:00:00.002Z';
+        const value1 = `{"versionId":"${versionId1}", "last-modified": "${date1}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey1),
+            value: value1,
+        }), FILTER_ACCEPT);
+
+        // filter second version
+        const versionId2 = 'version2';
+        const versionKey2 = `${masterKey}${VID_SEP}${versionId2}`;
+        const date2 = '1970-01-01T00:00:00.001Z';
+        const value2 = `{"versionId":"${versionId2}", "last-modified": "${date2}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey2),
+            value: value2,
+        }), FILTER_ACCEPT);
+
+        const expectedResult = {
+            Contents: [
+                {
+                    key: masterKey,
+                    value: `{"versionId":"${versionId2}","last-modified":"${date2}","staleDate":"${date1}"}`,
+                },
+            ],
+            IsTruncated: false,
+        };
+
+        assert.deepStrictEqual(delimiter.result(), expectedResult);
+    });
+
+    it('should accept three versions and return the non current version which stale date before beforeDate', () => {
+        const beforeDate = '1970-01-01T00:00:00.002Z';
+        const delimiter = new DelimiterNonCurrent({ beforeDate }, fakeLogger, 'v1');
+
+        const masterKey = 'key';
+
+        // filter first version
+        const versionId1 = 'version1';
+        const versionKey1 = `${masterKey}${VID_SEP}${versionId1}`;
+        const date1 = beforeDate;
+        const value1 = `{"versionId":"${versionId1}", "last-modified": "${date1}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey1),
+            value: value1,
+        }), FILTER_ACCEPT);
+
+        // filter second version
+        const versionId2 = 'version2';
+        const versionKey2 = `${masterKey}${VID_SEP}${versionId2}`;
+        const date2 = '1970-01-01T00:00:00.001Z';
+        const value2 = `{"versionId":"${versionId2}", "last-modified": "${date2}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey2),
+            value: value2,
+        }), FILTER_ACCEPT);
+
+        // filter third version
+        const versionId3 = 'version3';
+        const versionKey3 = `${masterKey}${VID_SEP}${versionId3}`;
+        const date3 = '1970-01-01T00:00:00.000Z';
+        const value3 = `{"versionId":"${versionId3}", "last-modified": "${date3}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey3),
+            value: value3,
+        }), FILTER_ACCEPT);
+
+        const expectedResult = {
+            Contents: [
+                {
+                    key: masterKey,
+                    value: `{"versionId":"${versionId3}","last-modified":"${date3}","staleDate":"${date2}"}`,
+                },
+            ],
+            IsTruncated: false,
+        };
+
+        assert.deepStrictEqual(delimiter.result(), expectedResult);
+    });
+
+    it('should accept one delete marker and one versions and return the non current version', () => {
+        const delimiter = new DelimiterNonCurrent({ }, fakeLogger, 'v1');
+
+        // const version = new Version({ isDeleteMarker: true });
+        const masterKey = 'key';
+
+        // filter delete marker
+        const versionId1 = 'version1';
+        const versionKey1 = `${masterKey}${VID_SEP}${versionId1}`;
+        const date1 = '1970-01-01T00:00:00.002Z';
+        const value1 = `{"versionId":"${versionId1}", "last-modified": "${date1}", "isDeleteMarker": true}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey1),
+            value: value1,
+        }), FILTER_ACCEPT);
+
+        // filter second version
+        const versionId2 = 'version2';
+        const versionKey2 = `${masterKey}${VID_SEP}${versionId2}`;
+        const date2 = '1970-01-01T00:00:00.001Z';
+        const value2 = `{"versionId":"${versionId2}", "last-modified": "${date2}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey2),
+            value: value2,
+        }), FILTER_ACCEPT);
+
+        const expectedResult = {
+            Contents: [
+                {
+                    key: masterKey,
+                    value: `{"versionId":"${versionId2}","last-modified":"${date2}","staleDate":"${date1}"}`,
+                },
+            ],
+            IsTruncated: false,
+        };
+
+        assert.deepStrictEqual(delimiter.result(), expectedResult);
+    });
+
+    it('should end filtering if max keys reached', () => {
+        const delimiter = new DelimiterNonCurrent({ maxKeys: 1 }, fakeLogger, 'v1');
+
+        const masterKey = 'key';
+
+        // filter delete marker
+        const versionId1 = 'version1';
+        const versionKey1 = `${masterKey}${VID_SEP}${versionId1}`;
+        const date1 = '1970-01-01T00:00:00.002Z';
+        const value1 = `{"versionId":"${versionId1}", "last-modified": "${date1}", "isDeleteMarker": true}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey1),
+            value: value1,
+        }), FILTER_ACCEPT);
+
+        // filter second version
+        const versionId2 = 'version2';
+        const versionKey2 = `${masterKey}${VID_SEP}${versionId2}`;
+        const date2 = '1970-01-01T00:00:00.001Z';
+        const value2 = `{"versionId":"${versionId2}", "last-modified": "${date2}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey2),
+            value: value2,
+        }), FILTER_ACCEPT);
+
+        // filter third version
+        const versionId3 = 'version3';
+        const versionKey3 = `${masterKey}${VID_SEP}${versionId3}`;
+        const date3 = '1970-01-01T00:00:00.000Z';
+        const value3 = `{"versionId":"${versionId3}", "last-modified": "${date3}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey3),
+            value: value3,
+        }), FILTER_END);
+
+
+        const expectedResult = {
+            Contents: [
+                {
+                    key: masterKey,
+                    value: `{"versionId":"${versionId2}","last-modified":"${date2}","staleDate":"${date1}"}`,
+                },
+            ],
+            IsTruncated: true,
+            NextKeyMarker: masterKey,
+            NextVersionIdMarker: versionId2,
+        };
+
+        assert.deepStrictEqual(delimiter.result(), expectedResult);
+    });
+
+    it('should end filtering if delimiter timeout', () => {
+        const delimiter = new DelimiterNonCurrent({ }, fakeLogger, 'v1');
+
+        const masterKey = 'key';
+
+        // filter delete marker
+        const versionId1 = 'version1';
+        const versionKey1 = `${masterKey}${VID_SEP}${versionId1}`;
+        const date1 = '1970-01-01T00:00:00.002Z';
+        const value1 = `{"versionId":"${versionId1}", "last-modified": "${date1}", "isDeleteMarker": true}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey1),
+            value: value1,
+        }), FILTER_ACCEPT);
+
+        // filter second version
+        const versionId2 = 'version2';
+        const versionKey2 = `${masterKey}${VID_SEP}${versionId2}`;
+        const date2 = '1970-01-01T00:00:00.001Z';
+        const value2 = `{"versionId":"${versionId2}", "last-modified": "${date2}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey2),
+            value: value2,
+        }), FILTER_ACCEPT);
+
+        // force delimiter to timeout.
+        delimiter.start = Date.now() - (DELIMITER_TIMEOUT_MS + 1);
+
+        // filter third version
+        const versionId3 = 'version3';
+        const versionKey3 = `${masterKey}${VID_SEP}${versionId3}`;
+        const date3 = '1970-01-01T00:00:00.000Z';
+        const value3 = `{"versionId":"${versionId3}", "last-modified": "${date3}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey3),
+            value: value3,
+        }), FILTER_END);
+
+
+        const expectedResult = {
+            Contents: [
+                {
+                    key: masterKey,
+                    value: `{"versionId":"${versionId2}","last-modified":"${date2}","staleDate":"${date1}"}`,
+                },
+            ],
+            IsTruncated: true,
+            NextKeyMarker: masterKey,
+            NextVersionIdMarker: versionId2,
+        };
+
+        assert.deepStrictEqual(delimiter.result(), expectedResult);
+    });
+
+    it('should end filtering if delimiter timeout with empty content', () => {
+        const delimiter = new DelimiterNonCurrent({ }, fakeLogger, 'v1');
+
+        // filter current version
+        const masterKey1 = 'key1';
+        const versionId1 = 'version1';
+        const versionKey1 = `${masterKey1}${VID_SEP}${versionId1}`;
+        const date1 = '1970-01-01T00:00:00.002Z';
+        const value1 = `{"versionId":"${versionId1}", "last-modified": "${date1}"`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey1),
+            value: value1,
+        }), FILTER_ACCEPT);
+
+        // filter current version
+        const masterKey2 = 'key2';
+        const versionId2 = 'version2';
+        const versionKey2 = `${masterKey2}${VID_SEP}${versionId2}`;
+        const date2 = '1970-01-01T00:00:00.001Z';
+        const value2 = `{"versionId":"${versionId2}", "last-modified": "${date2}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey2),
+            value: value2,
+        }), FILTER_ACCEPT);
+
+        // force delimiter to timeout.
+        delimiter.start = Date.now() - (DELIMITER_TIMEOUT_MS + 1);
+
+        // filter current version
+        const masterKey3 = 'key3';
+        const versionId3 = 'version3';
+        const versionKey3 = `${masterKey3}${VID_SEP}${versionId3}`;
+        const date3 = '1970-01-01T00:00:00.000Z';
+        const value3 = `{"versionId":"${versionId3}", "last-modified": "${date3}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey3),
+            value: value3,
+        }), FILTER_END);
+
+        const expectedResult = {
+            Contents: [],
+            IsTruncated: true,
+            NextKeyMarker: masterKey2,
+            NextVersionIdMarker: versionId2,
+        };
+
+        assert.deepStrictEqual(delimiter.result(), expectedResult);
+    });
+});


### PR DESCRIPTION
DelimiterNonCurrent is used for listing non-current versions.
The Metadata call returns the versions (V prefix).
The MD response is then processed to only return the non-current versions that became non-current before a defined date: `beforeDate`.