### PR TITLE
bf: ARSN-330 fix DelimiterVersions exception when key contains "undefined"

### DIFF
--- a/lib/algos/list/delimiterVersions.ts
+++ b/lib/algos/list/delimiterVersions.ts
@@ -257,6 +257,9 @@ export class DelimiterVersions extends Delimiter {
     }
 
     getCommonPrefix(key: string): string | undefined {
+        if (!this.delimiter) {
+            return undefined;
+        }
         const baseIndex = this.prefix ? this.prefix.length : 0;
         const delimiterIndex = key.indexOf(this.delimiter, baseIndex);
         if (delimiterIndex === -1) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.70.4",
+  "version": "7.70.5",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/algos/list/delimiterVersions.spec.js
+++ b/tests/unit/algos/list/delimiterVersions.spec.js
@@ -1371,6 +1371,23 @@ function getTestListing(mdParams, data, vFormat) {
             });
         });
 
+        it('should not crash if key contains "undefined" with no delimiter', () => {
+            const delimiter = new DelimiterVersions({}, logger, vFormat);
+            const value = '';
+
+            const listingKey = getListingKey('undefinedfoo', vFormat);
+            assert.strictEqual(delimiter.filter({ key: listingKey, value }), FILTER_ACCEPT);
+            assert.deepStrictEqual(delimiter.result(), {
+                CommonPrefixes: [],
+                Versions: [{
+                    key: 'undefinedfoo',
+                    value: '',
+                    versionId: 'null',
+                }],
+                IsTruncated: false,
+            });
+        });
+
         if (vFormat === 'v0') {
             it('should accept a PHD version as first input', () => {
                 const delimiter = new DelimiterVersions({}, logger, vFormat);


### PR DESCRIPTION
Fix a crash when a listed key contains the string "undefined": as the `key.indexOf` method was used without prior checking whether a delimiter was set, it converted the delimiter to the string "undefined", which could be found in a key containing such string, and causing an exception thereafter.