### PR TITLE
ARSN-354 List lifecycle current versions supports V0 bucket format

### DIFF
--- a/tests/unit/algos/list/delimiterCurrent.spec.js
+++ b/tests/unit/algos/list/delimiterCurrent.spec.js
@@ -15,7 +15,6 @@ const { DbPrefixes } = VSConst;
 
 const DELIMITER_TIMEOUT_MS = 10 * 1000; // 10s
 
-const VID_SEP = VSConst.VersionId.Separator;
 const EmptyResult = {
     Contents: [],
     IsTruncated: false,
@@ -30,352 +29,384 @@ const fakeLogger = {
     fatal: () => {},
 };
 
-function makeV1Key(key) {
-    const keyPrefix = key.includes(VID_SEP) ?
-        DbPrefixes.Version : DbPrefixes.Master;
-    return `${keyPrefix}${key}`;
+function getListingKey(key, vFormat) {
+    if (vFormat === 'v0') {
+        return key;
+    }
+    if (vFormat === 'v1') {
+        return `${DbPrefixes.Master}${key}`;
+    }
+    return assert.fail(`bad vFormat ${vFormat}`);
 }
 
-describe('DelimiterCurrent', () => {
-    it('should accept entry starting with prefix', () => {
-        const delimiter = new DelimiterCurrent({ prefix: 'prefix' }, fakeLogger, 'v1');
+['v0', 'v1'].forEach(v => {
+    describe(`DelimiterCurrent with ${v} bucket format`, () => {
+        it('should return expected metadata parameters', () => {
+            const prefix = 'pre';
+            const marker = 'premark';
+            const beforeDate = '1970-01-01T00:00:00.005Z';
+            const excludedDataStoreName = 'location1';
+            const delimiter = new DelimiterCurrent({
+                prefix,
+                marker,
+                beforeDate,
+                excludedDataStoreName,
+            }, fakeLogger, v);
 
-        const masterKey = 'prefix1';
-        const date1 = '1970-01-01T00:00:00.001Z';
-        const value1 = `{"last-modified": "${date1}"}`;
-        assert.strictEqual(delimiter.filter({ key: makeV1Key(masterKey), value: value1 }), FILTER_ACCEPT);
-
-        const expectedResult = {
-            Contents: [
-                {
-                    key: masterKey,
-                    value: value1,
+            const expectedParams = {
+                dataStoreName: {
+                    ne: excludedDataStoreName,
                 },
-            ],
-            IsTruncated: false,
-        };
-
-        assert.deepStrictEqual(delimiter.result(), expectedResult);
-    });
-
-    it('should skip entry not starting with prefix', () => {
-        const delimiter = new DelimiterCurrent({ prefix: 'prefix' }, fakeLogger, 'v1');
-
-        const listingKey = makeV1Key('noprefix');
-        const creationDate = '1970-01-01T00:00:00.001Z';
-        const value = `{"last-modified": "${creationDate}"}`;
-        assert.strictEqual(delimiter.filter({ key: listingKey, value }), FILTER_SKIP);
-
-        assert.deepStrictEqual(delimiter.result(), EmptyResult);
-    });
-
-    it('should accept a master and return it', () => {
-        const delimiter = new DelimiterCurrent({ }, fakeLogger, 'v1');
-
-        const masterKey = 'key';
-
-        const date1 = '1970-01-01T00:00:00.001Z';
-        const value1 = `{"last-modified": "${date1}"}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(masterKey),
-            value: value1,
-        }), FILTER_ACCEPT);
-
-        const expectedResult = {
-            Contents: [
-                {
-                    key: masterKey,
-                    value: value1,
+                lastModified: {
+                    lt: beforeDate,
                 },
-            ],
-            IsTruncated: false,
-        };
+                gt: getListingKey('premark', v),
+                lt: getListingKey('prf', v),
+            };
+            assert.deepStrictEqual(delimiter.genMDParams(), expectedParams);
+            assert(delimiter.start);
+        });
 
-        assert.deepStrictEqual(delimiter.result(), expectedResult);
-    });
+        it('should accept entry starting with prefix', () => {
+            const delimiter = new DelimiterCurrent({ prefix: 'prefix' }, fakeLogger, v);
 
-    it('should accept the first master and return the truncated content', () => {
-        const delimiter = new DelimiterCurrent({ maxKeys: 1 }, fakeLogger, 'v1');
+            const masterKey = 'prefix1';
+            const date1 = '1970-01-01T00:00:00.001Z';
+            const value1 = `{"last-modified": "${date1}"}`;
+            assert.strictEqual(delimiter.filter({ key: getListingKey(masterKey, v), value: value1 }), FILTER_ACCEPT);
 
-        const masterKey1 = 'key1';
-        const date1 = '1970-01-01T00:00:00.001Z';
-        const value1 = `{"last-modified": "${date1}"}`;
+            const expectedResult = {
+                Contents: [
+                    {
+                        key: masterKey,
+                        value: value1,
+                    },
+                ],
+                IsTruncated: false,
+            };
 
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(masterKey1),
-            value: value1,
-        }), FILTER_ACCEPT);
+            assert.deepStrictEqual(delimiter.result(), expectedResult);
+        });
 
-        const masterKey2 = 'key2';
-        const date2 = '1970-01-01T00:00:00.000Z';
-        const value2 = `{"last-modified": "${date2}"}`;
+        it('should skip entry not starting with prefix', () => {
+            const delimiter = new DelimiterCurrent({ prefix: 'prefix' }, fakeLogger, v);
 
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(masterKey2),
-            value: value2,
-        }), FILTER_END);
+            const listingKey = getListingKey('noprefix', v);
+            const creationDate = '1970-01-01T00:00:00.001Z';
+            const value = `{"last-modified": "${creationDate}"}`;
+            assert.strictEqual(delimiter.filter({ key: listingKey, value }), FILTER_SKIP);
 
-        const expectedResult = {
-            Contents: [
-                {
-                    key: masterKey1,
-                    value: value1,
-                },
-            ],
-            NextMarker: masterKey1,
-            IsTruncated: true,
-        };
+            assert.deepStrictEqual(delimiter.result(), EmptyResult);
+        });
 
-        assert.deepStrictEqual(delimiter.result(), expectedResult);
-    });
+        it('should accept a master and return it', () => {
+            const delimiter = new DelimiterCurrent({ }, fakeLogger, v);
 
-    it('should return the object created before beforeDate', () => {
-        const beforeDate = '1970-01-01T00:00:00.003Z';
-        const delimiter = new DelimiterCurrent({ beforeDate }, fakeLogger, 'v1');
+            const masterKey = 'key';
 
-        const masterKey1 = 'key1';
-        const date1 = '1970-01-01T00:00:00.004Z';
-        const value1 = `{"last-modified": "${date1}"}`;
+            const date1 = '1970-01-01T00:00:00.001Z';
+            const value1 = `{"last-modified": "${date1}"}`;
 
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(masterKey1),
-            value: value1,
-        }), FILTER_ACCEPT);
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(masterKey, v),
+                value: value1,
+            }), FILTER_ACCEPT);
 
-        const masterKey2 = 'key2';
-        const date2 = '1970-01-01T00:00:00.000Z';
-        const value2 = `{"last-modified": "${date2}"}`;
+            const expectedResult = {
+                Contents: [
+                    {
+                        key: masterKey,
+                        value: value1,
+                    },
+                ],
+                IsTruncated: false,
+            };
 
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(masterKey2),
-            value: value2,
-        }), FILTER_ACCEPT);
+            assert.deepStrictEqual(delimiter.result(), expectedResult);
+        });
 
-        const expectedResult = {
-            Contents: [
-                {
-                    key: masterKey2,
-                    value: value2,
-                },
-            ],
-            IsTruncated: false,
-        };
+        it('should accept the first master and return the truncated content', () => {
+            const delimiter = new DelimiterCurrent({ maxKeys: 1 }, fakeLogger, v);
 
-        assert.deepStrictEqual(delimiter.result(), expectedResult);
-    });
+            const masterKey1 = 'key1';
+            const date1 = '1970-01-01T00:00:00.001Z';
+            const value1 = `{"last-modified": "${date1}"}`;
 
-    it('should return an empty list if last-modified is an empty string', () => {
-        const beforeDate = '1970-01-01T00:00:00.003Z';
-        const delimiter = new DelimiterCurrent({ beforeDate }, fakeLogger, 'v1');
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(masterKey1, v),
+                value: value1,
+            }), FILTER_ACCEPT);
 
-        const masterKey0 = 'key0';
-        const value0 = '{"last-modified": ""}';
+            const masterKey2 = 'key2';
+            const date2 = '1970-01-01T00:00:00.000Z';
+            const value2 = `{"last-modified": "${date2}"}`;
 
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(masterKey0),
-            value: value0,
-        }), FILTER_ACCEPT);
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(masterKey2, v),
+                value: value2,
+            }), FILTER_END);
 
-        const expectedResult = {
-            Contents: [],
-            IsTruncated: false,
-        };
+            const expectedResult = {
+                Contents: [
+                    {
+                        key: masterKey1,
+                        value: value1,
+                    },
+                ],
+                NextMarker: masterKey1,
+                IsTruncated: true,
+            };
 
-        assert.deepStrictEqual(delimiter.result(), expectedResult);
-    });
+            assert.deepStrictEqual(delimiter.result(), expectedResult);
+        });
 
-    it('should return an empty list if last-modified is undefined', () => {
-        const beforeDate = '1970-01-01T00:00:00.003Z';
-        const delimiter = new DelimiterCurrent({ beforeDate }, fakeLogger, 'v1');
+        it('should return the object created before beforeDate', () => {
+            const beforeDate = '1970-01-01T00:00:00.003Z';
+            const delimiter = new DelimiterCurrent({ beforeDate }, fakeLogger, v);
 
-        const masterKey0 = 'key0';
-        const value0 = '{}';
+            const masterKey1 = 'key1';
+            const date1 = '1970-01-01T00:00:00.004Z';
+            const value1 = `{"last-modified": "${date1}"}`;
 
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(masterKey0),
-            value: value0,
-        }), FILTER_ACCEPT);
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(masterKey1, v),
+                value: value1,
+            }), FILTER_ACCEPT);
 
-        const expectedResult = {
-            Contents: [],
-            IsTruncated: false,
-        };
+            const masterKey2 = 'key2';
+            const date2 = '1970-01-01T00:00:00.000Z';
+            const value2 = `{"last-modified": "${date2}"}`;
 
-        assert.deepStrictEqual(delimiter.result(), expectedResult);
-    });
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(masterKey2, v),
+                value: value2,
+            }), FILTER_ACCEPT);
 
-    it('should return the object with dataStore name that does not match', () => {
-        const beforeDate = '1970-01-01T00:00:00.005Z';
-        const excludedDataStoreName = 'location-excluded';
-        const delimiter = new DelimiterCurrent({ beforeDate, excludedDataStoreName }, fakeLogger, 'v1');
+            const expectedResult = {
+                Contents: [
+                    {
+                        key: masterKey2,
+                        value: value2,
+                    },
+                ],
+                IsTruncated: false,
+            };
 
-        const masterKey1 = 'key1';
-        const date1 = '1970-01-01T00:00:00.004Z';
-        const value1 = `{"last-modified": "${date1}", "dataStoreName": "valid"}`;
+            assert.deepStrictEqual(delimiter.result(), expectedResult);
+        });
 
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(masterKey1),
-            value: value1,
-        }), FILTER_ACCEPT);
+        it('should return an empty list if last-modified is an empty string', () => {
+            const beforeDate = '1970-01-01T00:00:00.003Z';
+            const delimiter = new DelimiterCurrent({ beforeDate }, fakeLogger, v);
 
-        const masterKey2 = 'key2';
-        const date2 = '1970-01-01T00:00:00.000Z';
-        const value2 = `{"last-modified": "${date2}", "dataStoreName": "${excludedDataStoreName}"}`;
+            const masterKey0 = 'key0';
+            const value0 = '{"last-modified": ""}';
 
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(masterKey2),
-            value: value2,
-        }), FILTER_ACCEPT);
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(masterKey0, v),
+                value: value0,
+            }), FILTER_ACCEPT);
 
-        const expectedResult = {
-            Contents: [
-                {
-                    key: masterKey1,
-                    value: value1,
-                },
-            ],
-            IsTruncated: false,
-        };
+            const expectedResult = {
+                Contents: [],
+                IsTruncated: false,
+            };
 
-        assert.deepStrictEqual(delimiter.result(), expectedResult);
-    });
+            assert.deepStrictEqual(delimiter.result(), expectedResult);
+        });
 
-    it('should return the object created before beforeDate and with dataStore name that does not match', () => {
-        const beforeDate = '1970-01-01T00:00:00.003Z';
-        const excludedDataStoreName = 'location-excluded';
-        const delimiter = new DelimiterCurrent({ beforeDate, excludedDataStoreName }, fakeLogger, 'v1');
+        it('should return an empty list if last-modified is undefined', () => {
+            const beforeDate = '1970-01-01T00:00:00.003Z';
+            const delimiter = new DelimiterCurrent({ beforeDate }, fakeLogger, v);
 
-        const masterKey1 = 'key1';
-        const date1 = '1970-01-01T00:00:00.004Z';
-        const value1 = `{"last-modified": "${date1}", "dataStoreName": "valid"}`;
+            const masterKey0 = 'key0';
+            const value0 = '{}';
 
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(masterKey1),
-            value: value1,
-        }), FILTER_ACCEPT);
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(masterKey0, v),
+                value: value0,
+            }), FILTER_ACCEPT);
 
-        const masterKey2 = 'key2';
-        const date2 = '1970-01-01T00:00:00.001Z';
-        const value2 = `{"last-modified": "${date2}", "dataStoreName": "valid"}`;
+            const expectedResult = {
+                Contents: [],
+                IsTruncated: false,
+            };
 
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(masterKey2),
-            value: value2,
-        }), FILTER_ACCEPT);
+            assert.deepStrictEqual(delimiter.result(), expectedResult);
+        });
 
-        const masterKey3 = 'key3';
-        const date3 = '1970-01-01T00:00:00.000Z';
-        const value3 = `{"last-modified": "${date3}", "dataStoreName": "${excludedDataStoreName}"}`;
+        it('should return the object with dataStore name that does not match', () => {
+            const beforeDate = '1970-01-01T00:00:00.005Z';
+            const excludedDataStoreName = 'location-excluded';
+            const delimiter = new DelimiterCurrent({ beforeDate, excludedDataStoreName }, fakeLogger, v);
 
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(masterKey3),
-            value: value3,
-        }), FILTER_ACCEPT);
+            const masterKey1 = 'key1';
+            const date1 = '1970-01-01T00:00:00.004Z';
+            const value1 = `{"last-modified": "${date1}", "dataStoreName": "valid"}`;
 
-        const expectedResult = {
-            Contents: [
-                {
-                    key: masterKey2,
-                    value: value2,
-                },
-            ],
-            IsTruncated: false,
-        };
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(masterKey1, v),
+                value: value1,
+            }), FILTER_ACCEPT);
 
-        assert.deepStrictEqual(delimiter.result(), expectedResult);
-    });
+            const masterKey2 = 'key2';
+            const date2 = '1970-01-01T00:00:00.000Z';
+            const value2 = `{"last-modified": "${date2}", "dataStoreName": "${excludedDataStoreName}"}`;
 
-    it('should return the objects pushed before timeout', () => {
-        const beforeDate = '1970-01-01T00:00:00.003Z';
-        const delimiter = new DelimiterCurrent({ beforeDate }, fakeLogger, 'v1');
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(masterKey2, v),
+                value: value2,
+            }), FILTER_ACCEPT);
 
-        const masterKey1 = 'key1';
-        const date1 = '1970-01-01T00:00:00.000Z';
-        const value1 = `{"last-modified": "${date1}"}`;
+            const expectedResult = {
+                Contents: [
+                    {
+                        key: masterKey1,
+                        value: value1,
+                    },
+                ],
+                IsTruncated: false,
+            };
 
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(masterKey1),
-            value: value1,
-        }), FILTER_ACCEPT);
+            assert.deepStrictEqual(delimiter.result(), expectedResult);
+        });
 
-        const masterKey2 = 'key2';
-        const date2 = '1970-01-01T00:00:00.001Z';
-        const value2 = `{"last-modified": "${date2}"}`;
+        it('should return the object created before beforeDate and with dataStore name that does not match', () => {
+            const beforeDate = '1970-01-01T00:00:00.003Z';
+            const excludedDataStoreName = 'location-excluded';
+            const delimiter = new DelimiterCurrent({ beforeDate, excludedDataStoreName }, fakeLogger, v);
 
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(masterKey2),
-            value: value2,
-        }), FILTER_ACCEPT);
+            const masterKey1 = 'key1';
+            const date1 = '1970-01-01T00:00:00.004Z';
+            const value1 = `{"last-modified": "${date1}", "dataStoreName": "valid"}`;
 
-        delimiter.start = Date.now() - (DELIMITER_TIMEOUT_MS + 1);
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(masterKey1, v),
+                value: value1,
+            }), FILTER_ACCEPT);
 
-        const masterKey3 = 'key3';
-        const date3 = '1970-01-01T00:00:00.002Z';
-        const value3 = `{"last-modified": "${date3}"}`;
+            const masterKey2 = 'key2';
+            const date2 = '1970-01-01T00:00:00.001Z';
+            const value2 = `{"last-modified": "${date2}", "dataStoreName": "valid"}`;
 
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(masterKey3),
-            value: value3,
-        }), FILTER_END);
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(masterKey2, v),
+                value: value2,
+            }), FILTER_ACCEPT);
 
-        const expectedResult = {
-            Contents: [
-                {
-                    key: masterKey1,
-                    value: value1,
-                },
-                {
-                    key: masterKey2,
-                    value: value2,
-                },
-            ],
-            NextMarker: masterKey2,
-            IsTruncated: true,
-        };
+            const masterKey3 = 'key3';
+            const date3 = '1970-01-01T00:00:00.000Z';
+            const value3 = `{"last-modified": "${date3}", "dataStoreName": "${excludedDataStoreName}"}`;
 
-        assert.deepStrictEqual(delimiter.result(), expectedResult);
-    });
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(masterKey3, v),
+                value: value3,
+            }), FILTER_ACCEPT);
 
-    it('should return empty content after timeout', () => {
-        const beforeDate = '1970-01-01T00:00:00.003Z';
-        const delimiter = new DelimiterCurrent({ beforeDate }, fakeLogger, 'v1');
+            const expectedResult = {
+                Contents: [
+                    {
+                        key: masterKey2,
+                        value: value2,
+                    },
+                ],
+                IsTruncated: false,
+            };
 
-        const masterKey1 = 'key1';
-        const date1 = '1970-01-01T00:00:00.004Z';
-        const value1 = `{"last-modified": "${date1}"}`;
+            assert.deepStrictEqual(delimiter.result(), expectedResult);
+        });
 
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(masterKey1),
-            value: value1,
-        }), FILTER_ACCEPT);
+        it('should return the objects pushed before timeout', () => {
+            const beforeDate = '1970-01-01T00:00:00.003Z';
+            const delimiter = new DelimiterCurrent({ beforeDate }, fakeLogger, v);
 
-        const masterKey2 = 'key2';
-        const date2 = '1970-01-01T00:00:00.005Z';
-        const value2 = `{"last-modified": "${date2}"}`;
+            const masterKey1 = 'key1';
+            const date1 = '1970-01-01T00:00:00.000Z';
+            const value1 = `{"last-modified": "${date1}"}`;
 
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(masterKey2),
-            value: value2,
-        }), FILTER_ACCEPT);
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(masterKey1, v),
+                value: value1,
+            }), FILTER_ACCEPT);
 
-        delimiter.start = Date.now() - (DELIMITER_TIMEOUT_MS + 1);
+            const masterKey2 = 'key2';
+            const date2 = '1970-01-01T00:00:00.001Z';
+            const value2 = `{"last-modified": "${date2}"}`;
 
-        const masterKey3 = 'key3';
-        const date3 = '1970-01-01T00:00:00.006Z';
-        const value3 = `{"last-modified": "${date3}"}`;
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(masterKey2, v),
+                value: value2,
+            }), FILTER_ACCEPT);
 
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(masterKey3),
-            value: value3,
-        }), FILTER_END);
+            delimiter.start = Date.now() - (DELIMITER_TIMEOUT_MS + 1);
 
-        const expectedResult = {
-            Contents: [],
-            NextMarker: masterKey2,
-            IsTruncated: true,
-        };
+            const masterKey3 = 'key3';
+            const date3 = '1970-01-01T00:00:00.002Z';
+            const value3 = `{"last-modified": "${date3}"}`;
 
-        assert.deepStrictEqual(delimiter.result(), expectedResult);
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(masterKey3, v),
+                value: value3,
+            }), FILTER_END);
+
+            const expectedResult = {
+                Contents: [
+                    {
+                        key: masterKey1,
+                        value: value1,
+                    },
+                    {
+                        key: masterKey2,
+                        value: value2,
+                    },
+                ],
+                NextMarker: masterKey2,
+                IsTruncated: true,
+            };
+
+            assert.deepStrictEqual(delimiter.result(), expectedResult);
+        });
+
+        it('should return empty content after timeout', () => {
+            const beforeDate = '1970-01-01T00:00:00.003Z';
+            const delimiter = new DelimiterCurrent({ beforeDate }, fakeLogger, v);
+
+            const masterKey1 = 'key1';
+            const date1 = '1970-01-01T00:00:00.004Z';
+            const value1 = `{"last-modified": "${date1}"}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(masterKey1, v),
+                value: value1,
+            }), FILTER_ACCEPT);
+
+            const masterKey2 = 'key2';
+            const date2 = '1970-01-01T00:00:00.005Z';
+            const value2 = `{"last-modified": "${date2}"}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(masterKey2, v),
+                value: value2,
+            }), FILTER_ACCEPT);
+
+            delimiter.start = Date.now() - (DELIMITER_TIMEOUT_MS + 1);
+
+            const masterKey3 = 'key3';
+            const date3 = '1970-01-01T00:00:00.006Z';
+            const value3 = `{"last-modified": "${date3}"}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(masterKey3, v),
+                value: value3,
+            }), FILTER_END);
+
+            const expectedResult = {
+                Contents: [],
+                NextMarker: masterKey2,
+                IsTruncated: true,
+            };
+
+            assert.deepStrictEqual(delimiter.result(), expectedResult);
+        });
     });
 });


### PR DESCRIPTION
This PR includes the following changes:

- The `evaluatedKeys` have been renamed to `scannedKeys`.
- The implementation, now, leverages `DelimiterMaster` to provide an accurate list of objects, which then gets filtered based on `last-modified` date and `dataStoreName` location.
- The test has been updated to run on V0 and V1 bucket formats.