### PR TITLE
ARSN-359 Fix NextMarker calculation in listLifecycleCurrent 

### DIFF
--- a/lib/algos/list/delimiterCurrent.ts
+++ b/lib/algos/list/delimiterCurrent.ts
@@ -76,6 +76,10 @@ class DelimiterCurrent extends DelimiterMaster {
     }
 
     addContents(key, value) {
+        if (this._reachedMaxKeys()) {
+            return FILTER_END;
+        }
+
         if (this.start && Date.now() - this.start > DELIMITER_TIMEOUT_MS) {
             this.IsTruncated = true;
             this.logger.info('listing stopped after expected internal timeout',

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.70.8",
+  "version": "7.70.9",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {


### PR DESCRIPTION
Please note that there are no missing entries in the listing and no extra resource used since the next listing will do the fetching anyway. The issue lies in how we determine the NextMarker. It has to be compatible with the current logic merged in Artesca.

When using the listLifecycleCurrent function, we need to calculate the NextMarker correctly. Currently, if the maximum number of keys (max-keys) is reached, the function continues fetching more entries, which is unnecessary and should be done by the next listing. This is because the `_reachedMaxKeys` logic is set after the "filter" logic.

For instance, if max-keys is set to 1 and the first entry (key0) is eligible, while the following two entries (key1 and key2) are not eligible, but the fourth entry (key3) is eligible, the listing should stop at key0 and the NextMarker should be key0 instead the listing keep fetching until key3 and return the NextMarker key2.