### PR TITLE
ARSN-384: Add a website redirect with error and body

### DIFF
--- a/lib/errors/arsenalErrors.ts
+++ b/lib/errors/arsenalErrors.ts
@@ -690,6 +690,11 @@ export const ReportNotPresent: ErrorFormat = {
         'The request was rejected because the credential report does not exist. To generate a credential report, use GenerateCredentialReport.',
 };
 
+export const Found: ErrorFormat = {
+    code: 302,
+    description: 'Resource Found'
+};
+
 // ------------- Special non-AWS S3 errors -------------
 
 export const MPUinProgress: ErrorFormat = {

--- a/lib/s3routes/routes/routeWebsite.ts
+++ b/lib/s3routes/routes/routeWebsite.ts
@@ -27,6 +27,11 @@ export default function routerWebsite(
                 routesUtils.statsReport500(err, statsClient);
                 // request being redirected
                 if (redirectInfo) {
+                    if (err && redirectInfo.withError) {
+                        return routesUtils.redirectRequestOnError(err,
+                            'GET', redirectInfo, dataGetInfo, dataRetrievalFn,
+                            response, resMetaHeaders, log)
+                    }
                     // note that key might have been modified in websiteGet
                     // api to add index document
                     return routesUtils.redirectRequest(redirectInfo,
@@ -57,6 +62,11 @@ export default function routerWebsite(
             (err, resMetaHeaders, redirectInfo, key) => {
                 routesUtils.statsReport500(err, statsClient);
                 if (redirectInfo) {
+                    if (err && redirectInfo.withError) {
+                        return routesUtils.redirectRequestOnError(err,
+                            'HEAD', redirectInfo, null, dataRetrievalFn,
+                            response, resMetaHeaders, log)
+                    }
                     return routesUtils.redirectRequest(redirectInfo,
                         // TODO ARSN-217 encrypted does not exists in request.connection
                         // @ts-ignore

--- a/lib/s3routes/routesUtils.ts
+++ b/lib/s3routes/routesUtils.ts
@@ -895,7 +895,7 @@ export function redirectRequestOnError(
 ) {
     response.setHeader('Location', routingInfo.location);
 
-    if (!dataLocations && err.name === errors.Found.name) {
+    if (!dataLocations && err.is.Found) {
         if (method === 'HEAD') {
             return errorHeaderResponse(err, response, corsHeaders, log);
         }

--- a/lib/s3routes/routesUtils.ts
+++ b/lib/s3routes/routesUtils.ts
@@ -697,9 +697,7 @@ export function errorHtmlResponse(
     log.trace('sending generic html error page',
         { err });
     setCommonResponseHeaders(corsHeaders, response, log);
-    /** AWS uses old HTTP/1.0 statusMessage for 302 Found */
-    const statusMsg = err.code === 302 ? 'Moved Temporarily' : undefined;
-    response.writeHead(err.code, statusMsg, { 'Content-type': 'text/html' });
+    response.writeHead(err.code, { 'Content-type': 'text/html' });
     const html: string[] = [];
     // response.statusMessage will provide standard message for status
     // code so much set response status code before creating html
@@ -767,9 +765,7 @@ export function errorHeaderResponse(
     setCommonResponseHeaders(corsHeaders, response, log);
     response.setHeader('x-amz-error-code', err.message);
     response.setHeader('x-amz-error-message', err.description);
-    /** AWS uses old HTTP/1.0 statusMessage for 302 Found */
-    const statusMsg = err.code === 302 ? 'Moved Temporarily' : undefined;
-    response.writeHead(err.code, statusMsg);
+    response.writeHead(err.code);
     return response.end(() => {
         // TODO ARSN-216 Fix logger
         // @ts-expect-error

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.10.53",
+  "version": "7.10.54",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/s3routes/routesUtils/redirectRequestOnError.spec.js
+++ b/tests/unit/s3routes/routesUtils/redirectRequestOnError.spec.js
@@ -39,7 +39,7 @@ describe('routesUtils.redirectRequestOnError', () => {
             assertHeaders(responseMock, corsHeaders);
             assertHeaders(responseMock, errorHeaders);
             assert.strictEqual(responseMock._headers.Location, routing.location);
-            assert.match(responseMock._body, /<h1>302 Moved Temporarily<\/h1>/);
+            assert.match(responseMock._body, /<h1>302 Found<\/h1>/);
             assert.match(responseMock._body, /<li>Code: Found<\/li>/);
             assert.match(responseMock._body, /<li>Message: Resource Found<\/li>/);
         });

--- a/tests/unit/s3routes/routesUtils/redirectRequestOnError.spec.js
+++ b/tests/unit/s3routes/routesUtils/redirectRequestOnError.spec.js
@@ -1,0 +1,105 @@
+const assert = require('assert');
+const sinon = require('sinon');
+
+const DummyRequestLogger = require('../../storage/metadata/mongoclient/utils/DummyRequestLogger');
+const HttpResponseMock = require('../../../utils/HttpResponseMock');
+const routesUtils = require('../../../../lib/s3routes/routesUtils');
+const { errors } = require('../../../../index');
+const DataWrapper = require('../../../../lib/storage/data/DataWrapper');
+
+const corsHeaders = {
+    'access-control-allow-origin': '*',
+    'access-control-allow-methods': 'GET',
+};
+
+function assertHeaders(responseMock, expectedHeaders) {
+    for (const [key, val] of Object.entries(expectedHeaders)) {
+        assert.strictEqual(responseMock._headers[key], val);
+    }
+}
+
+describe('routesUtils.redirectRequestOnError', () => {
+    describe('from request on folder containing ' +
+    'index without trailing /', () => {
+        const errorHeaders = {
+            'x-amz-error-code': errors.Found.type,
+            'x-amz-error-message': errors.Found.description,
+        };
+
+        it('should redirect 302 with body on GET', () => {
+            const responseMock = new HttpResponseMock();
+            const routing = { withError: true, location: '/photos/' };
+            routesUtils.redirectRequestOnError(
+                errors.Found, 'GET',
+                routing, null, null, responseMock,
+                corsHeaders, new DummyRequestLogger(),
+            );
+
+            assert.strictEqual(responseMock.statusCode, 302);
+            assertHeaders(responseMock, corsHeaders);
+            assertHeaders(responseMock, errorHeaders);
+            assert.strictEqual(responseMock._headers.Location, routing.location);
+            assert.match(responseMock._body, /<h1>302 Moved Temporarily<\/h1>/);
+            assert.match(responseMock._body, /<li>Code: Found<\/li>/);
+            assert.match(responseMock._body, /<li>Message: Resource Found<\/li>/);
+        });
+
+        it('should redirect 302 without body on HEAD', () => {
+            const responseMock = new HttpResponseMock();
+            const routing = { withError: true, location: '/photos/' };
+            routesUtils.redirectRequestOnError(
+                errors.Found, 'HEAD',
+                routing, null, null, responseMock,
+                corsHeaders, new DummyRequestLogger(),
+            );
+
+            assert.strictEqual(responseMock.statusCode, 302);
+            assertHeaders(responseMock, corsHeaders);
+            assertHeaders(responseMock, errorHeaders);
+            assert.strictEqual(responseMock._headers.Location, routing.location);
+            assert.strictEqual(responseMock._body, null);
+        });
+    });
+
+    describe('from error document redirect location header', () => {
+        let dataWrapperGetStub;
+
+        afterAll(() => {
+            if (dataWrapperGetStub) {
+                dataWrapperGetStub.restore();
+            }
+        });
+
+        it('should redirect 301 with body on GET', () => {
+            const responseMock = new HttpResponseMock();
+            const routing = { withError: true,
+                location: 'http://scality.com/test' };
+            const errorHeaders = {
+                'x-amz-error-code': errors.AccessDenied.type,
+                'x-amz-error-message': errors.AccessDenied.description,
+            };
+            dataWrapperGetStub = sinon.stub(DataWrapper.prototype, 'get');
+
+            const mockedDataLocations = [{ mock: true }];
+            const mockedRetrieveDataParams = {
+                mockRetrieveDataParams: true,
+            };
+
+            routesUtils.redirectRequestOnError(
+                errors.AccessDenied, 'GET',
+                routing, mockedDataLocations, mockedRetrieveDataParams,
+                responseMock, corsHeaders, new DummyRequestLogger(),
+            );
+
+            assert.strictEqual(responseMock.statusCode, 301);
+            assertHeaders(responseMock, corsHeaders);
+            assertHeaders(responseMock, errorHeaders);
+            assert.strictEqual(responseMock._headers.Location, routing.location);
+            assert.strictEqual(dataWrapperGetStub.callCount, 1);
+            assert.strictEqual(dataWrapperGetStub.getCall(0).args[0],
+                mockedDataLocations[0]);
+            assert.strictEqual(dataWrapperGetStub.getCall(0).args[1],
+                responseMock);
+        });
+    });
+});

--- a/tests/utils/HttpResponseMock.js
+++ b/tests/utils/HttpResponseMock.js
@@ -1,3 +1,4 @@
+const http = require('http');
 
 /**
  * Basic response mock to catch response values.
@@ -9,6 +10,7 @@
 class HttpResponseMock {
     constructor() {
         this.statusCode = null;
+        this.statusMessage = null;
         this._headers = {};
         this._body = null;
     }
@@ -18,7 +20,13 @@ class HttpResponseMock {
     }
 
     end(data, encoding, callback) {
-        this.write(data, encoding, callback);
+        let cb = callback;
+        if (!cb && typeof data === 'function') {
+            cb = data;
+            cb();
+        } else {
+            this.write(data, encoding, callback);
+        }
     }
 
     write(chunk, encoding, callback) {
@@ -43,6 +51,9 @@ class HttpResponseMock {
 
     writeHead(statusCode, statusMessage, headers) {
         this.statusCode = statusCode;
+        /** AWS uses old HTTP/1.0 statusMessage for 302 Found */
+        this.statusMessage = statusCode === 302 ?
+            'Moved Temporarily' : http.STATUS_CODES[statusCode];
         let headersObj = headers;
 
         if (!headersObj && typeof statusMessage === 'object') {
@@ -61,6 +72,9 @@ class HttpResponseMock {
             Object.assign(this._headers, headersObj);
         }
     }
+
+    on() {}
+    once() {}
 }
 
 module.exports = HttpResponseMock;

--- a/tests/utils/HttpResponseMock.js
+++ b/tests/utils/HttpResponseMock.js
@@ -20,13 +20,10 @@ class HttpResponseMock {
     }
 
     end(data, encoding, callback) {
-        let cb = callback;
-        if (!cb && typeof data === 'function') {
-            cb = data;
-            cb();
-        } else {
-            this.write(data, encoding, callback);
+        if (!callback && typeof data === 'function') {
+            return data();
         }
+        return this.write(data, encoding, callback);
     }
 
     write(chunk, encoding, callback) {
@@ -51,9 +48,7 @@ class HttpResponseMock {
 
     writeHead(statusCode, statusMessage, headers) {
         this.statusCode = statusCode;
-        /** AWS uses old HTTP/1.0 statusMessage for 302 Found */
-        this.statusMessage = statusCode === 302 ?
-            'Moved Temporarily' : http.STATUS_CODES[statusCode];
+        this.statusMessage = http.STATUS_CODES[statusCode];
         let headersObj = headers;
 
         if (!headersObj && typeof statusMessage === 'object') {


### PR DESCRIPTION
There are 2 cases where a redirect can contain error headers and a body:

- If the custom error document contains an object redirect location: the response should be a redirect with the custom error document in the body ([CLDSRV-485](https://scality.atlassian.net/browse/CLDSRV-485))
  - See PR: https://github.com/scality/cloudserver/pull/5518

- If a request is sent to a folder without trailing / that holds an index document: the response should be a redirect 302 to append the trailing / with a default html response in body ([CLDSRV-489](https://scality.atlassian.net/browse/CLDSRV-489))
  - See PR: https://github.com/scality/cloudserver/pull/5520

[CLDSRV-485]: https://scality.atlassian.net/browse/CLDSRV-485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLDSRV-489]: https://scality.atlassian.net/browse/CLDSRV-489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ