### PR TITLE
ARSN-312 Add logic to list orphan delete markers for Lifecycle

### DIFF
--- a/lib/algos/list/delimiterOrphanDeleteMarker.js
+++ b/lib/algos/list/delimiterOrphanDeleteMarker.js
@@ -1,0 +1,202 @@
+'use strict'; // eslint-disable-line strict
+const Delimiter = require('./delimiter').Delimiter;
+const VSConst = require('../../versioning/constants').VersioningConstants;
+const { inc, FILTER_ACCEPT, FILTER_END, SKIP_NONE } = require('./tools');
+const VID_SEP = VSConst.VersionId.Separator;
+const { DbPrefixes } = VSConst;
+
+const DELIMITER_TIMEOUT_MS = 10 * 1000; // 10s
+const TRIM_METADATA_MIN_BLOB_SIZE = 10000;
+
+/**
+ * Handle object listing with parameters. This extends the base class Delimiter
+ * to return the orphan delete markers. Orphan delete markers are also
+ * refered as expired object delete marker.
+ * They are delete marker with zero noncurrent versions.
+ */
+class DelimiterOrphanDeleteMarker extends Delimiter {
+    /**
+     * Delimiter listing of non-current versions.
+     * @param {Object}  parameters            - listing parameters
+     * @param {String}  parameters.beforeDate - limit the response to keys older than beforeDate
+     * @param {RequestLogger} logger          - The logger of the request
+     * @param {String} [vFormat]              - versioning key format
+     */
+    constructor(parameters, logger, vFormat) {
+        super(parameters, logger, vFormat);
+
+        this.beforeDate = parameters.beforeDate;
+
+        this.skipping = this.skippingV1;
+        this.genMDParams = this.genMDParamsV1;
+
+        this.keyName = null;
+        this.staleDate = null;
+        this.value = null;
+
+        // used for monitoring
+        this.evaluatedKeys = 0;
+    }
+
+    skippingV1() {
+        return SKIP_NONE;
+    }
+
+    _reachedMaxKeys() {
+        if (this.keys >= this.maxKeys) {
+            return true;
+        }
+        return false;
+    }
+
+    genMDParamsV1() {
+        const params = {
+            gte: DbPrefixes.Version,
+            lt: inc(DbPrefixes.Version),
+        };
+
+        if (this.prefix) {
+            params.gte = `${DbPrefixes.Version}${this.prefix}`;
+            params.lt = `${DbPrefixes.Version}${inc(this.prefix)}`;
+        }
+
+        if (this.marker && `${DbPrefixes.Version}${this.marker}` >= params.gte) {
+            delete params.gte;
+            params.gt = DbPrefixes.Version
+                    + inc(this.marker + VID_SEP);
+        }
+
+        this.start = Date.now();
+
+        return params;
+    }
+
+    _addOrphan() {
+        const parsedValue = this._parse(this.value);
+        // if parsing fails, skip the key.
+        if (parsedValue) {
+            const lastModified = parsedValue['last-modified'];
+            const isDeleteMarker = parsedValue.isDeleteMarker;
+            // We then check if the orphan version is a delete marker and if it is older than the "beforeDate"
+            if ((!this.beforeDate || (lastModified && lastModified < this.beforeDate)) && isDeleteMarker) {
+                // Prefer returning an untrimmed data rather than stopping the service in case of parsing failure.
+                const s = this._trimAndStringify(parsedValue) || this.value;
+                this.Contents.push({ key: this.keyName, value: s });
+                this.NextMarker = this.keyName;
+                ++this.keys;
+            }
+        }
+    }
+
+    _parse(s) {
+        let p;
+        try {
+            p = JSON.parse(s);
+        } catch (e) {
+            this.logger.warn(
+                'Could not parse Object Metadata while listing',
+                { err: e.toString() });
+        }
+        return p;
+    }
+
+    _trimAndStringify(value) {
+        const p = value;
+        let s = undefined;
+        try {
+            if (p.length >= TRIM_METADATA_MIN_BLOB_SIZE) {
+                delete p.location;
+            }
+            s = JSON.stringify(p);
+        } catch (e) {
+            this.logger.warn('could not trim and stringify Object Metadata while listing',
+                {
+                    method: 'trimMetadataAddStaleDate',
+                    err: e.toString(),
+                });
+        }
+        return s;
+    }
+
+    /**
+     * NOTE: Each version of a specific key is sorted from the latest to the oldest
+     * thanks to the way version ids are generated.
+     * DESCRIPTION: For a given key, the latest version is kept in memory since it is the current version.
+     * If the following version reference a new key, it means that the previous one was an orphan version.
+     * We then check if the orphan version is a delete marker and if it is older than the "beforeDate"
+     * The process stops and returns the available results if either:
+     * - no more metadata key is left to be processed
+     * - the listing reaches the maximum number of key to be returned
+     * - the internal timeout is reached
+     * NOTE: we cannot leverage MongoDB to list keys older than "beforeDate"
+     * because then we will not be able to assess its orphanage.
+     *  @param {String} keyVersionSuffix   - The key with version id as a suffix.
+     *  @param {String} value              - The value of the key
+     *  @return {number}                   - indicates if iteration should continue
+     */
+    addContents(keyVersionSuffix, value) {
+        if (this._reachedMaxKeys()) {
+            return FILTER_END;
+        }
+
+        if (this.start && Date.now() - this.start > DELIMITER_TIMEOUT_MS) {
+            this.IsTruncated = true;
+            this.NextMarker = this.keyName;
+
+            this.logger.info('listing stopped after expected internal timeout',
+                {
+                    timeoutMs: DELIMITER_TIMEOUT_MS,
+                    evaluatedKeys: this.evaluatedKeys,
+                });
+            return FILTER_END;
+        }
+        ++this.evaluatedKeys;
+
+        const versionIdIndex = keyVersionSuffix.indexOf(VID_SEP);
+        // key without version suffix
+        const key = keyVersionSuffix.slice(0, versionIdIndex);
+
+        // For a given key, the youngest version is kept in memory since it represents the current version.
+        if (key !== this.keyName) {
+            // If this.value is defined, it means that <this.keyName, this.value> pair is "allowed" to be an orphan.
+            if (this.value) {
+                this._addOrphan();
+            }
+            this.keyName = key;
+            this.value = value;
+
+            return FILTER_ACCEPT;
+        }
+
+        this.keyName = key;
+        this.value = null;
+
+        return FILTER_ACCEPT;
+    }
+
+    result() {
+        // The following check makes sure the last orphan delete marker is not forgotten.
+        if (this.keys < this.maxKeys) {
+            if (this.value) {
+                this._addOrphan();
+            }
+        // The following make sure that if makeKeys is reached, isTruncated is set to true.
+        // We moved the "isTruncated" from _reachedMaxKeys to make sure we take into account the last entity
+        // if listing is truncated right before the last entity and the last entity is a orphan delete marker.
+        } else {
+            this.IsTruncated = this.maxKeys > 0;
+        }
+
+        const result = {
+            Contents: this.Contents,
+            IsTruncated: this.IsTruncated,
+        };
+
+        if (this.IsTruncated) {
+            result.NextMarker = this.NextMarker;
+        }
+
+        return result;
+    }
+}
+module.exports = { DelimiterOrphanDeleteMarker };

--- a/lib/algos/list/exportAlgos.js
+++ b/lib/algos/list/exportAlgos.js
@@ -8,4 +8,5 @@ module.exports = {
     MPU: require('./MPU').MultipartUploads,
     DelimiterCurrent: require('./delimiterCurrent').DelimiterCurrent,
     DelimiterNonCurrent: require('./delimiterNonCurrent').DelimiterNonCurrent,
+    DelimiterOrphanDeleteMarker: require('./delimiterOrphanDeleteMarker').DelimiterOrphanDeleteMarker,
 };

--- a/tests/functional/metadata/mongodb/listLifecycleObject/global.spec.js
+++ b/tests/functional/metadata/mongodb/listLifecycleObject/global.spec.js
@@ -87,4 +87,16 @@ describe('MongoClientInterface::metadata.listLifecycleObject::global', () => {
             return done();
         });
     });
+
+    it('Should return error listing orphan delete markers if v0 key format', done => {
+        const params = {
+            listingType: 'DelimiterOrphanDeleteMarker',
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert(err.NotImplemented);
+            assert(!data);
+
+            return done();
+        });
+    });
 });

--- a/tests/functional/metadata/mongodb/listLifecycleObject/orphanDeleteMarker.spec.js
+++ b/tests/functional/metadata/mongodb/listLifecycleObject/orphanDeleteMarker.spec.js
@@ -1,0 +1,446 @@
+const async = require('async');
+const assert = require('assert');
+const werelogs = require('werelogs');
+const { MongoMemoryReplSet } = require('mongodb-memory-server');
+const logger = new werelogs.Logger('MongoClientInterface', 'debug', 'debug');
+const MetadataWrapper =
+require('../../../../../lib/storage/metadata/MetadataWrapper');
+const { versioning } = require('../../../../../index');
+const { BucketVersioningKeyFormat } = versioning.VersioningConstants;
+const { makeBucketMD, putBulkObjectVersions } = require('./utils');
+
+const IMPL_NAME = 'mongodb';
+const DB_NAME = 'metadata';
+const BUCKET_NAME = 'test-lifecycle-list-orphan-bucket';
+
+const mongoserver = new MongoMemoryReplSet({
+    debug: false,
+    instanceOpts: [
+        { port: 27020 },
+    ],
+    replSet: {
+        name: 'rs0',
+        count: 1,
+        DB_NAME,
+        storageEngine: 'ephemeralForTest',
+    },
+});
+
+describe('MongoClientInterface::metadata.listLifecycleObject::orphan', () => {
+    let metadata;
+
+    beforeAll(done => {
+        mongoserver.waitUntilRunning().then(() => {
+            const opts = {
+                mongodb: {
+                    replicaSetHosts: 'localhost:27020',
+                    writeConcern: 'majority',
+                    replicaSet: 'rs0',
+                    readPreference: 'primary',
+                    database: DB_NAME,
+                },
+            };
+            metadata = new MetadataWrapper(IMPL_NAME, opts, null, logger);
+            metadata.client.defaultBucketKeyFormat = BucketVersioningKeyFormat.v1;
+            metadata.setup(done);
+        });
+    });
+
+    afterAll(done => {
+        async.series([
+            next => metadata.close(next),
+            next => mongoserver.stop()
+                .then(() => next())
+                .catch(next),
+        ], done);
+    });
+
+    beforeEach(done => {
+        const bucketMD = makeBucketMD(BUCKET_NAME);
+        const versionParams = {
+            versioning: true,
+            versionId: null,
+            repairMaster: null,
+        };
+        async.series([
+            next => metadata.createBucket(BUCKET_NAME, bucketMD, logger, next),
+            next => {
+                const keyName = 'pfx0-test-object';
+
+                const objVal = {
+                    'key': keyName,
+                    'isDeleteMarker': true,
+                    'last-modified': new Date(0).toISOString(), // 1970-01-01T00:00:00.000Z
+                };
+                const params = {
+                    versioning: true,
+                };
+                return metadata.putObjectMD(BUCKET_NAME, keyName, objVal, params, logger, next);
+            },
+            next => {
+                const params = {
+                    objName: 'pfx1-test-object',
+                    objVal: {
+                        key: 'pfx1-test-object',
+                        versionId: 'null',
+                    },
+                    nbVersions: 1,
+                };
+                const timestamp = 0;
+                putBulkObjectVersions(metadata, BUCKET_NAME, params.objName, params.objVal, versionParams,
+                    params.nbVersions, timestamp, logger, next);
+            },
+            next => {
+                const params = {
+                    objName: 'pfx2-test-object',
+                    objVal: {
+                        key: 'pfx2-test-object',
+                        versionId: 'null',
+                    },
+                    nbVersions: 1,
+                };
+                const timestamp = 0;
+                putBulkObjectVersions(metadata, BUCKET_NAME, params.objName, params.objVal, versionParams,
+                    params.nbVersions, timestamp, logger, next);
+            },
+            next => {
+                const keyName = 'pfx2-test-object';
+
+                const objVal = {
+                    'key': keyName,
+                    'isDeleteMarker': true,
+                    'last-modified': new Date(2).toISOString(), // 1970-01-01T00:00:00.002Z
+                };
+                const params = {
+                    versioning: true,
+                };
+                return metadata.putObjectMD(BUCKET_NAME, keyName, objVal, params, logger, next);
+            },
+            next => {
+                const keyName = 'pfx3-test-object';
+
+                const objVal = {
+                    'key': keyName,
+                    'isDeleteMarker': true,
+                    'last-modified': new Date(0).toISOString(), // 1970-01-01T00:00:00.000Z
+                };
+                const params = {
+                    versioning: true,
+                };
+                return metadata.putObjectMD(BUCKET_NAME, keyName, objVal, params, logger, next);
+            },
+            next => {
+                const keyName = 'pfx4-test-object';
+
+                const objVal = {
+                    'key': keyName,
+                    'isDeleteMarker': true,
+                    'last-modified': new Date(5).toISOString(), // 1970-01-01T00:00:00.005Z
+                };
+                const params = {
+                    versioning: true,
+                };
+                return metadata.putObjectMD(BUCKET_NAME, keyName, objVal, params, logger, next);
+            },
+            next => {
+                const keyName = 'pfx4-test-object2';
+
+                const objVal = {
+                    'key': keyName,
+                    'isDeleteMarker': true,
+                    'last-modified': new Date(6).toISOString(), // 1970-01-01T00:00:00.006Z
+                };
+                const params = {
+                    versioning: true,
+                };
+                return metadata.putObjectMD(BUCKET_NAME, keyName, objVal, params, logger, next);
+            },
+        ], done);
+    });
+    /* eslint-disable max-len */
+    // { "_id" : "Mpfx1-test-object", "value" : { "key" : "pfx1-test-object", "versionId" : "v1", "last-modified" : "1970-01-01T00:00:00.001Z" } }
+    // { "_id" : "Vpfx0-test-object{sep}v0", "value" : { "key" : "pfx0-test-object", "isDeleteMarker" : true, "last-modified" : "1970-01-01T00:00:00.000Z", "versionId" : "v0" } }
+    // { "_id" : "Vpfx1-test-object{sep}v1", "value" : { "key" : "pfx1-test-object", "versionId" : "v1", "last-modified" : "1970-01-01T00:00:00.001Z" } }
+    // { "_id" : "Vpfx2-test-object{sep}v3", "value" : { "key" : "pfx2-test-object", "isDeleteMarker" : true, "last-modified" : "1970-01-01T00:00:00.002Z", "versionId" : "v3" } }
+    // { "_id" : "Vpfx2-test-object{sep}v2", "value" : { "key" : "pfx2-test-object", "versionId" : "v2", "last-modified" : "1970-01-01T00:00:00.001Z" } }
+    // { "_id" : "Vpfx3-test-object{sep}v4", "value" : { "key" : "pfx3-test-object", "isDeleteMarker" : true, "last-modified" : "1970-01-01T00:00:00.000Z", "versionId" : "v4" } }
+    // { "_id" : "Vpfx4-test-object{sep}v5", "value" : { "key" : "pfx4-test-object", "isDeleteMarker" : true, "last-modified" : "1970-01-01T00:00:00.005Z", "versionId" : "v5" } }
+    // { "_id" : "Vpfx4-test-object2{sep}v6", "value" : { "key" : "pfx4-test-object", "isDeleteMarker" : true, "last-modified" : "1970-01-01T00:00:00.006Z", "versionId" : "v6" } }
+    /* eslint-enable max-len */
+
+    afterEach(done => {
+        metadata.deleteBucket(BUCKET_NAME, logger, done);
+    });
+
+    it('Should list orphan delete markers', done => {
+        const params = {
+            listingType: 'DelimiterOrphanDeleteMarker',
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(data.IsTruncated, false);
+            assert(!data.NextMarker);
+            assert.strictEqual(data.Contents.length, 4);
+            assert.strictEqual(data.Contents[0].key, 'pfx0-test-object');
+            assert.strictEqual(data.Contents[1].key, 'pfx3-test-object');
+            assert.strictEqual(data.Contents[2].key, 'pfx4-test-object');
+            assert.strictEqual(data.Contents[3].key, 'pfx4-test-object2');
+            return done();
+        });
+    });
+
+    it('Should return empty list when beforeDate is before youngest last-modified', done => {
+        const params = {
+            listingType: 'DelimiterOrphanDeleteMarker',
+            beforeDate: '1970-01-01T00:00:00.000Z',
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(data.IsTruncated, false);
+            assert(!data.NextMarker);
+            assert.strictEqual(data.Contents.length, 0);
+
+            return done();
+        });
+    });
+
+    it('Should list orphan delete markers older than 1970-01-01T00:00:00.003Z', done => {
+        const params = {
+            listingType: 'DelimiterOrphanDeleteMarker',
+            beforeDate: '1970-01-01T00:00:00.003Z',
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(data.IsTruncated, false);
+            assert(!data.NextMarker);
+            assert.strictEqual(data.Contents.length, 2);
+            assert.strictEqual(data.Contents[0].key, 'pfx0-test-object');
+            assert.strictEqual(data.Contents[1].key, 'pfx3-test-object');
+
+            return done();
+        });
+    });
+
+    it('Should return the first part of the orphan delete markers listing', done => {
+        const params = {
+            listingType: 'DelimiterOrphanDeleteMarker',
+            maxKeys: 1,
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(data.IsTruncated, true);
+            assert.strictEqual(data.NextMarker, 'pfx0-test-object');
+            assert.strictEqual(data.Contents.length, 1);
+            assert.strictEqual(data.Contents[0].key, 'pfx0-test-object');
+
+            return done();
+        });
+    });
+
+    it('Should return the second part of the orphan delete markers listing', done => {
+        const params = {
+            listingType: 'DelimiterOrphanDeleteMarker',
+            marker: 'pfx0-test-object',
+            maxKeys: 1,
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(data.IsTruncated, true);
+            assert.strictEqual(data.NextMarker, 'pfx3-test-object');
+            assert.strictEqual(data.Contents.length, 1);
+            assert.strictEqual(data.Contents[0].key, 'pfx3-test-object');
+
+            return done();
+        });
+    });
+
+    it('Should return the third part of the orphan delete markers listing', done => {
+        const params = {
+            listingType: 'DelimiterOrphanDeleteMarker',
+            marker: 'pfx3-test-object',
+            maxKeys: 1,
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(data.IsTruncated, true);
+            assert.strictEqual(data.NextMarker, 'pfx4-test-object');
+            assert.strictEqual(data.Contents.length, 1);
+            assert.strictEqual(data.Contents[0].key, 'pfx4-test-object');
+
+            return done();
+        });
+    });
+
+    it('Should return the fourth part of the orphan delete markers listing', done => {
+        const params = {
+            listingType: 'DelimiterOrphanDeleteMarker',
+            marker: 'pfx4-test-object',
+            maxKeys: 1,
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(data.IsTruncated, false);
+            assert(!data.NextMarker);
+            assert.strictEqual(data.Contents.length, 1);
+            assert.strictEqual(data.Contents[0].key, 'pfx4-test-object2');
+
+            return done();
+        });
+    });
+
+    it('Should list the two first orphan delete markers', done => {
+        const params = {
+            listingType: 'DelimiterOrphanDeleteMarker',
+            maxKeys: 2,
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(data.IsTruncated, true);
+            assert.strictEqual(data.Contents.length, 2);
+            assert.strictEqual(data.NextMarker, 'pfx3-test-object');
+            assert.strictEqual(data.Contents[0].key, 'pfx0-test-object');
+            assert.strictEqual(data.Contents[1].key, 'pfx3-test-object');
+
+            return done();
+        });
+    });
+
+    it('Should list the four first orphan delete markers', done => {
+        const params = {
+            listingType: 'DelimiterOrphanDeleteMarker',
+            maxKeys: 4,
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(data.IsTruncated, false);
+            assert(!data.NextMarker);
+            assert.strictEqual(data.Contents.length, 4);
+            assert.strictEqual(data.Contents[0].key, 'pfx0-test-object');
+            assert.strictEqual(data.Contents[1].key, 'pfx3-test-object');
+            assert.strictEqual(data.Contents[2].key, 'pfx4-test-object');
+            assert.strictEqual(data.Contents[3].key, 'pfx4-test-object2');
+
+            return done();
+        });
+    });
+
+    it('Should return an empty list if no orphan delete marker starts with prefix pfx2', done => {
+        const params = {
+            listingType: 'DelimiterOrphanDeleteMarker',
+            prefix: 'pfx2',
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(data.IsTruncated, false);
+            assert(!data.NextMarker);
+            assert.strictEqual(data.Contents.length, 0);
+
+            return done();
+        });
+    });
+
+    it('Should list orphan delete markers that start with prefix pfx4', done => {
+        const params = {
+            listingType: 'DelimiterOrphanDeleteMarker',
+            prefix: 'pfx4',
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(data.IsTruncated, false);
+            assert(!data.NextMarker);
+            assert.strictEqual(data.Contents.length, 2);
+            assert.strictEqual(data.Contents[0].key, 'pfx4-test-object');
+            assert.strictEqual(data.Contents[1].key, 'pfx4-test-object2');
+
+            return done();
+        });
+    });
+
+    it('Should return the first orphan delete marker version that starts with prefix', done => {
+        const params = {
+            listingType: 'DelimiterOrphanDeleteMarker',
+            prefix: 'pfx4',
+            maxKeys: 1,
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(data.IsTruncated, true);
+            assert.strictEqual(data.Contents.length, 1);
+            assert.strictEqual(data.NextMarker, 'pfx4-test-object');
+            assert.strictEqual(data.Contents[0].key, 'pfx4-test-object');
+
+            return done();
+        });
+    });
+
+    it('Should return the following orphan delete marker version that starts with prefix', done => {
+        const params = {
+            listingType: 'DelimiterOrphanDeleteMarker',
+            marker: 'pfx4-test-object',
+            prefix: 'pfx4',
+            maxKeys: 1,
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(data.IsTruncated, false);
+            assert(!data.NextMarker);
+            assert.strictEqual(data.Contents.length, 1);
+            assert.strictEqual(data.Contents[0].key, 'pfx4-test-object2');
+
+            return done();
+        });
+    });
+
+    it('Should return the truncated list of orphan delete markers older than 1970-01-01T00:00:00.006Z', done => {
+        const params = {
+            listingType: 'DelimiterOrphanDeleteMarker',
+            maxKeys: 2,
+            beforeDate: '1970-01-01T00:00:00.006Z',
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(data.IsTruncated, true);
+            assert.strictEqual(data.Contents.length, 2);
+            assert.strictEqual(data.Contents[0].key, 'pfx0-test-object');
+            assert.strictEqual(data.Contents[1].key, 'pfx3-test-object');
+            assert.strictEqual(data.NextMarker, 'pfx3-test-object');
+
+            return done();
+        });
+    });
+
+    it('Should return the following list of orphan delete markers older than 1970-01-01T00:00:00.006Z', done => {
+        const params = {
+            listingType: 'DelimiterOrphanDeleteMarker',
+            maxKeys: 2,
+            beforeDate: '1970-01-01T00:00:00.006Z',
+            marker: 'pfx3-test-object',
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(data.IsTruncated, false);
+            assert.strictEqual(data.Contents.length, 1);
+            assert.strictEqual(data.Contents[0].key, 'pfx4-test-object');
+
+            return done();
+        });
+    });
+
+    it('Should return the truncated list of orphan delete markers older than 1970-01-01T00:00:00.001Z', done => {
+        const params = {
+            listingType: 'DelimiterOrphanDeleteMarker',
+            maxKeys: 2,
+            beforeDate: '1970-01-01T00:00:00.001Z',
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(data.IsTruncated, true);
+            assert.strictEqual(data.Contents.length, 2);
+            assert.strictEqual(data.Contents[0].key, 'pfx0-test-object');
+            assert.strictEqual(data.Contents[1].key, 'pfx3-test-object');
+            assert.strictEqual(data.NextMarker, 'pfx3-test-object');
+
+            return done();
+        });
+    });
+});

--- a/tests/unit/algos/list/delimiterOrphanDeleteMarker.spec.js
+++ b/tests/unit/algos/list/delimiterOrphanDeleteMarker.spec.js
@@ -1,0 +1,378 @@
+'use strict'; // eslint-disable-line strict
+
+const assert = require('assert');
+
+const DelimiterOrphanDeleteMarker =
+    require('../../../../lib/algos/list/delimiterOrphanDeleteMarker').DelimiterOrphanDeleteMarker;
+const {
+    FILTER_ACCEPT,
+    FILTER_SKIP,
+    FILTER_END,
+} = require('../../../../lib/algos/list/tools');
+const VSConst =
+    require('../../../../lib/versioning/constants').VersioningConstants;
+const { DbPrefixes } = VSConst;
+
+// TODO: find an acceptable timeout value.
+const DELIMITER_TIMEOUT_MS = 10 * 1000; // 10s
+
+
+const VID_SEP = VSConst.VersionId.Separator;
+const EmptyResult = {
+    Contents: [],
+    IsTruncated: false,
+};
+
+const fakeLogger = {
+    trace: () => {},
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    fatal: () => {},
+};
+
+function makeV1Key(key) {
+    const keyPrefix = key.includes(VID_SEP) ?
+        DbPrefixes.Version : DbPrefixes.Master;
+    return `${keyPrefix}${key}`;
+}
+
+describe('DelimiterOrphanDeleteMarker', () => {
+    it('should accept entry starting with prefix', () => {
+        const delimiter = new DelimiterOrphanDeleteMarker({ prefix: 'prefix' }, fakeLogger, 'v1');
+
+        const listingKey = makeV1Key('prefix1');
+        assert.strictEqual(delimiter.filter({ key: listingKey, value: '' }), FILTER_ACCEPT);
+
+        assert.deepStrictEqual(delimiter.result(), EmptyResult);
+    });
+
+    it('should skip entry not starting with prefix', () => {
+        const delimiter = new DelimiterOrphanDeleteMarker({ prefix: 'prefix' }, fakeLogger, 'v1');
+
+        const listingKey = makeV1Key('noprefix');
+        assert.strictEqual(delimiter.filter({ key: listingKey, value: '' }), FILTER_SKIP);
+
+        assert.deepStrictEqual(delimiter.result(), EmptyResult);
+    });
+
+    it('should accept a version and return an empty content', () => {
+        const delimiter = new DelimiterOrphanDeleteMarker({ }, fakeLogger, 'v1');
+
+        const masterKey = 'key';
+
+        const versionId1 = 'version1';
+        const versionKey1 = `${masterKey}${VID_SEP}${versionId1}`;
+        const date1 = '1970-01-01T00:00:00.001Z';
+        const value1 = `{"versionId":"${versionId1}","last-modified":"${date1}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey1),
+            value: value1,
+        }), FILTER_ACCEPT);
+
+        assert.deepStrictEqual(delimiter.result(), EmptyResult);
+    });
+
+    it('should accept an orphan delete marker and return it from the content', () => {
+        const delimiter = new DelimiterOrphanDeleteMarker({ }, fakeLogger, 'v1');
+
+        const masterKey = 'key';
+
+        const versionId1 = 'version1';
+        const versionKey1 = `${masterKey}${VID_SEP}${versionId1}`;
+        const date1 = '1970-01-01T00:00:00.001Z';
+        const value1 = `{"versionId":"${versionId1}","last-modified":"${date1}","isDeleteMarker":true}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey1),
+            value: value1,
+        }), FILTER_ACCEPT);
+
+        const expectedResult = {
+            Contents: [
+                {
+                    key: masterKey,
+                    value: value1,
+                },
+            ],
+            IsTruncated: false,
+        };
+
+        assert.deepStrictEqual(delimiter.result(), expectedResult);
+    });
+
+    it('should accept two orphan delete markers and return them from the content', () => {
+        const delimiter = new DelimiterOrphanDeleteMarker({ }, fakeLogger, 'v1');
+
+        // filter the first orphan delete marker
+        const masterKey1 = 'key1';
+        const versionId1 = 'version1';
+        const versionKey1 = `${masterKey1}${VID_SEP}${versionId1}`;
+        const date1 = '1970-01-01T00:00:00.002Z';
+        const value1 = `{"versionId":"${versionId1}","last-modified":"${date1}","isDeleteMarker":true}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey1),
+            value: value1,
+        }), FILTER_ACCEPT);
+
+        // filter the second orphan delete marker
+        const masterKey2 = 'key2';
+        const versionId2 = 'version2';
+        const versionKey2 = `${masterKey2}${VID_SEP}${versionId2}`;
+        const date2 = '1970-01-01T00:00:00.001Z';
+        const value2 = `{"versionId":"${versionId2}","last-modified":"${date2}","isDeleteMarker":true}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey2),
+            value: value2,
+        }), FILTER_ACCEPT);
+
+        const expectedResult = {
+            Contents: [
+                {
+                    key: masterKey1,
+                    value: value1,
+                },
+                {
+                    key: masterKey2,
+                    value: value2,
+                },
+            ],
+            IsTruncated: false,
+        };
+
+        assert.deepStrictEqual(delimiter.result(), expectedResult);
+    });
+
+    it('should accept two orphan delete markers and return truncated content with one', () => {
+        const delimiter = new DelimiterOrphanDeleteMarker({ maxKeys: 1 }, fakeLogger, 'v1');
+
+        // filter the first orphan delete marker
+        const masterKey1 = 'key1';
+        const versionId1 = 'version1';
+        const versionKey1 = `${masterKey1}${VID_SEP}${versionId1}`;
+        const date1 = '1970-01-01T00:00:00.002Z';
+        const value1 = `{"versionId":"${versionId1}","last-modified":"${date1}","isDeleteMarker":true}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey1),
+            value: value1,
+        }), FILTER_ACCEPT);
+
+        // filter the second orphan delete marker
+        const masterKey2 = 'key2';
+        const versionId2 = 'version2';
+        const versionKey2 = `${masterKey2}${VID_SEP}${versionId2}`;
+        const date2 = '1970-01-01T00:00:00.001Z';
+        const value2 = `{"versionId":"${versionId2}","last-modified":"${date2}","isDeleteMarker":true}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey2),
+            value: value2,
+        }), FILTER_ACCEPT);
+
+        const expectedResult = {
+            Contents: [
+                {
+                    key: masterKey1,
+                    value: value1,
+                },
+            ],
+            NextMarker: masterKey1,
+            IsTruncated: true,
+        };
+
+        assert.deepStrictEqual(delimiter.result(), expectedResult);
+    });
+
+    it('should accept two orphan delete markers and return the one created before the beforeDate', () => {
+        const date1 = '1970-01-01T00:00:00.002Z';
+        const delimiter = new DelimiterOrphanDeleteMarker({ beforeDate: date1 }, fakeLogger, 'v1');
+
+        // filter the first orphan delete marker
+        const masterKey1 = 'key1';
+        const versionId1 = 'version1';
+        const versionKey1 = `${masterKey1}${VID_SEP}${versionId1}`;
+        const value1 = `{"versionId":"${versionId1}","last-modified":"${date1}","isDeleteMarker":true}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey1),
+            value: value1,
+        }), FILTER_ACCEPT);
+
+        // filter the second orphan delete marker
+        const masterKey2 = 'key2';
+        const versionId2 = 'version2';
+        const versionKey2 = `${masterKey2}${VID_SEP}${versionId2}`;
+        const date2 = '1970-01-01T00:00:00.001Z';
+        const value2 = `{"versionId":"${versionId2}","last-modified":"${date2}","isDeleteMarker":true}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey2),
+            value: value2,
+        }), FILTER_ACCEPT);
+
+        const expectedResult = {
+            Contents: [
+                {
+                    key: masterKey2,
+                    value: value2,
+                },
+            ],
+            IsTruncated: false,
+        };
+
+        assert.deepStrictEqual(delimiter.result(), expectedResult);
+    });
+
+    it('should end filtering if max keys reached', () => {
+        const delimiter = new DelimiterOrphanDeleteMarker({ maxKeys: 1 }, fakeLogger, 'v1');
+
+        // filter the first orphan delete marker
+        const masterKey1 = 'key1';
+        const versionId1 = 'version1';
+        const versionKey1 = `${masterKey1}${VID_SEP}${versionId1}`;
+        const date1 = '1970-01-01T00:00:00.002Z';
+        const value1 = `{"versionId":"${versionId1}","last-modified":"${date1}","isDeleteMarker":true}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey1),
+            value: value1,
+        }), FILTER_ACCEPT);
+
+        // filter the second orphan delete marker
+        const masterKey2 = 'key2';
+        const versionId2 = 'version2';
+        const versionKey2 = `${masterKey2}${VID_SEP}${versionId2}`;
+        const date2 = '1970-01-01T00:00:00.001Z';
+        const value2 = `{"versionId":"${versionId2}","last-modified":"${date2}","isDeleteMarker":true}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey2),
+            value: value2,
+        }), FILTER_ACCEPT);
+
+        // filter the third orphan delete marker
+        const masterKey3 = 'key3';
+        const versionId3 = 'version3';
+        const versionKey3 = `${masterKey3}${VID_SEP}${versionId3}`;
+        const date3 = '1970-01-01T00:00:00.000Z';
+        const value3 = `{"versionId":"${versionId3}","last-modified":"${date3}","isDeleteMarker":true}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey3),
+            value: value3,
+        }), FILTER_END);
+
+        const expectedResult = {
+            Contents: [
+                {
+                    key: masterKey1,
+                    value: value1,
+                },
+            ],
+            NextMarker: masterKey1,
+            IsTruncated: true,
+        };
+
+        assert.deepStrictEqual(delimiter.result(), expectedResult);
+    });
+
+    it('should end filtering if delimiter timeout', () => {
+        const delimiter = new DelimiterOrphanDeleteMarker({ }, fakeLogger, 'v1');
+
+        // filter the first orphan delete marker
+        const masterKey1 = 'key1';
+        const versionId1 = 'version1';
+        const versionKey1 = `${masterKey1}${VID_SEP}${versionId1}`;
+        const date1 = '1970-01-01T00:00:00.002Z';
+        const value1 = `{"versionId":"${versionId1}","last-modified":"${date1}","isDeleteMarker":true}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey1),
+            value: value1,
+        }), FILTER_ACCEPT);
+
+        // force delimiter to timeout.
+        delimiter.start = Date.now() - (DELIMITER_TIMEOUT_MS + 1);
+
+        // filter the second orphan delete marker
+        const masterKey2 = 'key2';
+        const versionId2 = 'version2';
+        const versionKey2 = `${masterKey2}${VID_SEP}${versionId2}`;
+        const date2 = '1970-01-01T00:00:00.001Z';
+        const value2 = `{"versionId":"${versionId2}","last-modified":"${date2}","isDeleteMarker":true}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey2),
+            value: value2,
+        }), FILTER_END);
+
+        const expectedResult = {
+            Contents: [
+                {
+                    key: masterKey1,
+                    value: value1,
+                },
+            ],
+            NextMarker: masterKey1,
+            IsTruncated: true,
+        };
+
+        assert.deepStrictEqual(delimiter.result(), expectedResult);
+    });
+
+    it('should end filtering if delimiter timeout with empty content', () => {
+        const delimiter = new DelimiterOrphanDeleteMarker({ }, fakeLogger, 'v1');
+
+        // filter the first orphan delete marker
+        const masterKey1 = 'key1';
+        const versionId1 = 'version1';
+        const versionKey1 = `${masterKey1}${VID_SEP}${versionId1}`;
+        const date1 = '1970-01-01T00:00:00.002Z';
+        const value1 = `{"versionId":"${versionId1}","last-modified":"${date1}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey1),
+            value: value1,
+        }), FILTER_ACCEPT);
+
+        // filter the second orphan delete marker
+        const masterKey2 = 'key2';
+        const versionId2 = 'version2';
+        const versionKey2 = `${masterKey2}${VID_SEP}${versionId2}`;
+        const date2 = '1970-01-01T00:00:00.001Z';
+        const value2 = `{"versionId":"${versionId2}","last-modified":"${date2}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey2),
+            value: value2,
+        }), FILTER_ACCEPT);
+
+        // force delimiter to timeout.
+        delimiter.start = Date.now() - (DELIMITER_TIMEOUT_MS + 1);
+
+        // filter the third orphan delete marker
+        const masterKey3 = 'key3';
+        const versionId3 = 'version3';
+        const versionKey3 = `${masterKey3}${VID_SEP}${versionId3}`;
+        const date3 = '1970-01-01T00:00:00.000Z';
+        const value3 = `{"versionId":"${versionId3}","last-modified":"${date3}","isDeleteMarker":true}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(versionKey3),
+            value: value3,
+        }), FILTER_END);
+
+        const expectedResult = {
+            Contents: [],
+            NextMarker: masterKey2,
+            IsTruncated: true,
+        };
+
+        assert.deepStrictEqual(delimiter.result(), expectedResult);
+    });
+});


### PR DESCRIPTION
DelimiterOrphan is used for listing orphan delete markers.
The Metadata call returns the versions (V prefix).
The MD response is then processed to only return the delete markers with zero noncurrent versions before a defined date: `beforeDate`.