### PR TITLE
Bugfix/arsn 385/fully align with aws on lifecycle configuration dates

### DIFF
--- a/lib/models/LifecycleConfiguration.ts
+++ b/lib/models/LifecycleConfiguration.ts
@@ -499,17 +499,35 @@ export default class LifecycleConfiguration {
      * @return Returns an error object or `null`
      */
     _checkDate(date: string) {
-        const isoRegex = new RegExp('^(-?(?:[1-9][0-9]*)?[0-9]{4})-' +
-            '(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9])' +
-            ':([0-5][0-9]):([0-5][0-9])(\\.[0-9]+)?(Z)?$');
-        if (!isoRegex.test(date)) {
+        const isoRegex = new RegExp(
+            "^(-?(?:[1-9][0-9]*)?[0-9]{4})" + // Year
+            "-(1[0-2]|0[1-9])" + // Month
+            "-(3[01]|0[1-9]|[12][0-9])" + // Day
+            "T(2[0-3]|[01][0-9])" + // Hour
+            ":([0-5][0-9])" + // Minute
+            ":([0-5][0-9])" + // Second
+            "(\\.[0-9]+)?" + // Fractional second
+            "(Z|[+-][01][0-9]:[0-5][0-9])?$", // Timezone
+            "g"
+        );
+        const matches = [...date.matchAll(isoRegex)];
+        if (matches.length !== 1) {
             const msg = 'Date must be in ISO 8601 format';
             return errors.InvalidArgument.customizeDescription(msg);
         }
-        const midnightRegex = new RegExp('^(-?(?:[1-9][0-9]*)?[0-9]{4})-' +
-            '(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T00' +
-            ':00:00(\\.0+)?(Z)?$');
-        if (!midnightRegex.test(date)) {
+        // Check for a timezone in the last match group. If none, add a Z to indicate UTC.
+        if (!matches[0][matches[0].length-1]) {
+            date += 'Z';
+        }
+        const dateObj = new Date(date);
+        if (Number.isNaN(dateObj.getTime())) {
+            const msg = 'Date is not a valid date';
+            return errors.InvalidArgument.customizeDescription(msg);
+        }
+        if (dateObj.getUTCHours() !== 0
+            || dateObj.getUTCMinutes() !== 0
+            || dateObj.getUTCSeconds() !== 0
+            || dateObj.getUTCMilliseconds() !== 0) {
             const msg = '\'Date\' must be at midnight GMT';
             return errors.InvalidArgument.customizeDescription(msg);
         }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.10.54",
+  "version": "7.10.55",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/models/LifecycleConfiguration.spec.js
+++ b/tests/unit/models/LifecycleConfiguration.spec.js
@@ -420,6 +420,12 @@ describe('LifecycleConfiguration', () => {
             assert.strictEqual(error, null);
         });
 
+        it('should return no error with a valid ISO date at midnight with timezone', () => {
+            const date = '2024-01-08T06:00:00+06:00';
+            const error = lifecycleConfiguration._checkDate(date);
+            assert.strictEqual(error, null);
+        });
+
         it('should return an error with a non-ISO date', () => {
             const date = '2016-01-01T00:00:00000Z';
             const error = lifecycleConfiguration._checkDate(date);
@@ -436,8 +442,24 @@ describe('LifecycleConfiguration', () => {
             expect(error.description).toEqual(msg);
         });
 
+        it('should return an error with a non-ISO date', () => {
+            const date = '2024-01-08T00:00:00+34:00';
+            const error = lifecycleConfiguration._checkDate(date);
+            const msg = 'Date must be in ISO 8601 format';
+            expect(error.is.InvalidArgument).toBeTruthy();
+            expect(error.description).toEqual(msg);
+        });
+
         it('should return an error with a date that is not set to midnight', () => {
             const date = '2024-01-04T15:22:40Z';
+            const error = lifecycleConfiguration._checkDate(date);
+            const msg = '\'Date\' must be at midnight GMT';
+            expect(error.is.InvalidArgument).toBeTruthy();
+            expect(error.description).toEqual(msg);
+        });
+
+        it('should return an error with a date that is not set to midnight', () => {
+            const date = '2024-01-08T00:00:00.123Z';
             const error = lifecycleConfiguration._checkDate(date);
             const msg = '\'Date\' must be at midnight GMT';
             expect(error.is.InvalidArgument).toBeTruthy();


### PR DESCRIPTION
Best reviewed as two commits. 

One change is about the parsing of dates for lifecycle configurations, we wanted to align closely to AWS.
The other change is what was needed to make the tests works in cloudserver, both against cloudserver and against AWS.