### PR TITLE
ARSN-381 RPC command system between cluster workers

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -21,6 +21,7 @@ import * as retention from './lib/s3middleware/objectRetention';
 import * as lifecycleHelpers from './lib/s3middleware/lifecycleHelpers';
 export { default as errors } from './lib/errors';
 export { default as Clustering } from './lib/Clustering';
+export * as ClusterRPC from './lib/clustering/ClusterRPC';
 export * as ipCheck from './lib/ipCheck';
 export * as auth from './lib/auth/auth';
 export * as constants from './lib/constants';

--- a/lib/clustering/ClusterRPC.ts
+++ b/lib/clustering/ClusterRPC.ts
@@ -1,0 +1,514 @@
+import cluster, { Worker } from 'cluster';
+import * as werelogs from 'werelogs';
+
+import { default as errors } from '../../lib/errors';
+
+const rpcLogger = new werelogs.Logger('ClusterRPC');
+
+/**
+ * Remote procedure calls support between cluster workers.
+ *
+ * When using the cluster module, new processes are forked and are
+ * dispatched workloads, usually HTTP requests. The ClusterRPC module
+ * implements a RPC system to send commands to all cluster worker
+ * processes at once from any particular worker, and retrieve their
+ * individual command results, like a distributed map operation.
+ *
+ * The existing nodejs cluster IPC channel is setup from the primary
+ * to each worker, but not between workers, so there has to be a hop
+ * by the primary.
+ *
+ * How a command is treated:
+ *
+ * - a worker sends a command message to the primary
+ *
+ * - the primary then forwards that command to each existing worker
+ *   (including the requestor)
+ *
+ * - each worker then executes the command and returns a result or an
+ *   error
+ *
+ * - the primary gathers all workers results into an array
+ *
+ * - finally, the primary dispatches the results array to the original
+ *   requesting worker
+ *
+ *
+ * Limitations:
+ *
+ * - The command payload must be serializable, which means that:
+ *   - it should not contain circular references
+ *   - it should be of a reasonable size to be sent in a single RPC message
+ *
+ * - The "toWorkers" parameter of value "*" targets the set of workers
+ *   that are available at the time the command is dispatched. Any new
+ *   worker spawned after the command has been dispatched for
+ *   processing, but before the command completes, don't execute
+ *   the command and hence are not part of the results array.
+ *
+ *
+ * To set it up:
+ *
+ * - On the primary:
+ *     if (cluster.isPrimary) {
+ *         setupRPCPrimary();
+ *     }
+ *
+ * - On the workers:
+ *     if (!cluster.isPrimary) {
+ *         setupRPCWorker({
+ *             handler1: (payload: object, uids: string, callback: HandlerCallback) => void,
+ *             handler2: ...
+ *         });
+ *     }
+ *     Handler functions will be passed the command payload, request
+ *     serialized uids, and must call the callback when the worker is done
+ *     processing the command:
+ *         callback(error: Error | null | undefined, result?: any)
+ *
+ * When this setup is done, any worker can start sending commands by calling
+ * the async function sendWorkerCommand().
+ */
+
+// exported types
+
+export type ResultObject = {
+    error: Error | null;
+    result: any;
+};
+
+/**
+ * saved Promise for sendWorkerCommand
+ */
+export type CommandPromise = {
+    resolve: (results?: ResultObject[]) => void;
+    reject: (error: Error) => void;
+    timeout: NodeJS.Timer | null;
+};
+export type HandlerCallback = (error: Error | null | undefined, result?: any) => void;
+export type HandlerFunction = (payload: object, uids: string, callback: HandlerCallback) => void;
+export type HandlersMap = {
+    [index: string]: HandlerFunction;
+};
+
+// private types
+
+type RPCMessage<T extends string, P> = {
+    type: T;
+    uids: string;
+    payload: P;
+};
+
+type RPCCommandMessage = RPCMessage<'cluster-rpc:command', any> & {
+    toWorkers: string;
+    toHandler: string;
+};
+
+type MarshalledResultObject = {
+    error: string | null;
+    result: any;
+};
+
+type RPCCommandResultMessage = RPCMessage<'cluster-rpc:commandResult', MarshalledResultObject>;
+
+type RPCCommandResultsMessage = RPCMessage<'cluster-rpc:commandResults', {
+    results: MarshalledResultObject[];
+}>;
+
+type RPCCommandErrorMessage = RPCMessage<'cluster-rpc:commandError', {
+    error: string;
+}>;
+
+
+/**
+ * In primary: store worker IDs that are waiting to be dispatched
+ * their command's results, as a mapping.
+ */
+const uidsToWorkerId: {
+    [index: string]: number;
+} = {};
+
+
+/**
+ * In primary: store worker responses for commands in progress as a
+ * mapping.
+ *
+ * Result objects are 'null' while the worker is still processing the
+ * command. When a worker finishes processing it stores the result as:
+ *    {
+ *        error: string | null,
+ *        result: any
+ *    }
+ */
+const uidsToCommandResults: {
+    [index: string]: {
+        [index: number]: MarshalledResultObject | null;
+    };
+} = {};
+
+/**
+ * In workers: store promise callbacks for commands waiting to be
+ * dispatched, as a mapping.
+ */
+const uidsToCommandPromise: {
+    [index: string]: CommandPromise;
+} = {};
+
+
+function _isRpcMessage(message) {
+    return (message !== null &&
+            typeof message === 'object' &&
+            typeof message.type === 'string' &&
+            message.type.startsWith('cluster-rpc:'));
+}
+
+/**
+ * Setup cluster RPC system on the primary
+ *
+ * @return {undefined}
+ */
+export function setupRPCPrimary() {
+    cluster.on('message', (worker, message) => {
+        if (_isRpcMessage(message)) {
+            _handlePrimaryMessage(worker?.id, message);
+        }
+    });
+}
+
+/**
+ * Setup RPCs on a cluster worker process
+ *
+ * @param {object} handlers - mapping of handler names to handler functions
+ *     handler function:
+ *         handler({object} payload, {string} uids, {function} callback)
+ *     handler callback must be called when worker is done with the command:
+ *         callback({Error|null} error, {any} [result])
+ * @return {undefined}
+ * }
+ */
+export function setupRPCWorker(handlers: HandlersMap) {
+    if (!process.send) {
+        throw new Error('fatal: cannot setup cluster RPC: "process.send" is not available');
+    }
+    process.on('message', (message: RPCCommandMessage | RPCCommandResultsMessage) => {
+        if (_isRpcMessage(message)) {
+            _handleWorkerMessage(message, handlers);
+        }
+    });
+}
+
+/**
+ * Send a command for workers to execute in parallel, and wait for results
+ *
+ * @param {string} toWorkers - which workers should execute the command
+ *     Currently the only supported value is "*", meaning all workers will
+ *     execute the command
+ * @param {string} toHandler - name of handler that will execute the
+ * command in workers, as declared in setupRPCWorker() parameter object
+ * @param {string} uids - unique identifier of the command, must be
+ * unique across all commands in progress
+ * @param {object} payload - message payload, sent as-is to the handler
+ * @param {number} [timeoutMs=60000] - timeout the command with a
+ * "RequestTimeout" error after this number of milliseconds - set to 0
+ * to disable timeouts (the command may then hang forever)
+ * @returns {Promise}
+ */
+export async function sendWorkerCommand(
+    toWorkers: string,
+    toHandler: string,
+    uids: string,
+    payload: object,
+    timeoutMs: number = 60000
+) {
+    if (typeof uids !== 'string') {
+        rpcLogger.error('missing or invalid "uids" field', { uids });
+        throw errors.MissingParameter;
+    }
+    if (uidsToCommandPromise[uids] !== undefined) {
+        rpcLogger.error('a command is already in progress with same uids', { uids });
+        throw errors.OperationAborted;
+    }
+    rpcLogger.info('sending command', { toWorkers, toHandler, uids, payload });
+    return new Promise((resolve, reject) => {
+        let timeout: NodeJS.Timer | null = null;
+        if (timeoutMs) {
+            timeout = setTimeout(() => {
+                delete uidsToCommandPromise[uids];
+                reject(errors.RequestTimeout);
+            }, timeoutMs);
+        }
+        uidsToCommandPromise[uids] = { resolve, reject, timeout };
+        const message: RPCCommandMessage = {
+            type: 'cluster-rpc:command',
+            toWorkers,
+            toHandler,
+            uids,
+            payload,
+        };
+        return process.send?.(message);
+    });
+}
+
+/**
+ * Get the number of commands in flight
+ * @returns {number}
+ */
+export function getPendingCommandsCount() {
+    return Object.keys(uidsToCommandPromise).length;
+}
+
+
+function _dispatchCommandResultsToWorker(
+    worker: Worker,
+    uids: string,
+    resultsArray: MarshalledResultObject[]
+): void {
+    const message: RPCCommandResultsMessage = {
+        type: 'cluster-rpc:commandResults',
+        uids,
+        payload: {
+            results: resultsArray,
+        },
+    };
+    worker.send(message);
+}
+
+function _dispatchCommandErrorToWorker(
+    worker: Worker,
+    uids: string,
+    error: Error,
+): void {
+    const message: RPCCommandErrorMessage = {
+        type: 'cluster-rpc:commandError',
+        uids,
+        payload: {
+            error: error.message,
+        },
+    };
+    worker.send(message);
+}
+
+function _handlePrimaryCommandMessage(
+    fromWorkerId: number,
+    logger: any,
+    message: RPCCommandMessage
+): void {
+    const { toWorkers, toHandler, uids, payload } = message;
+    if (toWorkers === '*') {
+        if (uidsToWorkerId[uids] !== undefined) {
+            logger.warn('new command already has a waiting worker with same uids', {
+                uids, workerId: uidsToWorkerId[uids],
+            });
+            return undefined;
+        }
+        const commandResults = {};
+        for (const workerId of Object.keys(cluster.workers || {})) {
+            commandResults[workerId] = null;
+        }
+        uidsToWorkerId[uids] = fromWorkerId;
+        uidsToCommandResults[uids] = commandResults;
+
+        for (const [workerId, worker] of Object.entries(cluster.workers || {})) {
+            logger.debug('sending command message to worker', {
+                workerId, toHandler, payload,
+            });
+            if (worker) {
+                worker.send(message);
+            }
+        }
+    } else {
+        logger.error('unsupported "toWorkers" field from worker command message', {
+            toWorkers,
+        });
+        const fromWorker = cluster.workers?.[fromWorkerId];
+        if (fromWorker) {
+            _dispatchCommandErrorToWorker(fromWorker, uids, errors.NotImplemented);
+        }
+    }
+}
+
+function _handlePrimaryCommandResultMessage(
+    fromWorkerId: number,
+    logger: any,
+    message: RPCCommandResultMessage
+): void {
+    const { uids, payload } = message;
+    const commandResults = uidsToCommandResults[uids];
+    if (!commandResults) {
+        logger.warn('received command response message from worker for command not in flight', {
+            workerId: fromWorkerId,
+            uids,
+        });
+        return undefined;
+    }
+    if (commandResults[fromWorkerId] === undefined) {
+        logger.warn('received command response message with unexpected worker ID', {
+            workerId: fromWorkerId,
+            uids,
+        });
+        return undefined;
+    }
+    if (commandResults[fromWorkerId] !== null) {
+        logger.warn('ignoring duplicate command response from worker', {
+            workerId: fromWorkerId,
+            uids,
+        });
+        return undefined;
+    }
+    commandResults[fromWorkerId] = payload;
+    const commandResultsArray = Object.values(commandResults);
+    if (commandResultsArray.every(response => response !== null)) {
+        logger.debug('all workers responded to command', { uids });
+        const completeCommandResultsArray = <MarshalledResultObject[]> commandResultsArray;
+        const toWorkerId = uidsToWorkerId[uids];
+        const toWorker = cluster.workers?.[toWorkerId];
+
+        delete uidsToCommandResults[uids];
+        delete uidsToWorkerId[uids];
+
+        if (!toWorker) {
+            logger.warn('worker shut down while its command was executing', {
+                workerId: toWorkerId, uids,
+            });
+            return undefined;
+        }
+        // send back response to original worker
+        _dispatchCommandResultsToWorker(toWorker, uids, completeCommandResultsArray);
+    }
+}
+
+function _handlePrimaryMessage(
+    fromWorkerId: number,
+    message: RPCCommandMessage | RPCCommandResultMessage
+): void {
+    const { type: messageType, uids } = message;
+    const logger = rpcLogger.newRequestLoggerFromSerializedUids(uids);
+    logger.debug('primary received message from worker', {
+        workerId: fromWorkerId, rpcMessage: message,
+    });
+    if (messageType === 'cluster-rpc:command') {
+        return _handlePrimaryCommandMessage(fromWorkerId, logger, message);
+    }
+    if (messageType === 'cluster-rpc:commandResult') {
+        return _handlePrimaryCommandResultMessage(fromWorkerId, logger, message);
+    }
+    logger.error('unsupported message type', {
+        workerId: fromWorkerId, messageType, uids,
+    });
+    return undefined;
+}
+
+function _sendWorkerCommandResult(
+    uids: string,
+    error: Error | null | undefined,
+    result?: any
+): void {
+    const message: RPCCommandResultMessage = {
+        type: 'cluster-rpc:commandResult',
+        uids,
+        payload: {
+            error: error ? error.message : null,
+            result,
+        },
+    };
+    process.send?.(message);
+}
+
+function _handleWorkerCommandMessage(
+    logger: any,
+    message: RPCCommandMessage,
+    handlers: HandlersMap
+): void {
+    const { toHandler, uids, payload } = message;
+    const cb: HandlerCallback = (err, result) => _sendWorkerCommandResult(uids, err, result);
+
+    if (toHandler in handlers) {
+        return handlers[toHandler](payload, uids, cb);
+    }
+    logger.error('no such handler in "toHandler" field from worker command message', {
+        toHandler,
+    });
+    return cb(errors.NotImplemented);
+}
+
+function _handleWorkerCommandResultsMessage(
+    logger: any,
+    message: RPCCommandResultsMessage,
+): void {
+    const { uids, payload } = message;
+    const { results } = payload;
+    const commandPromise: CommandPromise = uidsToCommandPromise[uids];
+    if (commandPromise === undefined) {
+        logger.error('missing promise for command results', { uids, payload });
+        return undefined;
+    }
+    if (commandPromise.timeout) {
+        clearTimeout(commandPromise.timeout);
+    }
+    delete uidsToCommandPromise[uids];
+    const unmarshalledResults = results.map(workerResult => {
+        let workerError: Error | null = null;
+        if (workerResult.error) {
+            if (workerResult.error in errors) {
+                workerError = errors[workerResult.error];
+            } else {
+                workerError = new Error(workerResult.error);
+            }
+        }
+        const unmarshalledResult: ResultObject = {
+            error: workerError,
+            result: workerResult.result,
+        };
+        return unmarshalledResult;
+    });
+    return commandPromise.resolve(unmarshalledResults);
+}
+
+function _handleWorkerCommandErrorMessage(
+    logger: any,
+    message: RPCCommandErrorMessage,
+): void {
+    const { uids, payload } = message;
+    const { error } = payload;
+    const commandPromise: CommandPromise = uidsToCommandPromise[uids];
+    if (commandPromise === undefined) {
+        logger.error('missing promise for command results', { uids, payload });
+        return undefined;
+    }
+    if (commandPromise.timeout) {
+        clearTimeout(commandPromise.timeout);
+    }
+    delete uidsToCommandPromise[uids];
+    let commandError: Error | null = null;
+    if (error in errors) {
+        commandError = errors[error];
+    } else {
+        commandError = new Error(error);
+    }
+    return commandPromise.reject(<Error> commandError);
+}
+
+function _handleWorkerMessage(
+    message: RPCCommandMessage | RPCCommandResultsMessage | RPCCommandErrorMessage,
+    handlers: HandlersMap
+): void {
+    const { type: messageType, uids } = message;
+    const workerId = cluster.worker?.id;
+    const logger = rpcLogger.newRequestLoggerFromSerializedUids(uids);
+    logger.debug('worker received message from primary', {
+        workerId, rpcMessage: message,
+    });
+    if (messageType === 'cluster-rpc:command') {
+        return _handleWorkerCommandMessage(logger, message, handlers);
+    }
+    if (messageType === 'cluster-rpc:commandResults') {
+        return _handleWorkerCommandResultsMessage(logger, message);
+    }
+    if (messageType === 'cluster-rpc:commandError') {
+        return _handleWorkerCommandErrorMessage(logger, message);
+    }
+    logger.error('unsupported message type', {
+        workerId, messageType,
+    });
+    return undefined;
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.70.19",
+  "version": "7.70.20",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/functional/clustering/ClusterRPC-test-server.js
+++ b/tests/functional/clustering/ClusterRPC-test-server.js
@@ -1,0 +1,309 @@
+const async = require('async');
+const cluster = require('cluster');
+const http = require('http');
+
+const errors = require('../../../build/lib/errors').default;
+
+const {
+    setupRPCPrimary,
+    setupRPCWorker,
+    sendWorkerCommand,
+    getPendingCommandsCount,
+} = require('../../../build/lib/clustering/ClusterRPC');
+
+/* eslint-disable prefer-const */
+let SERVER_PORT;
+let N_WORKERS;
+/* eslint-enable prefer-const */
+
+/* eslint-disable no-console */
+
+function genUIDS() {
+    return Math.trunc(Math.random() * 0x10000).toString(16);
+}
+
+// for testing robustness: regularly pollute the message channel with
+// unrelated IPC messages
+function sendPollutionMessage(message) {
+    if (cluster.isPrimary) {
+        const randomWorker = Math.trunc(Math.random() * cluster.workers.length);
+        const worker = cluster.workers[randomWorker];
+        if (worker) {
+            worker.send(message);
+        }
+    } else {
+        process.send(message);
+    }
+}
+const ipcPolluterIntervals = [
+    setInterval(
+        () => sendPollutionMessage('string pollution'), 1500),
+    setInterval(
+        () => sendPollutionMessage({ pollution: 'bar' }), 2321),
+    setInterval(
+        () => sendPollutionMessage({ type: 'pollution', foo: { bar: 'baz' } }), 2777),
+];
+
+function someTestHandlerFunc(payload, uids, callback) {
+    setTimeout(() => callback(null, { someResponsePayload: 'bar' }), 10);
+}
+
+function testHandlerWithFailureFunc(payload, uids, callback) {
+    setTimeout(() => {
+        // exactly one of the workers fails to execute this command
+        if (cluster.worker.id === 1) {
+            callback(errors.ServiceFailure);
+        } else {
+            callback(null, { someResponsePayload: 'bar' });
+        }
+    }, 10);
+}
+
+const rpcHandlers = {
+    SomeTestHandler: someTestHandlerFunc,
+    TestHandlerWithFailure: testHandlerWithFailureFunc,
+    TestHandlerWithNoResponse: () => {},
+};
+
+function respondOnTestFailure(message, error, results) {
+    console.error('After sendWorkerCommand() resolve/reject: ' +
+                  `${message}, error=${error}, results=${JSON.stringify(results)}`);
+    console.trace();
+    throw errors.InternalError;
+}
+
+async function successfulCommandTestGeneric(nWorkers) {
+    try {
+        const results = await sendWorkerCommand('*', 'SomeTestHandler', genUIDS(), {});
+        if (results.length !== nWorkers) {
+            return respondOnTestFailure(
+                `expected ${nWorkers} worker results, got ${results.length}`,
+                null, results);
+        }
+        for (const result of results) {
+            if (typeof result !== 'object' || result === null) {
+                return respondOnTestFailure('not all results are objects', null, results);
+            }
+            if (result.error !== null) {
+                return respondOnTestFailure(
+                    'one or more workers had an unexpected error',
+                    null, results);
+            }
+            if (typeof result.result !== 'object' || result.result === null) {
+                return respondOnTestFailure(
+                    'one or more workers did not return a result object',
+                    null, results);
+            }
+            if (result.result.someResponsePayload !== 'bar') {
+                return respondOnTestFailure(
+                    'one or more workers did not return the expected payload',
+                    null, results);
+            }
+        }
+        return undefined;
+    } catch (err) {
+        return respondOnTestFailure(`returned unexpected error ${err}`, err, null);
+    }
+}
+
+async function successfulCommandTest() {
+    return successfulCommandTestGeneric(N_WORKERS);
+}
+
+async function successfulCommandWithExtraWorkerTest() {
+    return successfulCommandTestGeneric(N_WORKERS + 1);
+}
+
+async function unsupportedToWorkersTest() {
+    try {
+        const results = await sendWorkerCommand('badToWorkers', 'SomeTestHandler', genUIDS(), {});
+        return respondOnTestFailure('expected an error', null, results);
+    } catch (err) {
+        if (!err.is.NotImplemented) {
+            return respondOnTestFailure('expected a NotImplemented error', err, null);
+        }
+        return undefined;
+    }
+}
+
+async function unsupportedHandlerTest() {
+    try {
+        const results = await sendWorkerCommand('*', 'AWrongTestHandler', genUIDS(), {});
+        if (results.length !== N_WORKERS) {
+            return respondOnTestFailure(
+                `expected ${N_WORKERS} worker results, got ${results.length}`,
+                null, results);
+        }
+        for (const result of results) {
+            if (typeof result !== 'object' || result === null) {
+                return respondOnTestFailure('not all results are objects', null, results);
+            }
+            if (result.error === null || !result.error.is.NotImplemented) {
+                return respondOnTestFailure(
+                    'one or more workers did not return the expected NotImplemented error',
+                    null, results);
+            }
+        }
+        return undefined;
+    } catch (err) {
+        return respondOnTestFailure(`returned unexpected error ${err}`, err, null);
+    }
+}
+
+async function missingUidsTest() {
+    try {
+        const results = await sendWorkerCommand('*', 'SomeTestHandler', undefined, {});
+        return respondOnTestFailure('expected an error', null, results);
+    } catch (err) {
+        if (!err.is.MissingParameter) {
+            return respondOnTestFailure('expected a MissingParameter error', err, null);
+        }
+        return undefined;
+    }
+}
+
+async function duplicateUidsTest() {
+    const dupUIDS = genUIDS();
+    const promises = [
+        sendWorkerCommand('*', 'SomeTestHandler', dupUIDS, {}),
+        sendWorkerCommand('*', 'SomeTestHandler', dupUIDS, {}),
+    ];
+    const results = await Promise.allSettled(promises);
+    if (results[1].status !== 'rejected') {
+        return respondOnTestFailure('expected an error from the second call', null, null);
+    }
+    if (!results[1].reason.is.OperationAborted) {
+        return respondOnTestFailure(
+            'expected a OperationAborted error', results[1].reason, null);
+    }
+    return undefined;
+}
+
+async function unsuccessfulWorkerTest() {
+    try {
+        const results = await sendWorkerCommand('*', 'TestHandlerWithFailure', genUIDS(), {});
+        if (results.length !== N_WORKERS) {
+            return respondOnTestFailure(
+                `expected ${N_WORKERS} worker results, got ${results.length}`,
+                null, results);
+        }
+        const nServiceFailures = results.filter(result => (
+            result.error && result.error.is.ServiceFailure
+        )).length;
+        if (nServiceFailures !== 1) {
+            return respondOnTestFailure(
+                'expected exactly one worker result to be ServiceFailure error',
+                null, results);
+        }
+        return undefined;
+    } catch (err) {
+        return respondOnTestFailure(`returned unexpected error ${err}`, err, null);
+    }
+}
+
+async function workerTimeoutTest() {
+    try {
+        const results = await sendWorkerCommand(
+            '*', 'TestHandlerWithNoResponse', genUIDS(), {}, 1000);
+        return respondOnTestFailure('expected an error', null, results);
+    } catch (err) {
+        if (!err.is.RequestTimeout) {
+            return respondOnTestFailure('expected a RequestTimeout error', err, null);
+        }
+        return undefined;
+    }
+}
+
+const TEST_URLS = {
+    '/successful-command': successfulCommandTest,
+    '/successful-command-with-extra-worker': successfulCommandWithExtraWorkerTest,
+    '/unsupported-to-workers': unsupportedToWorkersTest,
+    '/unsupported-handler': unsupportedHandlerTest,
+    '/missing-uids': missingUidsTest,
+    '/duplicate-uids': duplicateUidsTest,
+    '/unsuccessful-worker': unsuccessfulWorkerTest,
+    '/worker-timeout': workerTimeoutTest,
+};
+
+if (process.argv.length !== 4) {
+    console.error('ClusterRPC test server: GET requests on test URLs trigger test runs\n\n' +
+                  'Usage: node ClusterRPC-test-server.js <port> <nb-workers>\n\n' +
+                  'Available test URLs:');
+    console.error(`${Object.keys(TEST_URLS).map(url => `- ${url}\n`).join('')}`);
+    process.exit(2);
+}
+
+/* eslint-disable prefer-const */
+[
+    SERVER_PORT,
+    N_WORKERS,
+] = process.argv.slice(2, 4).map(value => Number.parseInt(value, 10));
+/* eslint-enable prefer-const */
+
+let server;
+
+if (cluster.isPrimary) {
+    async.timesSeries(
+        N_WORKERS,
+        (i, wcb) => cluster.fork().on('online', wcb),
+        () => {
+            setupRPCPrimary();
+        },
+    );
+} else {
+    // in worker
+    server = http.createServer((req, res) => {
+        if (req.url in TEST_URLS) {
+            return TEST_URLS[req.url]().then(() => {
+                if (getPendingCommandsCount() !== 0) {
+                    console.error(`There are still ${getPendingCommandsCount()} pending ` +
+                                  `RPC commands after test ${req.url} completed`);
+                    throw errors.InternalError;
+                }
+                res.writeHead(200);
+                res.end();
+            }).catch(err => {
+                res.writeHead(err.code);
+                res.end(err.message);
+            });
+        }
+        console.error(`Invalid test URL ${req.url}`);
+        res.writeHead(400);
+        res.end();
+        return undefined;
+    });
+    server.listen(SERVER_PORT);
+    server.on('listening', () => {
+        console.log('Worker is listening');
+    });
+
+    setupRPCWorker(rpcHandlers);
+}
+
+function stop(signal) {
+    if (cluster.isPrimary) {
+        console.log(`Handling signal ${signal}`);
+        for (const worker of Object.values(cluster.workers)) {
+            worker.kill(signal);
+            worker.on('exit', () => {
+                console.log(`Worker ${worker.id} exited`);
+            });
+        }
+    }
+    for (const interval of ipcPolluterIntervals) {
+        clearInterval(interval);
+    }
+}
+
+process.on('SIGTERM', stop);
+process.on('SIGINT', stop);
+process.on('SIGPIPE', () => {});
+
+// for testing: spawn a new worker each time SIGUSR1 is received
+function spawnNewWorker() {
+    if (cluster.isPrimary) {
+        cluster.fork();
+    }
+}
+
+process.on('SIGUSR1', spawnNewWorker);

--- a/tests/functional/clustering/ClusterRPC.spec.js
+++ b/tests/functional/clustering/ClusterRPC.spec.js
@@ -1,0 +1,109 @@
+'use strict'; // eslint-disable-line
+
+const http = require('http');
+const readline = require('readline');
+const spawn = require('child_process').spawn;
+
+const TEST_SERVER_PORT = 8800;
+const NB_WORKERS = 4;
+
+let testServer = null;
+
+/*
+ * jest tests don't correctly support cluster mode with child forked
+ * processes, instead we use an external test server that launches
+ * each test based on the provided URL, and returns either 200 for
+ * success or 500 for failure. A crash would also cause a failure
+ * from the client side.
+ */
+function startTestServer(done) {
+    testServer = spawn('node', [
+        `${__dirname}/ClusterRPC-test-server.js`,
+        TEST_SERVER_PORT,
+        NB_WORKERS,
+    ]);
+    // gather server stderr to display test failures info
+    testServer.stdout.pipe(process.stdout);
+    testServer.stderr.pipe(process.stderr);
+
+    const rl = readline.createInterface({
+        input: testServer.stdout,
+    });
+    let nbListeningWorkers = 0;
+    rl.on('line', line => {
+        if (line === 'Worker is listening') {
+            nbListeningWorkers++;
+            if (nbListeningWorkers === NB_WORKERS) {
+                rl.close();
+                done();
+            }
+        }
+    });
+}
+
+function stopTestServer(done) {
+    testServer.kill('SIGTERM');
+    testServer.on('close', done);
+}
+
+function runTest(testUrl, cb) {
+    const req = http.request(`http://localhost:${TEST_SERVER_PORT}/${testUrl}`, res => {
+        res
+            .on('data', () => {})
+            .on('end', () => {
+                expect(res.statusCode).toEqual(200);
+                cb();
+            })
+            .on('error', err => cb(err));
+    });
+    req
+        .end()
+        .on('error', err => cb(err));
+}
+
+describe('ClusterRPC', () => {
+    beforeAll(done => startTestServer(done));
+    afterAll(done => stopTestServer(done));
+
+    it('should send a successful command to all workers', done => {
+        runTest('successful-command', done);
+    });
+
+    it('should error if "toWorkers" field is not "*"', done => {
+        runTest('unsupported-to-workers', done);
+    });
+
+    it('should error if handler name is not known', done => {
+        runTest('unsupported-handler', done);
+    });
+
+    it('should error if "uids" field is not passed', done => {
+        runTest('missing-uids', done);
+    });
+
+    it('should error if two simultaneous commands with same "uids" field are sent', done => {
+        runTest('duplicate-uids', done);
+    });
+
+    it('should timeout if one or more workers don\'t respond in allocated time', done => {
+        runTest('worker-timeout', done);
+    });
+
+    it('should return worker errors in results array', done => {
+        runTest('unsuccessful-worker', done);
+    });
+
+    it('should send a successful command to all workers after an extra worker is spawned', done => {
+        const rl = readline.createInterface({
+            input: testServer.stdout,
+        });
+        rl.on('line', line => {
+            if (line === 'Worker is listening') {
+                rl.close();
+                runTest('successful-command-with-extra-worker', done);
+            }
+        });
+        // The test server spawns a new worker when it receives SIGUSR1
+        testServer.kill('SIGUSR1');
+    });
+});


### PR DESCRIPTION
When using the cluster module, new processes are forked and are dispatched workloads, usually HTTP requests. The ClusterRPC module implements a RPC system to send commands to all cluster worker processes at once from any particular worker, and retrieve their individual command results, like a distributed map operation.

The existing cluster IPC channel is setup from the primary to each worker, but not between workers, so there has to be a hop by the primary.

How a command is treated:

- a worker sends a command message to the primary

- the primary then forwards that command to each existing worker (including the requestor)

- each worker then executes the command and returns a result or an error

- the primary gathers all workers results into an array

- finally, the primary dispatches the results array to the original requesting worker callback

The original use of this feature is in Metadata DBD (bucketd) to implement a global cache refresh across worker processes.
