### PR TITLE
ARSN-366 Limit lifecycle listing on scanned entries

### DIFF
--- a/lib/algos/list/delimiterNonCurrent.js
+++ b/lib/algos/list/delimiterNonCurrent.js
@@ -1,8 +1,6 @@
 const { DelimiterVersions } = require('./delimiterVersions');
 const { FILTER_END, FILTER_SKIP } = require('./tools');
 
-// TODO: find an acceptable timeout value.
-const DELIMITER_TIMEOUT_MS = 10 * 1000; // 10s
 const TRIM_METADATA_MIN_BLOB_SIZE = 10000;
 
 /**
@@ -17,7 +15,8 @@ class DelimiterNonCurrent extends DelimiterVersions {
      * @param {String}  parameters.versionIdMarker  - version id marker
      * @param {String}  parameters.beforeDate       - limit the response to keys with stale date older than beforeDate.
      * “stale date” is the date on when a version becomes non-current.
-     *  @param {String} parameters.excludedDataStoreName - exclude dataStoreName matches from the versions
+     * @param {Number} parameters.maxScannedLifecycleListingEntries - max number of entries to be scanned
+     * @param {String} parameters.excludedDataStoreName - exclude dataStoreName matches from the versions
      * @param {RequestLogger} logger                - The logger of the request
      * @param {String} [vFormat]                    - versioning key format
      */
@@ -26,20 +25,13 @@ class DelimiterNonCurrent extends DelimiterVersions {
 
         this.beforeDate = parameters.beforeDate;
         this.excludedDataStoreName = parameters.excludedDataStoreName;
+        this.maxScannedLifecycleListingEntries = parameters.maxScannedLifecycleListingEntries;
 
         // internal state
         this.prevKey = null;
         this.staleDate = null;
 
-        // used for monitoring
         this.scannedKeys = 0;
-    }
-
-    genMDParamsV0() {
-        // The genMDParamsV1() function calls genMDParamsV0()in the DelimiterVersions class,
-        // making sure that this.start is set for both v0 and v1 bucket formats
-        this.start = Date.now();
-        return super.genMDParamsV0();
     }
 
     getLastModified(value) {
@@ -78,11 +70,11 @@ class DelimiterNonCurrent extends DelimiterVersions {
     }
 
     filter(obj) {
-        if (this.start && Date.now() - this.start > DELIMITER_TIMEOUT_MS) {
+        if (this.maxScannedLifecycleListingEntries && this.scannedKeys >= this.maxScannedLifecycleListingEntries) {
             this.IsTruncated = true;
-            this.logger.info('listing stopped after expected internal timeout',
+            this.logger.info('listing stopped due to reaching the maximum scanned entries limit',
                 {
-                    timeoutMs: DELIMITER_TIMEOUT_MS,
+                    maxScannedLifecycleListingEntries: this.maxScannedLifecycleListingEntries,
                     scannedKeys: this.scannedKeys,
                 });
             return FILTER_END;

--- a/lib/algos/list/delimiterOrphanDeleteMarker.js
+++ b/lib/algos/list/delimiterOrphanDeleteMarker.js
@@ -1,6 +1,5 @@
 const DelimiterVersions = require('./delimiterVersions').DelimiterVersions;
 const { FILTER_END } = require('./tools');
-const DELIMITER_TIMEOUT_MS = 10 * 1000; // 10s
 const TRIM_METADATA_MIN_BLOB_SIZE = 10000;
 /**
  * Handle object listing with parameters. This extends the base class DelimiterVersions
@@ -13,6 +12,7 @@ class DelimiterOrphanDeleteMarker extends DelimiterVersions {
      * Delimiter listing of orphan delete markers.
      * @param {Object}  parameters            - listing parameters
      * @param {String}  parameters.beforeDate - limit the response to keys older than beforeDate
+     * @param {Number} parameters.maxScannedLifecycleListingEntries - max number of entries to be scanned
      * @param {RequestLogger} logger          - The logger of the request
      * @param {String} [vFormat]              - versioning key format
      */
@@ -22,6 +22,7 @@ class DelimiterOrphanDeleteMarker extends DelimiterVersions {
             maxKeys,
             prefix,
             beforeDate,
+            maxScannedLifecycleListingEntries,
         } = parameters;
 
         const versionParams = {
@@ -33,18 +34,11 @@ class DelimiterOrphanDeleteMarker extends DelimiterVersions {
         };
         super(versionParams, logger, vFormat);
 
+        this.maxScannedLifecycleListingEntries = maxScannedLifecycleListingEntries;
         this.beforeDate = beforeDate;
         this.keyName = null;
         this.value = null;
-        // used for monitoring
         this.scannedKeys = 0;
-    }
-
-    genMDParamsV0() {
-        // The genMDParamsV1() function calls genMDParamsV0() in the DelimiterVersions class,
-        // making sure that this.start is set for both v0 and v1 bucket formats
-        this.start = Date.now();
-        return super.genMDParamsV0();
     }
 
     _reachedMaxKeys() {
@@ -106,14 +100,23 @@ class DelimiterOrphanDeleteMarker extends DelimiterVersions {
         }
         return s;
     }
+    /**
+     * The purpose of _isMaxScannedEntriesReached is to restrict the number of scanned entries,
+     * thus controlling resource overhead (CPU...).
+     * @return {boolean} isMaxScannedEntriesReached - true if the maximum limit on the number
+     * of entries scanned has been reached, false otherwise.
+    */
+    _isMaxScannedEntriesReached() {
+        return this.maxScannedLifecycleListingEntries && this.scannedKeys >= this.maxScannedLifecycleListingEntries;
+    }
 
     filter(obj) {
-        if (this.start && Date.now() - this.start > DELIMITER_TIMEOUT_MS) {
+        if (this._isMaxScannedEntriesReached()) {
             this.nextKeyMarker = this.keyName;
             this.IsTruncated = true;
-            this.logger.info('listing stopped after expected internal timeout',
+            this.logger.info('listing stopped due to reaching the maximum scanned entries limit',
                 {
-                    timeoutMs: DELIMITER_TIMEOUT_MS,
+                    maxScannedLifecycleListingEntries: this.maxScannedLifecycleListingEntries,
                     scannedKeys: this.scannedKeys,
                 });
             return FILTER_END;
@@ -159,16 +162,20 @@ class DelimiterOrphanDeleteMarker extends DelimiterVersions {
     }
 
     result() {
-        // The following check makes sure the last orphan delete marker is not forgotten.
-        if (this.keys < this.maxKeys) {
-            if (this.value) {
-                this._addOrphan();
+        // Only check for remaining last orphan delete marker if the listing is not interrupted.
+        // This will help avoid false positives.
+        if (!this._isMaxScannedEntriesReached()) {
+            // The following check makes sure the last orphan delete marker is not forgotten.
+            if (this.keys < this.maxKeys) {
+                if (this.value) {
+                    this._addOrphan();
+                }
+            // The following make sure that if makeKeys is reached, isTruncated is set to true.
+            // We moved the "isTruncated" from _reachedMaxKeys to make sure we take into account the last entity
+            // if listing is truncated right before the last entity and the last entity is a orphan delete marker.
+            } else {
+                this.IsTruncated = this.maxKeys > 0;
             }
-        // The following make sure that if makeKeys is reached, isTruncated is set to true.
-        // We moved the "isTruncated" from _reachedMaxKeys to make sure we take into account the last entity
-        // if listing is truncated right before the last entity and the last entity is a orphan delete marker.
-        } else {
-            this.IsTruncated = this.maxKeys > 0;
         }
 
         const result = {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.70.10",
+  "version": "7.70.11",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {


### PR DESCRIPTION
Implement the "New Limit on Scanned Entries Approach" for metadata filtering to improve response time and resource management.

**Description:**
Metadata filtering process might experience delays, impacting response times and server resources. To address this issue, we propose implementing the "New Limit on Scanned Entries Approach". 
It was currently implemented as an "Internal Timeout Approach": cf https://scality.atlassian.net/browse/S3C-7928

**Approach:**
The "New Limit on Scanned Entries Approach" involves setting a maximum number of entries to scan and filter before responding with up to 1000 entries. This approach aims to provide more predictable resource usage while potentially delivering more comprehensive results.

**Benefits:**
- Predictable resource usage.
- Potential for more comprehensive results.