### PR TITLE
ARSN-376 Probe response logic should be handled in the handler

### DIFF
--- a/lib/network/probe/ProbeServer.ts
+++ b/lib/network/probe/ProbeServer.ts
@@ -90,12 +90,6 @@ export class ProbeServer extends httpServer {
             return;
         }
 
-        const probeResponse = this._handlers.get(req.url!)!(res, log);
-        if (probeResponse !== undefined && probeResponse !== '') {
-            // Return an internal error with the response
-            errors.InternalError
-                .customizeDescription(probeResponse)
-                .writeResponse(res);
-        }
+        this._handlers.get(req.url!)!(res, log);
     }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.10.46",
+  "version": "7.10.46-1",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/network/probe/ProbeServer.spec.js
+++ b/tests/unit/network/probe/ProbeServer.spec.js
@@ -89,16 +89,34 @@ describe('network.probe.ProbeServer', () => {
     });
 
     it('500 response on bad probe', done => {
-        server.addHandler('/check', () => 'check failed');
+        const failedMessage = 'failed_message';
+        server.addHandler('/check', res => {
+            res.writeHead(500);
+            res.end(failedMessage);
+        });
         makeRequest('GET', '/check', (err, res) => {
             assert.ifError(err);
             assert.strictEqual(res.statusCode, 500);
             res.setEncoding('utf8');
             res.on('data', body => {
-                assert.strictEqual(
-                    body,
-                    '{"errorType":"InternalError","errorMessage":"check failed"}',
-                );
+                assert.strictEqual(body, failedMessage);
+                done();
+            });
+        });
+    });
+
+    it('500 response on bad async probe', done => {
+        const failedMessage = 'failed_message';
+        server.addHandler('/check', async res => {
+            res.writeHead(500);
+            res.end(failedMessage);
+        });
+        makeRequest('GET', '/check', (err, res) => {
+            assert.ifError(err);
+            assert.strictEqual(res.statusCode, 500);
+            res.setEncoding('utf8');
+            res.on('data', body => {
+                assert.strictEqual(body, failedMessage);
                 done();
             });
         });


### PR DESCRIPTION
**NOTE: code has already been reviewed.**

Currently, the probe response logic is distributed between Backbeat probe handlers and Arsenal's onRequest method.

This scattered approach causes confusion for developers and results in bugs.

The solution is to centralize the probe response logic exclusively within the Backbeat probe handlers.