### PR TITLE
Improvement/arsn 375 chain backend imp deny

### DIFF
--- a/lib/auth/backends/ChainBackend.ts
+++ b/lib/auth/backends/ChainBackend.ts
@@ -151,7 +151,15 @@ export default class ChainBackend extends BaseBackend {
         });
 
         return Object.keys(policyMap).map(key => {
-            const policyRes: any = { isAllowed: policyMap[key].isAllowed };
+            const policyRes: any = {
+                isAllowed: policyMap[key].isAllowed,
+            };
+            if (policyMap[key].action) {
+                policyRes.action = policyMap[key].action;
+            }
+            if (typeof policyMap[key].isImplicit === 'boolean') {
+                policyRes.isImplicit = policyMap[key].isImplicit;
+            }
             if (policyMap[key].arn !== '') {
                 policyRes.arn = policyMap[key].arn;
             }


### PR DESCRIPTION
Adding new implicitDeny logic to ChainBackend returns.

PLEASE NOTE:
I do not know what the initial requirement/intended functionality of this class is.
Thus, I am unsure of the expected 'isImplicit' result of the policy merging functionality in this interface.
What I can discern from the code is this:
- The ChainBackend `checkPolicies` method is called. It returns an array of the authorisation results of the request for each client in the ChainBackend (by calling the checkPolicies functions of these clients).
- Each element of the array is an array of the authorisation results from the different policies for a client.
- Currently, if there is a duplicate policy (of the same ARN), the one that has `isAllowed === true` takes priority. I would've thought it would make sense to have Deny take priority here. This means I would change [this](https://github.com/scality/Arsenal/pull/2187/files#diff-90af4210fb2769622a7b74669bc2ecc07df9e49b8e18adafbd1050aa8dcf79d1R138) line in the `_mergePolicies` method:
```
                if (!policyMap[key] || !policyMap[key].isAllowed) {
```
to this
```
                if (!policyMap[key] || !policy.isAllowed) {
```

However, the tests expect the current behaviour. Why? 
What would be the expected behaviour from this for the `isImplicit` variable?
Who would have this context? The code was initially created by Alex Chan after report by @rachedbenmustapha 
Thanks for any feedback