### PR TITLE
ft: ARSN-388 implement GapSet (caching of listing gaps)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -52,6 +52,7 @@ export const algorithms = {
         DelimiterTools: require('./lib/algos/list/tools'),
     },
     cache: {
+        GapSet: require('./lib/algos/cache/GapSet'),
         LRUCache: require('./lib/algos/cache/LRUCache'),
     },
     stream: {

--- a/lib/algos/cache/GapSet.ts
+++ b/lib/algos/cache/GapSet.ts
@@ -1,0 +1,362 @@
+import assert from 'assert';
+import { OrderedSet } from '@js-sdsl/ordered-set';
+
+import errors from '../../errors';
+
+export type GapSetEntry = {
+    firstKey: string,
+    lastKey: string,
+    weight: number,
+};
+
+export interface GapSetInterface {
+    maxWeight: number;
+    size: number;
+
+    setGap: (firstKey: string, lastKey: string, weight: number) => GapSetEntry;
+    removeOverlappingGaps: (overlappingKeys: string[]) => number;
+    lookupGap: (minKey: string, maxKey?: string) => Promise<GapSetEntry | null>;
+    [Symbol.iterator]: () => Iterator<GapSetEntry>;
+    toArray: () => GapSetEntry[];
+};
+
+/**
+ * Specialized data structure to support caching of listing "gaps",
+ * i.e. ranges of keys that can be skipped over during listing
+ * (because they only contain delete markers as latest versions)
+ */
+export default class GapSet implements GapSetInterface, Iterable<GapSetEntry> {
+    _gaps: OrderedSet<GapSetEntry>;
+    _maxWeight: number;
+
+    /**
+     * @constructor
+
+     * @param {number} maxWeight - weight threshold for each cached
+     * gap (unitless). Triggers splitting gaps when reached
+     */
+    constructor(maxWeight: number) {
+        this._gaps = new OrderedSet(
+            [],
+            (left: GapSetEntry, right: GapSetEntry) => (
+                left.firstKey < right.firstKey ? -1 :
+                left.firstKey > right.firstKey ? 1 : 0
+            )
+        );
+        this._maxWeight = maxWeight;
+    }
+
+    /**
+     * Create a GapSet from an array of gap entries (used in tests)
+     */
+    static createFromArray(gaps: GapSetEntry[], maxWeight: number): GapSet {
+        const gapSet = new GapSet(maxWeight);
+        for (const gap of gaps) {
+            gapSet._gaps.insert(gap);
+        }
+        return gapSet;
+    }
+
+    /**
+     * Record a gap between two keys, associated with a weight to limit
+     * individual gap sizes in the cache.
+     *
+     * The function handles splitting and merging existing gaps to
+     * maintain an optimal weight of cache entries.
+     *
+     * @param {string} firstKey - first key of the gap
+     * @param {string} lastKey - last key of the gap, must be greater
+     * or equal than 'firstKey'
+     * @param {number} weight - total weight between 'firstKey' and 'lastKey'
+     * @return {GapSetEntry} - existing or new gap entry
+     */
+    setGap(firstKey: string, lastKey: string, weight: number): GapSetEntry {
+        assert(lastKey >= firstKey);
+
+        // Step 1/4: Find the closest left-overlapping gap, and either re-use it
+        // or chain it with a new gap depending on the weights if it exists (otherwise
+        // just creates a new gap).
+        const curGapIt = this._gaps.reverseLowerBound(<GapSetEntry>{ firstKey });
+        let curGap;
+        if (curGapIt.isAccessible()) {
+            curGap = curGapIt.pointer;
+            if (curGap.lastKey >= lastKey) {
+                // return fully overlapping gap already cached
+                return curGap;
+            }
+        }
+        let remainingWeight = weight;
+        if (!curGap                         // no previous gap
+            || curGap.lastKey < firstKey    // previous gap not overlapping
+            || (curGap.lastKey === firstKey // previous gap overlapping by one key...
+                && curGap.weight + weight > this._maxWeight) // ...but we can't extend it
+           ) {
+            // create a new gap indexed by 'firstKey'
+            curGap = { firstKey, lastKey: firstKey, weight: 0 };
+            this._gaps.insert(curGap);
+        } else if (curGap.lastKey > firstKey && weight > this._maxWeight) {
+            // previous gap is either fully or partially contained in the new gap
+            // and cannot be extended: substract its weight from the total (heuristic
+            // in case the previous gap doesn't start at 'firstKey', which is the
+            // uncommon case)
+            remainingWeight -= curGap.weight;
+
+            // there may be an existing chained gap starting with the previous gap's
+            // 'lastKey': use it if it exists
+            const chainedGapIt = this._gaps.find(<GapSetEntry>{ firstKey: curGap.lastKey });
+            if (chainedGapIt.isAccessible()) {
+                curGap = chainedGapIt.pointer;
+            } else {
+                // no existing chained gap: chain a new gap to the previous gap
+                curGap = {
+                    firstKey: curGap.lastKey,
+                    lastKey: curGap.lastKey,
+                    weight: 0,
+                };
+                this._gaps.insert(curGap);
+            }
+        }
+        // Step 2/4: Cleanup existing gaps fully included in firstKey -> lastKey, and
+        // aggregate their weights in curGap to define the minimum weight up to the
+        // last merged gap.
+        let nextGap;
+        while (true) {
+            const nextGapIt = this._gaps.upperBound(<GapSetEntry>{ firstKey: curGap.firstKey });
+            nextGap = nextGapIt.isAccessible() && nextGapIt.pointer;
+            // stop the cleanup when no more gap or if the next gap is not fully
+            // included in curGap
+            if (!nextGap || nextGap.lastKey > lastKey) {
+                break;
+            }
+            this._gaps.eraseElementByIterator(nextGapIt);
+            curGap.lastKey = nextGap.lastKey;
+            curGap.weight += nextGap.weight;
+        }
+
+        // Step 3/4: Extend curGap to lastKey, adjusting the weight.
+        // At this point, curGap weight is the minimum weight of the finished gap, save it
+        // for step 4.
+        let minMergedWeight = curGap.weight;
+        if (curGap.lastKey === firstKey && firstKey !== lastKey) {
+            // extend the existing gap by the full amount 'firstKey -> lastKey'
+            curGap.lastKey = lastKey;
+            curGap.weight += remainingWeight;
+        } else if (curGap.lastKey <= lastKey) {
+            curGap.lastKey = lastKey;
+            curGap.weight = remainingWeight;
+        }
+
+        // Step 4/4: Find the closest right-overlapping gap, and if it exists, either merge
+        // it or chain it with curGap depending on the weights.
+        if (nextGap && nextGap.firstKey <= lastKey) {
+            // nextGap overlaps with the new gap: check if we can merge it
+            minMergedWeight += nextGap.weight;
+            let mergedWeight;
+            if (lastKey === nextGap.firstKey) {
+                // nextGap is chained with curGap: add the full weight of nextGap
+                mergedWeight = curGap.weight + nextGap.weight;
+            } else {
+                // strict overlap: don't add nextGap's weight unless
+                // it's larger than the sum of merged ranges (as it is
+                // then included in `minMergedWeight`)
+                mergedWeight = Math.max(curGap.weight, minMergedWeight);
+            }
+            if (mergedWeight <= this._maxWeight) {
+                // merge nextGap into curGap
+                curGap.lastKey = nextGap.lastKey;
+                curGap.weight = mergedWeight;
+                this._gaps.eraseElementByKey(nextGap);
+            } else {
+                // adjust the last key to chain with nextGap and substract the next
+                // gap's weight from curGap (heuristic)
+                curGap.lastKey = nextGap.firstKey;
+                curGap.weight = Math.max(mergedWeight - nextGap.weight, 0);
+                curGap = nextGap;
+            }
+        }
+        // return a copy of curGap
+        return Object.assign({}, curGap);
+    }
+
+    /**
+     * Remove gaps that overlap with one or more keys in a given array or
+     * OrderedSet. Used to invalidate gaps when keys are inserted or deleted.
+     *
+     * @param {OrderedSet<string> | string[]} overlappingKeys - remove gaps that overlap
+     * with any of this set of keys
+     * @return {number} - how many gaps were removed
+     */
+    removeOverlappingGaps(overlappingKeys: OrderedSet<string> | string[]): number {
+        // To optimize processing with a large number of keys and/or gaps, this function:
+        //
+        // 1. converts the overlappingKeys array to a OrderedSet (if not already a OrderedSet)
+        // 2. queries both the gaps set and the overlapping keys set in a loop, which allows:
+        //    - skipping ranges of overlapping keys at once when there is no new overlapping gap
+        //    - skipping ranges of gaps at once when there is no overlapping key
+        //
+        // This way, it is efficient when the number of non-overlapping gaps is large
+        // (which is the most common case in practice).
+
+        let overlappingKeysSet;
+        if (Array.isArray(overlappingKeys)) {
+            overlappingKeysSet = new OrderedSet(overlappingKeys);
+        } else {
+            overlappingKeysSet = overlappingKeys;
+        }
+        const firstKeyIt = overlappingKeysSet.begin();
+        let currentKey = firstKeyIt.isAccessible() && firstKeyIt.pointer;
+        let nRemoved = 0;
+        while (currentKey) {
+            const closestGapIt = this._gaps.reverseUpperBound(<GapSetEntry>{ firstKey: currentKey });
+            if (closestGapIt.isAccessible()) {
+                const closestGap = closestGapIt.pointer;
+                if (currentKey <= closestGap.lastKey) {
+                    // currentKey overlaps closestGap: remove the gap
+                    this._gaps.eraseElementByIterator(closestGapIt);
+                    nRemoved += 1;
+                }
+            }
+            const nextGapIt = this._gaps.lowerBound(<GapSetEntry>{ firstKey: currentKey });
+            if (!nextGapIt.isAccessible()) {
+                // no more gap: we're done
+                return nRemoved;
+            }
+            const nextGap = nextGapIt.pointer;
+            // advance to the last key potentially overlapping with nextGap
+            let currentKeyIt = overlappingKeysSet.reverseLowerBound(nextGap.lastKey);
+            if (currentKeyIt.isAccessible()) {
+                currentKey = currentKeyIt.pointer;
+                if (currentKey >= nextGap.firstKey) {
+                    // currentKey overlaps nextGap: remove the gap
+                    this._gaps.eraseElementByIterator(nextGapIt);
+                    nRemoved += 1;
+                }
+            }
+            // advance to the first key potentially overlapping with another gap
+            currentKeyIt = overlappingKeysSet.lowerBound(nextGap.lastKey);
+            currentKey = currentKeyIt.isAccessible() && currentKeyIt.pointer;
+        }
+        return nRemoved;
+    }
+
+    /**
+     * Internal helper to coalesce multiple chained gaps into a single gap.
+     *
+     * It is only used to construct lookupGap() return values and
+     * doesn't modify the GapSet.
+     *
+     * NOTE: The function may take a noticeable amount of time and CPU
+     * to execute if a large number of chained gaps have to be
+     * coalesced, but it should never take more than a few seconds. In
+     * most cases it should take less than a millisecond. It regularly
+     * yields to the nodejs event loop to avoid blocking it during a
+     * long execution.
+     *
+     * @param {GapSetEntry} firstGap - first gap of the chain to coalesce with
+     * the next ones in the chain
+     * @return {Promise<GapSetEntry>} - a new coalesced entry, as a Promise
+     */
+    _coalesceGapChain(firstGap: GapSetEntry): Promise<GapSetEntry> {
+        return new Promise(resolve => {
+            const coalescedGap: GapSetEntry = Object.assign({}, firstGap);
+            const coalesceGapChainIteration = () => {
+                // efficiency trade-off: 100 iterations of log(N) complexity lookups should
+                // not block the event loop for too long
+                for (let opCounter = 0; opCounter < 100; ++opCounter) {
+                    const chainedGapIt = this._gaps.find(
+                            <GapSetEntry>{ firstKey: coalescedGap.lastKey });
+                    if (!chainedGapIt.isAccessible()) {
+                        // chain is complete
+                        return resolve(coalescedGap);
+                    }
+                    const chainedGap = chainedGapIt.pointer;
+                    coalescedGap.lastKey = chainedGap.lastKey;
+                    coalescedGap.weight += chainedGap.weight;
+                }
+                // yield to the event loop before continuing the process
+                // of coalescing the gap chain
+                return process.nextTick(coalesceGapChainIteration);
+            };
+            coalesceGapChainIteration();
+        });
+    }
+
+    /**
+     * Lookup the next gap that overlaps with [minKey, maxKey]. Internally chained
+     * gaps are coalesced in the response into a single contiguous large gap.
+     *
+     * @param {string} minKey - minimum key overlapping with the returned gap
+     * @param {string} [maxKey] - maximum key overlapping with the returned gap
+     * @return {Promise<GapSetEntry | null>} - result of the lookup if a gap
+     *   was found, null otherwise, as a Promise
+     */
+    async lookupGap(minKey: string, maxKey?: string): Promise<GapSetEntry | null> {
+        let firstGap: GapSetEntry | null = null;
+        const minGapIt = this._gaps.reverseLowerBound(<GapSetEntry>{ firstKey: minKey });
+        const minGap = minGapIt.isAccessible() && minGapIt.pointer;
+        if (minGap && minGap.lastKey >= minKey) {
+            firstGap = minGap;
+        } else {
+            const maxGapIt = this._gaps.upperBound(<GapSetEntry>{ firstKey: minKey });
+            const maxGap = maxGapIt.isAccessible() && maxGapIt.pointer;
+            if (maxGap && (maxKey === undefined || maxGap.firstKey <= maxKey)) {
+                firstGap = maxGap;
+            }
+        }
+        if (!firstGap) {
+            return null;
+        }
+        return this._coalesceGapChain(firstGap);
+    }
+
+    /**
+     * Get the maximum weight setting for individual gaps.
+     *
+     * @return {number} - maximum weight of individual gaps
+     */
+    get maxWeight(): number {
+        return this._maxWeight;
+    }
+
+    /**
+     * Set the maximum weight setting for individual gaps.
+     *
+     * @param {number} gapWeight - maximum weight of individual gaps
+     */
+    set maxWeight(gapWeight: number) {
+        this._maxWeight = gapWeight;
+    }
+
+    /**
+     * Get the number of gaps stored in this set.
+     *
+     * @return {number} - number of gaps stored in this set
+     */
+    get size(): number {
+        return this._gaps.size();
+    }
+
+    /**
+     * Iterate over each gap of the set, ordered by first key
+     *
+     * @return {Iterator<GapSetEntry>} - an iterator over all gaps
+     *   Example:
+     *     for (const gap of myGapSet) { ... }
+     */
+    [Symbol.iterator](): Iterator<GapSetEntry> {
+        return this._gaps[Symbol.iterator]();
+    }
+
+    /**
+     * Return an array containing all gaps, ordered by first key
+     *
+     * NOTE: there is a toArray() method in the OrderedSet implementation
+     * but it does not scale well and overflows the stack quickly. This is
+     * why we provide an implementation based on an iterator.
+     *
+     * @return {GapSetEntry[]} - an array containing all gaps
+     */
+    toArray(): GapSetEntry[] {
+        return [...this];
+    }
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/scality/Arsenal#readme",
   "dependencies": {
+    "@js-sdsl/ordered-set": "^4.4.2",
     "@types/async": "^3.2.12",
     "@types/utf8": "^3.0.1",
     "JSONStream": "^1.0.0",

--- a/tests/unit/algos/cache/GapSet.spec.ts
+++ b/tests/unit/algos/cache/GapSet.spec.ts
@@ -1,0 +1,859 @@
+import { OrderedSet } from '@js-sdsl/ordered-set';
+import GapSet from '../../../../lib/algos/cache/GapSet';
+
+function genRandomKey(): string {
+    const CHARS = 'abcdefghijklmnopqrstuvwxyz0123456789';
+    return new Array(16).fill(undefined).map(
+        () => CHARS[Math.trunc(Math.random() * CHARS.length)]
+    ).join('');
+}
+
+function genRandomUnchainedGaps(nGaps) {
+    const gapBounds = new Array(nGaps * 2).fill(undefined).map(
+        () => genRandomKey()
+    );
+    gapBounds.sort();
+    const gapsArray = new Array(nGaps).fill(undefined).map(
+        (_, i) => ({
+            firstKey: gapBounds[2 * i],
+            lastKey: gapBounds[2 * i + 1],
+            weight: 10,
+        })
+    );
+    return gapsArray;
+}
+
+function genRandomChainedGaps(nGaps) {
+    const gapBounds = new Array(nGaps + 1).fill(undefined).map(
+        () => genRandomKey()
+    );
+    gapBounds.sort();
+    const gapsArray = new Array(nGaps).fill(undefined).map(
+        (_, i) => ({
+            firstKey: gapBounds[i],
+            lastKey: gapBounds[i + 1],
+            weight: 10,
+        })
+    );
+    return gapsArray;
+}
+
+/**
+ * Shuffle an array in-place
+ *
+ * @param {any[]} - The array to shuffle
+ * @return {undefined}
+ */
+function shuffleArray(array) {
+    for (let i = array.length - 1; i > 0; i--) {
+        const randIndex = Math.trunc(Math.random() * (i + 1));
+        /* eslint-disable no-param-reassign */
+        const randIndexVal = array[randIndex];
+        array[randIndex] = array[i];
+        array[i] = randIndexVal;
+        /* eslint-enable no-param-reassign */
+    }
+}
+
+describe('GapSet', () => {
+    const INITIAL_GAPSET = [
+        { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+        { firstKey: 'qux', lastKey: 'quz', weight: 20 },
+    ];
+    const INITIAL_GAPSET_WITH_CHAIN = [
+        // single-key gap
+        { firstKey: 'ape', lastKey: 'ape', weight: 1 },
+        // start of chain
+        { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+        { firstKey: 'baz', lastKey: 'qux', weight: 15 },
+        { firstKey: 'qux', lastKey: 'quz', weight: 20 },
+        { firstKey: 'quz', lastKey: 'rat', weight: 25 },
+        { firstKey: 'rat', lastKey: 'yak', weight: 30 },
+        // end of chain
+    ]
+
+    let gapsArray;
+    let gapSet;
+    let gapsArrayWithChain;
+    let gapSetWithChain;
+    beforeEach(() => {
+        gapsArray = JSON.parse(
+            JSON.stringify(INITIAL_GAPSET)
+        );
+        gapSet = GapSet.createFromArray(gapsArray, 100);
+        gapsArrayWithChain = JSON.parse(
+            JSON.stringify(INITIAL_GAPSET_WITH_CHAIN)
+        );
+        gapSetWithChain = GapSet.createFromArray(gapsArrayWithChain, 100);
+    });
+
+    describe('GapSet::size', () => {
+        it('should return 0 for an empty gap set', () => {
+            const emptyGapSet = new GapSet(100);
+            expect(emptyGapSet.size).toEqual(0);
+        });
+
+        it('should return the size of the gap set', () => {
+            expect(gapSet.size).toEqual(2);
+        });
+
+        it('should reflect the new size after removal of gaps', () => {
+            gapSet._gaps.eraseElementByKey({ firstKey: 'bar' });
+            expect(gapSet.size).toEqual(1);
+        });
+    });
+
+    describe('GapSet::maxWeight', () => {
+        it('getter', () => {
+            const emptyGapSet = new GapSet(123);
+            expect(emptyGapSet.maxWeight).toEqual(123);
+        });
+
+        it('setter', () => {
+            const emptyGapSet = new GapSet(123);
+            emptyGapSet.maxWeight = 456;
+            expect(emptyGapSet.maxWeight).toEqual(456);
+        });
+    });
+
+    describe('GapSet::setGap()', () => {
+        it('should start a gap with a single key in empty gap set', () => {
+            const emptyGapSet = new GapSet(100);
+            const gap = emptyGapSet.setGap('foo', 'foo', 1);
+            expect(gap).toEqual({ firstKey: 'foo', lastKey: 'foo', weight: 1 });
+            expect(emptyGapSet.toArray()).toEqual([
+                { firstKey: 'foo', lastKey: 'foo', weight: 1 },
+            ]);
+        });
+
+        it('should start a gap with a single key in non-empty gap set', () => {
+            const gap = gapSet.setGap('foo', 'foo', 1);
+            expect(gap).toEqual({ firstKey: 'foo', lastKey: 'foo', weight: 1 });
+            expect(gapSet.toArray()).toEqual([
+                { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+                { firstKey: 'foo', lastKey: 'foo', weight: 1 },
+                { firstKey: 'qux', lastKey: 'quz', weight: 20 },
+            ]);
+        });
+
+        it('should start a gap with multiple keys in empty gap set', () => {
+            const emptyGapSet = new GapSet(100);
+            const gap = emptyGapSet.setGap('foo', 'qux', 5);
+            expect(gap).toEqual({ firstKey: 'foo', lastKey: 'qux', weight: 5 });
+            expect(emptyGapSet.toArray()).toEqual([
+                { firstKey: 'foo', lastKey: 'qux', weight: 5 },
+            ]);
+        });
+
+        it('should return a new object rather than a gap managed by GapSet', () => {
+            const emptyGapSet = new GapSet(100);
+            const gap = emptyGapSet.setGap('foo', 'qux', 5);
+            gap.lastKey = 'quz';
+            // check that modifying the returned gap doesn't affect the GapSet
+            expect(emptyGapSet.toArray()).toEqual([
+                { firstKey: 'foo', lastKey: 'qux', weight: 5 },
+            ]);
+        });
+
+        it('should return an existing gap that includes the wanted gap', () => {
+            const gap = gapSet.setGap('bat', 'bay', 5);
+            expect(gap).toEqual({ firstKey: 'bar', lastKey: 'baz', weight: 10 });
+            expect(gapSet.toArray()).toEqual(INITIAL_GAPSET);
+        });
+
+        it('should return an existing gap that starts with the wanted gap first key', () => {
+            const gap = gapSet.setGap('bar', 'bay', 5);
+            expect(gap).toEqual({ firstKey: 'bar', lastKey: 'baz', weight: 10 });
+            expect(gapSet.toArray()).toEqual(INITIAL_GAPSET);
+        });
+
+        it('should return an existing gap that ends with the wanted gap last key', () => {
+            const gap = gapSet.setGap('bat', 'baz', 5);
+            expect(gap).toEqual({ firstKey: 'bar', lastKey: 'baz', weight: 10 });
+            expect(gapSet.toArray()).toEqual(INITIAL_GAPSET);
+        });
+
+        it('should return the existing chained gap that starts with the first key', () => {
+            const gap = gapSetWithChain.setGap('baz', 'quo', 10);
+            expect(gap).toEqual({ firstKey: 'baz', lastKey: 'qux', weight: 15 });
+            expect(gapSetWithChain.toArray()).toEqual(INITIAL_GAPSET_WITH_CHAIN);
+        });
+
+        it('should extend a single-key gap with no other gap', () => {
+            const singleKeyGap = { firstKey: 'foo', lastKey: 'foo', weight: 1 };
+            const singleKeyGapSet = GapSet.createFromArray([singleKeyGap], 100);
+
+            const extendedGap = singleKeyGapSet.setGap('foo', 'qux', 30);
+            expect(extendedGap).toEqual({ firstKey: 'foo', lastKey: 'qux', weight: 31 });
+            expect(singleKeyGapSet.toArray()).toEqual([
+                { firstKey: 'foo', lastKey: 'qux', weight: 31 },
+            ]);
+        });
+
+        it('should extend a gap with no next gap', () => {
+            // existing gap: 'qux' -> 'quz'
+            const extendedGap = gapSet.setGap('qux', 'rat', 25);
+            expect(extendedGap).toEqual({ firstKey: 'qux', lastKey: 'rat', weight: 25 });
+            expect(gapSet.toArray()).toEqual([
+                { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+                { firstKey: 'qux', lastKey: 'rat', weight: 25 },
+            ]);
+        });
+
+        it('should extend a gap without overlap with next gap', () => {
+            // existing gap: 'bar' -> 'baz'
+            const extendedGap = gapSet.setGap('bar', 'dog', 15);
+            expect(extendedGap).toEqual({ firstKey: 'bar', lastKey: 'dog', weight: 15 });
+            expect(gapSet.toArray()).toEqual([
+                { firstKey: 'bar', lastKey: 'dog', weight: 15 },
+                { firstKey: 'qux', lastKey: 'quz', weight: 20 },
+            ]);
+        });
+
+        it('should extend a gap starting from its last key', () => {
+            // existing gap: 'qux' -> 'quz'
+            const extendedGap = gapSet.setGap('quz', 'rat', 5);
+            expect(extendedGap).toEqual({ firstKey: 'qux', lastKey: 'rat', weight: 25 });
+            expect(gapSet.toArray()).toEqual([
+                { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+                { firstKey: 'qux', lastKey: 'rat', weight: 25 },
+            ]);
+        });
+
+        it('should merge with next gap with single-key overlap if total weight is ' +
+        'under maxWeight', () => {
+            const extendedGap = gapSet.setGap('bar', 'qux', 80);
+            // updated weight is accurately set as the sum of
+            // overlapping individual gap weights
+            expect(extendedGap).toEqual({ firstKey: 'bar', lastKey: 'quz', weight: 80 + 20 });
+            expect(gapSet.toArray()).toEqual([
+                { firstKey: 'bar', lastKey: 'quz', weight: 80 + 20 },
+            ]);
+        });
+
+        it('should chain with next gap with single-key overlap if total weight is ' +
+        'above maxWeight', () => {
+            const extendedGap = gapSet.setGap('bar', 'qux', 90);
+            expect(extendedGap).toEqual({ firstKey: 'qux', lastKey: 'quz', weight: 20 });
+            expect(gapSet.toArray()).toEqual([
+                { firstKey: 'bar', lastKey: 'qux', weight: 90 },
+                { firstKey: 'qux', lastKey: 'quz', weight: 20 },
+            ]);
+        });
+
+        it('should merge with both previous and next gap if bounds overlap by a ' +
+        'single key and total weight is under maxWeight', () => {
+            const extendedGap = gapSet.setGap('baz', 'qux', 30);
+            // updated weight is accurately set as the sum of
+            // overlapping individual gap weights
+            expect(extendedGap).toEqual({ firstKey: 'bar', lastKey: 'quz', weight: 10 + 30 + 20 });
+            expect(gapSet.toArray()).toEqual([
+                { firstKey: 'bar', lastKey: 'quz', weight: 10 + 30 + 20 },
+            ]);
+        });
+
+        it('should merge with previous gap and chain with next gap if bounds overlap by a ' +
+        'single key on either side and weight is above maxWeight when merging on right side', () => {
+            const extendedGap = gapSet.setGap('baz', 'qux', 90);
+            expect(extendedGap).toEqual({ firstKey: 'qux', lastKey: 'quz', weight: 20 });
+            expect(gapSet.toArray()).toEqual([
+                { firstKey: 'bar', lastKey: 'qux', weight: 100 },
+                { firstKey: 'qux', lastKey: 'quz', weight: 20 },
+            ]);
+        });
+
+        it('should chain with previous gap and merge with next gap if bounds overlap by a ' +
+        'single key on either side and weight is above maxWeight when merging on left side', () => {
+            // modified version of the common test set with increased weight
+            // for 'bar' -> 'baz'
+            const gapSet = GapSet.createFromArray([
+                { firstKey: 'bar', lastKey: 'baz', weight: 80 },
+                { firstKey: 'qux', lastKey: 'quz', weight: 20 },
+            ], 100);
+            const extendedGap = gapSet.setGap('baz', 'qux', 70);
+            expect(extendedGap).toEqual({ firstKey: 'baz', lastKey: 'quz', weight: 90 });
+            expect(gapSet.toArray()).toEqual([
+                { firstKey: 'bar', lastKey: 'baz', weight: 80 },
+                { firstKey: 'baz', lastKey: 'quz', weight: 90 },
+            ]);
+        });
+
+        it('should merge with both previous and next gap if left bound overlaps by a ' +
+        'single key and total weight is under maxWeight', () => {
+            const extendedGap = gapSet.setGap('baz', 'quxxx', 40);
+            // updated weight is heuristically set as the sum of the
+            // previous chained gap's weight and the new weight
+            // (excluding the overlapping gap on right side)
+            expect(extendedGap).toEqual({ firstKey: 'bar', lastKey: 'quz', weight: 10 + 40 });
+            expect(gapSet.toArray()).toEqual([
+                { firstKey: 'bar', lastKey: 'quz', weight: 10 + 40 },
+            ]);
+        });
+
+        it('should chain with previous gap and merge with next gap if left bound overlaps by a ' +
+        'single key and total weight is above maxWeight', () => {
+            const extendedGap = gapSet.setGap('baz', 'quxxx', 95);
+            // updated weight is accurately set as the sum of
+            // overlapping individual gap weights
+            expect(extendedGap).toEqual({ firstKey: 'baz', lastKey: 'quz', weight: 95 });
+            expect(gapSet.toArray()).toEqual([
+                { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+                { firstKey: 'baz', lastKey: 'quz', weight: 95 },
+            ]);
+        });
+
+        it('should extend a gap with overlap with next gap and large weight', () => {
+            const extendedGap = gapSet.setGap('bar', 'quxxx', 80);
+            // updated weight is heuristically chosen to be the new
+            // gap weight which is larger than the sum of the existing merged
+            // gap weights
+            expect(extendedGap).toEqual({ firstKey: 'bar', lastKey: 'quz', weight: 80 });
+            expect(gapSet.toArray()).toEqual([
+                { firstKey: 'bar', lastKey: 'quz', weight: 80 },
+            ]);
+        });
+
+        it('should extend a gap with overlap with next gap and small weight', () => {
+            const extendedGap = gapSet.setGap('bar', 'quxxx', 11);
+            // updated weight is heuristically chosen to be the sum of the existing merged
+            // gap weights which is larger than the new gap weight
+            expect(extendedGap).toEqual({ firstKey: 'bar', lastKey: 'quz', weight: 10 + 20 });
+            expect(gapSet.toArray()).toEqual([
+                { firstKey: 'bar', lastKey: 'quz', weight: 10 + 20 },
+            ]);
+        });
+
+        it('should extend a gap with overlap beyond last key of next gap', () => {
+            const extendedGap = gapSet.setGap('bar', 'rat', 80);
+            // updated weight is the new gap weight
+            expect(extendedGap).toEqual({ firstKey: 'bar', lastKey: 'rat', weight: 80 });
+            expect(gapSet.toArray()).toEqual([
+                { firstKey: 'bar', lastKey: 'rat', weight: 80 },
+            ]);
+        });
+
+        it('should extend a gap with overlap beyond last key of next gap with a chained gap ' +
+        'if above maxWeight', () => {
+            // gapSet was initialized with maxWeight=100
+            const extendedGap = gapSet.setGap('bar', 'rat', 105);
+            // returned new gap is the right-side chained gap
+            // updated weight is the new gap weight minus the left-side chained gap's weight
+            expect(extendedGap).toEqual({ firstKey: 'baz', lastKey: 'rat', weight: 105 - 10 });
+            expect(gapSet.toArray()).toEqual([
+                { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+                { firstKey: 'baz', lastKey: 'rat', weight: 105 - 10 },
+            ]);
+        });
+
+        it('should extend a single-key gap with overlap on chained gaps', () => {
+            // existing gap: 'ape' -> 'ape' (weight=1)
+            const extendedGap = gapSetWithChain.setGap('ape', 'dog', 30);
+            // updated weight heuristically including the new gap
+            // weight, which is larger than the overlapping gaps cumulated
+            // weights (10+15=25)
+            expect(extendedGap).toEqual({ firstKey: 'ape', lastKey: 'qux', weight: 30 });
+            expect(gapSetWithChain.toArray()).toEqual([
+                { firstKey: 'ape', lastKey: 'qux', weight: 30 },
+                { firstKey: 'qux', lastKey: 'quz', weight: 20 },
+                { firstKey: 'quz', lastKey: 'rat', weight: 25 },
+                { firstKey: 'rat', lastKey: 'yak', weight: 30 },
+            ]);
+        });
+
+        it('should merge and extend + update weight a gap with overlap not past end of chained gaps',
+        () => {
+            const extendedGap = gapSetWithChain.setGap('baz', 'sea', 80);
+            expect(extendedGap).toEqual({ firstKey: 'baz', lastKey: 'yak', weight: 90 });
+            expect(gapSetWithChain.toArray()).toEqual([
+                { firstKey: 'ape', lastKey: 'ape', weight: 1 },
+                { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+                { firstKey: 'baz', lastKey: 'yak', weight: 90 },
+            ]);
+        });
+
+        it('should merge and extend + update weight a gap with overlap past end of chained gaps',
+        () => {
+            const extendedGap = gapSetWithChain.setGap('baz', 'zoo', 95);
+            expect(extendedGap).toEqual({ firstKey: 'baz', lastKey: 'zoo', weight: 95 });
+            expect(gapSetWithChain.toArray()).toEqual([
+                { firstKey: 'ape', lastKey: 'ape', weight: 1 },
+                { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+                { firstKey: 'baz', lastKey: 'zoo', weight: 95 },
+            ]);
+        });
+
+        it('should extend gap + update weight with overlap past end of chained gaps and ' +
+        'above maxWeight', () => {
+            const extendedGap = gapSetWithChain.setGap('baz', 'zoo', 105);
+            // updated weight is the new gap weight minus the left-side chained gap's weight
+            expect(extendedGap).toEqual({ firstKey: 'qux', lastKey: 'zoo', weight: 105 - 15 });
+            expect(gapSetWithChain.toArray()).toEqual([
+                { firstKey: 'ape', lastKey: 'ape', weight: 1 },
+                { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+                { firstKey: 'baz', lastKey: 'qux', weight: 15 },
+                { firstKey: 'qux', lastKey: 'zoo', weight: 105 - 15 },
+            ]);
+        });
+
+        it('should return existing chained gap with overlap above maxWeight', () => {
+            const chainedGapsArray = [
+                { firstKey: 'ant', lastKey: 'cat', weight: 90 },
+                { firstKey: 'cat', lastKey: 'fox', weight: 40 },
+            ];
+            const chainedGapsSet = GapSet.createFromArray(chainedGapsArray, 100);
+            const extendedGap = chainedGapsSet.setGap('bat', 'dog', 105);
+            expect(extendedGap).toEqual({ firstKey: 'cat', lastKey: 'fox', weight: 40 });
+            expect(chainedGapsSet.toArray()).toEqual([
+                { firstKey: 'ant', lastKey: 'cat', weight: 90 },
+                { firstKey: 'cat', lastKey: 'fox', weight: 40 },
+            ]);
+        });
+
+        it('should merge but not extend nor update weight with overlap on chained gaps', () => {
+            // existing chained gap: 'baz' -> 'qux'
+            const extendedGap = gapSetWithChain.setGap('baz', 'quxxx', 25);
+            // updated weight is the sum of the two merged gap's weights
+            expect(extendedGap).toEqual({ firstKey: 'baz', lastKey: 'quz', weight: 15 + 20 });
+            expect(gapSetWithChain.toArray()).toEqual([
+                { firstKey: 'ape', lastKey: 'ape', weight: 1 },
+                { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+                { firstKey: 'baz', lastKey: 'quz', weight: 15 + 20 },
+                { firstKey: 'quz', lastKey: 'rat', weight: 25 },
+                { firstKey: 'rat', lastKey: 'yak', weight: 30 },
+            ]);
+        });
+    });
+
+    describe('GapSet::removeOverlappingGaps()', () => {
+        describe('with zero key as parameter', () => {
+            it('passed in an array: should not remove any gap', () => {
+                const nRemoved = gapSet.removeOverlappingGaps([]);
+                expect(nRemoved).toEqual(0);
+                expect(gapSet.toArray()).toEqual(INITIAL_GAPSET);
+            });
+            it('passed in a OrderedSet: should not remove any gap', () => {
+                const nRemoved = gapSet.removeOverlappingGaps(new OrderedSet());
+                expect(nRemoved).toEqual(0);
+                expect(gapSet.toArray()).toEqual(INITIAL_GAPSET);
+            });
+        });
+        describe('with an array of one key as parameter', () => {
+            it('should not remove any gap if no overlap', () => {
+                const nRemoved = gapSet.removeOverlappingGaps(['rat']);
+                expect(nRemoved).toEqual(0);
+                expect(gapSet.toArray()).toEqual(INITIAL_GAPSET);
+            });
+
+            it('should remove a single gap if overlaps', () => {
+                const nRemoved = gapSet.removeOverlappingGaps(['bat']);
+                expect(nRemoved).toEqual(1);
+                expect(gapSet.toArray()).toEqual([
+                    // removed: { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+                    { firstKey: 'qux', lastKey: 'quz', weight: 20 },
+                ]);
+            });
+
+            it('should remove a single gap if overlaps with first key of first gap', () => {
+                const nRemoved = gapSet.removeOverlappingGaps(['bar']);
+                expect(nRemoved).toEqual(1);
+                expect(gapSet.toArray()).toEqual([
+                    // removed: { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+                    { firstKey: 'qux', lastKey: 'quz', weight: 20 },
+                ]);
+            });
+
+            it('should remove a single gap if overlaps with first key of non-first gap', () => {
+                const nRemoved = gapSet.removeOverlappingGaps(['qux']);
+                expect(nRemoved).toEqual(1);
+                expect(gapSet.toArray()).toEqual([
+                    { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+                    // removed: { firstKey: 'qux', lastKey: 'quz', weight: 20 },
+                ]);
+            });
+
+            it('should remove a single gap if overlaps with last key', () => {
+                const nRemoved = gapSet.removeOverlappingGaps(['quz']);
+                expect(nRemoved).toEqual(1);
+                expect(gapSet.toArray()).toEqual([
+                    { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+                    // removed: { firstKey: 'qux', lastKey: 'quz', weight: 20 },
+                ]);
+            });
+
+            it('should remove a single gap in chain if overlaps with one chained gap', () => {
+                const nRemoved = gapSetWithChain.removeOverlappingGaps(['dog']);
+                expect(nRemoved).toEqual(1);
+                expect(gapSetWithChain.toArray()).toEqual([
+                    { firstKey: 'ape', lastKey: 'ape', weight: 1 },
+                    { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+                    // removed: { firstKey: 'baz', lastKey: 'qux', weight: 15 },
+                    { firstKey: 'qux', lastKey: 'quz', weight: 20 },
+                    { firstKey: 'quz', lastKey: 'rat', weight: 25 },
+                    { firstKey: 'rat', lastKey: 'yak', weight: 30 },
+                ]);
+            });
+
+            it('should remove two gaps in chain if overlaps with two chained gap', () => {
+                const nRemoved = gapSetWithChain.removeOverlappingGaps(['qux']);
+                expect(nRemoved).toEqual(2);
+                expect(gapSetWithChain.toArray()).toEqual([
+                    { firstKey: 'ape', lastKey: 'ape', weight: 1 },
+                    { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+                    // removed: { firstKey: 'baz', lastKey: 'qux', weight: 15 },
+                    // removed: { firstKey: 'qux', lastKey: 'quz', weight: 20 },
+                    { firstKey: 'quz', lastKey: 'rat', weight: 25 },
+                    { firstKey: 'rat', lastKey: 'yak', weight: 30 },
+                ]);
+            });
+        });
+
+        describe('with an array of two keys as parameter', () => {
+            it('should not remove any gap if no overlap', () => {
+                const nRemoved = gapSet.removeOverlappingGaps(['rat', `rat\0v100`]);
+                expect(nRemoved).toEqual(0);
+                expect(gapSet.toArray()).toEqual(INITIAL_GAPSET);
+            });
+
+            it('should remove a single gap if both keys overlap', () => {
+                const nRemoved = gapSet.removeOverlappingGaps(['bat', 'bat\0v100']);
+                expect(nRemoved).toEqual(1);
+                expect(gapSet.toArray()).toEqual([
+                    // removed: { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+                    { firstKey: 'qux', lastKey: 'quz', weight: 20 },
+                ]);
+            });
+
+            it('should remove a single gap if min key overlaps with first key of first gap', () => {
+                const nRemoved = gapSet.removeOverlappingGaps(['bar\0v100', 'bar']);
+                expect(nRemoved).toEqual(1);
+                expect(gapSet.toArray()).toEqual([
+                    // removed: { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+                    { firstKey: 'qux', lastKey: 'quz', weight: 20 },
+                ]);
+            });
+
+            it('should remove a single gap if max key overlaps with first key of first gap', () => {
+                const nRemoved = gapSet.removeOverlappingGaps(['ape', 'bar']);
+                expect(nRemoved).toEqual(1);
+                expect(gapSet.toArray()).toEqual([
+                    // removed: { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+                    { firstKey: 'qux', lastKey: 'quz', weight: 20 },
+                ]);
+            });
+
+            it('should not remove any gap if both keys straddle an existing gap without overlap',
+            () => {
+                const nRemoved = gapSet.removeOverlappingGaps(['cow', 'ape']);
+                expect(nRemoved).toEqual(0);
+                expect(gapSet.toArray()).toEqual([
+                    { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+                    { firstKey: 'qux', lastKey: 'quz', weight: 20 },
+                ]);
+            });
+
+            it('should remove the two last gaps in chained gaps if last gap bounds match ' +
+            'the two keys', () => {
+                const nRemoved = gapSetWithChain.removeOverlappingGaps(['yak', 'rat']);
+                expect(nRemoved).toEqual(2);
+                expect(gapSetWithChain.toArray()).toEqual([
+                    { firstKey: 'ape', lastKey: 'ape', weight: 1 },
+                    { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+                    { firstKey: 'baz', lastKey: 'qux', weight: 15 },
+                    { firstKey: 'qux', lastKey: 'quz', weight: 20 },
+                    // removed: { firstKey: 'quz', lastKey: 'rat', weight: 25 },
+                    // removed: { firstKey: 'rat', lastKey: 'yak', weight: 30 },
+                ]);
+            });
+
+            it('should remove first and last gap in chained gaps if their bounds match ' +
+            'the two keys', () => {
+                const nRemoved = gapSetWithChain.removeOverlappingGaps(['yak', 'bar']);
+                expect(nRemoved).toEqual(2);
+                expect(gapSetWithChain.toArray()).toEqual([
+                    { firstKey: 'ape', lastKey: 'ape', weight: 1 },
+                    // removed: { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+                    { firstKey: 'baz', lastKey: 'qux', weight: 15 },
+                    { firstKey: 'qux', lastKey: 'quz', weight: 20 },
+                    { firstKey: 'quz', lastKey: 'rat', weight: 25 },
+                    // removed: { firstKey: 'rat', lastKey: 'yak', weight: 30 },
+                ]);
+            });
+        });
+
+        describe('with an array of three keys as parameter', () => {
+            it('should remove a single gap if only median key overlaps with gap', () => {
+                const nRemoved = gapSet.removeOverlappingGaps(['ape', 'bat', 'cow']);
+                expect(nRemoved).toEqual(1);
+                expect(gapSet.toArray()).toEqual([
+                    // removed: { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+                    { firstKey: 'qux', lastKey: 'quz', weight: 20 },
+                ]);
+            });
+
+            it('should remove a single-key gap and two contiguous chained gaps each overlapping' +
+            'with one key', () => {
+                const nRemoved = gapSetWithChain.removeOverlappingGaps(['ape', 'bat', 'cow']);
+                expect(nRemoved).toEqual(3);
+                expect(gapSetWithChain.toArray()).toEqual([
+                    // removed: { firstKey: 'ape', lastKey: 'ape', weight: 1 },
+                    // removed: { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+                    // removed: { firstKey: 'baz', lastKey: 'qux', weight: 15 },
+                    { firstKey: 'qux', lastKey: 'quz', weight: 20 },
+                    { firstKey: 'quz', lastKey: 'rat', weight: 25 },
+                    { firstKey: 'rat', lastKey: 'yak', weight: 30 },
+                ]);
+            });
+
+            it('should not remove any gap if all keys are intermingled but do not overlap', () => {
+                const nRemoved = gapSet.removeOverlappingGaps(['ape', 'rat', 'cow']);
+                expect(nRemoved).toEqual(0);
+                expect(gapSet.toArray()).toEqual([
+                    { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+                    { firstKey: 'qux', lastKey: 'quz', weight: 20 },
+                ]);
+            });
+
+            it('should remove three discontiguous chained gaps each overlapping with one key', () => {
+                const nRemoved = gapSetWithChain.removeOverlappingGaps(['bat', 'quxxx', 'tiger']);
+                expect(nRemoved).toEqual(3);
+                expect(gapSetWithChain.toArray()).toEqual([
+                    { firstKey: 'ape', lastKey: 'ape', weight: 1 },
+                    // removed: { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+                    { firstKey: 'baz', lastKey: 'qux', weight: 15 },
+                    // removed: { firstKey: 'qux', lastKey: 'quz', weight: 20 },
+                    { firstKey: 'quz', lastKey: 'rat', weight: 25 },
+                    // { firstKey: 'rat', lastKey: 'yak', weight: 30 },
+                ]);
+            });
+        });
+
+        describe('with a OrderedSet of three keys as parameter', () => {
+            it('should remove a single gap if only median key overlaps with gap', () => {
+                const nRemoved = gapSet.removeOverlappingGaps(
+                    new OrderedSet(['ape', 'bat', 'cow']));
+                expect(nRemoved).toEqual(1);
+                expect(gapSet.toArray()).toEqual([
+                    // removed: { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+                    { firstKey: 'qux', lastKey: 'quz', weight: 20 },
+                ]);
+            });
+        });
+
+        // this helper checks that:
+        // - the gaps not overlapping with any key are still present in newGapsArray
+        // - and the gaps overlapping with at least one key have been removed from oldGapsArray
+        // NOTE: It uses a sorted list of keys for efficiency, otherwise it would require
+        // O(n^2) compute time which would be expensive with 50K keys.
+        function checkOverlapInvariant(sortedKeys, oldGapsArray, newGapsArray) {
+            let oldGapIdx = 0;
+            let newGapIdx = 0;
+            for (const key of sortedKeys) {
+                // for all gaps not overlapping with any key in 'sortedKeys',
+                // check that they are still in 'newGapsArray'
+                while (oldGapIdx < oldGapsArray.length &&
+                       oldGapsArray[oldGapIdx].lastKey < key) {
+                    expect(oldGapsArray[oldGapIdx]).toEqual(newGapsArray[newGapIdx]);
+                    oldGapIdx += 1;
+                    newGapIdx += 1;
+                }
+                // for the gap(s) overlapping with the current key,
+                // check that they have been removed from 'newGapsArray'
+                while (oldGapIdx < oldGapsArray.length &&
+                       oldGapsArray[oldGapIdx].firstKey <= key) {
+                    if (newGapIdx < newGapsArray.length) {
+                        expect(oldGapsArray[oldGapIdx]).not.toEqual(newGapsArray[newGapIdx]);
+                    }
+                    ++oldGapIdx;
+                }
+            }
+            // check the range after the last key in 'sortedKeys'
+            while (oldGapIdx < oldGapsArray.length) {
+                expect(oldGapsArray[oldGapIdx]).toEqual(newGapsArray[newGapIdx]);
+                oldGapIdx += 1;
+                newGapIdx += 1;
+            }
+            // check that no extra range is in newGapsArray
+            expect(newGapIdx).toEqual(newGapsArray.length);
+        }
+
+        [false, true].forEach(chained => {
+            describe(`with 10K random ${chained ? 'chained' : 'unchained'} gaps`, () => {
+                let largeGapsArray;
+                let largeGapSet;
+                beforeEach(() => {
+                    largeGapsArray = chained ?
+                        genRandomChainedGaps(10000) :
+                        genRandomUnchainedGaps(10000);
+                    largeGapSet = GapSet.createFromArray(largeGapsArray, 100);
+                });
+
+                [{
+                    desc: 'equal to their first key',
+                    getGapKey: gap => gap.firstKey,
+                }, {
+                    desc: 'equal to their last key',
+                    getGapKey: gap => gap.lastKey,
+                }, {
+                    desc: 'neither their first nor last key',
+                    getGapKey: gap => `${gap.firstKey}/foo`,
+                }].forEach(testCase => {
+                    it(`should remove the overlapping gap(s) with one key ${testCase.desc}`, () => {
+                        const gapIndex = 5000;
+                        const gap = largeGapsArray[gapIndex];
+                        const overlappingKey = testCase.getGapKey(gap);
+                        const nRemoved = largeGapSet.removeOverlappingGaps([overlappingKey]);
+                        let firstRemovedGapIndex, lastRemovedGapIndex;
+                        if (chained && overlappingKey === gap.firstKey) {
+                            expect(nRemoved).toEqual(2);
+                            [firstRemovedGapIndex, lastRemovedGapIndex] = [4999, 5000];
+                        } else if (chained && overlappingKey === gap.lastKey) {
+                            expect(nRemoved).toEqual(2);
+                            [firstRemovedGapIndex, lastRemovedGapIndex] = [5000, 5001];
+                        } else {
+                            expect(nRemoved).toEqual(1);
+                            [firstRemovedGapIndex, lastRemovedGapIndex] = [5000, 5000];
+                        }
+                        const expectedGaps = [
+                            ...largeGapsArray.slice(0, firstRemovedGapIndex),
+                            ...largeGapsArray.slice(lastRemovedGapIndex + 1)
+                        ];
+                        const newGaps = largeGapSet.toArray();
+                        expect(newGaps).toEqual(expectedGaps);
+                    });
+
+                    it(`should remove all gaps when they all overlap with one key ${testCase.desc}`,
+                       () => {
+                           // simulate a scenario made of 200 batches of 50 operations, each with
+                           // random keys scattered across all gaps that each overlaps a distinct gap
+                           // (supposedly a worst-case performance scenario for such batch sizes)
+                           const overlappingKeys = largeGapsArray.map(testCase.getGapKey);
+                           shuffleArray(overlappingKeys);
+                           for (let i = 0; i < overlappingKeys.length; i += 50) {
+                               const nRemoved = largeGapSet.removeOverlappingGaps(
+                                   overlappingKeys.slice(i, i + 50));
+                               // with unchained gaps, we expect to have removed exactly
+                               // 50 gaps (the size of 'overlappingKeys').
+                               if (!chained) {
+                                   expect(nRemoved).toEqual(50);
+                               }
+                           }
+                           const newGaps = largeGapSet.toArray();
+                           expect(newGaps).toEqual([]);
+                       });
+                });
+
+                it('should remove only and all overlapping gaps with 50K randomized keys', () => {
+                    const randomizedKeys = new Array(50000).fill(undefined).map(
+                        () => genRandomKey()
+                    );
+                    for (let i = 0; i < randomizedKeys.length; i += 50) {
+                        largeGapSet.removeOverlappingGaps(
+                            randomizedKeys.slice(i, i + 50));
+                    }
+                    const newGaps = largeGapSet.toArray();
+                    randomizedKeys.sort();
+                    checkOverlapInvariant(randomizedKeys, largeGapsArray, newGaps);
+                });
+            });
+        });
+    });
+
+    describe('GapSet::_coalesceGapChain()', () => {
+        afterEach(() => {
+            // check that the gap sets were not modified by the operation
+            expect(gapSet.toArray()).toEqual(INITIAL_GAPSET);
+            expect(gapSetWithChain.toArray()).toEqual(INITIAL_GAPSET_WITH_CHAIN);
+        });
+        it('should not coalesce if gaps are not chained', async () => {
+            const gap = { firstKey: 'bar', lastKey: 'baz', weight: 10 };
+            const coalescedGap = await gapSet._coalesceGapChain(gap);
+            expect(coalescedGap).toEqual({ firstKey: 'bar', lastKey: 'baz', weight: 10 });
+        });
+
+        it('should coalesce one chained gap', async () => {
+            const gap = { firstKey: 'quz', lastKey: 'rat', weight: 25 };
+            const coalescedGap = await gapSetWithChain._coalesceGapChain(gap);
+            expect(coalescedGap).toEqual({ firstKey: 'quz', lastKey: 'yak', weight: 55 });
+        });
+
+        it('should coalesce a chain of five gaps', async () => {
+            const gap = { firstKey: 'bar', lastKey: 'baz', weight: 10 };
+            const coalescedGap = await gapSetWithChain._coalesceGapChain(gap);
+            expect(coalescedGap).toEqual({ firstKey: 'bar', lastKey: 'yak', weight: 100 });
+        });
+
+        it('should coalesce a chain of one thousand gaps', async () => {
+            const getKey = i => `000${i}`.slice(-4);
+            const thousandGapsArray = new Array(1000).fill(undefined).map(
+                (_, i) => ({ firstKey: getKey(i), lastKey: getKey(i + 1), weight: 10 })
+            );
+            const thousandGapsSet = GapSet.createFromArray(thousandGapsArray, 100);
+            const gap = { firstKey: '0000', lastKey: '0001', weight: 10 };
+            const coalescedGap = await thousandGapsSet._coalesceGapChain(gap);
+            expect(coalescedGap).toEqual({ firstKey: '0000', lastKey: '1000', weight: 10000 });
+        });
+    });
+
+    describe('GapSet::lookupGap()', () => {
+        afterEach(() => {
+            // check that the gap sets were not modified by the operation
+            expect(gapSet.toArray()).toEqual(INITIAL_GAPSET);
+            expect(gapSetWithChain.toArray()).toEqual(INITIAL_GAPSET_WITH_CHAIN);
+        });
+
+        it('should return null with empty cache', async () => {
+            const emptyGapSet = new GapSet(100);
+            const gap = await emptyGapSet.lookupGap('cat', 'dog');
+            expect(gap).toBeNull();
+        });
+
+        it('should return null if no gap overlaps [minKey, maxKey]', async () => {
+            const gap = await gapSet.lookupGap('cat', 'dog');
+            expect(gap).toBeNull();
+        });
+
+        it('should return the first gap that overlaps if all gaps overlap', async () => {
+            const gap = await gapSet.lookupGap('ape', 'zoo');
+            expect(gap).toEqual({ firstKey: 'bar', lastKey: 'baz', weight: 10 });
+        });
+
+        it('should return an existing gap that contains [minKey, maxKey]', async () => {
+            const gap1 = await gapSet.lookupGap('bat', 'bay');
+            expect(gap1).toEqual({ firstKey: 'bar', lastKey: 'baz', weight: 10 });
+            const gap2 = await gapSet.lookupGap('quxxx', 'quy');
+            expect(gap2).toEqual({ firstKey: 'qux', lastKey: 'quz', weight: 20 });
+        });
+
+        it('should return an existing gap that overlaps with minKey but not maxKey', async () => {
+            const gap = await gapSet.lookupGap('ape', 'bat');
+            expect(gap).toEqual({ firstKey: 'bar', lastKey: 'baz', weight: 10 });
+        });
+
+        it('should return an existing gap that overlaps just with minKey when no maxKey is provided',
+        async () => {
+            const gap = await gapSet.lookupGap('ape');
+            expect(gap).toEqual({ firstKey: 'bar', lastKey: 'baz', weight: 10 });
+        });
+
+        it('should return an existing gap that overlaps with maxKey but not minKey', async () => {
+            const gap = await gapSet.lookupGap('bat', 'cat');
+            expect(gap).toEqual({ firstKey: 'bar', lastKey: 'baz', weight: 10 });
+        });
+
+        it('should return an existing gap that is contained in [minKey, maxKey] strictly', async () => {
+            const gap = await gapSet.lookupGap('dog', 'rat');
+            expect(gap).toEqual({ firstKey: 'qux', lastKey: 'quz', weight: 20 });
+        });
+
+        it('should return a coalesced gap from chained gaps that fully overlaps [minKey, maxKey]', async () => {
+            const gap = await gapSetWithChain.lookupGap('bat', 'zoo');
+            expect(gap).toEqual({ firstKey: 'bar', lastKey: 'yak', weight: 100 });
+        });
+
+        it('should return a coalesced gap from chained gaps that contain [minKey, maxKey] strictly',
+        async () => {
+            const gap = await gapSetWithChain.lookupGap('bog', 'dog');
+            expect(gap).toEqual({ firstKey: 'baz', lastKey: 'yak', weight: 90 });
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1200,6 +1200,11 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@js-sdsl/ordered-set@^4.4.2":
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-set/-/ordered-set-4.4.2.tgz#ab857eb63cf358b5a0f74fdd458b4601423779b7"
+  integrity sha512-ieYQ8WlBPKYzEo81H3q0DFbd8WtFRXXABb4+vRCF0AO3WWtJZFxYvRGdipUXGrd6tlSySmqhcPuO3J6SCodCxg==
+
 "@npmcli/fs@^1.0.0":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@npmcli/fs/-/fs-1.1.1.tgz#72f719fe935e687c56a4faecf3c03d06ba593257"


### PR DESCRIPTION
The GapSet class is intended for caching listing "gaps", which are contiguous series of current delete markers in buckets, although the semantics can allow for other uses in the future.

The end goal is to increase the performance of listings on V0 buckets when a lot of delete markers are present, as a temporary solution until buckets are migrated to V1 format.

This data structure is intented to be used by a GapCache instance, which implements specific caching semantics (to ensure consistency wrt. DB updates for example).
