### PR TITLE
Adapt delimiterCurrent for S3C Metadata

### DIFF
--- a/lib/algos/list/delimiterCurrent.ts
+++ b/lib/algos/list/delimiterCurrent.ts
@@ -1,4 +1,5 @@
 const { Delimiter } = require('./delimiter');
+const { FILTER_ACCEPT, FILTER_END } = require('./tools');
 
 type ResultObject = {
     Contents: {
@@ -8,6 +9,8 @@ type ResultObject = {
     IsTruncated: boolean;
     NextMarker ?: string;
 };
+
+const DELIMITER_TIMEOUT_MS = 10 * 1000; // 10s
 
 /**
  * Handle object listing with parameters. This extends the base class Delimiter
@@ -27,6 +30,9 @@ class DelimiterCurrent extends Delimiter {
 
         this.beforeDate = parameters.beforeDate;
         this.excludedDataStoreName = parameters.excludedDataStoreName;
+        // used for monitoring
+        this.start = null;
+        this.evaluatedKeys = 0;
     }
 
     genMDParamsV1() {
@@ -43,7 +49,60 @@ class DelimiterCurrent extends Delimiter {
                 ne: this.excludedDataStoreName,
             }
         }
+
+        this.start = Date.now();
+
         return params;
+    }
+
+    /**
+     * Parses the stringified entry's value.
+     * @param s - sringified value
+     * @return - undefined if parsing fails, otherwise it contains the parsed value.
+     */
+    _parse(s) {
+        let p;
+        try {
+            p = JSON.parse(s);
+        } catch (e: any) {
+            this.logger.warn(
+                'Could not parse Object Metadata while listing',
+                { err: e.toString() });
+        }
+        return p;
+    }
+
+    filter(obj) {
+        if (this.start && Date.now() - this.start > DELIMITER_TIMEOUT_MS) {
+            this.IsTruncated = true;
+            this.logger.info('listing stopped after expected internal timeout',
+                {
+                    timeoutMs: DELIMITER_TIMEOUT_MS,
+                    evaluatedKeys: this.evaluatedKeys,
+                });
+            return FILTER_END;
+        }
+        ++this.evaluatedKeys;
+
+        const parsedValue = this._parse(obj.value);
+        // if parsing fails, skip the key.
+        if (parsedValue) {
+            const lastModified = parsedValue['last-modified'];
+            const dataStoreName = parsedValue.dataStoreName;
+            // We then check if the current version is older than the "beforeDate" and
+            // "excludedDataStoreName" is not specified or if specified and the data store name is different.
+            if ((!this.beforeDate || (lastModified && lastModified < this.beforeDate)) && 
+            (!this.excludedDataStoreName || dataStoreName !== this.excludedDataStoreName)) {
+                return super.filter(obj);
+            }
+            // In the event of a timeout occurring before any content is added,
+            // NextMarker is updated even if the object is not eligible.
+            // It minimizes the amount of data that the client needs to re-process if the request times out.
+            const key = this.getObjectKey(obj);
+            this.NextMarker = key;
+        }
+
+        return FILTER_ACCEPT;
     }
 
     result(): ResultObject {

--- a/tests/unit/algos/list/delimiterCurrent.spec.js
+++ b/tests/unit/algos/list/delimiterCurrent.spec.js
@@ -13,6 +13,8 @@ const VSConst =
     require('../../../../lib/versioning/constants').VersioningConstants;
 const { DbPrefixes } = VSConst;
 
+const DELIMITER_TIMEOUT_MS = 10 * 1000; // 10s
+
 const VID_SEP = VSConst.VersionId.Separator;
 const EmptyResult = {
     Contents: [],
@@ -60,7 +62,9 @@ describe('DelimiterCurrent', () => {
         const delimiter = new DelimiterCurrent({ prefix: 'prefix' }, fakeLogger, 'v1');
 
         const listingKey = makeV1Key('noprefix');
-        assert.strictEqual(delimiter.filter({ key: listingKey, value: '' }), FILTER_SKIP);
+        const creationDate = '1970-01-01T00:00:00.001Z';
+        const value = `{"last-modified": "${creationDate}"}`;
+        assert.strictEqual(delimiter.filter({ key: listingKey, value }), FILTER_SKIP);
 
         assert.deepStrictEqual(delimiter.result(), EmptyResult);
     });
@@ -120,6 +124,255 @@ describe('DelimiterCurrent', () => {
                 },
             ],
             NextMarker: masterKey1,
+            IsTruncated: true,
+        };
+
+        assert.deepStrictEqual(delimiter.result(), expectedResult);
+    });
+
+    it('should return the object created before beforeDate', () => {
+        const beforeDate = '1970-01-01T00:00:00.003Z';
+        const delimiter = new DelimiterCurrent({ beforeDate }, fakeLogger, 'v1');
+
+        const masterKey1 = 'key1';
+        const date1 = '1970-01-01T00:00:00.004Z';
+        const value1 = `{"last-modified": "${date1}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(masterKey1),
+            value: value1,
+        }), FILTER_ACCEPT);
+
+        const masterKey2 = 'key2';
+        const date2 = '1970-01-01T00:00:00.000Z';
+        const value2 = `{"last-modified": "${date2}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(masterKey2),
+            value: value2,
+        }), FILTER_ACCEPT);
+
+        const expectedResult = {
+            Contents: [
+                {
+                    key: masterKey2,
+                    value: value2,
+                },
+            ],
+            IsTruncated: false,
+        };
+
+        assert.deepStrictEqual(delimiter.result(), expectedResult);
+    });
+
+    it('should return an empty list if last-modified is an empty string', () => {
+        const beforeDate = '1970-01-01T00:00:00.003Z';
+        const delimiter = new DelimiterCurrent({ beforeDate }, fakeLogger, 'v1');
+
+        const masterKey0 = 'key0';
+        const value0 = '{"last-modified": ""}';
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(masterKey0),
+            value: value0,
+        }), FILTER_ACCEPT);
+
+        const expectedResult = {
+            Contents: [],
+            IsTruncated: false,
+        };
+
+        assert.deepStrictEqual(delimiter.result(), expectedResult);
+    });
+
+    it('should return an empty list if last-modified is undefined', () => {
+        const beforeDate = '1970-01-01T00:00:00.003Z';
+        const delimiter = new DelimiterCurrent({ beforeDate }, fakeLogger, 'v1');
+
+        const masterKey0 = 'key0';
+        const value0 = '{}';
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(masterKey0),
+            value: value0,
+        }), FILTER_ACCEPT);
+
+        const expectedResult = {
+            Contents: [],
+            IsTruncated: false,
+        };
+
+        assert.deepStrictEqual(delimiter.result(), expectedResult);
+    });
+
+    it('should return the object with dataStore name that does not match', () => {
+        const beforeDate = '1970-01-01T00:00:00.005Z';
+        const excludedDataStoreName = 'location-excluded';
+        const delimiter = new DelimiterCurrent({ beforeDate, excludedDataStoreName }, fakeLogger, 'v1');
+
+        const masterKey1 = 'key1';
+        const date1 = '1970-01-01T00:00:00.004Z';
+        const value1 = `{"last-modified": "${date1}", "dataStoreName": "valid"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(masterKey1),
+            value: value1,
+        }), FILTER_ACCEPT);
+
+        const masterKey2 = 'key2';
+        const date2 = '1970-01-01T00:00:00.000Z';
+        const value2 = `{"last-modified": "${date2}", "dataStoreName": "${excludedDataStoreName}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(masterKey2),
+            value: value2,
+        }), FILTER_ACCEPT);
+
+        const expectedResult = {
+            Contents: [
+                {
+                    key: masterKey1,
+                    value: value1,
+                },
+            ],
+            IsTruncated: false,
+        };
+
+        assert.deepStrictEqual(delimiter.result(), expectedResult);
+    });
+
+    it('should return the object created before beforeDate and with dataStore name that does not match', () => {
+        const beforeDate = '1970-01-01T00:00:00.003Z';
+        const excludedDataStoreName = 'location-excluded';
+        const delimiter = new DelimiterCurrent({ beforeDate, excludedDataStoreName }, fakeLogger, 'v1');
+
+        const masterKey1 = 'key1';
+        const date1 = '1970-01-01T00:00:00.004Z';
+        const value1 = `{"last-modified": "${date1}", "dataStoreName": "valid"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(masterKey1),
+            value: value1,
+        }), FILTER_ACCEPT);
+
+        const masterKey2 = 'key2';
+        const date2 = '1970-01-01T00:00:00.001Z';
+        const value2 = `{"last-modified": "${date2}", "dataStoreName": "valid"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(masterKey2),
+            value: value2,
+        }), FILTER_ACCEPT);
+
+        const masterKey3 = 'key3';
+        const date3 = '1970-01-01T00:00:00.000Z';
+        const value3 = `{"last-modified": "${date3}", "dataStoreName": "${excludedDataStoreName}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(masterKey3),
+            value: value3,
+        }), FILTER_ACCEPT);
+
+        const expectedResult = {
+            Contents: [
+                {
+                    key: masterKey2,
+                    value: value2,
+                },
+            ],
+            IsTruncated: false,
+        };
+
+        assert.deepStrictEqual(delimiter.result(), expectedResult);
+    });
+
+    it('should return the objects pushed before timeout', () => {
+        const beforeDate = '1970-01-01T00:00:00.003Z';
+        const delimiter = new DelimiterCurrent({ beforeDate }, fakeLogger, 'v1');
+
+        const masterKey1 = 'key1';
+        const date1 = '1970-01-01T00:00:00.000Z';
+        const value1 = `{"last-modified": "${date1}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(masterKey1),
+            value: value1,
+        }), FILTER_ACCEPT);
+
+        const masterKey2 = 'key2';
+        const date2 = '1970-01-01T00:00:00.001Z';
+        const value2 = `{"last-modified": "${date2}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(masterKey2),
+            value: value2,
+        }), FILTER_ACCEPT);
+
+        delimiter.start = Date.now() - (DELIMITER_TIMEOUT_MS + 1);
+
+        const masterKey3 = 'key3';
+        const date3 = '1970-01-01T00:00:00.002Z';
+        const value3 = `{"last-modified": "${date3}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(masterKey3),
+            value: value3,
+        }), FILTER_END);
+
+        const expectedResult = {
+            Contents: [
+                {
+                    key: masterKey1,
+                    value: value1,
+                },
+                {
+                    key: masterKey2,
+                    value: value2,
+                },
+            ],
+            NextMarker: masterKey2,
+            IsTruncated: true,
+        };
+
+        assert.deepStrictEqual(delimiter.result(), expectedResult);
+    });
+
+    it('should return empty content after timeout', () => {
+        const beforeDate = '1970-01-01T00:00:00.003Z';
+        const delimiter = new DelimiterCurrent({ beforeDate }, fakeLogger, 'v1');
+
+        const masterKey1 = 'key1';
+        const date1 = '1970-01-01T00:00:00.004Z';
+        const value1 = `{"last-modified": "${date1}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(masterKey1),
+            value: value1,
+        }), FILTER_ACCEPT);
+
+        const masterKey2 = 'key2';
+        const date2 = '1970-01-01T00:00:00.005Z';
+        const value2 = `{"last-modified": "${date2}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(masterKey2),
+            value: value2,
+        }), FILTER_ACCEPT);
+
+        delimiter.start = Date.now() - (DELIMITER_TIMEOUT_MS + 1);
+
+        const masterKey3 = 'key3';
+        const date3 = '1970-01-01T00:00:00.006Z';
+        const value3 = `{"last-modified": "${date3}"}`;
+
+        assert.strictEqual(delimiter.filter({
+            key: makeV1Key(masterKey3),
+            value: value3,
+        }), FILTER_END);
+
+        const expectedResult = {
+            Contents: [],
+            NextMarker: masterKey2,
             IsTruncated: true,
         };
 


### PR DESCRIPTION
In Artesca, for listing the current versions, filtering on “last-modified“ was done at the MongoDB level (query filter).

Metadata does not support built-in filters today.

Listing algorism for the current versions has to be modified to filter out non-eligible masters based on their “last-modified” date and “dataStoreName“.