### PR TITLE
ARSN-390: Add scuba arn for policy

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -126,3 +126,6 @@ export const supportedLifecycleRules = [
 // Maximum number of buckets to cache (bucket metadata)
 export const maxCachedBuckets = process.env.METADATA_MAX_CACHED_BUCKETS ?
     Number(process.env.METADATA_MAX_CACHED_BUCKETS) : 1000;
+
+/** For policy resource arn check we allow empty account ID to not break compatibility */
+export const policyArnAllowedEmptyAccountId = ['utapi', 'scuba'];

--- a/lib/policyEvaluator/RequestContext.ts
+++ b/lib/policyEvaluator/RequestContext.ts
@@ -12,6 +12,7 @@ import {
     actionMapSSO,
     actionMapSTS,
     actionMapMetadata,
+    actionMapScuba,
 } from './utils/actionMaps';
 
 const _actionNeedQuotaCheck = {
@@ -37,8 +38,7 @@ function _findAction(service: string, method: string) {
         case 'metadata':
             return actionMapMetadata[method];
         case 'scuba':
-            // currently only method is GetMetrics
-            return `scuba:${method}`;
+            return actionMapScuba[method];
         default:
             return undefined;
     }
@@ -110,7 +110,7 @@ function _buildArn(
         }
         case 'scuba': {
             return `arn:scality:scuba::${requesterInfo!.accountid}:` +
-            `${generalResource}/${specificResource || ''}`
+            `${generalResource}/${specificResource || ''}`;
         }
         default:
             return undefined;

--- a/lib/policyEvaluator/RequestContext.ts
+++ b/lib/policyEvaluator/RequestContext.ts
@@ -36,6 +36,9 @@ function _findAction(service: string, method: string) {
             return actionMapSTS[method];
         case 'metadata':
             return actionMapMetadata[method];
+        case 'scuba':
+            // currently only method is GetMetrics
+            return `scuba:${method}`;
         default:
             return undefined;
     }
@@ -104,6 +107,10 @@ function _buildArn(
             }
             return `arn:scality:metadata::${requesterInfo!.accountid}:` +
             `${generalResource}/`;
+        }
+        case 'scuba': {
+            return `arn:scality:scuba::${requesterInfo!.accountid}:` +
+            `${generalResource}/${specificResource || ''}`
         }
         default:
             return undefined;

--- a/lib/policyEvaluator/utils/actionMaps.ts
+++ b/lib/policyEvaluator/utils/actionMaps.ts
@@ -206,6 +206,10 @@ const actionMapMetadata = {
     default: 'metadata:bucketd',
 };
 
+const actionMapScuba = {
+    GetMetrics: 'scuba:GetMetrics',
+};
+
 export {
     actionMapRQ,
     actionMapBP,
@@ -215,4 +219,5 @@ export {
     actionMapSSO,
     actionMapSTS,
     actionMapMetadata,
+    actionMapScuba,
 };

--- a/lib/policyEvaluator/utils/checkArnMatch.ts
+++ b/lib/policyEvaluator/utils/checkArnMatch.ts
@@ -1,5 +1,5 @@
 import { handleWildcardInResource } from './wildcards';
-
+import { policyArnAllowedEmptyAccountId } from '../../constants';
 /**
  * Checks whether an ARN from a request matches an ARN in a policy
  * to compare against each portion of the ARN from the request
@@ -40,8 +40,8 @@ export default function checkArnMatch(
         const policyArnArr = policyArn.split(':');
         // We want to allow an empty account ID for utapi and scuba service ARNs to not
         // break compatibility.
-        const allowedEmptyAccountId = ['utapi', 'scuba'];
-        if (j === 4 && allowedEmptyAccountId.includes(policyArnArr[2]) && policyArnArr[4] === '') {
+        if (j === 4 && policyArnAllowedEmptyAccountId.includes(policyArnArr[2])
+            && policyArnArr[4] === '') {
             continue;
         } else if (!segmentRegEx.test(requestSegment)) {
             return false;

--- a/lib/policyEvaluator/utils/checkArnMatch.ts
+++ b/lib/policyEvaluator/utils/checkArnMatch.ts
@@ -38,9 +38,10 @@ export default function checkArnMatch(
         const requestSegment = caseSensitive ? requestArnArr[j] :
             requestArnArr[j].toLowerCase();
         const policyArnArr = policyArn.split(':');
-        // We want to allow an empty account ID for utapi service ARNs to not
+        // We want to allow an empty account ID for utapi and scuba service ARNs to not
         // break compatibility.
-        if (j === 4 && policyArnArr[2] === 'utapi' && policyArnArr[4] === '') {
+        const allowedEmptyAccountId = ['utapi', 'scuba'];
+        if (j === 4 && allowedEmptyAccountId.includes(policyArnArr[2]) && policyArnArr[4] === '') {
             continue;
         } else if (!segmentRegEx.test(requestSegment)) {
             return false;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.10.56",
+  "version": "7.10.57",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {


### PR DESCRIPTION
Relates to Scuba Auth: [SCUBA-76](https://scality.atlassian.net/browse/SCUBA-76) and [SCUBA-77](https://scality.atlassian.net/browse/SCUBA-77)

This will be used by:
- https://github.com/scality/Vault/pull/2144
- https://github.com/scality/scuba/pull/74

[SCUBA-76]: https://scality.atlassian.net/browse/SCUBA-76?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SCUBA-77]: https://scality.atlassian.net/browse/SCUBA-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ