### PR TITLE
ARSN-369 orphan delete marker list interruption skips processed key

### DIFF
--- a/lib/algos/list/delimiterOrphanDeleteMarker.js
+++ b/lib/algos/list/delimiterOrphanDeleteMarker.js
@@ -36,6 +36,12 @@ class DelimiterOrphanDeleteMarker extends DelimiterVersions {
 
         this.maxScannedLifecycleListingEntries = maxScannedLifecycleListingEntries;
         this.beforeDate = beforeDate;
+        // this.prevKeyName is used as a marker for the next listing when the current one reaches its entry limit.
+        // We cannot rely on this.keyName, as it contains the name of the current key.
+        // In the event of a listing interruption due to reaching the maximum scanned entries,
+        // relying on this.keyName would cause the next listing to skip the current key because S3 starts
+        // listing after the marker.
+        this.prevKeyName = null;
         this.keyName = null;
         this.value = null;
         this.scannedKeys = 0;
@@ -112,7 +118,7 @@ class DelimiterOrphanDeleteMarker extends DelimiterVersions {
 
     filter(obj) {
         if (this._isMaxScannedEntriesReached()) {
-            this.nextKeyMarker = this.keyName;
+            this.nextKeyMarker = this.prevKeyName;
             this.IsTruncated = true;
             this.logger.info('listing stopped due to reaching the maximum scanned entries limit',
                 {
@@ -149,12 +155,16 @@ class DelimiterOrphanDeleteMarker extends DelimiterVersions {
             if (this.value) {
                 this._addOrphan();
             }
+            this.prevKeyName = this.keyName;
             this.keyName = key;
             this.value = value;
 
             return;
         }
 
+        // If the key is not the current version, we can skip it in the next listing
+        // in the case where the current listing is interrupted due to reaching the maximum scanned entries.
+        this.prevKeyName = key;
         this.keyName = key;
         this.value = null;
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.70.11",
+  "version": "7.70.12",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {


### PR DESCRIPTION
In the event of a listing interruption due to reaching the maximum scanned entries, the next “orphan delete marker“ listing skips the currently processed key.