### PR TITLE
Improvement/arsn 362 implicit deny

### DIFF
--- a/lib/policyEvaluator/evaluator.ts
+++ b/lib/policyEvaluator/evaluator.ts
@@ -310,7 +310,7 @@ export function evaluatePolicy(
 }
 
 /**
- * @deprecated Upgrade to evaluateAllPoliciesNew
+ * @deprecated Upgrade to standardEvaluateAllPolicies
  * Evaluate whether a request is permitted under a policy.
  * @param requestContext - Info necessary to
  * evaluate permission
@@ -326,9 +326,9 @@ export function evaluateAllPolicies(
     allPolicies: any[],
     log: Logger,
 ): string {
-    return evaluateAllPoliciesNew(requestContext, allPolicies, log).verdict;
+    return standardEvaluateAllPolicies(requestContext, allPolicies, log).verdict;
 }
-export function evaluateAllPoliciesNew(
+export function standardEvaluateAllPolicies(
     requestContext: RequestContext,
     allPolicies: any[],
     log: Logger,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.10.48",
+  "version": "7.10.49",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/policyEvaluator.spec.js
+++ b/tests/unit/policyEvaluator.spec.js
@@ -6,7 +6,7 @@ const fakeTimers = require('@sinonjs/fake-timers');
 const evaluator = require('../../lib/policyEvaluator/evaluator');
 const evaluatePolicy = evaluator.evaluatePolicy;
 const evaluateAllPolicies = evaluator.evaluateAllPolicies;
-const evaluateAllPoliciesNew = evaluator.evaluateAllPoliciesNew;
+const standardEvaluateAllPolicies = evaluator.standardEvaluateAllPolicies;
 const handleWildcards =
     require('../../lib/policyEvaluator/utils/wildcards').handleWildcards;
 const substituteVariables =
@@ -1457,7 +1457,7 @@ describe('policyEvaluator', () => {
                 'my_favorite_bucket', undefined,
                 undefined, undefined, 'bucketDelete', 's3');
             requestContext.setRequesterInfo({});
-            const result = evaluateAllPoliciesNew(requestContext,
+            const result = standardEvaluateAllPolicies(requestContext,
                 [samples['arn:aws:iam::aws:policy/AmazonS3FullAccess'],
                     samples['Deny Bucket Policy']], log);
             assert.deepStrictEqual(result, {
@@ -1471,7 +1471,7 @@ describe('policyEvaluator', () => {
                 'notVeryPrivate', undefined,
                 undefined, undefined, 'bucketDelete', 's3');
             requestContext.setRequesterInfo({});
-            const result = evaluateAllPoliciesNew(requestContext,
+            const result = standardEvaluateAllPolicies(requestContext,
                 [samples['Multi-Statement Policy'],
                     samples['Variable Bucket Policy']], log);
             assert.deepStrictEqual(result, {
@@ -1485,7 +1485,7 @@ describe('policyEvaluator', () => {
                 'notbucket', undefined,
                 undefined, undefined, 'objectGet', 's3');
             requestContext.setRequesterInfo({});
-            const result = evaluateAllPoliciesNew(requestContext, [
+            const result = standardEvaluateAllPolicies(requestContext, [
                 samples['Multi-Statement Policy'],
                 samples['Variable Bucket Policy'],
             ], log);
@@ -1670,7 +1670,7 @@ describe('policyEvaluator', () => {
                     'my_favorite_bucket', undefined,
                     undefined, undefined, 'objectGet', 's3');
                 requestContext.setRequesterInfo({});
-                const result = evaluateAllPoliciesNew(
+                const result = standardEvaluateAllPolicies(
                     requestContext,
                     testCase.policiesToEvaluate.map(policyName => TestMatrixPolicies[policyName]),
                     log);


### PR DESCRIPTION
Opened after closed PR [here](https://github.com/scality/Arsenal/pull/2164)

Adds ImplicitDeny logic to policy checks, where an ImplicitDeny will be sent back in case no policy validates an action, but does not explicitly Deny it either, allowing for bucket policies and other authorization mechanisms to grant permission.

Part of the bucket policy redo epic: https://scality.atlassian.net/jira/software/c/projects/OS/boards/214?selectedIssue=S3C-7756

Green build in Vault and CS:
https://github.com/scality/Vault/actions/runs/6694175632/job/18186886853?pr=2135
https://github.com/scality/cloudserver/actions/runs/6693681174/job/18185346914?pr=5322

*Would appreciate reviews on Integration branches as well* 
*Arsenal version has been bumped lastly*