### PR TITLE
ARSN-328 Exclude keys based on their dataStoreName

### DIFF
--- a/lib/algos/list/delimiterCurrent.ts
+++ b/lib/algos/list/delimiterCurrent.ts
@@ -18,6 +18,7 @@ class DelimiterCurrent extends Delimiter {
      * Delimiter listing of current versions.
      * @param {Object}  parameters            - listing parameters
      * @param {String}  parameters.beforeDate - limit the response to keys older than beforeDate
+     * @param {String}  parameters.excludedDataStoreName - excluded datatore name
      * @param {RequestLogger} logger          - The logger of the request
      * @param {String} [vFormat]              - versioning key format
      */
@@ -25,15 +26,22 @@ class DelimiterCurrent extends Delimiter {
         super(parameters, logger, vFormat);
 
         this.beforeDate = parameters.beforeDate;
+        this.excludedDataStoreName = parameters.excludedDataStoreName;
     }
 
     genMDParamsV1() {
         const params = super.genMDParamsV1();
- 
+
         if (this.beforeDate) {
             params.lastModified = {
                 lt: this.beforeDate,
             };
+        }
+
+        if (this.excludedDataStoreName) {
+            params.dataStoreName = {
+                ne: this.excludedDataStoreName,
+            }
         }
         return params;
     }

--- a/lib/algos/list/delimiterNonCurrent.js
+++ b/lib/algos/list/delimiterNonCurrent.js
@@ -30,6 +30,7 @@ class DelimiterNonCurrent extends Delimiter {
         this.versionIdMarker = parameters.versionIdMarker;
         this.beforeDate = parameters.beforeDate;
         this.keyMarker = parameters.keyMarker;
+        this.excludedDataStoreName = parameters.excludedDataStoreName;
         this.NextKeyMarker = null;
 
         this.skipping = this.skippingV1;
@@ -100,9 +101,10 @@ class DelimiterNonCurrent extends Delimiter {
      * DESCRIPTION: For a given key, the latest version is skipped since it represents the current version or
      * the last version of the previous truncated listing.
      * The current last-modified date is kept in memory and used as a "stale date" for the following version.
-     * The following version is pushed only if the "stale date" (picked up from the previous version)
-     * is available (JSON.parse has not failed), if the "beforeDate" argument is specified, and
-     * the "stale date" is older than the "beforeDate".
+     * The following version is pushed only:
+     * - if the "stale date" (picked up from the previous version) is available (JSON.parse has not failed),
+     * - if "beforeDate" is not specified or if specified and the "stale date" is older.
+     * - if "excludedDataStoreName" is not specified or if specified and the data store name is different
      * The in-memory "stale date" is then updated with the version's last-modified date to be used for
      * the following version.
      * The process stops and returns the available results if either:
@@ -148,18 +150,25 @@ class DelimiterNonCurrent extends Delimiter {
             return FILTER_ACCEPT;
         }
 
-        // The following version is pushed only if the "stale date" (picked up from the previous version)
-        // is available (JSON.parse has not failed) and, if the "beforeDate" argument is specified,
-        // the "stale date" is older than the "beforeDate".
+        // The following version is pushed only:
+        // - if the "stale date" (picked up from the previous version) is available (JSON.parse has not failed),
+        // - if "beforeDate" is not specified or if specified and the "stale date" is older.
+        // - if "excludedDataStoreName" is not specified or if specified and the data store name is different
         let lastModified;
         if (this.staleDate && (!this.beforeDate || this.staleDate < this.beforeDate)) {
-            const v = this.trimMetadataAddStaleDate(value, this.staleDate);
-            lastModified = v.lastModified;
-            const { contentValue } = v;
-            // check that trimMetadataAddStaleDate succeeds to only push objects with a defined staleDate.
-            if (contentValue) {
-                this.Contents.push({ key, value: contentValue });
-                ++this.keys;
+            const parsedValue = this._parse(value);
+            // if parsing fails, skip the key.
+            if (parsedValue) {
+                const dataStoreName = parsedValue.dataStoreName;
+                lastModified = parsedValue['last-modified'];
+                if (!this.excludedDataStoreName || dataStoreName !== this.excludedDataStoreName) {
+                    const s = this._stringify(parsedValue, this.staleDate);
+                    // check that _stringify succeeds to only push objects with a defined staleDate.
+                    if (s) {
+                        this.Contents.push({ key, value: s });
+                        ++this.keys;
+                    }
+                }
             }
         }
 
@@ -170,30 +179,35 @@ class DelimiterNonCurrent extends Delimiter {
         return FILTER_ACCEPT;
     }
 
-    trimMetadataAddStaleDate(value, staleDate) {
-        let ret = undefined;
-        let lastModified = undefined;
+    _parse(s) {
+        let p;
         try {
-            ret = JSON.parse(value);
-            ret.staleDate = staleDate;
-            lastModified = ret['last-modified'];
-            if (value.length >= TRIM_METADATA_MIN_BLOB_SIZE) {
-                delete ret.location;
+            p = JSON.parse(s);
+            if (s.length >= TRIM_METADATA_MIN_BLOB_SIZE) {
+                delete p.location;
             }
-            ret = JSON.stringify(ret);
         } catch (e) {
-            // Prefer returning an unfiltered data rather than
-            // stopping the service in case of parsing failure.
-            // The risk of this approach is a potential
-            // reproduction of MD-692, where too much memory is
-            // used by repd.
-            this.logger.warn('could not parse Object Metadata while listing',
-                {
-                    method: 'trimMetadataAddStaleDate',
-                    err: e.toString(),
-                });
+            this.logger.warn('Could not parse Object Metadata while listing', {
+                method: 'DelimiterNonCurrent._parse',
+                err: e.toString(),
+            });
         }
-        return { contentValue: ret, lastModified };
+        return p;
+    }
+
+    _stringify(parsedMD, staleDate) {
+        const p = parsedMD;
+        let s = undefined;
+        p.staleDate = staleDate;
+        try {
+            s = JSON.stringify(p);
+        } catch (e) {
+            this.logger.warn('could not stringify Object Metadata while listing', {
+                method: 'DelimiterNonCurrent._stringify',
+                err: e.toString(),
+            });
+        }
+        return s;
     }
 
     result() {

--- a/lib/algos/list/delimiterOrphanDeleteMarker.js
+++ b/lib/algos/list/delimiterOrphanDeleteMarker.js
@@ -80,7 +80,7 @@ class DelimiterOrphanDeleteMarker extends Delimiter {
             // We then check if the orphan version is a delete marker and if it is older than the "beforeDate"
             if ((!this.beforeDate || (lastModified && lastModified < this.beforeDate)) && isDeleteMarker) {
                 // Prefer returning an untrimmed data rather than stopping the service in case of parsing failure.
-                const s = this._trimAndStringify(parsedValue) || this.value;
+                const s = this._stringify(parsedValue) || this.value;
                 this.Contents.push({ key: this.keyName, value: s });
                 this.NextMarker = this.keyName;
                 ++this.keys;
@@ -92,26 +92,27 @@ class DelimiterOrphanDeleteMarker extends Delimiter {
         let p;
         try {
             p = JSON.parse(s);
+            if (s.length >= TRIM_METADATA_MIN_BLOB_SIZE) {
+                delete p.location;
+            }
         } catch (e) {
-            this.logger.warn(
-                'Could not parse Object Metadata while listing',
-                { err: e.toString() });
+            this.logger.warn('Could not parse Object Metadata while listing', {
+                method: 'DelimiterOrphanDeleteMarker._parse',
+                err: e.toString(),
+            });
         }
         return p;
     }
 
-    _trimAndStringify(value) {
+    _stringify(value) {
         const p = value;
         let s = undefined;
         try {
-            if (p.length >= TRIM_METADATA_MIN_BLOB_SIZE) {
-                delete p.location;
-            }
             s = JSON.stringify(p);
         } catch (e) {
-            this.logger.warn('could not trim and stringify Object Metadata while listing',
+            this.logger.warn('could not stringify Object Metadata while listing',
                 {
-                    method: 'trimMetadataAddStaleDate',
+                    method: 'DelimiterOrphanDeleteMarker._stringify',
                     err: e.toString(),
                 });
         }

--- a/lib/storage/metadata/mongoclient/readStream.js
+++ b/lib/storage/metadata/mongoclient/readStream.js
@@ -63,6 +63,14 @@ class MongoReadStream extends Readable {
             }
         }
 
+        if (options.dataStoreName) {
+            query['value.dataStoreName'] = {};
+
+            if (options.dataStoreName.ne) {
+                query['value.dataStoreName'].$ne = options.dataStoreName.ne;
+            }
+        }
+
         if (!Object.keys(query._id).length) {
             delete query._id;
         }

--- a/tests/functional/metadata/mongodb/listLifecycleObject/noncurrent.spec.js
+++ b/tests/functional/metadata/mongodb/listLifecycleObject/noncurrent.spec.js
@@ -33,6 +33,8 @@ describe('MongoClientInterface::metadata.listLifecycleObject::noncurrent', () =>
     const key1 = 'pfx1-test-object';
     const key2 = 'pfx2-test-object';
     const key3 = 'pfx3-test-object';
+    const location1 = 'loc1';
+    const location2 = 'loc2';
 
     beforeAll(done => {
         mongoserver.waitUntilRunning().then(() => {
@@ -77,18 +79,16 @@ describe('MongoClientInterface::metadata.listLifecycleObject::noncurrent', () =>
                 return next();
             }),
             next => {
-                const params = {
-                    objName: key1,
-                    objVal: {
-                        key: key1,
-                        versionId: 'null',
-                    },
-                    nbVersions: 5,
+                const objVal = {
+                    key: key1,
+                    versionId: 'null',
+                    dataStoreName: location1,
                 };
+                const nbVersions = 5;
                 const timestamp = 0;
-                putBulkObjectVersions(metadata, BUCKET_NAME, params.objName, params.objVal, versionParams,
-                    params.nbVersions, timestamp, logger, (err, data) => {
-                        expectedVersionIds[key1] = data;
+                putBulkObjectVersions(metadata, BUCKET_NAME, key1, objVal, versionParams,
+                    nbVersions, timestamp, logger, (err, data) => {
+                        expectedVersionIds[key1] = data.expectedVersionIds;
                         return next(err);
                     });
                 /* eslint-disable max-len */
@@ -101,18 +101,16 @@ describe('MongoClientInterface::metadata.listLifecycleObject::noncurrent', () =>
                 /* eslint-enable max-len */
             },
             next => {
-                const params = {
-                    objName: key2,
-                    objVal: {
-                        key: key2,
-                        versionId: 'null',
-                    },
-                    nbVersions: 5,
+                const objVal = {
+                    key: key2,
+                    versionId: 'null',
+                    dataStoreName: location2,
                 };
+                const nbVersions = 5;
                 const timestamp = 0;
-                putBulkObjectVersions(metadata, BUCKET_NAME, params.objName, params.objVal, versionParams,
-                    params.nbVersions, timestamp, logger, (err, data) => {
-                        expectedVersionIds[key2] = data;
+                putBulkObjectVersions(metadata, BUCKET_NAME, key2, objVal, versionParams,
+                    nbVersions, timestamp, logger, (err, data) => {
+                        expectedVersionIds[key2] = data.expectedVersionIds;
                         return next(err);
                     });
                 /* eslint-disable max-len */
@@ -125,18 +123,16 @@ describe('MongoClientInterface::metadata.listLifecycleObject::noncurrent', () =>
                 /* eslint-enable max-len */
             },
             next => {
-                const params = {
-                    objName: key3,
-                    objVal: {
-                        key: key3,
-                        versionId: 'null',
-                    },
-                    nbVersions: 5,
+                const objVal = {
+                    key: key3,
+                    versionId: 'null',
+                    dataStoreName: location1,
                 };
+                const nbVersions = 5;
                 const timestamp = 0;
-                putBulkObjectVersions(metadata, BUCKET_NAME, params.objName, params.objVal, versionParams,
-                    params.nbVersions, timestamp, logger, (err, data) => {
-                        expectedVersionIds[key3] = data;
+                putBulkObjectVersions(metadata, BUCKET_NAME, key3, objVal, versionParams,
+                    nbVersions, timestamp, logger, (err, data) => {
+                        expectedVersionIds[key3] = data.expectedVersionIds;
                         return next(err);
                     });
                 /* eslint-disable max-len */
@@ -166,61 +162,73 @@ describe('MongoClientInterface::metadata.listLifecycleObject::noncurrent', () =>
                     key: key1,
                     LastModified: '1970-01-01T00:00:00.004Z',
                     staleDate: '1970-01-01T00:00:00.005Z',
+                    dataStoreName: location1,
                 },
                 {
                     key: key1,
                     LastModified: '1970-01-01T00:00:00.003Z',
                     staleDate: '1970-01-01T00:00:00.004Z',
+                    dataStoreName: location1,
                 },
                 {
                     key: key1,
                     LastModified: '1970-01-01T00:00:00.002Z',
                     staleDate: '1970-01-01T00:00:00.003Z',
+                    dataStoreName: location1,
                 },
                 {
                     key: key1,
                     LastModified: '1970-01-01T00:00:00.001Z',
                     staleDate: '1970-01-01T00:00:00.002Z',
+                    dataStoreName: location1,
                 },
                 {
                     key: key2,
                     LastModified: '1970-01-01T00:00:00.004Z',
                     staleDate: '1970-01-01T00:00:00.005Z',
+                    dataStoreName: location2,
                 },
                 {
                     key: key2,
                     LastModified: '1970-01-01T00:00:00.003Z',
                     staleDate: '1970-01-01T00:00:00.004Z',
+                    dataStoreName: location2,
                 },
                 {
                     key: key2,
                     LastModified: '1970-01-01T00:00:00.002Z',
                     staleDate: '1970-01-01T00:00:00.003Z',
+                    dataStoreName: location2,
                 },
                 {
                     key: key2,
                     LastModified: '1970-01-01T00:00:00.001Z',
                     staleDate: '1970-01-01T00:00:00.002Z',
+                    dataStoreName: location2,
                 },
                 {
                     key: key3,
                     LastModified: '1970-01-01T00:00:00.004Z',
                     staleDate: '1970-01-01T00:00:00.005Z',
+                    dataStoreName: location1,
                 },
                 {
                     key: key3,
                     LastModified: '1970-01-01T00:00:00.003Z',
                     staleDate: '1970-01-01T00:00:00.004Z',
+                    dataStoreName: location1,
                 },
                 {
                     key: key3,
                     LastModified: '1970-01-01T00:00:00.002Z',
                     staleDate: '1970-01-01T00:00:00.003Z',
+                    dataStoreName: location1,
                 },
                 {
                     key: key3,
                     LastModified: '1970-01-01T00:00:00.001Z',
                     staleDate: '1970-01-01T00:00:00.002Z',
+                    dataStoreName: location1,
                 },
             ];
             assertContents(data.Contents, expected);
@@ -252,6 +260,156 @@ describe('MongoClientInterface::metadata.listLifecycleObject::noncurrent', () =>
         });
     });
 
+    it('Should list non-current versions excluding keys stored in location1', done => {
+        const params = {
+            listingType: 'DelimiterNonCurrent',
+            excludedDataStoreName: location1,
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(data.IsTruncated, false);
+            assert.strictEqual(data.Contents.length, 4);
+            const expected = [
+                {
+                    key: key2,
+                    LastModified: '1970-01-01T00:00:00.004Z',
+                    staleDate: '1970-01-01T00:00:00.005Z',
+                    VersionId: expectedVersionIds[key2][0],
+                    dataStoreName: location2,
+                },
+                {
+                    key: key2,
+                    LastModified: '1970-01-01T00:00:00.003Z',
+                    staleDate: '1970-01-01T00:00:00.004Z',
+                    VersionId: expectedVersionIds[key2][1],
+                    dataStoreName: location2,
+                },
+                {
+                    key: key2,
+                    LastModified: '1970-01-01T00:00:00.002Z',
+                    staleDate: '1970-01-01T00:00:00.003Z',
+                    VersionId: expectedVersionIds[key2][2],
+                    dataStoreName: location2,
+                },
+                {
+                    key: key2,
+                    LastModified: '1970-01-01T00:00:00.001Z',
+                    staleDate: '1970-01-01T00:00:00.002Z',
+                    VersionId: expectedVersionIds[key2][3],
+                    dataStoreName: location2,
+                },
+            ];
+            assertContents(data.Contents, expected);
+
+            const key2VersionIds = data.Contents.filter(k => k.key === key2).map(k => k.value.VersionId);
+            assert.deepStrictEqual(key2VersionIds, expectedVersionIds[key2]);
+
+            return done();
+        });
+    });
+
+    it('Should list non-current versions older than a specific date and excluding keys stored in location1', done => {
+        const params = {
+            listingType: 'DelimiterNonCurrent',
+            excludedDataStoreName: location1,
+            beforeDate: '1970-01-01T00:00:00.004Z',
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(data.IsTruncated, false);
+            assert.strictEqual(data.Contents.length, 2);
+            const expected = [
+                {
+                    key: key2,
+                    LastModified: '1970-01-01T00:00:00.002Z',
+                    staleDate: '1970-01-01T00:00:00.003Z',
+                    VersionId: expectedVersionIds[key2][2],
+                    dataStoreName: location2,
+                },
+                {
+                    key: key2,
+                    LastModified: '1970-01-01T00:00:00.001Z',
+                    staleDate: '1970-01-01T00:00:00.002Z',
+                    VersionId: expectedVersionIds[key2][3],
+                    dataStoreName: location2,
+                },
+            ];
+            assertContents(data.Contents, expected);
+
+            return done();
+        });
+    });
+
+    it('Should return trucated list of non-current versions excluding keys stored in location1', done => {
+        const params = {
+            listingType: 'DelimiterNonCurrent',
+            excludedDataStoreName: location1,
+            maxKeys: 2,
+        };
+        return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+            assert.deepStrictEqual(err, null);
+            assert.strictEqual(data.IsTruncated, true);
+            assert.strictEqual(data.NextKeyMarker, key2);
+            assert.strictEqual(data.NextVersionIdMarker, data.Contents[1].value.VersionId);
+            assert.strictEqual(data.Contents.length, 2);
+            const expected = [
+                {
+                    key: key2,
+                    LastModified: '1970-01-01T00:00:00.004Z',
+                    staleDate: '1970-01-01T00:00:00.005Z',
+                    VersionId: expectedVersionIds[key2][0],
+                    dataStoreName: location2,
+                },
+                {
+                    key: key2,
+                    LastModified: '1970-01-01T00:00:00.003Z',
+                    staleDate: '1970-01-01T00:00:00.004Z',
+                    VersionId: expectedVersionIds[key2][1],
+                    dataStoreName: location2,
+                },
+            ];
+            assertContents(data.Contents, expected);
+
+            params.keyMarker = data.NextKeyMarker;
+            params.versionIdMarker = data.NextVersionIdMarker;
+
+            return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+                assert.deepStrictEqual(err, null);
+                assert.strictEqual(data.IsTruncated, true);
+                assert.strictEqual(data.NextKeyMarker, key2);
+                assert.strictEqual(data.NextVersionIdMarker, data.Contents[1].value.VersionId);
+                assert.strictEqual(data.Contents.length, 2);
+                const expected = [
+                    {
+                        key: key2,
+                        LastModified: '1970-01-01T00:00:00.002Z',
+                        staleDate: '1970-01-01T00:00:00.003Z',
+                        VersionId: expectedVersionIds[key2][2],
+                        dataStoreName: location2,
+                    },
+                    {
+                        key: key2,
+                        LastModified: '1970-01-01T00:00:00.001Z',
+                        staleDate: '1970-01-01T00:00:00.002Z',
+                        VersionId: expectedVersionIds[key2][3],
+                        dataStoreName: location2,
+                    },
+                ];
+                assertContents(data.Contents, expected);
+
+                params.keyMarker = data.NextKeyMarker;
+                params.versionIdMarker = data.NextVersionIdMarker;
+
+                return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+                    assert.deepStrictEqual(err, null);
+                    assert.strictEqual(data.IsTruncated, false);
+                    assert.strictEqual(data.Contents.length, 0);
+                    return done();
+                });
+            });
+        });
+    });
+
     it('Should return the non-current versions with stale date older than 1970-01-01T00:00:00.003Z', done => {
         const params = {
             listingType: 'DelimiterNonCurrent',
@@ -267,18 +425,21 @@ describe('MongoClientInterface::metadata.listLifecycleObject::noncurrent', () =>
                     LastModified: '1970-01-01T00:00:00.001Z',
                     staleDate: '1970-01-01T00:00:00.002Z',
                     VersionId: expectedVersionIds[key1][3],
+                    dataStoreName: location1,
                 },
                 {
                     key: key2,
                     LastModified: '1970-01-01T00:00:00.001Z',
                     staleDate: '1970-01-01T00:00:00.002Z',
                     VersionId: expectedVersionIds[key2][3],
+                    dataStoreName: location2,
                 },
                 {
                     key: key3,
                     LastModified: '1970-01-01T00:00:00.001Z',
                     staleDate: '1970-01-01T00:00:00.002Z',
                     VersionId: expectedVersionIds[key3][3],
+                    dataStoreName: location1,
                 },
             ];
             assertContents(data.Contents, expected);
@@ -306,18 +467,21 @@ describe('MongoClientInterface::metadata.listLifecycleObject::noncurrent', () =>
                         LastModified: '1970-01-01T00:00:00.004Z',
                         staleDate: '1970-01-01T00:00:00.005Z',
                         VersionId: expectedVersionIds[key1][0],
+                        dataStoreName: location1,
                     },
                     {
                         key: key1,
                         LastModified: '1970-01-01T00:00:00.003Z',
                         staleDate: '1970-01-01T00:00:00.004Z',
                         VersionId: expectedVersionIds[key1][1],
+                        dataStoreName: location1,
                     },
                     {
                         key: key1,
                         LastModified: '1970-01-01T00:00:00.002Z',
                         staleDate: '1970-01-01T00:00:00.003Z',
                         VersionId: expectedVersionIds[key1][2],
+                        dataStoreName: location1,
                     },
                 ];
                 assertContents(data.Contents, expected);
@@ -339,18 +503,21 @@ describe('MongoClientInterface::metadata.listLifecycleObject::noncurrent', () =>
                         LastModified: '1970-01-01T00:00:00.001Z',
                         staleDate: '1970-01-01T00:00:00.002Z',
                         VersionId: expectedVersionIds[key1][3],
+                        dataStoreName: location1,
                     },
                     {
                         key: key2,
                         LastModified: '1970-01-01T00:00:00.004Z',
                         staleDate: '1970-01-01T00:00:00.005Z',
                         VersionId: expectedVersionIds[key2][0],
+                        dataStoreName: location2,
                     },
                     {
                         key: key2,
                         LastModified: '1970-01-01T00:00:00.003Z',
                         staleDate: '1970-01-01T00:00:00.004Z',
                         VersionId: expectedVersionIds[key2][1],
+                        dataStoreName: location2,
                     },
                 ];
                 assertContents(data.Contents, expected);
@@ -372,18 +539,21 @@ describe('MongoClientInterface::metadata.listLifecycleObject::noncurrent', () =>
                         LastModified: '1970-01-01T00:00:00.002Z',
                         staleDate: '1970-01-01T00:00:00.003Z',
                         VersionId: expectedVersionIds[key2][2],
+                        dataStoreName: location2,
                     },
                     {
                         key: key2,
                         LastModified: '1970-01-01T00:00:00.001Z',
                         staleDate: '1970-01-01T00:00:00.002Z',
                         VersionId: expectedVersionIds[key2][3],
+                        dataStoreName: location2,
                     },
                     {
                         key: key3,
                         LastModified: '1970-01-01T00:00:00.004Z',
                         staleDate: '1970-01-01T00:00:00.005Z',
                         VersionId: expectedVersionIds[key3][0],
+                        dataStoreName: location1,
                     },
                 ];
                 assertContents(data.Contents, expected);
@@ -403,18 +573,21 @@ describe('MongoClientInterface::metadata.listLifecycleObject::noncurrent', () =>
                         LastModified: '1970-01-01T00:00:00.003Z',
                         staleDate: '1970-01-01T00:00:00.004Z',
                         VersionId: expectedVersionIds[key3][1],
+                        dataStoreName: location1,
                     },
                     {
                         key: key3,
                         LastModified: '1970-01-01T00:00:00.002Z',
                         staleDate: '1970-01-01T00:00:00.003Z',
                         VersionId: expectedVersionIds[key3][2],
+                        dataStoreName: location1,
                     },
                     {
                         key: key3,
                         LastModified: '1970-01-01T00:00:00.001Z',
                         staleDate: '1970-01-01T00:00:00.002Z',
                         VersionId: expectedVersionIds[key3][3],
+                        dataStoreName: location1,
                     },
                 ];
                 assertContents(data.Contents, expected);
@@ -444,21 +617,25 @@ describe('MongoClientInterface::metadata.listLifecycleObject::noncurrent', () =>
                         key: key1,
                         LastModified: '1970-01-01T00:00:00.004Z',
                         staleDate: '1970-01-01T00:00:00.005Z',
+                        dataStoreName: location1,
                     },
                     {
                         key: key1,
                         LastModified: '1970-01-01T00:00:00.003Z',
                         staleDate: '1970-01-01T00:00:00.004Z',
+                        dataStoreName: location1,
                     },
                     {
                         key: key1,
                         LastModified: '1970-01-01T00:00:00.002Z',
                         staleDate: '1970-01-01T00:00:00.003Z',
+                        dataStoreName: location1,
                     },
                     {
                         key: key1,
                         LastModified: '1970-01-01T00:00:00.001Z',
                         staleDate: '1970-01-01T00:00:00.002Z',
+                        dataStoreName: location1,
                     },
                 ];
 
@@ -483,21 +660,25 @@ describe('MongoClientInterface::metadata.listLifecycleObject::noncurrent', () =>
                         key: key2,
                         LastModified: '1970-01-01T00:00:00.004Z',
                         staleDate: '1970-01-01T00:00:00.005Z',
+                        dataStoreName: location2,
                     },
                     {
                         key: key2,
                         LastModified: '1970-01-01T00:00:00.003Z',
                         staleDate: '1970-01-01T00:00:00.004Z',
+                        dataStoreName: location2,
                     },
                     {
                         key: key2,
                         LastModified: '1970-01-01T00:00:00.002Z',
                         staleDate: '1970-01-01T00:00:00.003Z',
+                        dataStoreName: location2,
                     },
                     {
                         key: key2,
                         LastModified: '1970-01-01T00:00:00.001Z',
                         staleDate: '1970-01-01T00:00:00.002Z',
+                        dataStoreName: location2,
                     },
                 ];
                 assertContents(data.Contents, expected);
@@ -519,21 +700,25 @@ describe('MongoClientInterface::metadata.listLifecycleObject::noncurrent', () =>
                         key: key3,
                         LastModified: '1970-01-01T00:00:00.004Z',
                         staleDate: '1970-01-01T00:00:00.005Z',
+                        dataStoreName: location1,
                     },
                     {
                         key: key3,
                         LastModified: '1970-01-01T00:00:00.003Z',
                         staleDate: '1970-01-01T00:00:00.004Z',
+                        dataStoreName: location1,
                     },
                     {
                         key: key3,
                         LastModified: '1970-01-01T00:00:00.002Z',
                         staleDate: '1970-01-01T00:00:00.003Z',
+                        dataStoreName: location1,
                     },
                     {
                         key: key3,
                         LastModified: '1970-01-01T00:00:00.001Z',
                         staleDate: '1970-01-01T00:00:00.002Z',
+                        dataStoreName: location1,
                     },
                 ];
                 assertContents(data.Contents, expected);
@@ -568,12 +753,14 @@ describe('MongoClientInterface::metadata.listLifecycleObject::noncurrent', () =>
                         LastModified: '1970-01-01T00:00:00.004Z',
                         staleDate: '1970-01-01T00:00:00.005Z',
                         VersionId: expectedVersionIds[key2][0],
+                        dataStoreName: location2,
                     },
                     {
                         key: key2,
                         LastModified: '1970-01-01T00:00:00.003Z',
                         staleDate: '1970-01-01T00:00:00.004Z',
                         VersionId: expectedVersionIds[key2][1],
+                        dataStoreName: location2,
                     },
                 ];
 
@@ -594,12 +781,14 @@ describe('MongoClientInterface::metadata.listLifecycleObject::noncurrent', () =>
                         LastModified: '1970-01-01T00:00:00.002Z',
                         staleDate: '1970-01-01T00:00:00.003Z',
                         VersionId: expectedVersionIds[key2][2],
+                        dataStoreName: location2,
                     },
                     {
                         key: key2,
                         LastModified: '1970-01-01T00:00:00.001Z',
                         staleDate: '1970-01-01T00:00:00.002Z',
                         VersionId: expectedVersionIds[key2][3],
+                        dataStoreName: location2,
                     },
                 ];
                 assertContents(data.Contents, expected);
@@ -630,21 +819,25 @@ describe('MongoClientInterface::metadata.listLifecycleObject::noncurrent', () =>
                     key: key2,
                     LastModified: '1970-01-01T00:00:00.004Z',
                     staleDate: '1970-01-01T00:00:00.005Z',
+                    dataStoreName: location2,
                 },
                 {
                     key: key2,
                     LastModified: '1970-01-01T00:00:00.003Z',
                     staleDate: '1970-01-01T00:00:00.004Z',
+                    dataStoreName: location2,
                 },
                 {
                     key: key2,
                     LastModified: '1970-01-01T00:00:00.002Z',
                     staleDate: '1970-01-01T00:00:00.003Z',
+                    dataStoreName: location2,
                 },
                 {
                     key: key2,
                     LastModified: '1970-01-01T00:00:00.001Z',
                     staleDate: '1970-01-01T00:00:00.002Z',
+                    dataStoreName: location2,
                 },
             ];
             assertContents(data.Contents, expected);
@@ -669,21 +862,25 @@ describe('MongoClientInterface::metadata.listLifecycleObject::noncurrent', () =>
                 key: key2,
                 LastModified: '1970-01-01T00:00:00.004Z',
                 staleDate: '1970-01-01T00:00:00.005Z',
+                dataStoreName: location2,
             },
             {
                 key: key2,
                 LastModified: '1970-01-01T00:00:00.003Z',
                 staleDate: '1970-01-01T00:00:00.004Z',
+                dataStoreName: location2,
             },
             {
                 key: key2,
                 LastModified: '1970-01-01T00:00:00.002Z',
                 staleDate: '1970-01-01T00:00:00.003Z',
+                dataStoreName: location2,
             },
             {
                 key: key2,
                 LastModified: '1970-01-01T00:00:00.001Z',
                 staleDate: '1970-01-01T00:00:00.002Z',
+                dataStoreName: location2,
             }];
             assertContents(data.Contents, expected);
 
@@ -710,6 +907,7 @@ describe('MongoClientInterface::metadata.listLifecycleObject::noncurrent', () =>
                 LastModified: '1970-01-01T00:00:00.001Z',
                 staleDate: '1970-01-01T00:00:00.002Z',
                 VersionId: expectedVersionIds[key2][3],
+                dataStoreName: location2,
             }];
             assertContents(data.Contents, expected);
 
@@ -735,12 +933,14 @@ describe('MongoClientInterface::metadata.listLifecycleObject::noncurrent', () =>
                     LastModified: '1970-01-01T00:00:00.003Z',
                     staleDate: '1970-01-01T00:00:00.004Z',
                     VersionId: expectedVersionIds[key2][1],
+                    dataStoreName: location2,
                 },
                 {
                     key: key2,
                     LastModified: '1970-01-01T00:00:00.002Z',
                     staleDate: '1970-01-01T00:00:00.003Z',
                     VersionId: expectedVersionIds[key2][2],
+                    dataStoreName: location2,
                 },
             ];
             assert.strictEqual(data.Contents.length, 2);
@@ -820,6 +1020,56 @@ describe('MongoClientInterface::metadata.listLifecycleObject::noncurrent', () =>
                 assert.ifError(err);
                 assert.strictEqual(data.IsTruncated, false);
                 assert.strictEqual(data.Contents.length, 0);
+                return next();
+            }),
+        ], done);
+    });
+
+    it('Should exclude keys stored in location1', done => {
+        let expectedId;
+        const objLoc1 = {
+            'key': 'pfx4-test-object',
+            'versionId': 'null',
+            'dataStoreName': location1,
+            'last-modified': new Date(0).toISOString(),
+        };
+
+        const objLoc2 = {
+            'key': 'pfx4-test-object',
+            'versionId': 'null',
+            'dataStoreName': location2,
+            'last-modified': new Date(0).toISOString(),
+        };
+        const versionParams = {
+            versioning: true,
+        };
+        const params = {
+            listingType: 'DelimiterNonCurrent',
+            prefix: 'pfx4',
+            excludedDataStoreName: location1,
+        };
+
+        async.series([
+            next => metadata.putObjectMD(BUCKET_NAME, 'pfx4-test-object', objLoc1, versionParams,
+                logger, next),
+            next => metadata.putObjectMD(BUCKET_NAME, 'pfx4-test-object', objLoc2, versionParams,
+                logger, (err, data) => {
+                    expectedId = JSON.parse(data).versionId;
+                    return next(err);
+                }),
+            next => metadata.putObjectMD(BUCKET_NAME, 'pfx4-test-object', objLoc1, versionParams,
+                logger, next),
+            next => metadata.putObjectMD(BUCKET_NAME, 'pfx4-test-object', objLoc2, versionParams,
+                logger, next),
+            next => metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
+                assert.ifError(err);
+                assert.strictEqual(data.IsTruncated, false);
+                assert.strictEqual(data.Contents.length, 1);
+
+                const firstKey = data.Contents[0];
+                assert.strictEqual(firstKey.key, 'pfx4-test-object');
+                assert.strictEqual(firstKey.value.VersionId, expectedId);
+                assert.strictEqual(firstKey.value.dataStoreName, location2);
                 return next();
             }),
         ], done);

--- a/tests/functional/metadata/mongodb/listLifecycleObject/utils.js
+++ b/tests/functional/metadata/mongodb/listLifecycleObject/utils.js
@@ -30,10 +30,10 @@ function putBulkObjectVersions(metadata, bucketName, objName, objVal, params, ve
             });
         }, (err, expectedVersionIds) => {
             // The last version is removed since it represents the current version.
-            expectedVersionIds.pop();
+            const lastVersionId = expectedVersionIds.pop();
             // array is reversed to be alligned with the version order (latest to oldest).
             expectedVersionIds.reverse();
-            return cb(err, expectedVersionIds);
+            return cb(err, { lastVersionId, expectedVersionIds });
         });
 }
 
@@ -68,10 +68,12 @@ function makeBucketMD(bucketName) {
 }
 
 function assertContents(contents, expected) {
+    assert.strictEqual(contents.length, expected.length);
     contents.forEach((c, i) => {
         assert.strictEqual(c.key, expected[i].key);
         assert.strictEqual(c.value.LastModified, expected[i].LastModified);
         assert.strictEqual(c.value.staleDate, expected[i].staleDate);
+        assert.strictEqual(c.value.dataStoreName, expected[i].dataStoreName);
         if (expected[i].VersionId) {
             assert.strictEqual(c.value.VersionId, expected[i].VersionId);
         }


### PR DESCRIPTION
To list the current versions using the **listLifecycleCurrents** function, the filtering is performed at the MongoDB query level.

In contrast, when listing the non-current versions with the **listLifecycleNoncurrents** function, filtering is done at the application level. Here, each key is evaluated and assessed for eligibility based on its datastore name. 

Finally, when calling the **listLifecycleOrphans** function to list the orphan delete markers, no filtering is done based on the datastore name. This is because orphan delete markers do not go through a transition workflow.