### PR TITLE
ARSN-350 Missing Null Version in Lifecycle List of Non-Current Versions

### DIFF
--- a/lib/algos/list/delimiterNonCurrent.js
+++ b/lib/algos/list/delimiterNonCurrent.js
@@ -3,6 +3,7 @@ const Delimiter = require('./delimiter').Delimiter;
 const VSConst = require('../../versioning/constants').VersioningConstants;
 const { inc, FILTER_ACCEPT, FILTER_END, SKIP_NONE } = require('./tools');
 const VID_SEP = VSConst.VersionId.Separator;
+const Version = require('../../versioning/Version').Version;
 const { DbPrefixes } = VSConst;
 
 // TODO: find an acceptable timeout value.
@@ -36,8 +37,10 @@ class DelimiterNonCurrent extends Delimiter {
         this.skipping = this.skippingV1;
         this.genMDParams = this.genMDParamsV1;
 
-        this.keyName = null;
+        // internal state
         this.staleDate = null;
+        this.masterKey = undefined;
+        this.masterVersionId = undefined;
 
         // used for monitoring
         this.evaluatedKeys = 0;
@@ -47,37 +50,54 @@ class DelimiterNonCurrent extends Delimiter {
         return SKIP_NONE;
     }
 
+    compareObjects(masterObj, versionObj) {
+        const masterKey = masterObj.key.slice(DbPrefixes.Master.length);
+        const versionKey = versionObj.key.slice(DbPrefixes.Version.length);
+        return masterKey < versionKey ? -1 : 1;
+    }
+
     genMDParamsV1() {
-        const params = {
+        const vParams = {
             gte: DbPrefixes.Version,
             lt: inc(DbPrefixes.Version),
         };
 
+        const mParams = {
+            gte: DbPrefixes.Master,
+            lt: inc(DbPrefixes.Master),
+        };
+
         if (this.prefix) {
-            params.gte = `${DbPrefixes.Version}${this.prefix}`;
-            params.lt = `${DbPrefixes.Version}${inc(this.prefix)}`;
+            const masterWithPrefix = `${DbPrefixes.Master}${this.prefix}`;
+            mParams.gte = masterWithPrefix;
+            mParams.lt = inc(masterWithPrefix);
+
+            const versionWithPrefix = `${DbPrefixes.Version}${this.prefix}`;
+            vParams.gte = versionWithPrefix;
+            vParams.lt = inc(versionWithPrefix);
         }
 
-        if (this.keyMarker && `${DbPrefixes.Version}${this.keyMarker}` >= params.gte) {
+        if (this.keyMarker && `${DbPrefixes.Version}${this.keyMarker}` >= vParams.gte) {
             if (this.versionIdMarker) {
+                const keyMarkerWithVersionId = `${this.keyMarker}${VID_SEP}${this.versionIdMarker}`;
                 // versionIdMarker should always come with keyMarker but may not be the other way around.
                 // NOTE: "gte" (instead of "gt") is used to include the last version of the "previous"
                 // truncated listing when a versionId marker is specified.
                 // This "previous"/"already evaluated" version will be used to retrieve the stale date and
                 // skipped to not evaluate the same key twice in the addContents() method.
-                params.gte = DbPrefixes.Version
-                    + this.keyMarker
-                    + VID_SEP
-                    + this.versionIdMarker;
+                vParams.gte = `${DbPrefixes.Version}${keyMarkerWithVersionId}`;
+                mParams.gte = `${DbPrefixes.Master}${keyMarkerWithVersionId}`;
             } else {
-                delete params.gte;
-                params.gt = DbPrefixes.Version + inc(this.keyMarker + VID_SEP);
+                delete vParams.gte;
+                delete mParams.gte;
+                vParams.gt = DbPrefixes.Version + inc(this.keyMarker + VID_SEP);
+                mParams.gt = DbPrefixes.Master + inc(this.keyMarker + VID_SEP);
             }
         }
 
         this.start = Date.now();
 
-        return params;
+        return [mParams, vParams];
     }
 
     getLastModified(value) {
@@ -93,6 +113,33 @@ class DelimiterNonCurrent extends Delimiter {
                 });
         }
         return lastModified;
+    }
+
+    parseKey(fullKey) {
+        const versionIdIndex = fullKey.indexOf(VID_SEP);
+        if (versionIdIndex === -1) {
+            return { key: fullKey };
+        }
+        const nonversionedKey = fullKey.slice(0, versionIdIndex);
+        const versionId = fullKey.slice(versionIdIndex + 1);
+        return { key: nonversionedKey, versionId };
+    }
+
+    /**
+     *  Filter to apply on each iteration
+     *  @param {Object} obj       - The key and value of the element
+     *  @param {String} obj.key   - The key of the element
+     *  @param {String} obj.value - The value of the element
+     *  @return {number}          - indicates if iteration should continue
+     */
+    filter(obj) {
+        const value = obj.value;
+        // NOTE: this check on PHD is only useful for Artesca, S3C
+        // does not use PHDs in V1 format
+        if (Version.isPHD(value)) {
+            return FILTER_ACCEPT;
+        }
+        return super.filter(obj);
     }
 
     /**
@@ -131,22 +178,26 @@ class DelimiterNonCurrent extends Delimiter {
         }
         ++this.evaluatedKeys;
 
-        const versionIdIndex = keyVersionSuffix.indexOf(VID_SEP);
-        const key = keyVersionSuffix.slice(0, versionIdIndex);
-        const versionId = keyVersionSuffix.slice(versionIdIndex + 1);
+        const { key, versionId } = this.parseKey(keyVersionSuffix);
 
         this.NextKeyMarker = key;
         this.NextVersionIdMarker = versionId;
 
-        // For a given key, the latest version is skipped since it represents either:
-        // - the current version or
-        // - the last version of the previous truncated listing
-        const isLatestVersion = key !== this.keyName;
+        // The master key serves two purposes:
+        // - It retrieves the expiration date for the previous version that is no longer current.
+        // - It excludes the current version from the list.
+        const isMasterKey = versionId === undefined;
+        if (isMasterKey) {
+            this.masterKey = key;
+            this.masterVersionId = Version.from(value).getVersionId() || 'null';
 
-        if (isLatestVersion) {
-            this.keyName = key;
-            // The current last-modified date is kept in memory and used as a "stale date" for the following version.
             this.staleDate = this.getLastModified(value);
+            return FILTER_ACCEPT;
+        }
+
+        const isCurrentVersion = this.masterKey === key && this.masterVersionId === versionId;
+        if (isCurrentVersion) {
+            // filter out the master version
             return FILTER_ACCEPT;
         }
 

--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -1808,10 +1808,11 @@ class MongoClientInterface {
             const extName = params.listingType;
 
             const extension = new listAlgos[extName](params, log, vFormat);
-            const mainStreamParams = extension.genMDParams();
+            const extensionParams = extension.genMDParams();
 
             const internalParams = {
-                mainStreamParams,
+                mainStreamParams: Array.isArray(extensionParams) ? extensionParams[0] : extensionParams,
+                secondaryStreamParams: Array.isArray(extensionParams) ? extensionParams[1] : null,
             };
 
             return this.internalListObject(bucketName, internalParams, extension, vFormat, log, cb);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "8.1.104",
+  "version": "8.1.105",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/functional/metadata/mongodb/listLifecycleObject/nullVersion.spec.js
+++ b/tests/functional/metadata/mongodb/listLifecycleObject/nullVersion.spec.js
@@ -100,17 +100,65 @@ describe('MongoClientInterface::metadata.listLifecycleObject::nullVersion', () =
                 const lastModified = new Date(timestamp).toISOString();
                 const objVal = {
                     'key': objName,
-                    'versionId': 'null',
                     'last-modified': lastModified,
                 };
                 return metadata.putObjectMD(BUCKET_NAME, objName, objVal, versionParams, logger, next);
             },
+            // key2 simulates a scenario where:
+            // 1) bucket is versioned
+            // 2) put object key2
+            // 3) bucket versioning gets suspended
+            // 4) put object key2
+            // result:
+            // {
+            //     "_id" : "Mkey0",
+            //     "value" : {
+            //         "key" : "key2",
+            //         "isNull" : true,
+            //         "versionId" : "<VersionId2>",
+            //         "last-modified" : "2023-07-11T14:16:00.151Z",
+            //     }
+            // },
+            // {
+            //     "_id" : "Vkey0\u0000<VersionId1>",
+            //     "value" : {
+            //         "key" : "key2",
+            //         "versionId" : "<VersionId1>",
+            //         "tags" : {
+            //         },
+            //         "last-modified" : "2023-07-11T14:15:36.713Z",
+            //     }
+            // },
+            next => {
+                const objName = 'key2';
+                const timestamp = 0;
+
+                const lastModified = new Date(timestamp).toISOString();
+                const objVal = {
+                    'key': objName,
+                    'last-modified': lastModified,
+                };
+                return metadata.putObjectMD(BUCKET_NAME, objName, objVal, versionParams, logger, next);
+            },
+            next => {
+                const objName = 'key2';
+                const timestamp = 0;
+                const params = {
+                    versionId: '',
+                };
+
+                const lastModified = new Date(timestamp).toISOString();
+                const objVal = {
+                    'key': objName,
+                    'last-modified': lastModified,
+                    'isNull': true,
+                };
+                return metadata.putObjectMD(BUCKET_NAME, objName, objVal, params, logger, next);
+            },
         ], done);
     });
 
-    afterEach(done => {
-        metadata.deleteBucket(BUCKET_NAME, logger, done);
-    });
+    afterEach(done => metadata.deleteBucket(BUCKET_NAME, logger, done));
 
     it('Should list the null current version and set IsNull to true', done => {
         const params = {
@@ -119,17 +167,22 @@ describe('MongoClientInterface::metadata.listLifecycleObject::nullVersion', () =
         return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
             assert.ifError(err);
             assert.strictEqual(data.IsTruncated, false);
-            assert.strictEqual(data.Contents.length, 2);
+            assert.strictEqual(data.Contents.length, 3);
 
             // check that key0 has a null current version
             const firstKey = data.Contents[0];
             assert.strictEqual(firstKey.key, 'key0');
             assert.strictEqual(firstKey.value.IsNull, true);
 
-            // check that key1 has not a null current version
+            // check that key1 has no null current version
             const secondKey = data.Contents[1];
             assert.strictEqual(secondKey.key, 'key1');
             assert(!secondKey.value.IsNull);
+
+            // check that key2 has a null current version
+            const thirdKey = data.Contents[2];
+            assert.strictEqual(thirdKey.key, 'key2');
+            assert.strictEqual(thirdKey.value.IsNull, true);
             return done();
         });
     });
@@ -141,12 +194,17 @@ describe('MongoClientInterface::metadata.listLifecycleObject::nullVersion', () =
         return metadata.listLifecycleObject(BUCKET_NAME, params, logger, (err, data) => {
             assert.deepStrictEqual(err, null);
             assert.strictEqual(data.IsTruncated, false);
-            assert.strictEqual(data.Contents.length, 1);
+            assert.strictEqual(data.Contents.length, 2);
 
             // check that key1 has a null non-current version
             const firstKey = data.Contents[0];
             assert.strictEqual(firstKey.key, 'key1');
             assert.strictEqual(firstKey.value.IsNull, true);
+
+            // check that key2 has no null non-current version
+            const secondKey = data.Contents[1];
+            assert.strictEqual(secondKey.key, 'key2');
+            assert(!secondKey.value.IsNull);
             return done();
         });
     });


### PR DESCRIPTION
_Note: We only support the v1 bucket format for "list lifecycle" in Artesca._

We made the assumption that the first version key stored the current/latest version, which is true in most cases except for "null" versions. In the case of a "null" version, the current version is stored in the master key alone, rather than being stored in both the master key and a new version key. Here's an example of the key structure:

`Mkey0`: Represents the null version ID.
`VKey0<versionID>`: Represents a non-current version.

Additionally, we assumed that the versions for a given key were ordered by creation date, from newest to oldest. However, in Ring S3C, for non-current null versions, the metadata version ID is not part of the metadata key id. Therefore, the non-current null version is listed before the current version that has a version ID. Here's an example of the key ordering:

`Mkey0`: Master version
`Vkey0`: "Null" Non-current version
`VKey0<versionID>`: Current version

**The listing was using only versions, but because those assumptions are incorrect, we now use both the master and the versions for each given key to ensure that we return the correct non-current versions.**