### PR TITLE
ARSN-380 rf: DelimiterVersions class inherits from Extension

### DIFF
--- a/lib/algos/list/delimiterNonCurrent.js
+++ b/lib/algos/list/delimiterNonCurrent.js
@@ -102,7 +102,7 @@ class DelimiterNonCurrent extends DelimiterVersions {
      *  @param {String} value - The value of the key
      *  @return {undefined}
      */
-    addContents(key, versionId, value) {
+    addVersion(key, versionId, value) {
         this.nextKeyMarker = key;
         this.nextVersionIdMarker = versionId;
 
@@ -130,7 +130,7 @@ class DelimiterNonCurrent extends DelimiterVersions {
                     const s = this._stringify(parsedValue, this.staleDate);
                     // check that _stringify succeeds to only push objects with a defined staleDate.
                     if (s) {
-                        this.Contents.push({ key, value: s });
+                        this.Versions.push({ key, value: s });
                         ++this.keys;
                     }
                 }

--- a/lib/algos/list/delimiterOrphanDeleteMarker.js
+++ b/lib/algos/list/delimiterOrphanDeleteMarker.js
@@ -64,7 +64,7 @@ class DelimiterOrphanDeleteMarker extends DelimiterVersions {
             if ((!this.beforeDate || (lastModified && lastModified < this.beforeDate)) && isDeleteMarker) {
                 // Prefer returning an untrimmed data rather than stopping the service in case of parsing failure.
                 const s = this._stringify(parsedValue) || this.value;
-                this.Contents.push({ key: this.keyName, value: s });
+                this.Versions.push({ key: this.keyName, value: s });
                 this.nextKeyMarker = this.keyName;
                 ++this.keys;
             }
@@ -148,7 +148,7 @@ class DelimiterOrphanDeleteMarker extends DelimiterVersions {
      *  @param {String} value - The value of the key
      *  @return {undefined}
      */
-    addContents(key, versionId, value) {
+    addVersion(key, versionId, value) {
         // For a given key, the youngest version is kept in memory since it represents the current version.
         if (key !== this.keyName) {
             // If this.value is defined, it means that <this.keyName, this.value> pair is "allowed" to be an orphan.
@@ -189,7 +189,7 @@ class DelimiterOrphanDeleteMarker extends DelimiterVersions {
         }
 
         const result = {
-            Contents: this.Contents,
+            Contents: this.Versions,
             IsTruncated: this.IsTruncated,
         };
 

--- a/lib/algos/list/delimiterVersions.ts
+++ b/lib/algos/list/delimiterVersions.ts
@@ -1,6 +1,7 @@
 'use strict'; // eslint-disable-line strict
 
-const Delimiter = require('./delimiter').Delimiter;
+const Extension = require('./Extension').default;
+
 const Version = require('../../versioning/Version').Version;
 const VSConst = require('../../versioning/constants').VersioningConstants;
 const { inc, FILTER_END, FILTER_ACCEPT, FILTER_SKIP, SKIP_NONE } =
@@ -75,13 +76,17 @@ type GenMDParamsItem = {
  * @prop {String|undefined} prefix     - prefix per amazon format
  * @prop {Number} maxKeys              - number of keys to list
  */
-export class DelimiterVersions extends Delimiter {
+export class DelimiterVersions extends Extension {
 
     state: FilterState;
     keyHandlers: { [id: number]: KeyHandler };
 
     constructor(parameters, logger, vFormat) {
-        super(parameters, logger, vFormat);
+        super(parameters, logger);
+        // original listing parameters
+        this.delimiter = parameters.delimiter;
+        this.prefix = parameters.prefix;
+        this.maxKeys = parameters.maxKeys || 1000;
         // specific to version listing
         this.keyMarker = parameters.keyMarker;
         this.versionIdMarker = parameters.versionIdMarker;
@@ -89,7 +94,11 @@ export class DelimiterVersions extends Delimiter {
         this.masterKey = undefined;
         this.masterVersionId = undefined;
         this.nullKey = null;
+        this.vFormat = vFormat || BucketVersioningKeyFormat.v0;
         // listing results
+        this.CommonPrefixes = [];
+        this.Versions = [];
+        this.IsTruncated = false;
         this.nextKeyMarker = parameters.keyMarker;
         this.nextVersionIdMarker = undefined;
 
@@ -194,6 +203,20 @@ export class DelimiterVersions extends Delimiter {
     }
 
     /**
+     * check if the max keys count has been reached and set the
+     * final state of the result if it is the case
+     * @return {Boolean} - indicates if the iteration has to stop
+     */
+    _reachedMaxKeys(): boolean {
+        if (this.keys >= this.maxKeys) {
+            // In cases of maxKeys <= 0 -> IsTruncated = false
+            this.IsTruncated = this.maxKeys > 0;
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * Used to synchronize listing of M and V prefixes by object key
      *
      * @param {object} masterObj object listed from first range
@@ -248,7 +271,7 @@ export class DelimiterVersions extends Delimiter {
                 prefix: commonPrefix,
             });
         } else {
-            this.addContents(key, versionId, value);
+            this.addVersion(key, versionId, value);
         }
     }
 
@@ -261,8 +284,8 @@ export class DelimiterVersions extends Delimiter {
      *  @param {String} value       - The value of the key
      *  @return {undefined}
      */
-    addContents(key: string, versionId: string, value: string) {
-        this.Contents.push({
+    addVersion(key: string, versionId: string, value: string) {
+        this.Versions.push({
             key,
             versionId,
             value: this.trimMetadata(value),
@@ -294,6 +317,7 @@ export class DelimiterVersions extends Delimiter {
         this.CommonPrefixes.push(commonPrefix);
         ++this.keys;
         this.nextKeyMarker = commonPrefix;
+        this.nextVersionIdMarker = undefined;
     }
 
     /**
@@ -432,7 +456,7 @@ export class DelimiterVersions extends Delimiter {
         return this.handleKey(key, versionId, value);
     }
 
-    skippingBase() {
+    skippingBase(): string | undefined {
         switch (this.state.id) {
         case DelimiterVersionsFilterStateId.SkippingPrefix:
             const { prefix } = <DelimiterVersionsFilterState_SkippingPrefix> this.state;
@@ -492,7 +516,7 @@ export class DelimiterVersions extends Delimiter {
         }
         const result: ResultObject = {
             CommonPrefixes: this.CommonPrefixes,
-            Versions: this.Contents,
+            Versions: this.Versions,
             IsTruncated: this.IsTruncated,
         };
         if (this.delimiter) {


### PR DESCRIPTION
Small refactor of DelimiterVersions class to inherit from the base class Extension rather than Delimiter. Copy the missing fields and methods from `Delimiter`.

This prepares for merging ARSN-379 which would otherwise cause a lot of incompatibilities due to changes in the interface of `DelimiterVersions` from S3C-8242.

Other minor tweaks:

- reset `nextVersionIdMarker` when skipping a common prefix

- rename `this.Contents` to `this.Versions` as we don't need to keep compatibility with `Delimiter`, and as it is the name used in the final result