### PR TITLE
ARSN-377 correctly handle null keys with common prefix

### DIFF
--- a/lib/algos/list/delimiterNonCurrent.js
+++ b/lib/algos/list/delimiterNonCurrent.js
@@ -52,9 +52,8 @@ class DelimiterNonCurrent extends DelimiterVersions {
     // Overwrite keyHandler_SkippingVersions to include the last version from the previous listing.
     // The creation (last-modified) date of this version will be the stale date for the following version.
     // eslint-disable-next-line camelcase
-    keyHandler_SkippingVersions(key, value) {
-        const { key: nonversionedKey, versionId } = this.parseKey(key);
-        if (nonversionedKey === this.keyMarker) {
+    keyHandler_SkippingVersions(key, versionId, value) {
+        if (key === this.keyMarker) {
             // since the nonversioned key equals the marker, there is
             // necessarily a versionId in this key
             const _versionId = versionId;
@@ -66,7 +65,7 @@ class DelimiterNonCurrent extends DelimiterVersions {
         this.setState({
             id: 1 /* NotSkipping */,
         });
-        return this.handleKey(key, value);
+        return this.handleKey(key, versionId, value);
     }
 
     filter(obj) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.70.15",
+  "version": "7.70.16",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/algos/list/delimiterVersions.spec.js
+++ b/tests/unit/algos/list/delimiterVersions.spec.js
@@ -45,6 +45,8 @@ const valuePHD = '{"isPHD":"true","versionId":"1234567890abcdefg"}';
 const fooDM = '{"hello":"world","isDeleteMarker":"true","versionId":"foo"}';
 const barDM = '{"hello":"world","isDeleteMarker":"true","versionId":"bar"}';
 const quxDM = '{"hello":"world","isDeleteMarker":"true","versionId":"qux"}';
+const nullVersionMD = '{"hello":"world","isNull":true,"isNull2":true,"versionId":"vnull"}';
+const nullDMMD = '{"hello":"world","isNull":true,"isNull2":true,"isDeleteMarker":"true","versionId":"bar"}';
 const dataVersioned = {
     v0: [
         { key: 'Pâtisserie=中文-español-English', value: bar },
@@ -94,6 +96,11 @@ const dataVersioned = {
         { key: `nullkey/5.txt${VID_SEP}`, value: qux },
         { key: `nullkey/5.txt${VID_SEP}bar`, value: bar },
         { key: `nullkey/5.txt${VID_SEP}foo`, value: foo },
+        { key: 'nullkey2/1.txt', value: fooDM },
+        { key: `nullkey2/1.txt${VID_SEP}`, value: nullVersionMD },
+        { key: `nullkey2/1.txt${VID_SEP}foo`, value: fooDM }, // current version
+        { key: 'nullkey3/1.txt', value: nullDMMD }, // current version
+        { key: `nullkey3/1.txt${VID_SEP}foo`, value: fooDM },
     ],
     v1: [ // we add M and V prefixes in getTestListing() due to the
         // test cases needing the original key to filter
@@ -139,6 +146,10 @@ const dataVersioned = {
         { key: `nullkey/5.txt${VID_SEP}`, value: qux },
         { key: `nullkey/5.txt${VID_SEP}bar`, value: bar },
         { key: `nullkey/5.txt${VID_SEP}foo`, value: foo },
+        { key: `nullkey2/1.txt${VID_SEP}`, value: nullVersionMD },
+        { key: `nullkey2/1.txt${VID_SEP}foo`, value: fooDM }, // current version
+        { key: `nullkey3/1.txt${VID_SEP}`, value: nullDMMD }, // current version
+        { key: `nullkey3/1.txt${VID_SEP}foo`, value: fooDM },
     ],
 };
 const receivedData = [
@@ -176,6 +187,10 @@ const receivedData = [
     { key: 'nullkey/5.txt', value: bar, versionId: 'bar' },
     { key: 'nullkey/5.txt', value: foo, versionId: 'foo' },
     { key: 'nullkey/5.txt', value: qux, versionId: 'qux' },
+    { key: 'nullkey2/1.txt', value: fooDM, versionId: 'foo' },
+    { key: 'nullkey2/1.txt', value: nullVersionMD, versionId: 'vnull' },
+    { key: 'nullkey3/1.txt', value: nullDMMD, versionId: 'bar' },
+    { key: 'nullkey3/1.txt', value: fooDM, versionId: 'foo' },
 ];
 const tests = [
     new Test('all versions', {}, {
@@ -278,6 +293,8 @@ const tests = [
         CommonPrefixes: [
             'notes/',
             'nullkey/',
+            'nullkey2/',
+            'nullkey3/',
         ],
         Delimiter: '/',
         IsTruncated: false,

--- a/tests/unit/algos/list/delimiterVersions.spec.js
+++ b/tests/unit/algos/list/delimiterVersions.spec.js
@@ -42,7 +42,9 @@ const foo = '{"versionId":"foo"}';
 const bar = '{"versionId":"bar"}';
 const qux = '{"versionId":"qux"}';
 const valuePHD = '{"isPHD":"true","versionId":"1234567890abcdefg"}';
-const valueDeleteMarker = '{"hello":"world","isDeleteMarker":"true"}';
+const fooDM = '{"hello":"world","isDeleteMarker":"true","versionId":"foo"}';
+const barDM = '{"hello":"world","isDeleteMarker":"true","versionId":"bar"}';
+const quxDM = '{"hello":"world","isDeleteMarker":"true","versionId":"qux"}';
 const dataVersioned = {
     v0: [
         { key: 'Pâtisserie=中文-español-English', value: bar },
@@ -53,7 +55,7 @@ const dataVersioned = {
         { key: `notes/spring/1.txt${VID_SEP}foo`, value: foo },
         { key: `notes/spring/1.txt${VID_SEP}qux`, value: qux },
         { key: 'notes/spring/2.txt', value: valuePHD },
-        { key: `notes/spring/2.txt${VID_SEP}bar`, value: valueDeleteMarker },
+        { key: `notes/spring/2.txt${VID_SEP}bar`, value: barDM },
         { key: `notes/spring/2.txt${VID_SEP}foo`, value: foo },
         { key: 'notes/spring/march/1.txt',
             value: '{"versionId":"null","isNull":true}' },
@@ -65,13 +67,13 @@ const dataVersioned = {
         { key: 'notes/summer/2.txt', value: bar },
         { key: `notes/summer/2.txt${VID_SEP}bar`, value: bar },
         { key: 'notes/summer/4.txt', value: valuePHD },
-        { key: `notes/summer/4.txt${VID_SEP}bar`, value: valueDeleteMarker },
-        { key: `notes/summer/4.txt${VID_SEP}foo`, value: valueDeleteMarker },
-        { key: `notes/summer/4.txt${VID_SEP}qux`, value: valueDeleteMarker },
+        { key: `notes/summer/4.txt${VID_SEP}bar`, value: barDM },
+        { key: `notes/summer/4.txt${VID_SEP}foo`, value: fooDM },
+        { key: `notes/summer/4.txt${VID_SEP}qux`, value: quxDM },
         { key: 'notes/summer/44.txt', value: valuePHD },
-        { key: 'notes/summer/444.txt', value: valueDeleteMarker },
+        { key: 'notes/summer/444.txt', value: fooDM },
         { key: 'notes/summer/4444.txt', value: valuePHD },
-        { key: 'notes/summer/44444.txt', value: valueDeleteMarker },
+        { key: 'notes/summer/44444.txt', value: fooDM },
         { key: 'notes/summer/444444.txt', value: valuePHD },
         { key: 'notes/summer/august/1.txt', value },
         { key: 'notes/year.txt', value },
@@ -102,7 +104,7 @@ const dataVersioned = {
         { key: `notes/spring/1.txt${VID_SEP}bar`, value: bar },
         { key: `notes/spring/1.txt${VID_SEP}foo`, value: foo },
         { key: `notes/spring/1.txt${VID_SEP}qux`, value: qux },
-        { key: `notes/spring/2.txt${VID_SEP}bar`, value: valueDeleteMarker },
+        { key: `notes/spring/2.txt${VID_SEP}bar`, value: barDM },
         { key: `notes/spring/2.txt${VID_SEP}foo`, value: foo },
         { key: 'notes/spring/march/1.txt',
             value: '{"versionId":"null","isNull":true}' },
@@ -113,14 +115,14 @@ const dataVersioned = {
         { key: `notes/summer/1.txt${VID_SEP}foo`, value: foo },
         { key: 'notes/summer/2.txt', value: bar },
         { key: `notes/summer/2.txt${VID_SEP}bar`, value: bar },
-        { key: `notes/summer/4.txt${VID_SEP}bar`, value: valueDeleteMarker },
-        { key: `notes/summer/4.txt${VID_SEP}foo`, value: valueDeleteMarker },
-        { key: `notes/summer/4.txt${VID_SEP}qux`, value: valueDeleteMarker },
+        { key: `notes/summer/4.txt${VID_SEP}bar`, value: barDM },
+        { key: `notes/summer/4.txt${VID_SEP}foo`, value: fooDM },
+        { key: `notes/summer/4.txt${VID_SEP}qux`, value: quxDM },
         // Compared to v0, the two following keys are version keys
-        // that we give a version ID, because delete markers do not
+        // that have a version ID, because delete markers do not
         // have a master key in v1.
-        { key: `notes/summer/444.txt${VID_SEP}null`, value: valueDeleteMarker },
-        { key: `notes/summer/44444.txt${VID_SEP}null`, value: valueDeleteMarker },
+        { key: `notes/summer/444.txt${VID_SEP}foo`, value: fooDM },
+        { key: `notes/summer/44444.txt${VID_SEP}foo`, value: fooDM },
         { key: 'notes/summer/august/1.txt', value },
         { key: 'notes/year.txt', value },
         { key: 'notes/yore.rs', value },
@@ -145,7 +147,7 @@ const receivedData = [
     { key: 'notes/spring/1.txt', value: bar, versionId: 'bar' },
     { key: 'notes/spring/1.txt', value: foo, versionId: 'foo' },
     { key: 'notes/spring/1.txt', value: qux, versionId: 'qux' },
-    { key: 'notes/spring/2.txt', value: valueDeleteMarker, versionId: 'bar' },
+    { key: 'notes/spring/2.txt', value: barDM, versionId: 'bar' },
     { key: 'notes/spring/2.txt', value: foo, versionId: 'foo' },
     { key: 'notes/spring/march/1.txt',
         value: '{"versionId":"null","isNull":true}', versionId: 'null' },
@@ -154,13 +156,11 @@ const receivedData = [
     { key: 'notes/summer/1.txt', value: bar, versionId: 'bar' },
     { key: 'notes/summer/1.txt', value: foo, versionId: 'foo' },
     { key: 'notes/summer/2.txt', value: bar, versionId: 'bar' },
-    { key: 'notes/summer/4.txt', value: valueDeleteMarker, versionId: 'bar' },
-    { key: 'notes/summer/4.txt', value: valueDeleteMarker, versionId: 'foo' },
-    { key: 'notes/summer/4.txt', value: valueDeleteMarker, versionId: 'qux' },
-    { key: 'notes/summer/444.txt',
-        value: valueDeleteMarker, versionId: 'null' },
-    { key: 'notes/summer/44444.txt',
-        value: valueDeleteMarker, versionId: 'null' },
+    { key: 'notes/summer/4.txt', value: barDM, versionId: 'bar' },
+    { key: 'notes/summer/4.txt', value: fooDM, versionId: 'foo' },
+    { key: 'notes/summer/4.txt', value: quxDM, versionId: 'qux' },
+    { key: 'notes/summer/444.txt', value: fooDM, versionId: 'foo' },
+    { key: 'notes/summer/44444.txt', value: fooDM, versionId: 'foo' },
     { key: 'notes/summer/august/1.txt', value, versionId: 'null' },
     { key: 'notes/year.txt', value, versionId: 'null' },
     { key: 'notes/yore.rs', value, versionId: 'null' },


### PR DESCRIPTION
When encountering a null key, check for its common prefix before including it in either the Versions array or CommonPrefixes array, instead of always including it in the Versions array.

This commit refactors how `DelimiterVersions` works with null keys slightly: the null key is now inserted at its correct ordered position by the top-level `filter()` method, and the state machine handlers only have to deal with sorted versions. Previously the individual handlers would have to deal with the null key positioning themselves resulting in more complex state management.
