### PR TITLE
ARSN-387: check for forwarded proto header

### DIFF
--- a/lib/policyEvaluator/utils/conditions.ts
+++ b/lib/policyEvaluator/utils/conditions.ts
@@ -61,7 +61,7 @@ export function findConditionKey(
     case 'aws:referer': return headers.referer;
     // aws:SecureTransport – Used to check whether the request was sent
     // using SSL (see Boolean Condition Operators).
-    case 'aws:SecureTransport': return requestContext.getSslEnabled() ? 'true' : 'false';
+    case 'aws:SecureTransport': return headers?.['x-forwarded-proto'] === 'https' ? 'true' : 'false';
     // aws:SourceArn – Used check the source of the request,
     // using the ARN of the source. N/A here.
     case 'aws:SourceArn': return undefined;

--- a/lib/policyEvaluator/utils/variables.ts
+++ b/lib/policyEvaluator/utils/variables.ts
@@ -38,7 +38,7 @@ function findVariable(variable: string, requestContext: RequestContext): string 
     // aws:SecureTransport is boolean value that represents whether the
     // request was sent using SSL
     map.set('aws:SecureTransport',
-        requestContext.getSslEnabled() ? 'true' : 'false');
+        headers?.['x-forwarded-proto'] === 'https' ? 'true' : 'false');
     // aws:SourceIp is requester's IP address, for use with IP address
     // conditions
     map.set('aws:SourceIp', requestContext.getRequesterIp());

--- a/tests/unit/policyEvaluator.spec.js
+++ b/tests/unit/policyEvaluator.spec.js
@@ -915,7 +915,9 @@ describe('policyEvaluator', () => {
             () => {
                 policy.Statement.Condition = { Bool:
                         { 'aws:SecureTransport': 'true' } };
-                const rcModifiers = { _sslEnabled: true };
+                const rcModifiers = { _headers: {
+                    'x-forwarded-proto': 'https',
+                } };
                 check(requestContext, rcModifiers, policy, 'Allow');
             });
 

--- a/tests/unit/policyEvaluator.spec.js
+++ b/tests/unit/policyEvaluator.spec.js
@@ -906,7 +906,9 @@ describe('policyEvaluator', () => {
             () => {
                 policy.Statement.Condition = { Bool:
                         { 'aws:SecureTransport': 'true' } };
-                const rcModifiers = { _sslEnabled: false };
+                const rcModifiers = { _headers: {
+                    'x-forwarded-proto': 'http',
+                } };
                 check(requestContext, rcModifiers, policy, 'Neutral');
             });
 


### PR DESCRIPTION
This fix is for the `aws:secureTransport` condition, related to the [TSKB](https://github.com/scality/tskb/pull/429).

With load balancers in front, the check for SSL in the request must be done on the x-forwarded-proto header. 

Tests have been updated accordingly.

The other necessary change for this condition to work correctly is for the nginx config to properly pass this header:
```
proxy_set_header X-Forwarded-Proto $scheme;
```

Edit:
Green CS and Vault builds:
https://github.com/scality/Vault/pull/2151
https://github.com/scality/cloudserver/pull/5546