### PR TITLE
add s3:lifecycleexpiration to the list of supported notifications events

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -141,7 +141,10 @@ export const supportedNotificationEvents = new Set([
     's3:ObjectRestore:Post',
     's3:ObjectRestore:Completed',
     's3:ObjectRestore:Delete',
-    's3:LifecycleTransition'
+    's3:LifecycleTransition',
+    's3:LifecycleExpiration:*',
+    's3:LifecycleExpiration:DeleteMarkerCreated',
+    's3:LifecycleExpiration:Delete',
 ]);
 export const notificationArnPrefix = 'arn:scality:bucketnotif';
 // HTTP server keep-alive timeout is set to a higher value than


### PR DESCRIPTION
Add s3:lifecycleexpiration to the ist of supported notification events

Issue: ARSN-322
