### PR TITLE
ARSN-356 List lifecycle orphan delete markers supports V0

### DIFF
--- a/lib/algos/list/delimiterCurrent.ts
+++ b/lib/algos/list/delimiterCurrent.ts
@@ -51,6 +51,8 @@ class DelimiterCurrent extends DelimiterMaster {
             }
         }
 
+        // The genMDParamsV1() function calls genMDParamsV0() in the Delimiter class,
+        // making sure that this.start is set for both v0 and v1 bucket formats
         this.start = Date.now();
 
         return params;

--- a/lib/algos/list/delimiterNonCurrent.js
+++ b/lib/algos/list/delimiterNonCurrent.js
@@ -36,6 +36,8 @@ class DelimiterNonCurrent extends DelimiterVersions {
     }
 
     genMDParamsV0() {
+        // The genMDParamsV1() function calls genMDParamsV0()in the DelimiterVersions class,
+        // making sure that this.start is set for both v0 and v1 bucket formats
         this.start = Date.now();
         return super.genMDParamsV0();
     }

--- a/lib/algos/list/delimiterOrphanDeleteMarker.js
+++ b/lib/algos/list/delimiterOrphanDeleteMarker.js
@@ -1,45 +1,50 @@
-'use strict'; // eslint-disable-line strict
-const Delimiter = require('./delimiter').Delimiter;
-const VSConst = require('../../versioning/constants').VersioningConstants;
-const { inc, FILTER_ACCEPT, FILTER_END, SKIP_NONE } = require('./tools');
-const VID_SEP = VSConst.VersionId.Separator;
-const { DbPrefixes } = VSConst;
-
+const DelimiterVersions = require('./delimiterVersions').DelimiterVersions;
+const { FILTER_END } = require('./tools');
 const DELIMITER_TIMEOUT_MS = 10 * 1000; // 10s
 const TRIM_METADATA_MIN_BLOB_SIZE = 10000;
-
 /**
- * Handle object listing with parameters. This extends the base class Delimiter
+ * Handle object listing with parameters. This extends the base class DelimiterVersions
  * to return the orphan delete markers. Orphan delete markers are also
  * refered as expired object delete marker.
  * They are delete marker with zero noncurrent versions.
  */
-class DelimiterOrphanDeleteMarker extends Delimiter {
+class DelimiterOrphanDeleteMarker extends DelimiterVersions {
     /**
-     * Delimiter listing of non-current versions.
+     * Delimiter listing of orphan delete markers.
      * @param {Object}  parameters            - listing parameters
      * @param {String}  parameters.beforeDate - limit the response to keys older than beforeDate
      * @param {RequestLogger} logger          - The logger of the request
      * @param {String} [vFormat]              - versioning key format
      */
     constructor(parameters, logger, vFormat) {
-        super(parameters, logger, vFormat);
+        const {
+            marker,
+            maxKeys,
+            prefix,
+            beforeDate,
+        } = parameters;
 
-        this.beforeDate = parameters.beforeDate;
+        const versionParams = {
+            // The orphan delete marker logic uses the term 'marker' instead of 'keyMarker',
+            // as the latter could suggest the presence of a 'versionIdMarker'.
+            keyMarker: marker,
+            maxKeys,
+            prefix,
+        };
+        super(versionParams, logger, vFormat);
 
-        this.skipping = this.skippingV1;
-        this.genMDParams = this.genMDParamsV1;
-
+        this.beforeDate = beforeDate;
         this.keyName = null;
-        this.staleDate = null;
         this.value = null;
-
         // used for monitoring
-        this.evaluatedKeys = 0;
+        this.scannedKeys = 0;
     }
 
-    skippingV1() {
-        return SKIP_NONE;
+    genMDParamsV0() {
+        // The genMDParamsV1() function calls genMDParamsV0() in the DelimiterVersions class,
+        // making sure that this.start is set for both v0 and v1 bucket formats
+        this.start = Date.now();
+        return super.genMDParamsV0();
     }
 
     _reachedMaxKeys() {
@@ -47,28 +52,6 @@ class DelimiterOrphanDeleteMarker extends Delimiter {
             return true;
         }
         return false;
-    }
-
-    genMDParamsV1() {
-        const params = {
-            gte: DbPrefixes.Version,
-            lt: inc(DbPrefixes.Version),
-        };
-
-        if (this.prefix) {
-            params.gte = `${DbPrefixes.Version}${this.prefix}`;
-            params.lt = `${DbPrefixes.Version}${inc(this.prefix)}`;
-        }
-
-        if (this.marker && `${DbPrefixes.Version}${this.marker}` >= params.gte) {
-            delete params.gte;
-            params.gt = DbPrefixes.Version
-                    + inc(this.marker + VID_SEP);
-        }
-
-        this.start = Date.now();
-
-        return params;
     }
 
     _addOrphan() {
@@ -82,12 +65,17 @@ class DelimiterOrphanDeleteMarker extends Delimiter {
                 // Prefer returning an untrimmed data rather than stopping the service in case of parsing failure.
                 const s = this._stringify(parsedValue) || this.value;
                 this.Contents.push({ key: this.keyName, value: s });
-                this.NextMarker = this.keyName;
+                this.nextKeyMarker = this.keyName;
                 ++this.keys;
             }
         }
     }
 
+    /**
+     * Parses the stringified entry's value and remove the location property if too large.
+     * @param {string} s - sringified value
+     * @return {object} p - undefined if parsing fails, otherwise it contains the parsed value.
+     */
     _parse(s) {
         let p;
         try {
@@ -119,6 +107,21 @@ class DelimiterOrphanDeleteMarker extends Delimiter {
         return s;
     }
 
+    filter(obj) {
+        if (this.start && Date.now() - this.start > DELIMITER_TIMEOUT_MS) {
+            this.nextKeyMarker = this.keyName;
+            this.IsTruncated = true;
+            this.logger.info('listing stopped after expected internal timeout',
+                {
+                    timeoutMs: DELIMITER_TIMEOUT_MS,
+                    scannedKeys: this.scannedKeys,
+                });
+            return FILTER_END;
+        }
+        ++this.scannedKeys;
+        return super.filter(obj);
+    }
+
     /**
      * NOTE: Each version of a specific key is sorted from the latest to the oldest
      * thanks to the way version ids are generated.
@@ -131,32 +134,12 @@ class DelimiterOrphanDeleteMarker extends Delimiter {
      * - the internal timeout is reached
      * NOTE: we cannot leverage MongoDB to list keys older than "beforeDate"
      * because then we will not be able to assess its orphanage.
-     *  @param {String} keyVersionSuffix   - The key with version id as a suffix.
-     *  @param {String} value              - The value of the key
-     *  @return {number}                   - indicates if iteration should continue
+     *  @param {String} key   - The object key.
+     * @param {String} versionId   - The object version id.
+     *  @param {String} value - The value of the key
+     *  @return {undefined}
      */
-    addContents(keyVersionSuffix, value) {
-        if (this._reachedMaxKeys()) {
-            return FILTER_END;
-        }
-
-        if (this.start && Date.now() - this.start > DELIMITER_TIMEOUT_MS) {
-            this.IsTruncated = true;
-            this.NextMarker = this.keyName;
-
-            this.logger.info('listing stopped after expected internal timeout',
-                {
-                    timeoutMs: DELIMITER_TIMEOUT_MS,
-                    evaluatedKeys: this.evaluatedKeys,
-                });
-            return FILTER_END;
-        }
-        ++this.evaluatedKeys;
-
-        const versionIdIndex = keyVersionSuffix.indexOf(VID_SEP);
-        // key without version suffix
-        const key = keyVersionSuffix.slice(0, versionIdIndex);
-
+    addContents(key, versionId, value) {
         // For a given key, the youngest version is kept in memory since it represents the current version.
         if (key !== this.keyName) {
             // If this.value is defined, it means that <this.keyName, this.value> pair is "allowed" to be an orphan.
@@ -166,13 +149,13 @@ class DelimiterOrphanDeleteMarker extends Delimiter {
             this.keyName = key;
             this.value = value;
 
-            return FILTER_ACCEPT;
+            return;
         }
 
         this.keyName = key;
         this.value = null;
 
-        return FILTER_ACCEPT;
+        return;
     }
 
     result() {
@@ -194,10 +177,11 @@ class DelimiterOrphanDeleteMarker extends Delimiter {
         };
 
         if (this.IsTruncated) {
-            result.NextMarker = this.NextMarker;
+            result.NextMarker = this.nextKeyMarker;
         }
 
         return result;
     }
 }
+
 module.exports = { DelimiterOrphanDeleteMarker };

--- a/tests/unit/algos/list/delimiterOrphanDeleteMarker.spec.js
+++ b/tests/unit/algos/list/delimiterOrphanDeleteMarker.spec.js
@@ -6,8 +6,8 @@ const DelimiterOrphanDeleteMarker =
     require('../../../../lib/algos/list/delimiterOrphanDeleteMarker').DelimiterOrphanDeleteMarker;
 const {
     FILTER_ACCEPT,
-    FILTER_SKIP,
     FILTER_END,
+    inc,
 } = require('../../../../lib/algos/list/tools');
 const VSConst =
     require('../../../../lib/versioning/constants').VersioningConstants;
@@ -32,347 +32,370 @@ const fakeLogger = {
     fatal: () => {},
 };
 
-function makeV1Key(key) {
-    const keyPrefix = key.includes(VID_SEP) ?
-        DbPrefixes.Version : DbPrefixes.Master;
-    return `${keyPrefix}${key}`;
+function getListingKey(key, vFormat) {
+    if (vFormat === 'v0') {
+        return key;
+    }
+    if (vFormat === 'v1') {
+        const keyPrefix = key.includes(VID_SEP) ?
+            DbPrefixes.Version : DbPrefixes.Master;
+        return `${keyPrefix}${key}`;
+    }
+    return assert.fail(`bad format ${vFormat}`);
 }
 
-describe('DelimiterOrphanDeleteMarker', () => {
-    it('should accept entry starting with prefix', () => {
-        const delimiter = new DelimiterOrphanDeleteMarker({ prefix: 'prefix' }, fakeLogger, 'v1');
-
-        const listingKey = makeV1Key('prefix1');
-        assert.strictEqual(delimiter.filter({ key: listingKey, value: '' }), FILTER_ACCEPT);
-
-        assert.deepStrictEqual(delimiter.result(), EmptyResult);
-    });
-
-    it('should skip entry not starting with prefix', () => {
-        const delimiter = new DelimiterOrphanDeleteMarker({ prefix: 'prefix' }, fakeLogger, 'v1');
-
-        const listingKey = makeV1Key('noprefix');
-        assert.strictEqual(delimiter.filter({ key: listingKey, value: '' }), FILTER_SKIP);
-
-        assert.deepStrictEqual(delimiter.result(), EmptyResult);
-    });
-
-    it('should accept a version and return an empty content', () => {
-        const delimiter = new DelimiterOrphanDeleteMarker({ }, fakeLogger, 'v1');
-
-        const masterKey = 'key';
-
-        const versionId1 = 'version1';
-        const versionKey1 = `${masterKey}${VID_SEP}${versionId1}`;
-        const date1 = '1970-01-01T00:00:00.001Z';
-        const value1 = `{"versionId":"${versionId1}","last-modified":"${date1}"}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey1),
-            value: value1,
-        }), FILTER_ACCEPT);
-
-        assert.deepStrictEqual(delimiter.result(), EmptyResult);
-    });
-
-    it('should accept an orphan delete marker and return it from the content', () => {
-        const delimiter = new DelimiterOrphanDeleteMarker({ }, fakeLogger, 'v1');
-
-        const masterKey = 'key';
-
-        const versionId1 = 'version1';
-        const versionKey1 = `${masterKey}${VID_SEP}${versionId1}`;
-        const date1 = '1970-01-01T00:00:00.001Z';
-        const value1 = `{"versionId":"${versionId1}","last-modified":"${date1}","isDeleteMarker":true}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey1),
-            value: value1,
-        }), FILTER_ACCEPT);
-
-        const expectedResult = {
-            Contents: [
-                {
-                    key: masterKey,
-                    value: value1,
-                },
-            ],
-            IsTruncated: false,
-        };
-
-        assert.deepStrictEqual(delimiter.result(), expectedResult);
-    });
-
-    it('should accept two orphan delete markers and return them from the content', () => {
-        const delimiter = new DelimiterOrphanDeleteMarker({ }, fakeLogger, 'v1');
-
-        // filter the first orphan delete marker
-        const masterKey1 = 'key1';
-        const versionId1 = 'version1';
-        const versionKey1 = `${masterKey1}${VID_SEP}${versionId1}`;
-        const date1 = '1970-01-01T00:00:00.002Z';
-        const value1 = `{"versionId":"${versionId1}","last-modified":"${date1}","isDeleteMarker":true}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey1),
-            value: value1,
-        }), FILTER_ACCEPT);
-
-        // filter the second orphan delete marker
-        const masterKey2 = 'key2';
-        const versionId2 = 'version2';
-        const versionKey2 = `${masterKey2}${VID_SEP}${versionId2}`;
-        const date2 = '1970-01-01T00:00:00.001Z';
-        const value2 = `{"versionId":"${versionId2}","last-modified":"${date2}","isDeleteMarker":true}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey2),
-            value: value2,
-        }), FILTER_ACCEPT);
-
-        const expectedResult = {
-            Contents: [
-                {
-                    key: masterKey1,
-                    value: value1,
-                },
-                {
-                    key: masterKey2,
-                    value: value2,
-                },
-            ],
-            IsTruncated: false,
-        };
-
-        assert.deepStrictEqual(delimiter.result(), expectedResult);
-    });
-
-    it('should accept two orphan delete markers and return truncated content with one', () => {
-        const delimiter = new DelimiterOrphanDeleteMarker({ maxKeys: 1 }, fakeLogger, 'v1');
-
-        // filter the first orphan delete marker
-        const masterKey1 = 'key1';
-        const versionId1 = 'version1';
-        const versionKey1 = `${masterKey1}${VID_SEP}${versionId1}`;
-        const date1 = '1970-01-01T00:00:00.002Z';
-        const value1 = `{"versionId":"${versionId1}","last-modified":"${date1}","isDeleteMarker":true}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey1),
-            value: value1,
-        }), FILTER_ACCEPT);
-
-        // filter the second orphan delete marker
-        const masterKey2 = 'key2';
-        const versionId2 = 'version2';
-        const versionKey2 = `${masterKey2}${VID_SEP}${versionId2}`;
-        const date2 = '1970-01-01T00:00:00.001Z';
-        const value2 = `{"versionId":"${versionId2}","last-modified":"${date2}","isDeleteMarker":true}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey2),
-            value: value2,
-        }), FILTER_ACCEPT);
-
-        const expectedResult = {
-            Contents: [
-                {
-                    key: masterKey1,
-                    value: value1,
-                },
-            ],
-            NextMarker: masterKey1,
-            IsTruncated: true,
-        };
-
-        assert.deepStrictEqual(delimiter.result(), expectedResult);
-    });
-
-    it('should accept two orphan delete markers and return the one created before the beforeDate', () => {
-        const date1 = '1970-01-01T00:00:00.002Z';
-        const delimiter = new DelimiterOrphanDeleteMarker({ beforeDate: date1 }, fakeLogger, 'v1');
-
-        // filter the first orphan delete marker
-        const masterKey1 = 'key1';
-        const versionId1 = 'version1';
-        const versionKey1 = `${masterKey1}${VID_SEP}${versionId1}`;
-        const value1 = `{"versionId":"${versionId1}","last-modified":"${date1}","isDeleteMarker":true}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey1),
-            value: value1,
-        }), FILTER_ACCEPT);
-
-        // filter the second orphan delete marker
-        const masterKey2 = 'key2';
-        const versionId2 = 'version2';
-        const versionKey2 = `${masterKey2}${VID_SEP}${versionId2}`;
-        const date2 = '1970-01-01T00:00:00.001Z';
-        const value2 = `{"versionId":"${versionId2}","last-modified":"${date2}","isDeleteMarker":true}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey2),
-            value: value2,
-        }), FILTER_ACCEPT);
-
-        const expectedResult = {
-            Contents: [
-                {
-                    key: masterKey2,
-                    value: value2,
-                },
-            ],
-            IsTruncated: false,
-        };
-
-        assert.deepStrictEqual(delimiter.result(), expectedResult);
-    });
-
-    it('should end filtering if max keys reached', () => {
-        const delimiter = new DelimiterOrphanDeleteMarker({ maxKeys: 1 }, fakeLogger, 'v1');
-
-        // filter the first orphan delete marker
-        const masterKey1 = 'key1';
-        const versionId1 = 'version1';
-        const versionKey1 = `${masterKey1}${VID_SEP}${versionId1}`;
-        const date1 = '1970-01-01T00:00:00.002Z';
-        const value1 = `{"versionId":"${versionId1}","last-modified":"${date1}","isDeleteMarker":true}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey1),
-            value: value1,
-        }), FILTER_ACCEPT);
-
-        // filter the second orphan delete marker
-        const masterKey2 = 'key2';
-        const versionId2 = 'version2';
-        const versionKey2 = `${masterKey2}${VID_SEP}${versionId2}`;
-        const date2 = '1970-01-01T00:00:00.001Z';
-        const value2 = `{"versionId":"${versionId2}","last-modified":"${date2}","isDeleteMarker":true}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey2),
-            value: value2,
-        }), FILTER_ACCEPT);
-
-        // filter the third orphan delete marker
-        const masterKey3 = 'key3';
-        const versionId3 = 'version3';
-        const versionKey3 = `${masterKey3}${VID_SEP}${versionId3}`;
-        const date3 = '1970-01-01T00:00:00.000Z';
-        const value3 = `{"versionId":"${versionId3}","last-modified":"${date3}","isDeleteMarker":true}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey3),
-            value: value3,
-        }), FILTER_END);
-
-        const expectedResult = {
-            Contents: [
-                {
-                    key: masterKey1,
-                    value: value1,
-                },
-            ],
-            NextMarker: masterKey1,
-            IsTruncated: true,
-        };
-
-        assert.deepStrictEqual(delimiter.result(), expectedResult);
-    });
-
-    it('should end filtering if delimiter timeout', () => {
-        const delimiter = new DelimiterOrphanDeleteMarker({ }, fakeLogger, 'v1');
-
-        // filter the first orphan delete marker
-        const masterKey1 = 'key1';
-        const versionId1 = 'version1';
-        const versionKey1 = `${masterKey1}${VID_SEP}${versionId1}`;
-        const date1 = '1970-01-01T00:00:00.002Z';
-        const value1 = `{"versionId":"${versionId1}","last-modified":"${date1}","isDeleteMarker":true}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey1),
-            value: value1,
-        }), FILTER_ACCEPT);
-
-        // force delimiter to timeout.
-        delimiter.start = Date.now() - (DELIMITER_TIMEOUT_MS + 1);
-
-        // filter the second orphan delete marker
-        const masterKey2 = 'key2';
-        const versionId2 = 'version2';
-        const versionKey2 = `${masterKey2}${VID_SEP}${versionId2}`;
-        const date2 = '1970-01-01T00:00:00.001Z';
-        const value2 = `{"versionId":"${versionId2}","last-modified":"${date2}","isDeleteMarker":true}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey2),
-            value: value2,
-        }), FILTER_END);
-
-        const expectedResult = {
-            Contents: [
-                {
-                    key: masterKey1,
-                    value: value1,
-                },
-            ],
-            NextMarker: masterKey1,
-            IsTruncated: true,
-        };
-
-        assert.deepStrictEqual(delimiter.result(), expectedResult);
-    });
-
-    it('should end filtering if delimiter timeout with empty content', () => {
-        const delimiter = new DelimiterOrphanDeleteMarker({ }, fakeLogger, 'v1');
-
-        // filter the first orphan delete marker
-        const masterKey1 = 'key1';
-        const versionId1 = 'version1';
-        const versionKey1 = `${masterKey1}${VID_SEP}${versionId1}`;
-        const date1 = '1970-01-01T00:00:00.002Z';
-        const value1 = `{"versionId":"${versionId1}","last-modified":"${date1}"}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey1),
-            value: value1,
-        }), FILTER_ACCEPT);
-
-        // filter the second orphan delete marker
-        const masterKey2 = 'key2';
-        const versionId2 = 'version2';
-        const versionKey2 = `${masterKey2}${VID_SEP}${versionId2}`;
-        const date2 = '1970-01-01T00:00:00.001Z';
-        const value2 = `{"versionId":"${versionId2}","last-modified":"${date2}"}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey2),
-            value: value2,
-        }), FILTER_ACCEPT);
-
-        // force delimiter to timeout.
-        delimiter.start = Date.now() - (DELIMITER_TIMEOUT_MS + 1);
-
-        // filter the third orphan delete marker
-        const masterKey3 = 'key3';
-        const versionId3 = 'version3';
-        const versionKey3 = `${masterKey3}${VID_SEP}${versionId3}`;
-        const date3 = '1970-01-01T00:00:00.000Z';
-        const value3 = `{"versionId":"${versionId3}","last-modified":"${date3}","isDeleteMarker":true}`;
-
-        assert.strictEqual(delimiter.filter({
-            key: makeV1Key(versionKey3),
-            value: value3,
-        }), FILTER_END);
-
-        const expectedResult = {
-            Contents: [],
-            NextMarker: masterKey2,
-            IsTruncated: true,
-        };
-
-        assert.deepStrictEqual(delimiter.result(), expectedResult);
+['v0', 'v1'].forEach(v => {
+    describe(`DelimiterOrphanDeleteMarker with ${v} bucket format`, () => {
+        it('should return expected metadata parameters', () => {
+            const prefix = 'pre';
+            const marker = 'premark';
+            const delimiter = new DelimiterOrphanDeleteMarker({
+                prefix,
+                marker,
+            }, fakeLogger, v);
+
+            let expectedParams;
+            if (v === 'v0') {
+                expectedParams = { gt: `premark${inc(VID_SEP)}`, lt: 'prf' };
+            } else {
+                expectedParams = [
+                    {
+                        gt: `${DbPrefixes.Master}premark${inc(VID_SEP)}`,
+                        lt: `${DbPrefixes.Master}prf`,
+                    },
+                    {
+                        gt: `${DbPrefixes.Version}premark${inc(VID_SEP)}`,
+                        lt: `${DbPrefixes.Version}prf`,
+                    },
+                ];
+            }
+            assert.deepStrictEqual(delimiter.genMDParams(), expectedParams);
+            assert(delimiter.start);
+        });
+        it('should accept entry starting with prefix', () => {
+            const delimiter = new DelimiterOrphanDeleteMarker({ prefix: 'prefix' }, fakeLogger, v);
+
+            const listingKey = getListingKey('prefix1', v);
+            assert.strictEqual(delimiter.filter({ key: listingKey, value: '' }), FILTER_ACCEPT);
+
+            assert.deepStrictEqual(delimiter.result(), EmptyResult);
+        });
+
+        it('should accept a version and return an empty content', () => {
+            const delimiter = new DelimiterOrphanDeleteMarker({ }, fakeLogger, v);
+
+            const masterKey = 'key';
+
+            const versionId1 = 'version1';
+            const versionKey1 = `${masterKey}${VID_SEP}${versionId1}`;
+            const date1 = '1970-01-01T00:00:00.001Z';
+            const value1 = `{"versionId":"${versionId1}","last-modified":"${date1}"}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey1, v),
+                value: value1,
+            }), FILTER_ACCEPT);
+
+            assert.deepStrictEqual(delimiter.result(), EmptyResult);
+        });
+
+        it('should accept an orphan delete marker and return it from the content', () => {
+            const delimiter = new DelimiterOrphanDeleteMarker({ }, fakeLogger, v);
+
+            const masterKey = 'key';
+
+            const versionId1 = 'version1';
+            const versionKey1 = `${masterKey}${VID_SEP}${versionId1}`;
+            const date1 = '1970-01-01T00:00:00.001Z';
+            const value1 = `{"versionId":"${versionId1}","last-modified":"${date1}","isDeleteMarker":true}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey1, v),
+                value: value1,
+            }), FILTER_ACCEPT);
+
+            const expectedResult = {
+                Contents: [
+                    {
+                        key: masterKey,
+                        value: value1,
+                    },
+                ],
+                IsTruncated: false,
+            };
+
+            assert.deepStrictEqual(delimiter.result(), expectedResult);
+        });
+
+        it('should accept two orphan delete markers and return them from the content', () => {
+            const delimiter = new DelimiterOrphanDeleteMarker({ }, fakeLogger, v);
+
+            // filter the first orphan delete marker
+            const masterKey1 = 'key1';
+            const versionId1 = 'version1';
+            const versionKey1 = `${masterKey1}${VID_SEP}${versionId1}`;
+            const date1 = '1970-01-01T00:00:00.002Z';
+            const value1 = `{"versionId":"${versionId1}","last-modified":"${date1}","isDeleteMarker":true}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey1, v),
+                value: value1,
+            }), FILTER_ACCEPT);
+
+            // filter the second orphan delete marker
+            const masterKey2 = 'key2';
+            const versionId2 = 'version2';
+            const versionKey2 = `${masterKey2}${VID_SEP}${versionId2}`;
+            const date2 = '1970-01-01T00:00:00.001Z';
+            const value2 = `{"versionId":"${versionId2}","last-modified":"${date2}","isDeleteMarker":true}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey2, v),
+                value: value2,
+            }), FILTER_ACCEPT);
+
+            const expectedResult = {
+                Contents: [
+                    {
+                        key: masterKey1,
+                        value: value1,
+                    },
+                    {
+                        key: masterKey2,
+                        value: value2,
+                    },
+                ],
+                IsTruncated: false,
+            };
+
+            assert.deepStrictEqual(delimiter.result(), expectedResult);
+        });
+
+        it('should accept two orphan delete markers and return truncated content with one', () => {
+            const delimiter = new DelimiterOrphanDeleteMarker({ maxKeys: 1 }, fakeLogger, v);
+
+            // filter the first orphan delete marker
+            const masterKey1 = 'key1';
+            const versionId1 = 'version1';
+            const versionKey1 = `${masterKey1}${VID_SEP}${versionId1}`;
+            const date1 = '1970-01-01T00:00:00.002Z';
+            const value1 = `{"versionId":"${versionId1}","last-modified":"${date1}","isDeleteMarker":true}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey1, v),
+                value: value1,
+            }), FILTER_ACCEPT);
+
+            // filter the second orphan delete marker
+            const masterKey2 = 'key2';
+            const versionId2 = 'version2';
+            const versionKey2 = `${masterKey2}${VID_SEP}${versionId2}`;
+            const date2 = '1970-01-01T00:00:00.001Z';
+            const value2 = `{"versionId":"${versionId2}","last-modified":"${date2}","isDeleteMarker":true}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey2, v),
+                value: value2,
+            }), FILTER_ACCEPT);
+
+            const expectedResult = {
+                Contents: [
+                    {
+                        key: masterKey1,
+                        value: value1,
+                    },
+                ],
+                NextMarker: masterKey1,
+                IsTruncated: true,
+            };
+
+            assert.deepStrictEqual(delimiter.result(), expectedResult);
+        });
+
+        it('should accept two orphan delete markers and return the one created before the beforeDate', () => {
+            const date1 = '1970-01-01T00:00:00.002Z';
+            const delimiter = new DelimiterOrphanDeleteMarker({ beforeDate: date1 }, fakeLogger, v);
+
+            // filter the first orphan delete marker
+            const masterKey1 = 'key1';
+            const versionId1 = 'version1';
+            const versionKey1 = `${masterKey1}${VID_SEP}${versionId1}`;
+            const value1 = `{"versionId":"${versionId1}","last-modified":"${date1}","isDeleteMarker":true}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey1, v),
+                value: value1,
+            }), FILTER_ACCEPT);
+
+            // filter the second orphan delete marker
+            const masterKey2 = 'key2';
+            const versionId2 = 'version2';
+            const versionKey2 = `${masterKey2}${VID_SEP}${versionId2}`;
+            const date2 = '1970-01-01T00:00:00.001Z';
+            const value2 = `{"versionId":"${versionId2}","last-modified":"${date2}","isDeleteMarker":true}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey2, v),
+                value: value2,
+            }), FILTER_ACCEPT);
+
+            const expectedResult = {
+                Contents: [
+                    {
+                        key: masterKey2,
+                        value: value2,
+                    },
+                ],
+                IsTruncated: false,
+            };
+
+            assert.deepStrictEqual(delimiter.result(), expectedResult);
+        });
+
+        it('should end filtering if max keys reached', () => {
+            const delimiter = new DelimiterOrphanDeleteMarker({ maxKeys: 1 }, fakeLogger, v);
+
+            // filter the first orphan delete marker
+            const masterKey1 = 'key1';
+            const versionId1 = 'version1';
+            const versionKey1 = `${masterKey1}${VID_SEP}${versionId1}`;
+            const date1 = '1970-01-01T00:00:00.002Z';
+            const value1 = `{"versionId":"${versionId1}","last-modified":"${date1}","isDeleteMarker":true}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey1, v),
+                value: value1,
+            }), FILTER_ACCEPT);
+
+            // filter the second orphan delete marker
+            const masterKey2 = 'key2';
+            const versionId2 = 'version2';
+            const versionKey2 = `${masterKey2}${VID_SEP}${versionId2}`;
+            const date2 = '1970-01-01T00:00:00.001Z';
+            const value2 = `{"versionId":"${versionId2}","last-modified":"${date2}","isDeleteMarker":true}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey2, v),
+                value: value2,
+            }), FILTER_ACCEPT);
+
+            // filter the third orphan delete marker
+            const masterKey3 = 'key3';
+            const versionId3 = 'version3';
+            const versionKey3 = `${masterKey3}${VID_SEP}${versionId3}`;
+            const date3 = '1970-01-01T00:00:00.000Z';
+            const value3 = `{"versionId":"${versionId3}","last-modified":"${date3}","isDeleteMarker":true}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey3, v),
+                value: value3,
+            }), FILTER_END);
+
+            const expectedResult = {
+                Contents: [
+                    {
+                        key: masterKey1,
+                        value: value1,
+                    },
+                ],
+                NextMarker: masterKey1,
+                IsTruncated: true,
+            };
+
+            assert.deepStrictEqual(delimiter.result(), expectedResult);
+        });
+
+        it('should end filtering if delimiter timeout', () => {
+            const delimiter = new DelimiterOrphanDeleteMarker({ }, fakeLogger, v);
+
+            // filter the first orphan delete marker
+            const masterKey1 = 'key1';
+            const versionId1 = 'version1';
+            const versionKey1 = `${masterKey1}${VID_SEP}${versionId1}`;
+            const date1 = '1970-01-01T00:00:00.002Z';
+            const value1 = `{"versionId":"${versionId1}","last-modified":"${date1}","isDeleteMarker":true}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey1, v),
+                value: value1,
+            }), FILTER_ACCEPT);
+
+            // force delimiter to timeout.
+            delimiter.start = Date.now() - (DELIMITER_TIMEOUT_MS + 1);
+
+            // filter the second orphan delete marker
+            const masterKey2 = 'key2';
+            const versionId2 = 'version2';
+            const versionKey2 = `${masterKey2}${VID_SEP}${versionId2}`;
+            const date2 = '1970-01-01T00:00:00.001Z';
+            const value2 = `{"versionId":"${versionId2}","last-modified":"${date2}","isDeleteMarker":true}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey2, v),
+                value: value2,
+            }), FILTER_END);
+
+            const expectedResult = {
+                Contents: [
+                    {
+                        key: masterKey1,
+                        value: value1,
+                    },
+                ],
+                NextMarker: masterKey1,
+                IsTruncated: true,
+            };
+
+            assert.deepStrictEqual(delimiter.result(), expectedResult);
+        });
+
+        it('should end filtering if delimiter timeout with empty content', () => {
+            const delimiter = new DelimiterOrphanDeleteMarker({ }, fakeLogger, v);
+
+            const masterKey1 = 'key1';
+            const versionId1 = 'version1';
+            const versionKey1 = `${masterKey1}${VID_SEP}${versionId1}`;
+            const date1 = '1970-01-01T00:00:00.002Z';
+            const value1 = `{"versionId":"${versionId1}","last-modified":"${date1}"}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey1, v),
+                value: value1,
+            }), FILTER_ACCEPT);
+
+            const masterKey2 = 'key2';
+            const versionId2 = 'version2';
+            const versionKey2 = `${masterKey2}${VID_SEP}${versionId2}`;
+            const date2 = '1970-01-01T00:00:00.001Z';
+            const value2 = `{"versionId":"${versionId2}","last-modified":"${date2}"}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey2, v),
+                value: value2,
+            }), FILTER_ACCEPT);
+
+            // force delimiter to timeout.
+            delimiter.start = Date.now() - (DELIMITER_TIMEOUT_MS + 1);
+
+            // filter the third orphan delete marker
+            const masterKey3 = 'key3';
+            const versionId3 = 'version3';
+            const versionKey3 = `${masterKey3}${VID_SEP}${versionId3}`;
+            const date3 = '1970-01-01T00:00:00.000Z';
+            const value3 = `{"versionId":"${versionId3}","last-modified":"${date3}","isDeleteMarker":true}`;
+
+            assert.strictEqual(delimiter.filter({
+                key: getListingKey(versionKey3, v),
+                value: value3,
+            }), FILTER_END);
+
+            const expectedResult = {
+                Contents: [],
+                NextMarker: masterKey2,
+                IsTruncated: true,
+            };
+
+            assert.deepStrictEqual(delimiter.result(), expectedResult);
+        });
     });
 });


### PR DESCRIPTION
This PR includes the following changes:

- The `evaluatedKeys` have been renamed to `scannedKeys`.
- The implementation, now, leverages `DelimiterVersions` to provide an accurate list of objects.
- The test has been updated to run on V0 and V1 bucket formats.