### PR TITLE
ARSN-347 socket.io client is disconnected when sending a big payload

### DIFF
--- a/lib/network/rpc/rpc.ts
+++ b/lib/network/rpc/rpc.ts
@@ -497,7 +497,7 @@ export function RPCServer(params: {
     assert(params.logger);
 
     const httpServer = http.createServer();
-    const server = new IOServer(httpServer);
+    const server = new IOServer(httpServer, { maxHttpBufferSize: 1e8 });
     const log = params.logger;
 
     /**

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.10.46",
+  "version": "7.10.47",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {


### PR DESCRIPTION
The file backend test fails when migrating the socket.io client from version 2.x to 4.x due to a change in the default value of maxHttpBufferSize. In the newer version, the default value has been reduced from 100MB to 1MB, causing the failure when attempting to initiate, put parts, and complete an MPU (Multipart Upload) with 10,000 parts.

More info: [Migrating from 2.x to 3.0 | Socket.IO](https://socket.io/docs/v4/migrating-from-2-x-to-3-0/#saner-default-values)

Issue: ARSN-347