### PR TITLE
objectMD: add transitionTime when starting a transition

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,8 +25,8 @@ jobs:
           - 6379:6379
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+      uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
         node-version: '16'
         cache: 'yarn'
@@ -46,7 +46,7 @@ jobs:
       run: yarn --silent coverage
     - name: run functional tests
       run: yarn ft_test
-    - uses: codecov/codecov-action@v2
+    - uses: codecov/codecov-action@v3
     - name: run executables tests
       run: yarn install && yarn test
       working-directory: 'lib/executables/pensieveCreds/'
@@ -57,9 +57,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install NodeJS
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: '16'
         cache: yarn
@@ -70,7 +70,7 @@ jobs:
       run: yarn build
       continue-on-error: true # TODO ARSN-97 Remove it when no errors in TS
     - name: Upload artifacts
-      uses: scality/action-artifacts@v2
+      uses: scality/action-artifacts@v3
       with:
         url: https://artifacts.scality.net
         user: ${{ secrets.ARTIFACTS_USER }}

--- a/lib/models/ObjectMD.ts
+++ b/lib/models/ObjectMD.ts
@@ -58,6 +58,7 @@ export type ObjectMDData = {
     'x-amz-server-side-encryption-customer-algorithm': string;
     'x-amz-website-redirect-location': string;
     'x-amz-scal-transition-in-progress'?: boolean;
+    'x-amz-scal-transition-time'?: string;
     azureInfo?: any;
     acl: ACL;
     key: string;
@@ -649,10 +650,24 @@ export default class ObjectMD {
      * Set metadata transition in progress value
      *
      * @param inProgress - True if transition is in progress, false otherwise
+     * @param transitionTime - Date when the transition started
      * @return itself
      */
-    setTransitionInProgress(inProgress: boolean) {
+    setTransitionInProgress(inProgress: false): this
+    setTransitionInProgress(inProgress: true, transitionTime: Date|string|number): this
+    setTransitionInProgress(inProgress: boolean, transitionTime?: Date|string|number) {
         this._data['x-amz-scal-transition-in-progress'] = inProgress;
+        if (!inProgress || !transitionTime) {
+            delete this._data['x-amz-scal-transition-time'];
+        } else {
+            if (typeof transitionTime === 'number') {
+                transitionTime = new Date(transitionTime);
+            }
+            if (transitionTime instanceof Date) {
+                transitionTime = transitionTime.toISOString();
+            }
+            this._data['x-amz-scal-transition-time'] = transitionTime;
+        }
         return this;
     }
 
@@ -663,6 +678,14 @@ export default class ObjectMD {
      */
     getTransitionInProgress() {
         return this._data['x-amz-scal-transition-in-progress'];
+    }
+
+    /**
+     * Gets the transition time of the object.
+     * @returns The transition time of the object.
+     */
+    getTransitionTime() {
+        return this._data['x-amz-scal-transition-time'];
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "8.1.114",
+  "version": "8.1.115",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/models/ObjectMD.spec.js
+++ b/tests/unit/models/ObjectMD.spec.js
@@ -355,6 +355,33 @@ describe('ObjectMD class setters/getters', () => {
         md.setArchive();
         assert.deepStrictEqual(md.getArchive(), undefined);
     });
+
+    it('ObjectMD::setTransitionInProgress(true) should set time from string', () => {
+        const time = new Date().toISOString();
+        md.setTransitionInProgress(true, time);
+        assert.deepStrictEqual(md.getTransitionInProgress(), true);
+        assert.deepStrictEqual(md.getTransitionTime(), time);
+    });
+
+    it('ObjectMD::setTransitionInProgress(true) should set time from Date', () => {
+        const time = new Date();
+        md.setTransitionInProgress(true, time);
+        assert.deepStrictEqual(md.getTransitionInProgress(), true);
+        assert.deepStrictEqual(md.getTransitionTime(), time.toISOString());
+    });
+
+    it('ObjectMD::setTransitionInProgress(true) should set time from timestamp', () => {
+        const time = new Date();
+        md.setTransitionInProgress(true, time.getTime());
+        assert.deepStrictEqual(md.getTransitionInProgress(), true);
+        assert.deepStrictEqual(md.getTransitionTime(), time.toISOString());
+    });
+
+    it('ObjectMD::setTransitionInProgress(false) should clear the time', () => {
+        md.setTransitionInProgress(false);
+        assert.deepStrictEqual(md.getTransitionInProgress(), false);
+        assert.deepStrictEqual(md.getTransitionTime(), undefined);
+    });
 });
 
 describe('ObjectMD import from stored blob', () => {


### PR DESCRIPTION
Store transition time when marking the object as ‘transition in progress’.
This is needed to compute lifecycle lateness & duration metrics.

Issue: ARSN-374
