### PR TITLE
ARSN-382: fix empty location when redirect to / 

### DIFF
--- a/lib/s3routes/routesUtils.ts
+++ b/lib/s3routes/routesUtils.ts
@@ -846,7 +846,7 @@ export function redirectRequest(
     }
     let redirectLocation = justPath ? `/${redirectKey}` :
         `${redirectProtocol}://${redirectHostName}/${redirectKey}`;
-    if (!redirectKey && redirectLocationHeader) {
+    if (!redirectKey && redirectLocationHeader && redirectLocation.length > 1) {
         // remove hanging slash
         redirectLocation = redirectLocation.slice(0, -1);
     }

--- a/lib/s3routes/routesUtils.ts
+++ b/lib/s3routes/routesUtils.ts
@@ -846,7 +846,7 @@ export function redirectRequest(
     }
     let redirectLocation = justPath ? `/${redirectKey}` :
         `${redirectProtocol}://${redirectHostName}/${redirectKey}`;
-    if (!redirectKey && redirectLocationHeader && redirectLocation.length > 1) {
+    if (!redirectKey && redirectLocationHeader && redirectLocation !== '/') {
         // remove hanging slash
         redirectLocation = redirectLocation.slice(0, -1);
     }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.10.52",
+  "version": "7.10.53",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/s3routes/routesUtils/redirectRequest.spec.js
+++ b/tests/unit/s3routes/routesUtils/redirectRequest.spec.js
@@ -1,0 +1,77 @@
+const assert = require('assert');
+
+const DummyRequestLogger = require('../../storage/metadata/mongoclient/utils/DummyRequestLogger');
+const HttpResponseMock = require('../../../utils/HttpResponseMock');
+const routesUtils = require('../../../../lib/s3routes/routesUtils');
+
+const encrypted = false;
+const hostHeader = 'cloudserver.test';
+const corsHeaders = {
+    'access-control-allow-origin': '*',
+    'access-control-allow-methods': 'GET',
+};
+
+function assertCors(responseMock) {
+    for (const [key, val] of Object.entries(corsHeaders)) {
+        assert.strictEqual(responseMock._headers[key], val);
+    }
+}
+
+describe('routesUtils.redirectRequest', () => {
+    describe('like object redirect header', () => {
+        const objectKey = '';
+        const redirectLocationHeader = true;
+
+        it('should redirect to absolute url', () => {
+            const responseMock = new HttpResponseMock();
+            const routing = {
+                redirectLocationHeader,
+                protocol: 'https',
+                hostName: 'scality.com/test',
+            };
+            routesUtils.redirectRequest(
+                routing, objectKey, encrypted, responseMock, hostHeader,
+                corsHeaders, new DummyRequestLogger(),
+            );
+            assert.strictEqual(responseMock.statusCode, 301);
+            assert.strictEqual(responseMock._body, null);
+            assertCors(responseMock);
+            assert.strictEqual(responseMock._headers.Location, 'https://scality.com/test');
+        });
+
+        it('should redirect to relative url', () => {
+            const responseMock = new HttpResponseMock();
+            const routing = {
+                redirectLocationHeader,
+                justPath: true,
+                replaceKeyWith: 'testing/redirect.html',
+            };
+            routesUtils.redirectRequest(
+                routing, objectKey, encrypted, responseMock, hostHeader,
+                corsHeaders, new DummyRequestLogger(),
+            );
+            assert.strictEqual(responseMock.statusCode, 301);
+            assert.strictEqual(responseMock._body, null);
+            assertCors(responseMock);
+            assert.strictEqual(responseMock._headers.Location, '/testing/redirect.html');
+        });
+
+        it('should redirect to root /', () => {
+            const responseMock = new HttpResponseMock();
+            const routing = {
+                redirectLocationHeader,
+                justPath: true,
+                // cloudserver removes the /, arsenal puts it back
+                replaceKeyWith: '',
+            };
+            routesUtils.redirectRequest(
+                routing, objectKey, encrypted, responseMock, hostHeader,
+                corsHeaders, new DummyRequestLogger(),
+            );
+            assert.strictEqual(responseMock.statusCode, 301);
+            assert.strictEqual(responseMock._body, null);
+            assertCors(responseMock);
+            assert.strictEqual(responseMock._headers.Location, '/');
+        });
+    });
+});

--- a/tests/utils/HttpResponseMock.js
+++ b/tests/utils/HttpResponseMock.js
@@ -1,0 +1,66 @@
+
+/**
+ * Basic response mock to catch response values.
+ *
+ * CAUTION: not all methods and fields are implemented.
+ *
+ * @see https://nodejs.org/api/http.html#class-httpserverresponse
+ */
+class HttpResponseMock {
+    constructor() {
+        this.statusCode = null;
+        this._headers = {};
+        this._body = null;
+    }
+
+    setHeader(key, val) {
+        this._headers[key] = val;
+    }
+
+    end(data, encoding, callback) {
+        this.write(data, encoding, callback);
+    }
+
+    write(chunk, encoding, callback) {
+        let str = chunk;
+
+        if (Buffer.isBuffer(str)) {
+            str = str.toString();
+        }
+        if (str instanceof Uint8Array) {
+            str = new TextDecoder().decode(str);
+        }
+        if (str) {
+            this._body = (this._body || '') + str;
+        }
+
+        let cb = callback;
+        if (!cb && typeof encoding === 'function') {
+            cb = encoding;
+        }
+        if (cb) cb();
+    }
+
+    writeHead(statusCode, statusMessage, headers) {
+        this.statusCode = statusCode;
+        let headersObj = headers;
+
+        if (!headersObj && typeof statusMessage === 'object') {
+            headersObj = statusMessage;
+        }
+
+        if (!headersObj) return;
+
+        if (Array.isArray(headersObj)) {
+            // the even-numbered offsets are key values,
+            // and the odd-numbered offsets are the associated values.
+            for (let i = 0; i < headersObj.length; i += 2) {
+                this._headers[headersObj[i]] = headersObj[i + 1];
+            }
+        } else {
+            Object.assign(this._headers, headersObj);
+        }
+    }
+}
+
+module.exports = HttpResponseMock;


### PR DESCRIPTION
If object has a redirect to / it is sliced out
and the function receives an empty string as redirectKey
Therefore if redirectLocation consists of a single character /
The Location header would be empty

Functional tests will be performed in cloudserver once it uses the new version of arsenal