### PR TITLE
ft: ARSN-391 GapCache: gap caching and invalidation

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -53,6 +53,7 @@ export const algorithms = {
     },
     cache: {
         GapSet: require('./lib/algos/cache/GapSet'),
+        GapCache: require('./lib/algos/cache/GapCache'),
         LRUCache: require('./lib/algos/cache/LRUCache'),
     },
     stream: {

--- a/lib/algos/cache/GapCache.ts
+++ b/lib/algos/cache/GapCache.ts
@@ -1,0 +1,346 @@
+import { OrderedSet } from '@js-sdsl/ordered-set';
+import {
+    default as GapSet,
+    GapSetEntry,
+} from './GapSet';
+
+// the API is similar but is not strictly a superset of GapSetInterface
+// so we don't extend from it
+export interface GapCacheInterface {
+    exposureDelayMs: number;
+    maxGapWeight: number;
+    size: number;
+
+    setGap: (firstKey: string, lastKey: string, weight: number) => void;
+    removeOverlappingGaps: (overlappingKeys: string[]) => number;
+    lookupGap: (minKey: string, maxKey?: string) => Promise<GapSetEntry | null>;
+    [Symbol.iterator]: () => Iterator<GapSetEntry>;
+    toArray: () => GapSetEntry[];
+};
+
+class GapCacheUpdateSet {
+    newGaps: GapSet;
+    updatedKeys: OrderedSet<string>;
+
+    constructor(maxGapWeight: number) {
+        this.newGaps = new GapSet(maxGapWeight);
+        this.updatedKeys = new OrderedSet();
+    }
+
+    addUpdateBatch(updatedKeys: OrderedSet<string>): void {
+        this.updatedKeys.union(updatedKeys);
+    }
+};
+
+/**
+ * Cache of listing "gaps" i.e. ranges of keys that can be skipped
+ * over during listing (because they only contain delete markers as
+ * latest versions).
+ *
+ * Typically, a single GapCache instance would be attached to a raft session.
+ *
+ * The API usage is as follows:
+ *
+ * - Initialize a GapCache instance by calling start() (this starts an internal timer)
+ *
+ * - Insert a gap or update an existing one via setGap()
+ *
+ * - Lookup existing gaps via lookupGap()
+ *
+ * - Invalidate gaps that overlap a specific set of keys via removeOverlappingGaps()
+ *
+ * - Shut down a GapCache instance by calling stop() (this stops the internal timer)
+ *
+ * Gaps inserted via setGap() are not exposed immediately to lookupGap(), but only:
+ *
+ * - after a certain delay always larger than 'exposureDelayMs' and usually shorter
+ *   than twice this value (but might be slightly longer in rare cases)
+ *
+ * - and only if they haven't been invalidated by a recent call to removeOverlappingGaps()
+ *
+ * This ensures atomicity between gap creation and invalidation from updates under
+ * the condition that a gap is created from first key to last key within the time defined
+ * by 'exposureDelayMs'.
+ *
+ * The implementation is based on two extra temporary "update sets" on top of the main
+ * exposed gap set, one called "staging" and the other "frozen", each containing a
+ * temporary updated gap set and a list of updated keys to invalidate gaps with (coming
+ * from calls to removeOverlappingGaps()). Every "exposureDelayMs" milliseconds, the frozen
+ * gaps are invalidated by all key updates coming from either of the "staging" or "frozen"
+ * update set, then merged into the exposed gaps set, after which the staging updates become
+ * the frozen updates and won't receive any new gap until the next cycle.
+ */
+export default class GapCache implements GapCacheInterface {
+    _exposureDelayMs: number;
+    maxGaps: number;
+
+    _stagingUpdates: GapCacheUpdateSet;
+    _frozenUpdates: GapCacheUpdateSet;
+    _exposedGaps: GapSet;
+    _exposeFrozenInterval: NodeJS.Timeout | null;
+
+    /**
+     * @constructor
+     *
+     * @param {number} exposureDelayMs - minimum delay between
+     * insertion of a gap via setGap() and its exposure via
+     * lookupGap()
+     * @param {number} maxGaps - maximum number of cached gaps, after
+     * which no new gap can be added by setGap(). (Note: a future
+     * improvement could replace this by an eviction strategy)
+     * @param {number} maxGapWeight - maximum "weight" of individual
+     * cached gaps, which is also the granularity for
+     * invalidation. Individual gaps can be chained together,
+     * which lookupGap() transparently consolidates in the response
+     * into a single large gap.
+     */
+    constructor(exposureDelayMs: number, maxGaps: number, maxGapWeight: number) {
+        this._exposureDelayMs = exposureDelayMs;
+        this.maxGaps = maxGaps;
+
+        this._stagingUpdates = new GapCacheUpdateSet(maxGapWeight);
+        this._frozenUpdates = new GapCacheUpdateSet(maxGapWeight);
+        this._exposedGaps = new GapSet(maxGapWeight);
+        this._exposeFrozenInterval = null;
+    }
+
+    /**
+     * Create a GapCache from an array of exposed gap entries (used in tests)
+     *
+     * @return {GapCache} - a new GapCache instance
+     */
+    static createFromArray(
+        gaps: GapSetEntry[],
+        exposureDelayMs: number,
+        maxGaps: number,
+        maxGapWeight: number
+    ): GapCache {
+        const gapCache = new GapCache(exposureDelayMs, maxGaps, maxGapWeight);
+        gapCache._exposedGaps = GapSet.createFromArray(gaps, maxGapWeight)
+        return gapCache;
+    }
+
+    /**
+     * Internal helper to remove gaps in the frozen set overlapping
+     * with previously updated keys, right before the frozen gaps get
+     * exposed.
+     *
+     * @return {undefined}
+     */
+    _removeOverlappingGapsBeforeExpose(): void {
+        // simple optimization to avoid looping over all updates if
+        // there is no gap in the frozen set
+        if (this._frozenUpdates.newGaps.size === 0) {
+            return;
+        }
+        for (const updateSet of [this._stagingUpdates, this._frozenUpdates]) {
+            this._frozenUpdates.newGaps.removeOverlappingGaps(updateSet.updatedKeys);
+        }
+    }
+
+    /**
+     * This function is the core mechanism that updates the exposed gaps in the
+     * cache. It is called on a regular interval defined by 'exposureDelayMs'.
+     *
+     * It does the following in order:
+     *
+     * - remove gaps from the frozen set that overlap with any key present in a
+     *   batch passed to removeOverlappingGaps() since the last two triggers of
+     *   _exposeFrozen()
+     *
+     * - merge the remaining gaps from the frozen set to the exposed set, which
+     *   makes them visible from calls to lookupGap()
+     *
+     * - rotate by freezing the currently staging updates and initiating a new
+     *   staging updates set
+     *
+     * @return {undefined}
+     */
+    _exposeFrozen(): void {
+        this._removeOverlappingGapsBeforeExpose();
+        for (const gap of this._frozenUpdates.newGaps) {
+            // Use a trivial strategy to keep the cache size within
+            // limits: refuse to add new gaps when the size is above
+            // the 'maxGaps' threshold. We solely rely on
+            // removeOverlappingGaps() to make space for new gaps.
+            if (this._exposedGaps.size < this.maxGaps) {
+                this._exposedGaps.setGap(gap.firstKey, gap.lastKey, gap.weight);
+            }
+        }
+        this._frozenUpdates = this._stagingUpdates;
+        this._stagingUpdates = new GapCacheUpdateSet(this.maxGapWeight);
+    }
+
+    /**
+     * Start the internal GapCache timer
+     *
+     * @return {undefined}
+     */
+    start(): void {
+        if (this._exposeFrozenInterval) {
+            return;
+        }
+        this._exposeFrozenInterval = setInterval(
+            () => this._exposeFrozen(),
+            this._exposureDelayMs);
+    }
+
+    /**
+     * Stop the internal GapCache timer
+     *
+     * @return {undefined}
+     */
+    stop(): void {
+        if (this._exposeFrozenInterval) {
+            clearInterval(this._exposeFrozenInterval);
+            this._exposeFrozenInterval = null;
+        }
+    }
+
+    /**
+     * Record a gap between two keys, associated with a weight to
+     * limit individual gap's spanning ranges in the cache, for a more
+     * granular invalidation.
+     *
+     * The function handles splitting and merging existing gaps to
+     * maintain an optimal weight of cache entries.
+     *
+     * NOTE 1: the caller must ensure that the full length of the gap
+     * between 'firstKey' and 'lastKey' has been built from a listing
+     * snapshot that is more recent than 'exposureDelayMs' milliseconds,
+     * in order to guarantee that the exposed gap will be fully
+     * covered (and potentially invalidated) from recent calls to
+     * removeOverlappingGaps().
+     *
+     * NOTE 2: a usual pattern when building a large gap from multiple
+     * calls to setGap() is to start the next gap from 'lastKey',
+     * which will be passed as 'firstKey' in the next call, so that
+     * gaps can be chained together and consolidated by lookupGap().
+     *
+     * @param {string} firstKey - first key of the gap
+     * @param {string} lastKey - last key of the gap, must be greater
+     * or equal than 'firstKey'
+     * @param {number} weight - total weight between 'firstKey' and 'lastKey'
+     * @return {undefined}
+     */
+    setGap(firstKey: string, lastKey: string, weight: number): void {
+        this._stagingUpdates.newGaps.setGap(firstKey, lastKey, weight);
+    }
+
+    /**
+     * Remove gaps that overlap with a given set of keys. Used to
+     * invalidate gaps when keys are inserted or deleted.
+     *
+     * @param {OrderedSet<string> | string[]} overlappingKeys - remove gaps that
+     * overlap with any of this set of keys
+     * @return {number} - how many gaps were removed from the exposed
+     * gaps only (overlapping gaps not yet exposed are also invalidated
+     * but are not accounted for in the returned value)
+     */
+    removeOverlappingGaps(overlappingKeys: OrderedSet<string> | string[]): number {
+        let overlappingKeysSet;
+        if (Array.isArray(overlappingKeys)) {
+            overlappingKeysSet = new OrderedSet(overlappingKeys);
+        } else {
+            overlappingKeysSet = overlappingKeys;
+        }
+        this._stagingUpdates.addUpdateBatch(overlappingKeysSet);
+        return this._exposedGaps.removeOverlappingGaps(overlappingKeysSet);
+    }
+
+    /**
+     * Lookup the next exposed gap that overlaps with [minKey, maxKey]. Internally
+     * chained gaps are coalesced in the response into a single contiguous large gap.
+     *
+     * @param {string} minKey - minimum key overlapping with the returned gap
+     * @param {string} [maxKey] - maximum key overlapping with the returned gap
+     * @return {Promise<GapSetEntry | null>} - result of the lookup if a gap
+     *   was found, null otherwise, as a Promise
+     */
+    lookupGap(minKey: string, maxKey?: string): Promise<GapSetEntry | null> {
+        return this._exposedGaps.lookupGap(minKey, maxKey);
+    }
+
+    /**
+     * Get the maximum weight setting for individual gaps.
+     *
+     * @return {number} - maximum weight of individual gaps
+     */
+    get maxGapWeight(): number {
+        return this._exposedGaps.maxWeight;
+    }
+
+    /**
+     * Set the maximum weight setting for individual gaps.
+     *
+     * @param {number} gapWeight - maximum weight of individual gaps
+     */
+    set maxGapWeight(gapWeight: number) {
+        this._exposedGaps.maxWeight = gapWeight;
+        // also update transient gap sets
+        this._stagingUpdates.newGaps.maxWeight = gapWeight;
+        this._frozenUpdates.newGaps.maxWeight = gapWeight;
+    }
+
+    /**
+     * Get the exposure delay in milliseconds, which is the minimum
+     * time after which newly cached gaps will be exposed by
+     * lookupGap().
+     *
+     * @return {number} - exposure delay in milliseconds
+     */
+    get exposureDelayMs(): number {
+        return this._exposureDelayMs;
+    }
+
+    /**
+     * Set the exposure delay in milliseconds, which is the minimum
+     * time after which newly cached gaps will be exposed by
+     * lookupGap(). Setting this attribute automatically updates the
+     * internal state to honor the new value.
+     *
+     * @param {number} - exposure delay in milliseconds
+     */
+    set exposureDelayMs(exposureDelayMs: number) {
+        if (exposureDelayMs !== this._exposureDelayMs) {
+            this._exposureDelayMs = exposureDelayMs;
+            if (this._exposeFrozenInterval) {
+                // invalidate all pending gap updates, as the new interval may not be
+                // safe for them
+                this._stagingUpdates = new GapCacheUpdateSet(this.maxGapWeight);
+                this._frozenUpdates = new GapCacheUpdateSet(this.maxGapWeight);
+
+                // reinitialize the _exposeFrozenInterval timer with the updated delay
+                this.stop();
+                this.start();
+            }
+        }
+    }
+
+    /**
+     * Get the number of exposed gaps
+     *
+     * @return {number} number of exposed gaps
+     */
+    get size(): number {
+        return this._exposedGaps.size;
+    }
+
+    /**
+     * Iterate over exposed gaps
+     *
+     * @return {Iterator<GapSetEntry>} an iterator over exposed gaps
+     */
+    [Symbol.iterator](): Iterator<GapSetEntry> {
+        return this._exposedGaps[Symbol.iterator]();
+    }
+
+    /**
+     * Get an array of all exposed gaps
+     *
+     * @return {GapSetEntry[]} array of exposed gaps
+     */
+    toArray(): GapSetEntry[] {
+        return this._exposedGaps.toArray();
+    }
+}

--- a/tests/unit/algos/cache/GapCache.spec.ts
+++ b/tests/unit/algos/cache/GapCache.spec.ts
@@ -1,0 +1,214 @@
+import GapCache from '../../../../lib/algos/cache/GapCache';
+
+describe('GapCache', () => {
+    let gapCache;
+
+    beforeEach(() => {
+        // exposureDelayMs=100, maxGaps=10, maxGapWeight=100
+        gapCache = new GapCache(100, 10, 100);
+        gapCache.start();
+    });
+    afterEach(() => {
+        gapCache.stop();
+    });
+
+    describe('getters and setters', () => {
+        it('maxGapWeight getter', () => {
+            expect(gapCache.maxGapWeight).toEqual(100);
+        });
+
+        it('maxGapWeight setter', () => {
+            gapCache.maxGapWeight = 123;
+            expect(gapCache.maxGapWeight).toEqual(123);
+            // check that internal gap sets have also been updated
+            expect(gapCache._stagingUpdates.newGaps.maxWeight).toEqual(123);
+            expect(gapCache._frozenUpdates.newGaps.maxWeight).toEqual(123);
+        });
+
+        it('exposureDelayMs getter', () => {
+            expect(gapCache.exposureDelayMs).toEqual(100);
+        });
+
+        it('exposureDelayMs setter', async () => {
+            // insert a first gap
+            gapCache.setGap('bar', 'baz', 10);
+
+            // change the exposure delay to 50ms
+            gapCache.exposureDelayMs = 50;
+            expect(gapCache.exposureDelayMs).toEqual(50);
+
+            gapCache.setGap('qux', 'quz', 10);
+
+            // wait for more than twice the new exposure delay
+            await new Promise(resolve => setTimeout(resolve, 200));
+
+            // only the second gap should have been exposed, due to the change of
+            // exposure delay subsequent to the first call to setGap()
+            expect(await gapCache.lookupGap('ape', 'zoo')).toEqual(
+                { firstKey: 'qux', lastKey: 'quz', weight: 10 }
+            );
+        });
+    });
+
+    it('should expose gaps after at least exposureDelayMs milliseconds', async () => {
+        gapCache.setGap('bar', 'baz', 10);
+        expect(await gapCache.lookupGap('ape', 'cat')).toBeNull();
+
+        // wait for 50ms which is half of the minimum time to exposure
+        await new Promise(resolve => setTimeout(resolve, 50));
+        // the gap should not be exposed yet
+        expect(await gapCache.lookupGap('ape', 'cat')).toBeNull();
+
+        // wait for an extra 250ms (total 300ms): the upper bound for exposure of any
+        // setGap() call is twice the exposureDelayMs value, so 200ms, wait an extra
+        // 100ms to cope with scheduling uncertainty and GapSet processing time, after
+        // which the gap introduced by setGap() should always be exposed.
+        await new Promise(resolve => setTimeout(resolve, 250));
+        expect(await gapCache.lookupGap('ape', 'cat')).toEqual(
+            { firstKey: 'bar', lastKey: 'baz', weight: 10 });
+
+        // check getters
+        expect(gapCache.maxGaps).toEqual(10);
+        expect(gapCache.maxGapWeight).toEqual(100);
+        expect(gapCache.size).toEqual(1);
+
+        // check iteration over the exposed gaps
+        let nGaps = 0;
+        for (const gap of gapCache) {
+            expect(gap).toEqual({ firstKey: 'bar', lastKey: 'baz', weight: 10 });
+            nGaps += 1;
+        }
+        expect(nGaps).toEqual(1);
+
+        // check toArray()
+        expect(gapCache.toArray()).toEqual([
+            { firstKey: 'bar', lastKey: 'baz', weight: 10 },
+        ]);
+    });
+
+    it('removeOverlappingGaps() should invalidate all overlapping gaps that are already exposed',
+    async () => {
+        gapCache.setGap('cat', 'fox', 10);
+        gapCache.setGap('lion', 'seal', 20);
+        // wait for 3x100ms to ensure all setGap() calls have been exposed
+        await new Promise(resolve => setTimeout(resolve, 300));
+        // expect 0 gap removed because 'hog' is not in any gap
+        expect(gapCache.removeOverlappingGaps(['hog'])).toEqual(0);
+        // expect 1 gap removed because 'cat' -> 'fox' should be already exposed
+        expect(gapCache.removeOverlappingGaps(['dog'])).toEqual(1);
+        // the gap should have been invalidated permanently
+        expect(await gapCache.lookupGap('dog', 'fox')).toBeNull();
+        // the other gap should still be present
+        expect(await gapCache.lookupGap('rat', 'tiger')).toEqual(
+            { firstKey: 'lion', lastKey: 'seal', weight: 20 });
+    });
+
+    it('removeOverlappingGaps() should invalidate all overlapping gaps that are not yet exposed',
+    async () => {
+        gapCache.setGap('cat', 'fox', 10);
+        gapCache.setGap('lion', 'seal', 20);
+        // make the following calls asynchronous for the sake of the
+        // test, but not waiting for the exposure delay
+        await new Promise(resolve => setImmediate(resolve));
+        // expect 0 gap removed because 'hog' is not in any gap
+        expect(gapCache.removeOverlappingGaps(['hog'])).toEqual(0);
+        // expect 0 gap removed because 'cat' -> 'fox' is not exposed yet,
+        // but internally it should have been removed from the staging or
+        // frozen gap set
+        expect(gapCache.removeOverlappingGaps(['dog'])).toEqual(0);
+
+        // wait for 3x100ms to ensure all non-invalidated setGap() calls have been exposed
+        await new Promise(resolve => setTimeout(resolve, 300));
+        // the gap should have been invalidated permanently
+        expect(await gapCache.lookupGap('dog', 'fox')).toBeNull();
+        // the other gap should now be exposed
+        expect(await gapCache.lookupGap('rat', 'tiger')).toEqual(
+            { firstKey: 'lion', lastKey: 'seal', weight: 20 });
+    });
+
+    it('removeOverlappingGaps() should invalidate gaps created later by setGap() but ' +
+    'within the exposure delay', async () => {
+        // there is no exposed gap yet, so expect 0 gap removed
+        expect(gapCache.removeOverlappingGaps(['dog'])).toEqual(0);
+
+        // wait for 50ms (half of exposure delay of 100ms) before
+        // setting a new gap overlapping with 'dog'
+        await new Promise(resolve => setTimeout(resolve, 50));
+        gapCache.setGap('cat', 'fox', 10);
+
+        // also set a non-overlapping gap to make sure it is not invalidated
+        gapCache.setGap('goat', 'hog', 20);
+
+        // wait an extra 250ms to ensure all valid gaps have been exposed
+        await new Promise(resolve => setTimeout(resolve, 250));
+        // the next gap is indeed 'goat'... because 'cat'... should have been invalidated
+        expect(await gapCache.lookupGap('bat', 'zoo')).toEqual(
+            { firstKey: 'goat', lastKey: 'hog', weight: 20 });
+    });
+
+    it('removeOverlappingGaps() should not invalidate gaps created more than twice ' +
+    'the exposure delay later', async () => {
+        // there is no exposed gap yet, so expect 0 gap removed
+        expect(gapCache.removeOverlappingGaps(['dog'])).toEqual(0);
+
+        // wait for 250ms (more than twice the exposure delay of 100ms) before
+        // setting a new gap overlapping with 'dog'
+        await new Promise(resolve => setTimeout(resolve, 250));
+        gapCache.setGap('cat', 'fox', 10);
+
+        // also set a non-overlapping gap to make sure it is not invalidated
+        gapCache.setGap('goat', 'hog', 20);
+
+        // wait for an extra 250ms to ensure the new gap is exposed
+        await new Promise(resolve => setTimeout(resolve, 250));
+        // should find the inserted gap as it should not have been invalidated
+        expect(await gapCache.lookupGap('bat', 'zoo')).toEqual(
+            { firstKey: 'cat', lastKey: 'fox', weight: 10 });
+    });
+
+    it('exposed gaps should be merged when possible', async () => {
+        gapCache.setGap('bar', 'baz', 10);
+        gapCache.setGap('baz', 'qux', 10);
+        // wait until the merged gap is exposed
+        await new Promise(resolve => setTimeout(resolve, 300));
+        expect(await gapCache.lookupGap('ape', 'cat')).toEqual(
+            { firstKey: 'bar', lastKey: 'qux', weight: 20 });
+    });
+
+    it('exposed gaps should be split when above maxGapWeight', async () => {
+        gapCache.setGap('bar', 'baz', gapCache.maxGapWeight - 1);
+        gapCache.setGap('baz', 'qux', 10);
+        // wait until the gaps are exposed
+        await new Promise(resolve => setTimeout(resolve, 300));
+        expect(await gapCache.lookupGap('cat', 'dog')).toEqual(
+            { firstKey: 'baz', lastKey: 'qux', weight: 10 });
+    });
+
+    it('gaps should not be exposed when reaching the maxGaps limit', async () => {
+        const gapsArray = new Array(gapCache.maxGaps).fill(undefined).map(
+            (_, i) => {
+                const firstKey = `0000${i}`.slice(-4);
+                return {
+                    firstKey,
+                    lastKey: `${firstKey}foo`,
+                    weight: 10,
+                };
+            }
+        );
+        for (const gap of gapsArray) {
+            gapCache.setGap(gap.firstKey, gap.lastKey, gap.weight);
+        }
+        // wait until the gaps are exposed
+        await new Promise(resolve => setTimeout(resolve, 300));
+        expect(gapCache.size).toEqual(gapCache.maxGaps);
+
+        gapCache.setGap('noroomforthisgap', 'noroomforthisgapfoo');
+        // wait until the gaps are exposed
+        await new Promise(resolve => setTimeout(resolve, 300));
+
+        // the number of gaps should still be 'maxGaps'
+        expect(gapCache.size).toEqual(gapCache.maxGaps);
+        // the gaps should correspond to the original array
+        expect(gapCache.toArray()).toEqual(gapsArray);
+    });
+});


### PR DESCRIPTION
Introduce a new helper class GapCache that sits on top of a set of GapSet instances, that delays exposure of gaps by a specific time to guarantee atomicity wrt. invalidation from overlapping PUT/DELETE operations.

The way it is implemented is the following:

- three update sets are used, each containing a GapSet instance and a series of key update batches: `staging`, `frozen`, and `exposed`

- `staging` receives the new gaps from `setGap()` calls and the updates from `removeOverlappingGaps()`

- `lookupGap()` only returns gaps present in `exposed`

- every `exposureDelayMs` milliseconds, the following happens:

  - the `frozen` gaps get invalidated by all key updates buffered in either `staging` or `frozen` update sets

  - the remainder of the `frozen` gaps is merged into `exposed` (via internal calls to `exposed.setGap()`)

  - the `staging` update set becomes the new `frozen` update set (both the gaps and the key updates)

  - a new `staging` update set is instanciated, empty

This guarantees that any gap set via `setGap()` is only exposed after a minimum of `exposureDelayMs`, and a maximum of twice that time (plus extra needed processing time). Also, keys passed to `removeOverlappingGaps()` are kept in memory for at least `exposureDelayMs` so they can invalidate new gaps that are created in this time frame.

This combined with insurance that setGap() is never called after `exposureDelayMs` has passed since the listing process started (from a DB snapshot), guarantees that all gaps not yet exposed have been invalidated by any overlapping PUT/DELETE operation, hence exposed gaps are still valid at the time they are exposed. They may still be
invalidated thereafter by future calls to removeOverlappingGaps().

The number of gaps that can be cached is bounded by the 'maxGaps' attribute. The current strategy consists of simply not adding new gaps when this limit is reached, solely relying on removeOverlappingGaps() to make room for new gaps. In the future we could consider implementing an eviction mechanism to remove less used gaps and/or
with smaller weights, but today the cost vs. benefit of doing this is unclear.
