### PR TITLE
Bugfix/arsn 386/fix generate v4 headers for put with body requests

### DIFF
--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -162,6 +162,20 @@ function doAuth(
 }
 
 /**
+ * This function will generate a version 4 content-md5 header
+ * It looks at the request path to determine what kind of header encoding is required
+ *
+ * @param path - the request path
+ * @param payload - the request payload to hash
+ */
+function generateContentMD5Header(
+    path: string,
+    payload: string,
+) {
+    const encoding = path && path.startsWith('/_/backbeat/') ? 'hex' : 'base64';
+    return crypto.createHash('md5').update(payload, 'binary').digest(encoding);
+}
+/**
  * This function will generate a version 4 header
  *
  * @param request - Http request object
@@ -173,6 +187,7 @@ function doAuth(
  * @param [proxyPath] - path that gets proxied by reverse proxy
  * @param [sessionToken] - security token if the access/secret keys
  *                                are temporary credentials from STS
+ * @param [payload] - body of the request if any
  */
 function generateV4Headers(
     request: any,
@@ -180,8 +195,9 @@ function generateV4Headers(
     accessKey: string,
     secretKeyValue: string,
     awsService: string,
-    proxyPath: string,
-    sessionToken: string
+    proxyPath?: string,
+    sessionToken?: string,
+    payload?: string,
 ) {
     Object.assign(request, { headers: {} });
     const amzDate = convertUTCtoISO8601(Date.now());
@@ -194,7 +210,7 @@ function generateV4Headers(
     const timestamp = amzDate;
     const algorithm = 'AWS4-HMAC-SHA256';
 
-    let payload = '';
+    payload = payload || '';
     if (request.method === 'POST') {
         payload = queryString.stringify(data, undefined, undefined, {
             encodeURIComponent,
@@ -205,6 +221,7 @@ function generateV4Headers(
     request.setHeader('host', request._headers.host);
     request.setHeader('x-amz-date', amzDate);
     request.setHeader('x-amz-content-sha256', payloadChecksum);
+    request.setHeader('content-md5', generateContentMD5Header(request.path, payload));
 
     if (sessionToken) {
         request.setHeader('x-amz-security-token', sessionToken);
@@ -215,6 +232,7 @@ function generateV4Headers(
         .filter(headerName =>
             headerName.startsWith('x-amz-')
             || headerName.startsWith('x-scal-')
+            || headerName === 'content-md5'
             || headerName === 'host'
         ).sort().join(';');
     const params = { request, signedHeaders, payloadChecksum,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.10.55",
+  "version": "7.10.56",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {


### PR DESCRIPTION
When attempting to send lifecycle configuration requests to AWS with this in-house client, I found that it did not include the necessary `content-md5` header. Unfortunately this header is also used when calling `backbeat`'s internal routes but the hash is expressed in hex form, not in base64.

Thus, I chose to go down the simplest path which is to add the header anyway but choose the encoding based on the route of the request. I am also adding the header all of the time, this does not have a negative impact on our tests in cloudserver (except for the one testing the behavior when the header is not present).

