### PR TITLE
bf(ARSN-361): Handle infinite versionID correctly on version specific PUT for file MD backend

### DIFF
--- a/lib/versioning/VersioningRequestProcessor.ts
+++ b/lib/versioning/VersioningRequestProcessor.ts
@@ -1,6 +1,6 @@
 import errors, { ArsenalError } from '../errors';
 import { Version } from './Version';
-import { generateVersionId as genVID } from './VersionID';
+import { generateVersionId as genVID, getInfVid } from './VersionID';
 import WriteCache from './WriteCache';
 import WriteGatheringManager from './WriteGatheringManager';
 
@@ -381,10 +381,13 @@ export default class VersioningRequestProcessor {
             const versionKey = formatVersionKey(request.key, versionId);
             const ops = [{ key: versionKey, value: request.value }];
             if (data === undefined ||
-                (Version.from(data).getVersionId() ?? '') >= versionId) {
+                (Version.from(data).getVersionId() ?? '') >= versionId ||
+                (versionId === getInfVid(this.replicationGroupId) && !Version.from(data).getVersionId())) {
                 // master does not exist or is not newer than put
                 // version and needs to be updated as well.
                 // Note that older versions have a greater version ID.
+                // If an infinite version ID is used and the master does not have a versionId,
+                // then the master is updated.
                 ops.push({ key: request.key, value: request.value });
             }
             return callback(null, ops, versionId);

--- a/tests/unit/versioning/VersioningRequestProcessor.spec.js
+++ b/tests/unit/versioning/VersioningRequestProcessor.spec.js
@@ -222,9 +222,6 @@ describe('test VSP', () => {
     });
 
     it('should update master if a infinite versionId is passed and the master does not have a versionId', done => {
-        let v1;
-        let v2;
-
         async.waterfall([next => {
             const request = {
                 db: 'foo',


### PR DESCRIPTION
When passing the infinite versionId (`0099999999999999999999RG001`) the file backend fails to update the master key if the the infinite version is also the latest version.