### PR TITLE
ARSN-355 List lifecycle non-current versions supports V0

### DIFF
--- a/lib/algos/list/delimiterNonCurrent.js
+++ b/lib/algos/list/delimiterNonCurrent.js
@@ -1,103 +1,43 @@
-'use strict'; // eslint-disable-line strict
-const Delimiter = require('./delimiter').Delimiter;
-const VSConst = require('../../versioning/constants').VersioningConstants;
-const { inc, FILTER_ACCEPT, FILTER_END, SKIP_NONE } = require('./tools');
-const VID_SEP = VSConst.VersionId.Separator;
-const Version = require('../../versioning/Version').Version;
-const { DbPrefixes } = VSConst;
+const { DelimiterVersions } = require('./delimiterVersions');
+const { FILTER_END, FILTER_SKIP } = require('./tools');
 
 // TODO: find an acceptable timeout value.
 const DELIMITER_TIMEOUT_MS = 10 * 1000; // 10s
 const TRIM_METADATA_MIN_BLOB_SIZE = 10000;
 
 /**
- * Handle object listing with parameters. This extends the base class Delimiter
+ * Handle object listing with parameters. This extends the base class DelimiterVersions
  * to return the raw non-current versions objects.
  */
-class DelimiterNonCurrent extends Delimiter {
+class DelimiterNonCurrent extends DelimiterVersions {
     /**
      * Delimiter listing of non-current versions.
      * @param {Object}  parameters                  - listing parameters
-     * @param {String}  parameters.versionIdMarker  - version id marker
-     * @param {String}  parameters.beforeDate       - limit the response to keys with stale date older than beforeDate
-     * “stale date” is the date on when a version becomes non-current.
      * @param {String}  parameters.keyMarker        - key marker
+     * @param {String}  parameters.versionIdMarker  - version id marker
+     * @param {String}  parameters.beforeDate       - limit the response to keys with stale date older than beforeDate.
+     * “stale date” is the date on when a version becomes non-current.
+     *  @param {String} parameters.excludedDataStoreName - exclude dataStoreName matches from the versions
      * @param {RequestLogger} logger                - The logger of the request
      * @param {String} [vFormat]                    - versioning key format
      */
     constructor(parameters, logger, vFormat) {
         super(parameters, logger, vFormat);
 
-        this.versionIdMarker = parameters.versionIdMarker;
         this.beforeDate = parameters.beforeDate;
-        this.keyMarker = parameters.keyMarker;
         this.excludedDataStoreName = parameters.excludedDataStoreName;
-        this.NextKeyMarker = null;
-
-        this.skipping = this.skippingV1;
-        this.genMDParams = this.genMDParamsV1;
 
         // internal state
+        this.prevKey = null;
         this.staleDate = null;
-        this.masterKey = undefined;
-        this.masterVersionId = undefined;
 
         // used for monitoring
-        this.evaluatedKeys = 0;
+        this.scannedKeys = 0;
     }
 
-    skippingV1() {
-        return SKIP_NONE;
-    }
-
-    compareObjects(masterObj, versionObj) {
-        const masterKey = masterObj.key.slice(DbPrefixes.Master.length);
-        const versionKey = versionObj.key.slice(DbPrefixes.Version.length);
-        return masterKey < versionKey ? -1 : 1;
-    }
-
-    genMDParamsV1() {
-        const vParams = {
-            gte: DbPrefixes.Version,
-            lt: inc(DbPrefixes.Version),
-        };
-
-        const mParams = {
-            gte: DbPrefixes.Master,
-            lt: inc(DbPrefixes.Master),
-        };
-
-        if (this.prefix) {
-            const masterWithPrefix = `${DbPrefixes.Master}${this.prefix}`;
-            mParams.gte = masterWithPrefix;
-            mParams.lt = inc(masterWithPrefix);
-
-            const versionWithPrefix = `${DbPrefixes.Version}${this.prefix}`;
-            vParams.gte = versionWithPrefix;
-            vParams.lt = inc(versionWithPrefix);
-        }
-
-        if (this.keyMarker && `${DbPrefixes.Version}${this.keyMarker}` >= vParams.gte) {
-            if (this.versionIdMarker) {
-                const keyMarkerWithVersionId = `${this.keyMarker}${VID_SEP}${this.versionIdMarker}`;
-                // versionIdMarker should always come with keyMarker but may not be the other way around.
-                // NOTE: "gte" (instead of "gt") is used to include the last version of the "previous"
-                // truncated listing when a versionId marker is specified.
-                // This "previous"/"already evaluated" version will be used to retrieve the stale date and
-                // skipped to not evaluate the same key twice in the addContents() method.
-                vParams.gte = `${DbPrefixes.Version}${keyMarkerWithVersionId}`;
-                mParams.gte = `${DbPrefixes.Master}${keyMarkerWithVersionId}`;
-            } else {
-                delete vParams.gte;
-                delete mParams.gte;
-                vParams.gt = DbPrefixes.Version + inc(this.keyMarker + VID_SEP);
-                mParams.gt = DbPrefixes.Master + inc(this.keyMarker + VID_SEP);
-            }
-        }
-
+    genMDParamsV0() {
         this.start = Date.now();
-
-        return [mParams, vParams];
+        return super.genMDParamsV0();
     }
 
     getLastModified(value) {
@@ -115,39 +55,45 @@ class DelimiterNonCurrent extends Delimiter {
         return lastModified;
     }
 
-    parseKey(fullKey) {
-        const versionIdIndex = fullKey.indexOf(VID_SEP);
-        if (versionIdIndex === -1) {
-            return { key: fullKey };
+    // Overwrite keyHandler_SkippingVersions to include the last version from the previous listing.
+    // The creation (last-modified) date of this version will be the stale date for the following version.
+    // eslint-disable-next-line camelcase
+    keyHandler_SkippingVersions(key, value) {
+        const { key: nonversionedKey, versionId } = this.parseKey(key);
+        if (nonversionedKey === this.keyMarker) {
+            // since the nonversioned key equals the marker, there is
+            // necessarily a versionId in this key
+            const _versionId = versionId;
+            if (_versionId < this.versionIdMarker) {
+                // skip all versions until marker
+                return FILTER_SKIP;
+            }
         }
-        const nonversionedKey = fullKey.slice(0, versionIdIndex);
-        const versionId = fullKey.slice(versionIdIndex + 1);
-        return { key: nonversionedKey, versionId };
+        this.setState({
+            id: 1 /* NotSkipping */,
+        });
+        return this.handleKey(key, value);
     }
 
-    /**
-     *  Filter to apply on each iteration
-     *  @param {Object} obj       - The key and value of the element
-     *  @param {String} obj.key   - The key of the element
-     *  @param {String} obj.value - The value of the element
-     *  @return {number}          - indicates if iteration should continue
-     */
     filter(obj) {
-        const value = obj.value;
-        // NOTE: this check on PHD is only useful for Artesca, S3C
-        // does not use PHDs in V1 format
-        if (Version.isPHD(value)) {
-            return FILTER_ACCEPT;
+        if (this.start && Date.now() - this.start > DELIMITER_TIMEOUT_MS) {
+            this.IsTruncated = true;
+            this.logger.info('listing stopped after expected internal timeout',
+                {
+                    timeoutMs: DELIMITER_TIMEOUT_MS,
+                    scannedKeys: this.scannedKeys,
+                });
+            return FILTER_END;
         }
+        ++this.scannedKeys;
         return super.filter(obj);
     }
 
     /**
      * NOTE: Each version of a specific key is sorted from the latest to the oldest
      * thanks to the way version ids are generated.
-     * DESCRIPTION: For a given key, the latest version is skipped since it represents the current version or
-     * the last version of the previous truncated listing.
-     * The current last-modified date is kept in memory and used as a "stale date" for the following version.
+     * DESCRIPTION: Skip the version if it represents the master key, but keep its last-modified date in memory,
+     * which will be the stale date of the following version.
      * The following version is pushed only:
      * - if the "stale date" (picked up from the previous version) is available (JSON.parse has not failed),
      * - if "beforeDate" is not specified or if specified and the "stale date" is older.
@@ -158,47 +104,22 @@ class DelimiterNonCurrent extends Delimiter {
      * - no more metadata key is left to be processed
      * - the listing reaches the maximum number of key to be returned
      * - the internal timeout is reached
-     *  @param {String} keyVersionSuffix   - The key to add
+     *  @param {String} key   - The key to add
+     *  @param {String} versionId - The version id
      *  @param {String} value - The value of the key
-     *  @return {number}      - indicates if iteration should continue
+     *  @return {undefined}
      */
-    addContents(keyVersionSuffix, value) {
-        if (this._reachedMaxKeys()) {
-            return FILTER_END;
-        }
+    addContents(key, versionId, value) {
+        this.nextKeyMarker = key;
+        this.nextVersionIdMarker = versionId;
 
-        if (this.start && Date.now() - this.start > DELIMITER_TIMEOUT_MS) {
-            this.IsTruncated = true;
-            this.logger.info('listing stopped after expected internal timeout',
-                {
-                    timeoutMs: DELIMITER_TIMEOUT_MS,
-                    evaluatedKeys: this.evaluatedKeys,
-                });
-            return FILTER_END;
-        }
-        ++this.evaluatedKeys;
-
-        const { key, versionId } = this.parseKey(keyVersionSuffix);
-
-        this.NextKeyMarker = key;
-        this.NextVersionIdMarker = versionId;
-
-        // The master key serves two purposes:
-        // - It retrieves the expiration date for the previous version that is no longer current.
-        // - It excludes the current version from the list.
-        const isMasterKey = versionId === undefined;
-        if (isMasterKey) {
-            this.masterKey = key;
-            this.masterVersionId = Version.from(value).getVersionId() || 'null';
-
-            this.staleDate = this.getLastModified(value);
-            return FILTER_ACCEPT;
-        }
-
-        const isCurrentVersion = this.masterKey === key && this.masterVersionId === versionId;
+        // Skip the version if it represents the non-current version, but keep its last-modified date,
+        // which will be the stale date of the following version.
+        const isCurrentVersion = key !== this.prevKey;
         if (isCurrentVersion) {
-            // filter out the master version
-            return FILTER_ACCEPT;
+            this.staleDate = this.getLastModified(value);
+            this.prevKey = key;
+            return;
         }
 
         // The following version is pushed only:
@@ -227,9 +148,14 @@ class DelimiterNonCurrent extends Delimiter {
         // the following version.
         this.staleDate = lastModified || this.getLastModified(value);
 
-        return FILTER_ACCEPT;
+        return;
     }
 
+    /**
+     * Parses the stringified entry's value and remove the location property if too large.
+     * @param {string} s - sringified value
+     * @return {object} p - undefined if parsing fails, otherwise it contains the parsed value.
+     */
     _parse(s) {
         let p;
         try {
@@ -262,14 +188,19 @@ class DelimiterNonCurrent extends Delimiter {
     }
 
     result() {
+        const { Versions, IsTruncated, NextKeyMarker, NextVersionIdMarker } = super.result();
+
         const result = {
-            Contents: this.Contents,
-            IsTruncated: this.IsTruncated,
+            Contents: Versions,
+            IsTruncated,
         };
 
-        if (this.IsTruncated) {
-            result.NextKeyMarker = this.NextKeyMarker;
-            result.NextVersionIdMarker = this.NextVersionIdMarker;
+        if (NextKeyMarker) {
+            result.NextKeyMarker = NextKeyMarker;
+        }
+
+        if (NextVersionIdMarker) {
+            result.NextVersionIdMarker = NextVersionIdMarker;
         }
 
         return result;

--- a/tests/unit/algos/list/delimiterNonCurrent.spec.js
+++ b/tests/unit/algos/list/delimiterNonCurrent.spec.js
@@ -6,7 +6,6 @@ const DelimiterNonCurrent =
     require('../../../../lib/algos/list/delimiterNonCurrent').DelimiterNonCurrent;
 const {
     FILTER_ACCEPT,
-    FILTER_SKIP,
     FILTER_END,
 } = require('../../../../lib/algos/list/tools');
 const VSConst =
@@ -31,342 +30,369 @@ const fakeLogger = {
     fatal: () => {},
 };
 
-function makeV1Key(key) {
-    const keyPrefix = key.includes(VID_SEP) ?
-        DbPrefixes.Version : DbPrefixes.Master;
-    return `${keyPrefix}${key}`;
+function getListingKey(key, vFormat) {
+    if (vFormat === 'v0') {
+        return key;
+    }
+    if (vFormat === 'v1') {
+        const keyPrefix = key.includes(VID_SEP) ?
+            DbPrefixes.Version : DbPrefixes.Master;
+        return `${keyPrefix}${key}`;
+    }
+    return assert.fail(`bad format ${vFormat}`);
 }
 
-describe('DelimiterNonCurrent', () => {
-    it('should accept entry starting with prefix', () => {
-        const delimiter = new DelimiterNonCurrent({ prefix: 'prefix' }, fakeLogger, 'v1');
-
-        const listingKey = makeV1Key('prefix1');
-        assert.strictEqual(delimiter.filter({ key: listingKey, value: '' }), FILTER_ACCEPT);
-
-        assert.deepStrictEqual(delimiter.result(), EmptyResult);
-    });
-
-    it('should skip entry not starting with prefix', () => {
-        const delimiter = new DelimiterNonCurrent({ prefix: 'prefix' }, fakeLogger, 'v1');
-
-        const listingKey = makeV1Key('noprefix');
-        assert.strictEqual(delimiter.filter({ key: listingKey, value: '' }), FILTER_SKIP);
-
-        assert.deepStrictEqual(delimiter.result(), EmptyResult);
-    });
-
-    it('should accept a version and return an empty content', () => {
-        const delimiter = new DelimiterNonCurrent({ }, fakeLogger, 'v1');
-
-        const masterKey = 'key';
-
-        const versionId1 = 'version1';
-        const versionKey1 = `${masterKey}${VID_SEP}${versionId1}`;
-        const date1 = '1970-01-01T00:00:00.001Z';
-        const value1 = `{"versionId":"${versionId1}", "last-modified": "${date1}"}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey1),
-            value: value1,
-        }), FILTER_ACCEPT);
-
-        assert.deepStrictEqual(delimiter.result(), EmptyResult);
-    });
-
-    it('should accept two versions and return the non current version', () => {
-        const delimiter = new DelimiterNonCurrent({ }, fakeLogger, 'v1');
-
-        const masterKey = 'key';
-
-        // filter first version
-        const versionId1 = 'version1';
-        const versionKey1 = `${masterKey}${VID_SEP}${versionId1}`;
-        const date1 = '1970-01-01T00:00:00.002Z';
-        const value1 = `{"versionId":"${versionId1}", "last-modified": "${date1}"}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey1),
-            value: value1,
-        }), FILTER_ACCEPT);
-
-        // filter second version
-        const versionId2 = 'version2';
-        const versionKey2 = `${masterKey}${VID_SEP}${versionId2}`;
-        const date2 = '1970-01-01T00:00:00.001Z';
-        const value2 = `{"versionId":"${versionId2}", "last-modified": "${date2}"}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey2),
-            value: value2,
-        }), FILTER_ACCEPT);
-
-        const expectedResult = {
-            Contents: [
-                {
-                    key: masterKey,
-                    value: `{"versionId":"${versionId2}","last-modified":"${date2}","staleDate":"${date1}"}`,
-                },
-            ],
-            IsTruncated: false,
-        };
-
-        assert.deepStrictEqual(delimiter.result(), expectedResult);
-    });
-
-    it('should accept three versions and return the non current version which stale date before beforeDate', () => {
-        const beforeDate = '1970-01-01T00:00:00.002Z';
-        const delimiter = new DelimiterNonCurrent({ beforeDate }, fakeLogger, 'v1');
-
-        const masterKey = 'key';
-
-        // filter first version
-        const versionId1 = 'version1';
-        const versionKey1 = `${masterKey}${VID_SEP}${versionId1}`;
-        const date1 = beforeDate;
-        const value1 = `{"versionId":"${versionId1}", "last-modified": "${date1}"}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey1),
-            value: value1,
-        }), FILTER_ACCEPT);
-
-        // filter second version
-        const versionId2 = 'version2';
-        const versionKey2 = `${masterKey}${VID_SEP}${versionId2}`;
-        const date2 = '1970-01-01T00:00:00.001Z';
-        const value2 = `{"versionId":"${versionId2}", "last-modified": "${date2}"}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey2),
-            value: value2,
-        }), FILTER_ACCEPT);
-
-        // filter third version
-        const versionId3 = 'version3';
-        const versionKey3 = `${masterKey}${VID_SEP}${versionId3}`;
-        const date3 = '1970-01-01T00:00:00.000Z';
-        const value3 = `{"versionId":"${versionId3}", "last-modified": "${date3}"}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey3),
-            value: value3,
-        }), FILTER_ACCEPT);
-
-        const expectedResult = {
-            Contents: [
-                {
-                    key: masterKey,
-                    value: `{"versionId":"${versionId3}","last-modified":"${date3}","staleDate":"${date2}"}`,
-                },
-            ],
-            IsTruncated: false,
-        };
-
-        assert.deepStrictEqual(delimiter.result(), expectedResult);
-    });
-
-    it('should accept one delete marker and one versions and return the non current version', () => {
-        const delimiter = new DelimiterNonCurrent({ }, fakeLogger, 'v1');
-
-        // const version = new Version({ isDeleteMarker: true });
-        const masterKey = 'key';
-
-        // filter delete marker
-        const versionId1 = 'version1';
-        const versionKey1 = `${masterKey}${VID_SEP}${versionId1}`;
-        const date1 = '1970-01-01T00:00:00.002Z';
-        const value1 = `{"versionId":"${versionId1}", "last-modified": "${date1}", "isDeleteMarker": true}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey1),
-            value: value1,
-        }), FILTER_ACCEPT);
-
-        // filter second version
-        const versionId2 = 'version2';
-        const versionKey2 = `${masterKey}${VID_SEP}${versionId2}`;
-        const date2 = '1970-01-01T00:00:00.001Z';
-        const value2 = `{"versionId":"${versionId2}", "last-modified": "${date2}"}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey2),
-            value: value2,
-        }), FILTER_ACCEPT);
-
-        const expectedResult = {
-            Contents: [
-                {
-                    key: masterKey,
-                    value: `{"versionId":"${versionId2}","last-modified":"${date2}","staleDate":"${date1}"}`,
-                },
-            ],
-            IsTruncated: false,
-        };
-
-        assert.deepStrictEqual(delimiter.result(), expectedResult);
-    });
-
-    it('should end filtering if max keys reached', () => {
-        const delimiter = new DelimiterNonCurrent({ maxKeys: 1 }, fakeLogger, 'v1');
-
-        const masterKey = 'key';
-
-        // filter delete marker
-        const versionId1 = 'version1';
-        const versionKey1 = `${masterKey}${VID_SEP}${versionId1}`;
-        const date1 = '1970-01-01T00:00:00.002Z';
-        const value1 = `{"versionId":"${versionId1}", "last-modified": "${date1}", "isDeleteMarker": true}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey1),
-            value: value1,
-        }), FILTER_ACCEPT);
-
-        // filter second version
-        const versionId2 = 'version2';
-        const versionKey2 = `${masterKey}${VID_SEP}${versionId2}`;
-        const date2 = '1970-01-01T00:00:00.001Z';
-        const value2 = `{"versionId":"${versionId2}", "last-modified": "${date2}"}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey2),
-            value: value2,
-        }), FILTER_ACCEPT);
-
-        // filter third version
-        const versionId3 = 'version3';
-        const versionKey3 = `${masterKey}${VID_SEP}${versionId3}`;
-        const date3 = '1970-01-01T00:00:00.000Z';
-        const value3 = `{"versionId":"${versionId3}", "last-modified": "${date3}"}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey3),
-            value: value3,
-        }), FILTER_END);
-
-
-        const expectedResult = {
-            Contents: [
-                {
-                    key: masterKey,
-                    value: `{"versionId":"${versionId2}","last-modified":"${date2}","staleDate":"${date1}"}`,
-                },
-            ],
-            IsTruncated: true,
-            NextKeyMarker: masterKey,
-            NextVersionIdMarker: versionId2,
-        };
-
-        assert.deepStrictEqual(delimiter.result(), expectedResult);
-    });
-
-    it('should end filtering if delimiter timeout', () => {
-        const delimiter = new DelimiterNonCurrent({ }, fakeLogger, 'v1');
-
-        const masterKey = 'key';
-
-        // filter delete marker
-        const versionId1 = 'version1';
-        const versionKey1 = `${masterKey}${VID_SEP}${versionId1}`;
-        const date1 = '1970-01-01T00:00:00.002Z';
-        const value1 = `{"versionId":"${versionId1}", "last-modified": "${date1}", "isDeleteMarker": true}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey1),
-            value: value1,
-        }), FILTER_ACCEPT);
-
-        // filter second version
-        const versionId2 = 'version2';
-        const versionKey2 = `${masterKey}${VID_SEP}${versionId2}`;
-        const date2 = '1970-01-01T00:00:00.001Z';
-        const value2 = `{"versionId":"${versionId2}", "last-modified": "${date2}"}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey2),
-            value: value2,
-        }), FILTER_ACCEPT);
-
-        // force delimiter to timeout.
-        delimiter.start = Date.now() - (DELIMITER_TIMEOUT_MS + 1);
-
-        // filter third version
-        const versionId3 = 'version3';
-        const versionKey3 = `${masterKey}${VID_SEP}${versionId3}`;
-        const date3 = '1970-01-01T00:00:00.000Z';
-        const value3 = `{"versionId":"${versionId3}", "last-modified": "${date3}"}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey3),
-            value: value3,
-        }), FILTER_END);
-
-
-        const expectedResult = {
-            Contents: [
-                {
-                    key: masterKey,
-                    value: `{"versionId":"${versionId2}","last-modified":"${date2}","staleDate":"${date1}"}`,
-                },
-            ],
-            IsTruncated: true,
-            NextKeyMarker: masterKey,
-            NextVersionIdMarker: versionId2,
-        };
-
-        assert.deepStrictEqual(delimiter.result(), expectedResult);
-    });
-
-    it('should end filtering if delimiter timeout with empty content', () => {
-        const delimiter = new DelimiterNonCurrent({ }, fakeLogger, 'v1');
-
-        // filter current version
-        const masterKey1 = 'key1';
-        const versionId1 = 'version1';
-        const versionKey1 = `${masterKey1}${VID_SEP}${versionId1}`;
-        const date1 = '1970-01-01T00:00:00.002Z';
-        const value1 = `{"versionId":"${versionId1}", "last-modified": "${date1}"`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey1),
-            value: value1,
-        }), FILTER_ACCEPT);
-
-        // filter current version
-        const masterKey2 = 'key2';
-        const versionId2 = 'version2';
-        const versionKey2 = `${masterKey2}${VID_SEP}${versionId2}`;
-        const date2 = '1970-01-01T00:00:00.001Z';
-        const value2 = `{"versionId":"${versionId2}", "last-modified": "${date2}"}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey2),
-            value: value2,
-        }), FILTER_ACCEPT);
-
-        // force delimiter to timeout.
-        delimiter.start = Date.now() - (DELIMITER_TIMEOUT_MS + 1);
-
-        // filter current version
-        const masterKey3 = 'key3';
-        const versionId3 = 'version3';
-        const versionKey3 = `${masterKey3}${VID_SEP}${versionId3}`;
-        const date3 = '1970-01-01T00:00:00.000Z';
-        const value3 = `{"versionId":"${versionId3}", "last-modified": "${date3}"}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey3),
-            value: value3,
-        }), FILTER_END);
-
-        const expectedResult = {
-            Contents: [],
-            IsTruncated: true,
-            NextKeyMarker: masterKey2,
-            NextVersionIdMarker: versionId2,
-        };
-
-        assert.deepStrictEqual(delimiter.result(), expectedResult);
+['v0', 'v1'].forEach(v => {
+    describe(`DelimiterNonCurrent with ${v} bucket format`, () => {
+        it('should return expected metadata parameters', () => {
+            const prefix = 'pre';
+            const keyMarker = 'premark';
+            const versionIdMarker = 'vid1';
+            const delimiter = new DelimiterNonCurrent({
+                prefix,
+                keyMarker,
+                versionIdMarker,
+            }, fakeLogger, v);
+
+            let expectedParams;
+            if (v === 'v0') {
+                expectedParams = { gte: `premark${VID_SEP}`, lt: 'prf' };
+            } else {
+                expectedParams = [
+                    {
+                        gte: `${DbPrefixes.Master}premark${VID_SEP}`,
+                        lt: `${DbPrefixes.Master}prf`,
+                    },
+                    {
+                        gte: `${DbPrefixes.Version}premark${VID_SEP}`,
+                        lt: `${DbPrefixes.Version}prf`,
+                    },
+                ];
+            }
+            assert.deepStrictEqual(delimiter.genMDParams(), expectedParams);
+            assert(delimiter.start);
+        });
+        it('should accept entry starting with prefix', () => {
+            const delimiter = new DelimiterNonCurrent({ prefix: 'prefix' }, fakeLogger, v);
+
+            const listingKey = getListingKey('prefix1', v);
+            assert.strictEqual(delimiter.filter({ key: listingKey, value: '' }), FILTER_ACCEPT);
+
+            assert.deepStrictEqual(delimiter.result(), EmptyResult);
+        });
+
+        it('should accept a version and return an empty content', () => {
+            const delimiter = new DelimiterNonCurrent({ }, fakeLogger, v);
+
+            const masterKey = 'key';
+
+            const versionId1 = 'version1';
+            const versionKey1 = `${masterKey}${VID_SEP}${versionId1}`;
+            const date1 = '1970-01-01T00:00:00.001Z';
+            const value1 = `{"versionId":"${versionId1}", "last-modified": "${date1}"}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey1, v),
+                value: value1,
+            }), FILTER_ACCEPT);
+
+            assert.deepStrictEqual(delimiter.result(), EmptyResult);
+        });
+
+        it('should accept two versions and return the noncurrent version', () => {
+            const delimiter = new DelimiterNonCurrent({ }, fakeLogger, v);
+
+            const masterKey = 'key';
+
+            // filter first version
+            const versionId1 = 'version1';
+            const versionKey1 = `${masterKey}${VID_SEP}${versionId1}`;
+            const date1 = '1970-01-01T00:00:00.002Z';
+            const value1 = `{"versionId":"${versionId1}", "last-modified": "${date1}"}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey1, v),
+                value: value1,
+            }), FILTER_ACCEPT);
+
+            // filter second version
+            const versionId2 = 'version2';
+            const versionKey2 = `${masterKey}${VID_SEP}${versionId2}`;
+            const date2 = '1970-01-01T00:00:00.001Z';
+            const value2 = `{"versionId":"${versionId2}", "last-modified": "${date2}"}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey2, v),
+                value: value2,
+            }), FILTER_ACCEPT);
+
+            const expectedResult = {
+                Contents: [
+                    {
+                        key: masterKey,
+                        value: `{"versionId":"${versionId2}","last-modified":"${date2}","staleDate":"${date1}"}`,
+                    },
+                ],
+                IsTruncated: false,
+            };
+
+            assert.deepStrictEqual(delimiter.result(), expectedResult);
+        });
+
+        it('should accept three versions and return the noncurrent version which stale date before beforeDate', () => {
+            const beforeDate = '1970-01-01T00:00:00.002Z';
+            const delimiter = new DelimiterNonCurrent({ beforeDate }, fakeLogger, v);
+
+            const masterKey = 'key';
+
+            // filter first version
+            const versionId1 = 'version1';
+            const versionKey1 = `${masterKey}${VID_SEP}${versionId1}`;
+            const date1 = beforeDate;
+            const value1 = `{"versionId":"${versionId1}", "last-modified": "${date1}"}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey1, v),
+                value: value1,
+            }), FILTER_ACCEPT);
+
+            // filter second version
+            const versionId2 = 'version2';
+            const versionKey2 = `${masterKey}${VID_SEP}${versionId2}`;
+            const date2 = '1970-01-01T00:00:00.001Z';
+            const value2 = `{"versionId":"${versionId2}", "last-modified": "${date2}"}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey2, v),
+                value: value2,
+            }), FILTER_ACCEPT);
+
+            // filter third version
+            const versionId3 = 'version3';
+            const versionKey3 = `${masterKey}${VID_SEP}${versionId3}`;
+            const date3 = '1970-01-01T00:00:00.000Z';
+            const value3 = `{"versionId":"${versionId3}", "last-modified": "${date3}"}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey3, v),
+                value: value3,
+            }), FILTER_ACCEPT);
+
+            const expectedResult = {
+                Contents: [
+                    {
+                        key: masterKey,
+                        value: `{"versionId":"${versionId3}","last-modified":"${date3}","staleDate":"${date2}"}`,
+                    },
+                ],
+                IsTruncated: false,
+            };
+
+            assert.deepStrictEqual(delimiter.result(), expectedResult);
+        });
+
+        it('should accept one delete marker and one version and return the noncurrent version', () => {
+            const delimiter = new DelimiterNonCurrent({ }, fakeLogger, v);
+
+            // const version = new Version({ isDeleteMarker: true });
+            const masterKey = 'key';
+
+            // filter delete marker
+            const versionId1 = 'version1';
+            const versionKey1 = `${masterKey}${VID_SEP}${versionId1}`;
+            const date1 = '1970-01-01T00:00:00.002Z';
+            const value1 = `{"versionId":"${versionId1}", "last-modified": "${date1}", "isDeleteMarker": true}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey1, v),
+                value: value1,
+            }), FILTER_ACCEPT);
+
+            // filter second version
+            const versionId2 = 'version2';
+            const versionKey2 = `${masterKey}${VID_SEP}${versionId2}`;
+            const date2 = '1970-01-01T00:00:00.001Z';
+            const value2 = `{"versionId":"${versionId2}", "last-modified": "${date2}"}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey2, v),
+                value: value2,
+            }), FILTER_ACCEPT);
+
+            const expectedResult = {
+                Contents: [
+                    {
+                        key: masterKey,
+                        value: `{"versionId":"${versionId2}","last-modified":"${date2}","staleDate":"${date1}"}`,
+                    },
+                ],
+                IsTruncated: false,
+            };
+
+            assert.deepStrictEqual(delimiter.result(), expectedResult);
+        });
+
+        it('should end filtering if max keys reached', () => {
+            const delimiter = new DelimiterNonCurrent({ maxKeys: 1 }, fakeLogger, v);
+
+            const masterKey = 'key';
+
+            // filter delete marker
+            const versionId1 = 'version1';
+            const versionKey1 = `${masterKey}${VID_SEP}${versionId1}`;
+            const date1 = '1970-01-01T00:00:00.002Z';
+            const value1 = `{"versionId":"${versionId1}", "last-modified": "${date1}", "isDeleteMarker": true}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey1, v),
+                value: value1,
+            }), FILTER_ACCEPT);
+
+            // filter second version
+            const versionId2 = 'version2';
+            const versionKey2 = `${masterKey}${VID_SEP}${versionId2}`;
+            const date2 = '1970-01-01T00:00:00.001Z';
+            const value2 = `{"versionId":"${versionId2}", "last-modified": "${date2}"}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey2, v),
+                value: value2,
+            }), FILTER_ACCEPT);
+
+            // filter third version
+            const versionId3 = 'version3';
+            const versionKey3 = `${masterKey}${VID_SEP}${versionId3}`;
+            const date3 = '1970-01-01T00:00:00.000Z';
+            const value3 = `{"versionId":"${versionId3}", "last-modified": "${date3}"}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey3, v),
+                value: value3,
+            }), FILTER_END);
+
+
+            const expectedResult = {
+                Contents: [
+                    {
+                        key: masterKey,
+                        value: `{"versionId":"${versionId2}","last-modified":"${date2}","staleDate":"${date1}"}`,
+                    },
+                ],
+                IsTruncated: true,
+                NextKeyMarker: masterKey,
+                NextVersionIdMarker: versionId2,
+            };
+
+            assert.deepStrictEqual(delimiter.result(), expectedResult);
+        });
+
+        it('should end filtering if delimiter timeout', () => {
+            const delimiter = new DelimiterNonCurrent({ }, fakeLogger, v);
+
+            const masterKey = 'key';
+
+            // filter delete marker
+            const versionId1 = 'version1';
+            const versionKey1 = `${masterKey}${VID_SEP}${versionId1}`;
+            const date1 = '1970-01-01T00:00:00.002Z';
+            const value1 = `{"versionId":"${versionId1}", "last-modified": "${date1}", "isDeleteMarker": true}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey1, v),
+                value: value1,
+            }), FILTER_ACCEPT);
+
+            // filter second version
+            const versionId2 = 'version2';
+            const versionKey2 = `${masterKey}${VID_SEP}${versionId2}`;
+            const date2 = '1970-01-01T00:00:00.001Z';
+            const value2 = `{"versionId":"${versionId2}", "last-modified": "${date2}"}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey2, v),
+                value: value2,
+            }), FILTER_ACCEPT);
+
+            // force delimiter to timeout.
+            delimiter.start = Date.now() - (DELIMITER_TIMEOUT_MS + 1);
+
+            // filter third version
+            const versionId3 = 'version3';
+            const versionKey3 = `${masterKey}${VID_SEP}${versionId3}`;
+            const date3 = '1970-01-01T00:00:00.000Z';
+            const value3 = `{"versionId":"${versionId3}", "last-modified": "${date3}"}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey3, v),
+                value: value3,
+            }), FILTER_END);
+
+
+            const expectedResult = {
+                Contents: [
+                    {
+                        key: masterKey,
+                        value: `{"versionId":"${versionId2}","last-modified":"${date2}","staleDate":"${date1}"}`,
+                    },
+                ],
+                IsTruncated: true,
+                NextKeyMarker: masterKey,
+                NextVersionIdMarker: versionId2,
+            };
+
+            assert.deepStrictEqual(delimiter.result(), expectedResult);
+        });
+
+        it('should end filtering if delimiter timeout with empty content', () => {
+            const delimiter = new DelimiterNonCurrent({ }, fakeLogger, v);
+
+            // filter current version
+            const masterKey1 = 'key1';
+            const versionId1 = 'version1';
+            const versionKey1 = `${masterKey1}${VID_SEP}${versionId1}`;
+            const date1 = '1970-01-01T00:00:00.002Z';
+            const value1 = `{"versionId":"${versionId1}", "last-modified": "${date1}"`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey1, v),
+                value: value1,
+            }), FILTER_ACCEPT);
+
+            // filter current version
+            const masterKey2 = 'key2';
+            const versionId2 = 'version2';
+            const versionKey2 = `${masterKey2}${VID_SEP}${versionId2}`;
+            const date2 = '1970-01-01T00:00:00.001Z';
+            const value2 = `{"versionId":"${versionId2}", "last-modified": "${date2}"}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey2, v),
+                value: value2,
+            }), FILTER_ACCEPT);
+
+            // force delimiter to timeout.
+            delimiter.start = Date.now() - (DELIMITER_TIMEOUT_MS + 1);
+
+            // filter current version
+            const masterKey3 = 'key3';
+            const versionId3 = 'version3';
+            const versionKey3 = `${masterKey3}${VID_SEP}${versionId3}`;
+            const date3 = '1970-01-01T00:00:00.000Z';
+            const value3 = `{"versionId":"${versionId3}", "last-modified": "${date3}"}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey3, v),
+                value: value3,
+            }), FILTER_END);
+
+            const expectedResult = {
+                Contents: [],
+                IsTruncated: true,
+                NextKeyMarker: masterKey2,
+                NextVersionIdMarker: versionId2,
+            };
+
+            assert.deepStrictEqual(delimiter.result(), expectedResult);
+        });
     });
 });


### PR DESCRIPTION
This PR includes the following changes:

- The `evaluatedKeys` have been renamed to `scannedKeys`.
- The implementation, now, leverages `DelimiterVersions` to provide an accurate list of versions.
- The test has been updated to run on V0 and V1 bucket formats.