### PR TITLE
ARSN-389 DelimiterMaster: v0 format gap skipping

### DIFF
--- a/lib/algos/list/Extension.js
+++ b/lib/algos/list/Extension.js
@@ -1,6 +1,6 @@
 'use strict'; // eslint-disable-line strict
 
-const { FILTER_SKIP, SKIP_NONE } = require('./tools');
+const { FILTER_ACCEPT, SKIP_NONE } = require('./tools');
 
 // Use a heuristic to amortize the cost of JSON
 // serialization/deserialization only on largest metadata where the
@@ -92,21 +92,26 @@ class Extension {
      * @param {object} entry - a listing entry from metadata
      *                         expected format: { key, value }
      * @return {number} - result of filtering the entry:
-     *                    > 0: entry is accepted and included in the result
-     *                    = 0: entry is accepted but not included (skipping)
-     *                    < 0: entry is not accepted, listing should finish
+     *                    FILTER_ACCEPT: entry is accepted and may or not be included
+     *                                   in the result
+     *                    FILTER_SKIP: listing may skip directly (with "gte" param) to
+     *                                 the key returned by the skipping() method
+     *                    FILTER_END: the results are complete, listing can be stopped
      */
-    filter(entry) {
-        return entry ? FILTER_SKIP : FILTER_SKIP;
+    filter(/* entry: { key, value } */) {
+        return FILTER_ACCEPT;
     }
 
     /**
-     * Provides the insight into why filter is skipping an entry. This could be
-     * because it is skipping a range of delimited keys or a range of specific
-     * version when doing master version listing.
+     * Provides the next key at which the listing task is allowed to skip to.
+     * This could allow to skip over:
+     * - a key prefix ending with the delimiter
+     * - all remaining versions of an object when doing a current
+     *   versions listing in v0 format
+     * - a cached "gap" of deleted objects when doing a current
+     *   versions listing in v0 format
      *
-     * @return {string} - the insight: a common prefix or a master key,
-     *                                 or SKIP_NONE if there is no insight
+     * @return {string} - the next key at which the listing task is allowed to skip to
      */
     skipping() {
         return SKIP_NONE;

--- a/lib/algos/list/MPU.js
+++ b/lib/algos/list/MPU.js
@@ -1,7 +1,7 @@
 'use strict'; // eslint-disable-line strict
 
 const { inc, checkLimit, listingParamsMasterKeysV0ToV1,
-    FILTER_END, FILTER_ACCEPT } = require('./tools');
+    FILTER_END, FILTER_ACCEPT, SKIP_NONE } = require('./tools');
 const DEFAULT_MAX_KEYS = 1000;
 const VSConst = require('../../versioning/constants').VersioningConstants;
 const { DbPrefixes, BucketVersioningKeyFormat } = VSConst;
@@ -163,7 +163,7 @@ class MultipartUploads {
     }
 
     skipping() {
-        return '';
+        return SKIP_NONE;
     }
 
     /**

--- a/lib/algos/list/basic.js
+++ b/lib/algos/list/basic.js
@@ -2,7 +2,7 @@
 
 const Extension = require('./Extension').default;
 
-const { checkLimit, FILTER_END, FILTER_ACCEPT, FILTER_SKIP } = require('./tools');
+const { checkLimit, FILTER_END, FILTER_ACCEPT } = require('./tools');
 const DEFAULT_MAX_KEYS = 10000;
 
 /**
@@ -91,7 +91,7 @@ class List extends Extension {
      *                     < 0 : listing done
      */
     filter(elem) {
-        // Check first in case of maxkeys <= 0
+        // Check if the result array is full
         if (this.keys >= this.maxKeys) {
             return FILTER_END;
         }
@@ -99,7 +99,7 @@ class List extends Extension {
              this.filterKeyStartsWith !== undefined) &&
             typeof elem === 'object' &&
             !this.customFilter(elem.value)) {
-            return FILTER_SKIP;
+            return FILTER_ACCEPT;
         }
         if (typeof elem === 'object') {
             this.res.push({

--- a/lib/algos/list/delimiter.ts
+++ b/lib/algos/list/delimiter.ts
@@ -32,7 +32,7 @@ export interface DelimiterFilterState_SkippingPrefix extends FilterState {
 
 type KeyHandler = (key: string, value: string) => FilterReturnValue;
 
-type ResultObject = {
+export type ResultObject = {
     CommonPrefixes: string[];
     Contents: {
         key: string;

--- a/lib/algos/list/delimiter.ts
+++ b/lib/algos/list/delimiter.ts
@@ -305,7 +305,7 @@ export class Delimiter extends Extension {
         switch (this.state.id) {
         case DelimiterFilterStateId.SkippingPrefix:
             const { prefix } = <DelimiterFilterState_SkippingPrefix> this.state;
-            return prefix;
+            return inc(prefix);
 
         default:
             return SKIP_NONE;

--- a/lib/algos/list/delimiterMaster.ts
+++ b/lib/algos/list/delimiterMaster.ts
@@ -5,18 +5,23 @@ import {
     DelimiterFilterStateId,
     DelimiterFilterState_NotSkipping,
     DelimiterFilterState_SkippingPrefix,
+    ResultObject,
 } from './delimiter';
 const Version = require('../../versioning/Version').Version;
 const VSConst = require('../../versioning/constants').VersioningConstants;
 const { BucketVersioningKeyFormat } = VSConst;
-const { FILTER_ACCEPT, FILTER_SKIP, FILTER_END, inc } = require('./tools');
+const { FILTER_ACCEPT, FILTER_SKIP, FILTER_END, SKIP_NONE, inc } = require('./tools');
+
+import { GapSetEntry } from '../cache/GapSet';
+import { GapCacheInterface } from '../cache/GapCache';
 
 const VID_SEP = VSConst.VersionId.Separator;
 const { DbPrefixes } = VSConst;
 
-const enum DelimiterMasterFilterStateId {
+export const enum DelimiterMasterFilterStateId {
     SkippingVersionsV0 = 101,
     WaitVersionAfterPHDV0 = 102,
+    SkippingGapV0 = 103,
 };
 
 interface DelimiterMasterFilterState_SkippingVersionsV0 extends FilterState {
@@ -29,36 +34,119 @@ interface DelimiterMasterFilterState_WaitVersionAfterPHDV0 extends FilterState {
     masterKey: string,
 };
 
+interface DelimiterMasterFilterState_SkippingGapV0 extends FilterState {
+    id: DelimiterMasterFilterStateId.SkippingGapV0,
+};
+
+export const enum GapCachingState {
+    NoGapCache = 0, // there is no gap cache
+    UnknownGap = 1, // waiting for a cache lookup
+    GapLookupInProgress = 2, // asynchronous gap lookup in progress
+    GapCached = 3, // an upcoming or already skippable gap is cached
+    NoMoreGap = 4, // the cache doesn't have any more gaps inside the listed range
+};
+
+type GapCachingInfo_NoGapCache = {
+    state: GapCachingState.NoGapCache;
+};
+
+type GapCachingInfo_NoCachedGap = {
+    state: GapCachingState.UnknownGap
+        | GapCachingState.GapLookupInProgress
+    gapCache: GapCacheInterface;
+};
+
+type GapCachingInfo_GapCached = {
+    state: GapCachingState.GapCached;
+    gapCache: GapCacheInterface;
+    gapCached: GapSetEntry;
+};
+
+type GapCachingInfo_NoMoreGap = {
+    state: GapCachingState.NoMoreGap;
+};
+
+type GapCachingInfo = GapCachingInfo_NoGapCache
+    | GapCachingInfo_NoCachedGap
+    | GapCachingInfo_GapCached
+    | GapCachingInfo_NoMoreGap;
+
+
+export const enum GapBuildingState {
+    Disabled = 0, // no gap cache or not allowed to build due to exposure delay timeout
+    NotBuilding = 1, // not currently building a gap (i.e. not listing within a gap)
+    Building = 2, // currently building a gap (i.e. listing within a gap)
+};
+
+type GapBuildingInfo_Disabled = {
+    state: GapBuildingState.Disabled;
+};
+
+type GapBuildingParams = {
+    /**
+     * minimum weight for a gap to be created in the cache
+     */
+    minGapWeight: number;
+    /**
+     * trigger a cache setGap() call every N skippable keys
+     */
+    triggerSaveGapWeight: number;
+    /**
+     * timestamp to assess whether we're still inside the validity period to
+     * be allowed to build gaps
+     */
+    initTimestamp: number;
+};
+
+type GapBuildingInfo_NotBuilding = {
+    state: GapBuildingState.NotBuilding;
+    gapCache: GapCacheInterface;
+    params: GapBuildingParams;
+};
+
+type GapBuildingInfo_Building = {
+    state: GapBuildingState.Building;
+    gapCache: GapCacheInterface;
+    params: GapBuildingParams;
+    /**
+     * Gap currently being created
+     */
+    gap: GapSetEntry;
+    /**
+     * total current weight of the gap being created
+     */
+    gapWeight: number;
+};
+
+type GapBuildingInfo = GapBuildingInfo_Disabled
+    | GapBuildingInfo_NotBuilding
+    | GapBuildingInfo_Building;
+
 /**
  * Handle object listing with parameters. This extends the base class Delimiter
  * to return the raw master versions of existing objects.
  */
 export class DelimiterMaster extends Delimiter {
 
+    _gapCaching: GapCachingInfo;
+    _gapBuilding: GapBuildingInfo;
+    _refreshedBuildingParams: GapBuildingParams | null;
+
     /**
      * Delimiter listing of master versions.
      * @param {Object}  parameters            - listing parameters
-     * @param {String}  parameters.delimiter  - delimiter per amazon format
-     * @param {String}  parameters.prefix     - prefix per amazon format
-     * @param {String}  parameters.marker     - marker per amazon format
-     * @param {Number}  parameters.maxKeys    - number of keys to list
-     * @param {Boolean} parameters.v2         - indicates whether v2 format
-     * @param {String}  parameters.startAfter - marker per amazon v2 format
-     * @param {String}  parameters.continuationToken - obfuscated amazon token
-     * @param {RequestLogger} logger          - The logger of the request
-     * @param {String} [vFormat]              - versioning key format
+     * @param {String}  [parameters.delimiter]  - delimiter per amazon format
+     * @param {String}  [parameters.prefix]     - prefix per amazon format
+     * @param {String}  [parameters.marker]     - marker per amazon format
+     * @param {Number}  [parameters.maxKeys]    - number of keys to list
+     * @param {Boolean} [parameters.v2]         - indicates whether v2 format
+     * @param {String}  [parameters.startAfter] - marker per amazon v2 format
+     * @param {String}  [parameters.continuationToken] - obfuscated amazon token
+     * @param {RequestLogger} logger            - The logger of the request
+     * @param {String}  [vFormat="v0"]          - versioning key format
      */
-    constructor(parameters, logger, vFormat) {
+    constructor(parameters, logger, vFormat?: string) {
         super(parameters, logger, vFormat);
-
-        Object.assign(this, {
-            [BucketVersioningKeyFormat.v0]: {
-                skipping: this.skippingV0,
-            },
-            [BucketVersioningKeyFormat.v1]: {
-                skipping: this.skippingV1,
-            },
-        }[this.vFormat]);
 
         if (this.vFormat === BucketVersioningKeyFormat.v0) {
             // override Delimiter's implementation of NotSkipping for
@@ -77,6 +165,10 @@ export class DelimiterMaster extends Delimiter {
                 DelimiterMasterFilterStateId.WaitVersionAfterPHDV0,
                 this.keyHandler_WaitVersionAfterPHDV0.bind(this));
 
+            this.setKeyHandler(
+                DelimiterMasterFilterStateId.SkippingGapV0,
+                this.keyHandler_SkippingGapV0.bind(this));
+
             if (this.marker) {
                 // distinct initial state to include some special logic
                 // before the first master key is found that does not have
@@ -93,6 +185,173 @@ export class DelimiterMaster extends Delimiter {
         }
         // in v1, we can directly use Delimiter's implementation,
         // which is already set to the proper state
+
+        // default initialization of the gap cache and building states, can be
+        // set by refreshGapCache()
+        this._gapCaching = {
+            state: GapCachingState.NoGapCache,
+        };
+        this._gapBuilding = {
+            state: GapBuildingState.Disabled,
+        };
+        this._refreshedBuildingParams = null;
+    }
+
+    /**
+     * Get the validity period left before a refresh of the gap cache is needed
+     * to continue building new gaps.
+     *
+     * @return {number|null} one of:
+     * - the remaining time in milliseconds in which gaps can be added to the
+     *   cache before a call to refreshGapCache() is required
+     * - or 0 if there is no time left and a call to refreshGapCache() is required
+     *   to resume caching gaps
+     * - or null if refreshing the cache is never needed (because the gap cache
+     *   is either not available or not used)
+     */
+    getGapBuildingValidityPeriodMs(): number | null {
+        let gapBuilding;
+        switch (this._gapBuilding.state) {
+        case GapBuildingState.Disabled:
+            return null;
+        case GapBuildingState.NotBuilding:
+            gapBuilding = <GapBuildingInfo_NotBuilding> this._gapBuilding;
+            break;
+        case GapBuildingState.Building:
+            gapBuilding = <GapBuildingInfo_Building> this._gapBuilding;
+            break;
+        }
+        const { gapCache, params } = gapBuilding;
+        const elapsedTime = Date.now() - params.initTimestamp;
+        return Math.max(gapCache.exposureDelayMs - elapsedTime, 0);
+    }
+
+    /**
+     * Refresh the gaps caching logic (gaps are series of current delete markers
+     * in V0 bucket metadata format). It has two effects:
+     *
+     * - starts exposing existing and future gaps from the cache to efficiently
+     *   skip over series of current delete markers that have been seen and cached
+     *   earlier
+     *
+     * - enables building and caching new gaps (or extend existing ones), for a
+     *   limited time period defined by the `gapCacheProxy.exposureDelayMs` value
+     *   in milliseconds. To refresh the validity period and resume building and
+     *   caching new gaps, one must restart a new listing from the database (starting
+     *   at the current listing key, included), then call refreshGapCache() again.
+     *
+     * @param {GapCacheInterface} gapCacheProxy - API proxy to the gaps cache
+     *   (the proxy should handle prefixing object keys with the bucket name)
+     * @param {number} [minGapWeight=100] - minimum weight of a gap for it to be
+     *   added in the cache
+     * @param {number} [triggerSaveGapWeight] - cumulative weight to wait for
+     *   before saving the current building gap. Cannot be greater than
+     *   `gapCacheProxy.maxGapWeight` (the value is thresholded to `maxGapWeight`
+     *   otherwise). Defaults to `gapCacheProxy.maxGapWeight / 2`.
+     * @return {undefined}
+     */
+    refreshGapCache(
+        gapCacheProxy: GapCacheInterface,
+        minGapWeight?: number,
+        triggerSaveGapWeight?: number
+    ): void {
+        if (this.vFormat !== BucketVersioningKeyFormat.v0) {
+            return;
+        }
+        if (this._gapCaching.state === GapCachingState.NoGapCache) {
+            this._gapCaching = {
+                state: GapCachingState.UnknownGap,
+                gapCache: gapCacheProxy,
+            };
+        }
+        const refreshedBuildingParams: GapBuildingParams = {
+            minGapWeight: minGapWeight || 100,
+            triggerSaveGapWeight: triggerSaveGapWeight
+                || Math.trunc(gapCacheProxy.maxGapWeight / 2),
+            initTimestamp: Date.now(),
+        };
+        if (this._gapBuilding.state === GapBuildingState.Building) {
+            // refreshed params will be applied as soon as the current building gap is saved
+            this._refreshedBuildingParams = refreshedBuildingParams;
+        } else {
+            this._gapBuilding = {
+                state: GapBuildingState.NotBuilding,
+                gapCache: gapCacheProxy,
+                params: refreshedBuildingParams,
+            };
+        }
+    }
+
+    /**
+     * Trigger a lookup of the closest upcoming or already skippable gap.
+     *
+     * @param {string} fromKey - lookup a gap not before 'fromKey'
+     * @return {undefined} - the lookup is asynchronous and its
+     * response is handled inside this function
+     */
+    _triggerGapLookup(gapCaching: GapCachingInfo_NoCachedGap, fromKey: string): void {
+        this._gapCaching = {
+            state: GapCachingState.GapLookupInProgress,
+            gapCache: gapCaching.gapCache,
+        };
+        const maxKey = this.prefix ? inc(this.prefix) : undefined;
+        gapCaching.gapCache.lookupGap(fromKey, maxKey).then(_gap => {
+            const gap = <GapSetEntry | null> _gap;
+            if (gap) {
+                this._gapCaching = {
+                    state: GapCachingState.GapCached,
+                    gapCache: gapCaching.gapCache,
+                    gapCached: gap,
+                };
+            } else {
+                this._gapCaching = {
+                    state: GapCachingState.NoMoreGap,
+                };
+            }
+        });
+    }
+
+    _checkGapOnMasterDeleteMarker(key: string): FilterReturnValue {
+        switch (this._gapBuilding.state) {
+        case GapBuildingState.Disabled:
+            break;
+        case GapBuildingState.NotBuilding:
+            this._createBuildingGap(key, 1);
+            break;
+        case GapBuildingState.Building:
+            this._updateBuildingGap(key);
+            break;
+        }
+        if (this._gapCaching.state === GapCachingState.GapCached) {
+            const { gapCached } = this._gapCaching;
+            if (key >= gapCached.firstKey) {
+                if (key <= gapCached.lastKey) {
+                    // we are inside the last looked up cached gap: transition to
+                    // 'SkippingGapV0' state
+                    this.setState(<DelimiterMasterFilterState_SkippingGapV0> {
+                        id: DelimiterMasterFilterStateId.SkippingGapV0,
+                    });
+                    // cut the current gap before skipping, it will be merged or
+                    // chained with the existing one (depending on its weight)
+                    if (this._gapBuilding.state === GapBuildingState.Building) {
+                        // substract 1 from the weight because we are going to chain this gap,
+                        // which has an overlap of one key.
+                        this._gapBuilding.gap.weight -= 1;
+                        this._cutBuildingGap();
+                    }
+                    return FILTER_SKIP;
+                }
+                // as we are past the cached gap, we will need another lookup
+                this._gapCaching = {
+                    state: GapCachingState.UnknownGap,
+                    gapCache: this._gapCaching.gapCache,
+                };
+            }
+        }
+        if (this._gapCaching.state === GapCachingState.UnknownGap) {
+            this._triggerGapLookup(this._gapCaching, key);
+        }
+        return FILTER_ACCEPT;
     }
 
     filter_onNewMasterKeyV0(key: string, value: string): FilterReturnValue {
@@ -104,7 +363,7 @@ export class DelimiterMaster extends Delimiter {
                 id: DelimiterMasterFilterStateId.SkippingVersionsV0,
                 masterKey: key,
             });
-            return FILTER_ACCEPT;
+            return this._checkGapOnMasterDeleteMarker(key);
         }
         if (Version.isPHD(value)) {
             // master version is a PHD version: wait for the first
@@ -116,6 +375,9 @@ export class DelimiterMaster extends Delimiter {
             });
             return FILTER_ACCEPT;
         }
+        // cut the current gap as soon as a non-deleted entry is seen
+        this._cutBuildingGap();
+
         if (key.startsWith(DbPrefixes.Replay)) {
             // skip internal replay prefix entirely
             this.setState(<DelimiterFilterState_SkippingPrefix> {
@@ -127,6 +389,7 @@ export class DelimiterMaster extends Delimiter {
         if (this._reachedMaxKeys()) {
             return FILTER_END;
         }
+
         const commonPrefix = this.addCommonPrefixOrContents(key, value);
         if (commonPrefix) {
             // transition into SkippingPrefix state to skip all following keys
@@ -154,6 +417,11 @@ export class DelimiterMaster extends Delimiter {
          * (<key><versionIdSeparator><version>) */
         const versionIdIndex = key.indexOf(VID_SEP);
         if (versionIdIndex !== -1) {
+            // version keys count in the building gap weight because they must
+            // also be listed until skipped
+            if (this._gapBuilding.state === GapBuildingState.Building) {
+                this._updateBuildingGap(key);
+            }
             return FILTER_SKIP;
         }
         return this.filter_onNewMasterKeyV0(key, value);
@@ -177,14 +445,140 @@ export class DelimiterMaster extends Delimiter {
         return this.filter_onNewMasterKeyV0(key, value);
     }
 
+    keyHandler_SkippingGapV0(key: string, value: string): FilterReturnValue {
+        const { gapCache, gapCached } = <GapCachingInfo_GapCached> this._gapCaching;
+        if (key <= gapCached.lastKey) {
+            return FILTER_SKIP;
+        }
+        this._gapCaching = {
+            state: GapCachingState.UnknownGap,
+            gapCache,
+        };
+        this.setState(<DelimiterMasterFilterState_SkippingVersionsV0> {
+            id: DelimiterMasterFilterStateId.SkippingVersionsV0,
+        });
+        // Start a gap with weight=0 from the latest skippable key. This will
+        // allow to extend the gap just skipped with a chained gap in case
+        // other delete markers are seen after the existing gap is skipped.
+        this._createBuildingGap(gapCached.lastKey, 0, gapCached.weight);
+
+        return this.handleKey(key, value);
+    }
+
     skippingBase(): string | undefined {
         switch (this.state.id) {
         case DelimiterMasterFilterStateId.SkippingVersionsV0:
             const { masterKey } = <DelimiterMasterFilterState_SkippingVersionsV0> this.state;
             return masterKey + inc(VID_SEP);
 
+        case DelimiterMasterFilterStateId.SkippingGapV0:
+            const { gapCached } = <GapCachingInfo_GapCached> this._gapCaching;
+            return gapCached.lastKey;
+
         default:
             return super.skippingBase();
+        }
+    }
+
+    result(): ResultObject {
+        this._cutBuildingGap();
+        return super.result();
+    }
+
+    _checkRefreshedBuildingParams(params: GapBuildingParams): GapBuildingParams {
+        if (this._refreshedBuildingParams) {
+            const newParams = this._refreshedBuildingParams;
+            this._refreshedBuildingParams = null;
+            return newParams;
+        }
+        return params;
+    }
+
+    _saveBuildingGap(): void {
+        const { gapCache, params, gap, gapWeight } =
+              <GapBuildingInfo_Building> this._gapBuilding;
+        const totalElapsed = Date.now() - params.initTimestamp;
+        if (totalElapsed >= gapCache.exposureDelayMs) {
+            this._gapBuilding = {
+                state: GapBuildingState.Disabled,
+            };
+            this._refreshedBuildingParams = null;
+            return;
+        }
+        const { firstKey, lastKey, weight } = gap;
+        gapCache.setGap(firstKey, lastKey, weight);
+        this._gapBuilding = {
+            state: GapBuildingState.Building,
+            gapCache,
+            params: this._checkRefreshedBuildingParams(params),
+            gap: {
+                firstKey: gap.lastKey,
+                lastKey: gap.lastKey,
+                weight: 0,
+            },
+            gapWeight,
+        };
+    }
+
+    /**
+     * Create a new gap to be extended afterwards
+     *
+     * @param {string} newKey - gap's first key
+     * @param {number} startWeight - initial weight of the building gap (usually 0 or 1)
+     * @param {number} [cachedWeight] - if continuing a cached gap, weight of the existing
+     *   cached portion
+     * @return {undefined}
+     */
+    _createBuildingGap(newKey: string, startWeight: number, cachedWeight?: number): void {
+        if (this._gapBuilding.state === GapBuildingState.NotBuilding) {
+            const { gapCache, params } = <GapBuildingInfo_NotBuilding> this._gapBuilding;
+            this._gapBuilding = {
+                state: GapBuildingState.Building,
+                gapCache,
+                params: this._checkRefreshedBuildingParams(params),
+                gap: {
+                    firstKey: newKey,
+                    lastKey: newKey,
+                    weight: startWeight,
+                },
+                gapWeight: (cachedWeight || 0) + startWeight,
+            };
+        }
+    }
+
+    _updateBuildingGap(newKey: string): void {
+        const gapBuilding = <GapBuildingInfo_Building> this._gapBuilding;
+        const { params, gap } = gapBuilding;
+        gap.lastKey = newKey;
+        gap.weight += 1;
+        gapBuilding.gapWeight += 1;
+        // the GapCache API requires updating a gap regularly because it can only split
+        // it once per update, by the known last key. In practice the default behavior
+        // is to trigger an update after a number of keys that is half the maximum weight.
+        // It is also useful for other listings to benefit from the cache sooner.
+        if (gapBuilding.gapWeight >= params.minGapWeight &&
+            gap.weight >= params.triggerSaveGapWeight) {
+            this._saveBuildingGap();
+        }
+    }
+
+    _cutBuildingGap(): void {
+        if (this._gapBuilding.state === GapBuildingState.Building) {
+            let gapBuilding = <GapBuildingInfo_Building> this._gapBuilding;
+            let { gapCache, params, gap, gapWeight } = gapBuilding;
+            // only set gaps that are significant enough in weight and
+            // with a non-empty extension
+            if (gapWeight >= params.minGapWeight && gap.weight > 0) {
+                this._saveBuildingGap();
+                // params may have been refreshed, reload them
+                gapBuilding = <GapBuildingInfo_Building> this._gapBuilding;
+                params = gapBuilding.params;
+            }
+            this._gapBuilding = {
+                state: GapBuildingState.NotBuilding,
+                gapCache,
+                params,
+            };
         }
     }
 }

--- a/lib/algos/list/delimiterMaster.ts
+++ b/lib/algos/list/delimiterMaster.ts
@@ -9,7 +9,7 @@ import {
 const Version = require('../../versioning/Version').Version;
 const VSConst = require('../../versioning/constants').VersioningConstants;
 const { BucketVersioningKeyFormat } = VSConst;
-const { FILTER_ACCEPT, FILTER_SKIP, FILTER_END } = require('./tools');
+const { FILTER_ACCEPT, FILTER_SKIP, FILTER_END, inc } = require('./tools');
 
 const VID_SEP = VSConst.VersionId.Separator;
 const { DbPrefixes } = VSConst;
@@ -181,7 +181,7 @@ export class DelimiterMaster extends Delimiter {
         switch (this.state.id) {
         case DelimiterMasterFilterStateId.SkippingVersionsV0:
             const { masterKey } = <DelimiterMasterFilterState_SkippingVersionsV0> this.state;
-            return masterKey + VID_SEP;
+            return masterKey + inc(VID_SEP);
 
         default:
             return super.skippingBase();

--- a/lib/algos/list/delimiterVersions.ts
+++ b/lib/algos/list/delimiterVersions.ts
@@ -452,11 +452,14 @@ export class DelimiterVersions extends Extension {
         switch (this.state.id) {
         case DelimiterVersionsFilterStateId.SkippingPrefix:
             const { prefix } = <DelimiterVersionsFilterState_SkippingPrefix> this.state;
-            return prefix;
+            return inc(prefix);
 
         case DelimiterVersionsFilterStateId.SkippingVersions:
             const { gt } = <DelimiterVersionsFilterState_SkippingVersions> this.state;
-            return gt;
+            // the contract of skipping() is to return the first key
+            // that can be skipped to, so adding a null byte to skip
+            // over the existing versioned key set in 'gt'
+            return `${gt}\0`;
 
         default:
             return SKIP_NONE;

--- a/lib/algos/list/skip.js
+++ b/lib/algos/list/skip.js
@@ -52,21 +52,21 @@ class Skip {
         assert(this.skipRangeCb);
 
         const filteringResult = this.extension.filter(entry);
-        const skippingRange = this.extension.skipping();
+        const skipTo = this.extension.skipping();
 
         if (filteringResult === FILTER_END) {
             this.listingEndCb();
         } else if (filteringResult === FILTER_SKIP
-                   && skippingRange !== SKIP_NONE) {
+                   && skipTo !== SKIP_NONE) {
             if (++this.streakLength >= MAX_STREAK_LENGTH) {
                 let newRange;
-                if (Array.isArray(skippingRange)) {
+                if (Array.isArray(skipTo)) {
                     newRange = [];
-                    for (let i = 0; i < skippingRange.length; ++i) {
-                        newRange.push(this._inc(skippingRange[i]));
+                    for (let i = 0; i < skipTo.length; ++i) {
+                        newRange.push(skipTo[i]);
                     }
                 } else {
-                    newRange = this._inc(skippingRange);
+                    newRange = skipTo;
                 }
                 /* Avoid to loop on the same range again and again. */
                 if (newRange === this.gteParams) {
@@ -78,16 +78,6 @@ class Skip {
         } else {
             this.streakLength = 0;
         }
-    }
-
-    _inc(str) {
-        if (!str) {
-            return str;
-        }
-        const lastCharValue = str.charCodeAt(str.length - 1);
-        const lastCharNewValue = String.fromCharCode(lastCharValue + 1);
-
-        return `${str.slice(0, str.length - 1)}${lastCharNewValue}`;
     }
 }
 

--- a/tests/unit/algos/list/delimiter.spec.js
+++ b/tests/unit/algos/list/delimiter.spec.js
@@ -727,7 +727,7 @@ function getTestListing(mdParams, data, vFormat) {
                 });
             }
             assert.strictEqual(delimiter.skipping(),
-                `${vFormat === 'v1' ? DbPrefixes.Master : ''}foo/`);
+                `${vFormat === 'v1' ? DbPrefixes.Master : ''}foo0`);
         });
 
         tests.forEach(test => {

--- a/tests/unit/algos/list/delimiterMaster.spec.js
+++ b/tests/unit/algos/list/delimiterMaster.spec.js
@@ -167,7 +167,7 @@ function getListingKey(key, vFormat) {
         });
 
         if (vFormat === 'v0') {
-            it('should return <key><VersionIdSeparator> for DelimiterMaster when ' +
+            it('skipping() should return <key>inc(<VersionIdSeparator>) for DelimiterMaster when ' +
             'NextMarker is set and there is a delimiter', () => {
                 const key = 'key';
                 const delimiter = new DelimiterMaster(
@@ -178,14 +178,10 @@ function getListingKey(key, vFormat) {
                 const listingKey = getListingKey(key, vFormat);
                 delimiter.filter({ key: listingKey, value: '' });
                 assert.strictEqual(delimiter.nextMarker, key);
-
-                /* With a delimiter skipping should return previous key + VID_SEP
-                 * (except when a delimiter is set and the NextMarker ends with the
-                 * delimiter) . */
-                assert.strictEqual(delimiter.skipping(), listingKey + VID_SEP);
+                assert.strictEqual(delimiter.skipping(), `${listingKey}${inc(VID_SEP)}`);
             });
 
-            it('should return <key><VersionIdSeparator> for DelimiterMaster when ' +
+            it('skipping() should return <key>inc(<VersionIdSeparator>) for DelimiterMaster when ' +
             'NextContinuationToken is set and there is a delimiter', () => {
                 const key = 'key';
                 const delimiter = new DelimiterMaster(
@@ -197,7 +193,7 @@ function getListingKey(key, vFormat) {
                 delimiter.filter({ key: listingKey, value: '' });
                 assert.strictEqual(delimiter.nextMarker, key);
 
-                assert.strictEqual(delimiter.skipping(), listingKey + VID_SEP);
+                assert.strictEqual(delimiter.skipping(), `${listingKey}${inc(VID_SEP)}`);
             });
 
             it('should accept a PHD version as first input', () => {
@@ -446,7 +442,7 @@ function getListingKey(key, vFormat) {
                         }),
                         FILTER_SKIP);
                     // ...it should skip the whole replay prefix
-                    assert.strictEqual(delimiter.skipping(), DbPrefixes.Replay);
+                    assert.strictEqual(delimiter.skipping(), inc(DbPrefixes.Replay));
 
                     // simulate a listing that reaches regular object keys
                     // beyond the replay prefix, ...
@@ -461,8 +457,8 @@ function getListingKey(key, vFormat) {
                     // as usual
                     assert.strictEqual(delimiter.skipping(),
                         delimiterChar ?
-                            `${inc(DbPrefixes.Replay)}foo/` :
-                            `${inc(DbPrefixes.Replay)}foo/bar${VID_SEP}`);
+                            `${inc(DbPrefixes.Replay)}foo0` :
+                            `${inc(DbPrefixes.Replay)}foo/bar${inc(VID_SEP)}`);
                 });
             });
         }
@@ -488,12 +484,12 @@ describe('DelimiterMaster listing algorithm: sequence of filter() scenarii', () 
                     key: `foo/deleted${VID_SEP}v1`,
                     isDeleteMarker: true,
                     res: FILTER_SKIP,
-                    skipping: `foo/deleted${VID_SEP}`,
+                    skipping: `foo/deleted${inc(VID_SEP)}`,
                 },
                 {
                     key: `foo/deleted${VID_SEP}v2`,
                     res: FILTER_SKIP,
-                    skipping: `foo/deleted${VID_SEP}`,
+                    skipping: `foo/deleted${inc(VID_SEP)}`,
                 },
                 {
                     key: 'foo/notdeleted',
@@ -502,7 +498,7 @@ describe('DelimiterMaster listing algorithm: sequence of filter() scenarii', () 
                 {
                     key: `foo/notdeleted${VID_SEP}v1`,
                     res: FILTER_SKIP,
-                    skipping: `foo/notdeleted${VID_SEP}`,
+                    skipping: `foo/notdeleted${inc(VID_SEP)}`,
                 },
                 {
                     key: 'foo/subprefix/key-1',
@@ -511,7 +507,7 @@ describe('DelimiterMaster listing algorithm: sequence of filter() scenarii', () 
                 {
                     key: `foo/subprefix/key-1${VID_SEP}v1`,
                     res: FILTER_SKIP,
-                    skipping: `foo/subprefix/key-1${VID_SEP}`,
+                    skipping: `foo/subprefix/key-1${inc(VID_SEP)}`,
                 },
             ],
             result: {
@@ -542,7 +538,7 @@ describe('DelimiterMaster listing algorithm: sequence of filter() scenarii', () 
                     key: `foo/01${VID_SEP}v1`,
                     isDeleteMarker: true,
                     res: FILTER_SKIP, // versions get skipped after master
-                    skipping: `foo/01${VID_SEP}`,
+                    skipping: `foo/01${inc(VID_SEP)}`,
                 },
                 {
                     key: 'foo/02',
@@ -553,7 +549,7 @@ describe('DelimiterMaster listing algorithm: sequence of filter() scenarii', () 
                     key: `foo/02${VID_SEP}v1`,
                     isDeleteMarker: true,
                     res: FILTER_SKIP,
-                    skipping: `foo/02${VID_SEP}`,
+                    skipping: `foo/02${inc(VID_SEP)}`,
                 },
                 {
                     key: 'foo/03',
@@ -562,7 +558,7 @@ describe('DelimiterMaster listing algorithm: sequence of filter() scenarii', () 
                 {
                     key: `foo/03${VID_SEP}v1`,
                     res: FILTER_SKIP,
-                    skipping: `foo/03${VID_SEP}`,
+                    skipping: `foo/03${inc(VID_SEP)}`,
                 },
             ],
             result: {
@@ -592,7 +588,7 @@ describe('DelimiterMaster listing algorithm: sequence of filter() scenarii', () 
                     key: `foo/bar/01${VID_SEP}v1`,
                     isDeleteMarker: true,
                     res: FILTER_SKIP, // versions get skipped after master
-                    skipping: `foo/bar/01${VID_SEP}`,
+                    skipping: `foo/bar/01${inc(VID_SEP)}`,
                 },
                 {
                     key: 'foo/bar/02',
@@ -603,12 +599,12 @@ describe('DelimiterMaster listing algorithm: sequence of filter() scenarii', () 
                     key: `foo/bar/02${VID_SEP}v1`,
                     isDeleteMarker: true,
                     res: FILTER_SKIP,
-                    skipping: `foo/bar/02${VID_SEP}`,
+                    skipping: `foo/bar/02${inc(VID_SEP)}`,
                 },
                 {
                     key: `foo/bar/02${VID_SEP}v2`,
                     res: FILTER_SKIP,
-                    skipping: `foo/bar/02${VID_SEP}`,
+                    skipping: `foo/bar/02${inc(VID_SEP)}`,
                 },
                 {
                     key: 'foo/bar/03',
@@ -618,19 +614,19 @@ describe('DelimiterMaster listing algorithm: sequence of filter() scenarii', () 
                     key: `foo/bar/03${VID_SEP}v1`,
                     res: FILTER_SKIP,
                     // from now on, skip the 'foo/bar/' prefix because we have already seen it
-                    skipping: 'foo/bar/',
+                    skipping: 'foo/bar0',
                 },
                 {
                     key: 'foo/bar/04',
                     isDeleteMarker: true,
                     res: FILTER_SKIP,
-                    skipping: 'foo/bar/',
+                    skipping: 'foo/bar0',
                 },
                 {
                     key: `foo/bar/04${VID_SEP}v1`,
                     isDeleteMarker: true,
                     res: FILTER_SKIP,
-                    skipping: 'foo/bar/',
+                    skipping: 'foo/bar0',
                 },
                 {
                     key: 'foo/baz/01',
@@ -640,7 +636,7 @@ describe('DelimiterMaster listing algorithm: sequence of filter() scenarii', () 
                     key: `foo/baz/01${VID_SEP}v1`,
                     res: FILTER_SKIP,
                     // skip the 'foo/baz/' prefix because we have already seen it
-                    skipping: 'foo/baz/',
+                    skipping: 'foo/baz0',
                 },
             ],
             result: {
@@ -669,7 +665,7 @@ describe('DelimiterMaster listing algorithm: sequence of filter() scenarii', () 
                 {
                     key: `foo/${VID_SEP}v1`,
                     res: FILTER_SKIP,
-                    skipping: `foo/${VID_SEP}`,
+                    skipping: `foo/${inc(VID_SEP)}`,
                 },
                 {
                     key: 'foo/deleted',
@@ -680,12 +676,12 @@ describe('DelimiterMaster listing algorithm: sequence of filter() scenarii', () 
                     key: `foo/deleted${VID_SEP}v1`,
                     isDeleteMarker: true,
                     res: FILTER_SKIP,
-                    skipping: `foo/deleted${VID_SEP}`,
+                    skipping: `foo/deleted${inc(VID_SEP)}`,
                 },
                 {
                     key: `foo/deleted${VID_SEP}v2`,
                     res: FILTER_SKIP,
-                    skipping: `foo/deleted${VID_SEP}`,
+                    skipping: `foo/deleted${inc(VID_SEP)}`,
                 },
                 {
                     key: 'foo/notdeleted',
@@ -694,7 +690,7 @@ describe('DelimiterMaster listing algorithm: sequence of filter() scenarii', () 
                 {
                     key: `foo/notdeleted${VID_SEP}v1`,
                     res: FILTER_SKIP,
-                    skipping: `foo/notdeleted${VID_SEP}`,
+                    skipping: `foo/notdeleted${inc(VID_SEP)}`,
                 },
                 {
                     key: 'foo/subprefix/key-1',
@@ -703,17 +699,17 @@ describe('DelimiterMaster listing algorithm: sequence of filter() scenarii', () 
                 {
                     key: `foo/subprefix/key-1${VID_SEP}v1`,
                     res: FILTER_SKIP,
-                    skipping: 'foo/subprefix/',
+                    skipping: 'foo/subprefix0',
                 },
                 {
                     key: 'foo/subprefix/key-2',
                     res: FILTER_SKIP,
-                    skipping: 'foo/subprefix/',
+                    skipping: 'foo/subprefix0',
                 },
                 {
                     key: `foo/subprefix/key-2${VID_SEP}v1`,
                     res: FILTER_SKIP,
-                    skipping: 'foo/subprefix/',
+                    skipping: 'foo/subprefix0',
                 },
             ],
             result: {
@@ -744,7 +740,7 @@ describe('DelimiterMaster listing algorithm: sequence of filter() scenarii', () 
                 {
                     key: `foo${VID_SEP}v1`,
                     res: FILTER_SKIP,
-                    skipping: `foo${VID_SEP}`,
+                    skipping: `foo${inc(VID_SEP)}`,
                 },
                 {
                     key: 'foo/deleted',
@@ -755,12 +751,12 @@ describe('DelimiterMaster listing algorithm: sequence of filter() scenarii', () 
                     key: `foo/deleted${VID_SEP}v1`,
                     isDeleteMarker: true,
                     res: FILTER_SKIP,
-                    skipping: `foo/deleted${VID_SEP}`,
+                    skipping: `foo/deleted${inc(VID_SEP)}`,
                 },
                 {
                     key: `foo/deleted${VID_SEP}v2`,
                     res: FILTER_SKIP,
-                    skipping: `foo/deleted${VID_SEP}`,
+                    skipping: `foo/deleted${inc(VID_SEP)}`,
                 },
                 {
                     key: 'foo/notdeleted',
@@ -769,17 +765,17 @@ describe('DelimiterMaster listing algorithm: sequence of filter() scenarii', () 
                 {
                     key: `foo/notdeleted${VID_SEP}v1`,
                     res: FILTER_SKIP,
-                    skipping: 'foo/',
+                    skipping: 'foo0',
                 },
                 {
                     key: 'foo/subprefix/key-1',
                     res: FILTER_SKIP,
-                    skipping: 'foo/',
+                    skipping: 'foo0',
                 },
                 {
                     key: `foo/subprefix/key-1${VID_SEP}v1`,
                     res: FILTER_SKIP,
-                    skipping: 'foo/',
+                    skipping: 'foo0',
                 },
             ],
             result: {
@@ -811,7 +807,7 @@ describe('DelimiterMaster listing algorithm: sequence of filter() scenarii', () 
                     key: `foo/${VID_SEP}v1`,
                     isDeleteMarker: true,
                     res: FILTER_SKIP,
-                    skipping: `foo/${VID_SEP}`,
+                    skipping: `foo/${inc(VID_SEP)}`,
                 },
                 {
                     key: 'foo/subprefix',
@@ -824,7 +820,7 @@ describe('DelimiterMaster listing algorithm: sequence of filter() scenarii', () 
                 {
                     key: 'foo/subprefix/02',
                     res: FILTER_SKIP,
-                    skipping: 'foo/subprefix/', // already added to common prefix
+                    skipping: 'foo/subprefix0', // already added to common prefix
                 },
             ],
             result: {
@@ -859,7 +855,7 @@ describe('DelimiterMaster listing algorithm: sequence of filter() scenarii', () 
                 {
                     key: `foo/01${VID_SEP}v2`,
                     res: FILTER_SKIP,
-                    skipping: `foo/01${VID_SEP}`,
+                    skipping: `foo/01${inc(VID_SEP)}`,
                 },
                 {
                     key: 'foo/02',
@@ -870,12 +866,12 @@ describe('DelimiterMaster listing algorithm: sequence of filter() scenarii', () 
                     key: `foo/02${VID_SEP}v1`,
                     isDeleteMarker: true,
                     res: FILTER_SKIP,
-                    skipping: `foo/02${VID_SEP}`,
+                    skipping: `foo/02${inc(VID_SEP)}`,
                 },
                 {
                     key: `foo/02${VID_SEP}v2`,
                     res: FILTER_SKIP,
-                    skipping: `foo/02${VID_SEP}`,
+                    skipping: `foo/02${inc(VID_SEP)}`,
                 },
             ],
             result: {
@@ -950,7 +946,7 @@ describe('DelimiterMaster listing algorithm: sequence of filter() scenarii', () 
                 {
                     key: `${DbPrefixes.Master}foo/subprefix/key-2`,
                     res: FILTER_SKIP,
-                    skipping: `${DbPrefixes.Master}foo/subprefix/`,
+                    skipping: `${DbPrefixes.Master}foo/subprefix0`,
                 },
             ],
             result: {
@@ -985,7 +981,7 @@ describe('DelimiterMaster listing algorithm: sequence of filter() scenarii', () 
                 {
                     key: `${DbPrefixes.Master}foo/subprefix/key-1`,
                     res: FILTER_SKIP,
-                    skipping: `${DbPrefixes.Master}foo/`,
+                    skipping: `${DbPrefixes.Master}foo0`,
                 },
             ],
             result: {

--- a/tests/unit/algos/list/delimiterMaster.spec.ts
+++ b/tests/unit/algos/list/delimiterMaster.spec.ts
@@ -2,8 +2,12 @@
 
 const assert = require('assert');
 
-const DelimiterMaster =
-    require('../../../../lib/algos/list/delimiterMaster').DelimiterMaster;
+import {
+    DelimiterMaster,
+    DelimiterMasterFilterStateId,
+    GapCachingState,
+    GapBuildingState,
+} from '../../../../lib/algos/list/delimiterMaster';
 const {
     FILTER_ACCEPT,
     FILTER_SKIP,
@@ -11,6 +15,8 @@ const {
     SKIP_NONE,
     inc,
 } = require('../../../../lib/algos/list/tools');
+import { default as GapSet, GapSetEntry } from '../../../../lib/algos/cache/GapSet';
+import { GapCacheInterface } from '../../../../lib/algos/cache/GapCache';
 const VSConst =
     require('../../../../lib/versioning/constants').VersioningConstants;
 const Version = require('../../../../lib/versioning/Version').Version;
@@ -1001,7 +1007,7 @@ describe('DelimiterMaster listing algorithm: sequence of filter() scenarii', () 
         it(`vFormat=${testCase.vFormat}: ${testCase.desc}`, () => {
             const delimiter = new DelimiterMaster(testCase.params, fakeLogger, testCase.vFormat);
             const resultEntries = testCase.entries.map(testEntry => {
-                const entry = {
+                const entry: any = {
                     key: testEntry.key,
                 };
                 if (testEntry.isDeleteMarker) {
@@ -1023,5 +1029,564 @@ describe('DelimiterMaster listing algorithm: sequence of filter() scenarii', () 
             assert.deepStrictEqual(resultEntries, testCase.entries);
             assert.deepStrictEqual(delimiter.result(), testCase.result);
         });
+    });
+});
+
+/**
+ * Test class that provides a GapCache-compatible interface via a
+ * GapSet implementation, i.e. without introducing a delay to expose
+ * gaps like the GapCache class does, so tests can check more easily
+ * which gaps have been updated.
+ */
+class GapCacheAsSet extends GapSet implements GapCacheInterface {
+    exposureDelayMs: number;
+
+    constructor(maxGapWeight: number) {
+        super(maxGapWeight);
+        this.exposureDelayMs = 1000;
+    }
+
+    static createFromArray(gaps: GapSetEntry[], maxWeight: number): GapCacheAsSet {
+        const gs = new GapCacheAsSet(maxWeight);
+        for (const gap of gaps) {
+            gs._gaps.insert(gap);
+        }
+        return gs;
+    }
+
+    get maxGapWeight(): number {
+        return super.maxWeight;
+    }
+}
+
+type FilterEntriesResumeState = {
+    i: number,
+    version: number,
+};
+
+/**
+ * Convenience test helper to build listing entries and pass them to
+ * the DelimiterMaster.filter() function in order, and checks the
+ * return code. It is also useful to check the state of the gap cache
+ * afterwards.
+ *
+ * The first object key is "pre/0001" and is incremented on each master key.
+ *
+ * The current object version is "v100" and the version is then incremented
+ * for each noncurrent version ("v101" etc.).
+ *
+ * @param {DelimiterMaster} listing - listing algorithm instance
+ * @param {string} pattern - pattern of keys to create:
+ *   - an upper-case letter is a master key
+ *   - a lower-case letter is a version key
+ *   - a 'd' (or 'D') letter is a delete marker
+ *   - any other letter (e.g. 'v' or 'V') is a regular version
+ *   - space characters ' ' are allowed and must be matched by
+ *     a space character at the same position in 'expectedCodes'
+
+ * @param {string} expectedCodes - string of expected codes from filter()
+ * matching each entry from 'pattern':
+ *   - 'a' stands for FILTER_ACCEPT
+ *   - 's' stands for FILTER_SKIP
+ *   - 'e' stands for FILTER_END
+ *   - ' ' must be matched by a space character in 'pattern'
+ * @return {FilterEntriesResumeState} - a state that can be passed in
+ * the next call as 'resumeFromState' to resume filtering the next
+ * keys
+ */
+function filterEntries(
+    listing: DelimiterMaster,
+    pattern: string,
+    expectedCodes: string,
+    resumeFromState?: FilterEntriesResumeState,
+): FilterEntriesResumeState {
+    const ExpectedCodeMap: string[] = [];
+    ExpectedCodeMap[FILTER_ACCEPT] = 'a';
+    ExpectedCodeMap[FILTER_SKIP] = 's';
+    ExpectedCodeMap[FILTER_END] = 'e';
+    let { i, version } = resumeFromState || { i: 0, version: 100 };
+    const obtainedCodes = pattern.split('').map(p => {
+        if (p === ' ') {
+            return ' ';
+        }
+        if (p.toUpperCase() === p) {
+            // master key
+            i += 1;
+            version = 100;
+        }
+        const keyId = `0000${i}`.slice(-4);
+        const key = `pre/${keyId}`;
+        const md: any = ('Dd'.includes(p)) ? { isDeleteMarker: true } : {};
+        md.versionId = `v${version}`;
+        const value = JSON.stringify(md);
+        const entry = (p.toUpperCase() === p) ? { key, value } : { key: `${key}\0v${version}`, value };
+        const ret = listing.filter(entry);
+        if (p.toLowerCase() === p) {
+            // version key
+            version += 1;
+        }
+        return ExpectedCodeMap[<number> <unknown> ret];
+    }).join('');
+    expect(obtainedCodes).toEqual(expectedCodes);
+
+    return { i, version };
+}
+
+describe('DelimiterMaster listing algorithm: gap caching and lookup', () => {
+    it('should not cache a gap of weight smaller than minGapWeight', () => {
+        const listing = new DelimiterMaster({}, fakeLogger, 'v0');
+        const gapCache = new GapCacheAsSet(100);
+        listing.refreshGapCache(gapCache, 7); // minGapWeight=7
+
+        filterEntries(listing, 'Vv Ddv Ddv Vv Ddv', 'as ass ass as ass');
+        expect(gapCache.toArray()).toEqual([]);
+    });
+
+    it('should cache a gap of weight equal to minGapWeight', () => {
+        const listing = new DelimiterMaster({}, fakeLogger, 'v0');
+        const gapCache = new GapCacheAsSet(100);
+        listing.refreshGapCache(gapCache, 9); // minGapWeight=9
+
+        filterEntries(listing, 'Vv Ddv Ddv Ddv Vv Ddv', 'as ass ass ass as ass');
+        expect(gapCache.toArray()).toEqual([
+            { firstKey: 'pre/0002', lastKey: `pre/0004${VID_SEP}v101`, weight: 9 },
+        ]);
+    });
+
+    it('should cache a gap of weight equal to maxWeight in a single gap', () => {
+        const listing = new DelimiterMaster({}, fakeLogger, 'v0');
+        const gapCache = new GapCacheAsSet(13); // maxWeight=13
+        listing.refreshGapCache(gapCache, 5); // minGapWeight=5
+
+        filterEntries(listing, 'Vv Ddv Ddvv Ddv Ddv Vv Ddv', 'as ass asss ass ass as ass');
+        expect(gapCache.toArray()).toEqual([
+            { firstKey: 'pre/0002', lastKey: `pre/0005${VID_SEP}v101`, weight: 13 },
+        ]);
+    });
+
+    it('should not cache a gap if listing has been running for more than exposureDelayMs',
+    async () => {
+        const listing = new DelimiterMaster({}, fakeLogger, 'v0');
+        const gapsArray = [
+            { firstKey: 'pre/0006', lastKey: `pre/0007${VID_SEP}v100`, weight: 6 },
+        ];
+        const gapCache = GapCacheAsSet.createFromArray(JSON.parse(
+            JSON.stringify(gapsArray)
+        ), 100);
+        listing.refreshGapCache(gapCache, 1, 1);
+
+        let resumeFromState = filterEntries(listing, 'Vv', 'as');
+        let validityPeriod = listing.getGapBuildingValidityPeriodMs();
+        expect(validityPeriod).toBeGreaterThan(gapCache.exposureDelayMs - 10);
+        expect(validityPeriod).toBeLessThan(gapCache.exposureDelayMs + 10);
+
+        await new Promise(resolve => setTimeout(resolve, gapCache.exposureDelayMs + 10));
+        validityPeriod = listing.getGapBuildingValidityPeriodMs();
+        expect(validityPeriod).toEqual(0);
+        resumeFromState = filterEntries(listing, 'Ddv Ddv Ddv Vvv', 'ass ass ass ass',
+                                        resumeFromState);
+        expect(gapCache.toArray()).toEqual(gapsArray);
+
+        // we should still be able to skip over the existing cached gaps
+        expect(listing._gapCaching.state).toEqual(GapCachingState.GapLookupInProgress);
+        await new Promise(resolve => setTimeout(resolve, 1));
+        expect(listing._gapCaching.state).toEqual(GapCachingState.GapCached);
+        filterEntries(listing, 'Ddv Ddv Ddv', 'sss sss ass', resumeFromState);
+    });
+
+    [1, 3, 5, 10].forEach(triggerSaveGapWeight => {
+        it('should cache a gap of weight maxWeight + 1 in two chained gaps ' +
+        `(triggerSaveGapWeight=${triggerSaveGapWeight})`, () => {
+            const listing = new DelimiterMaster({}, fakeLogger, 'v0');
+            const gapCache = new GapCacheAsSet(12); // maxWeight=12
+            listing.refreshGapCache(gapCache, 5, triggerSaveGapWeight);
+
+            filterEntries(listing, 'Vv Ddv Ddvv Ddv Ddv Vv Ddv', 'as ass asss ass ass as ass');
+            if (triggerSaveGapWeight === 1) {
+                // trigger=1 guarantees that the weight of split gaps is maximized
+                expect(gapCache.toArray()).toEqual([
+                    { firstKey: 'pre/0002', lastKey: `pre/0005${VID_SEP}v100`, weight: 12 },
+                    { firstKey: `pre/0005${VID_SEP}v100`, lastKey: `pre/0005${VID_SEP}v101`, weight: 1 },
+                ]);
+            } else if (triggerSaveGapWeight === 3) {
+                // - the first trigger happens after 'minGapWeight' listing entries, so 5
+                // - the second and third triggers happen after 'triggerSaveGapWeight' listing
+                //   entries, so 3 then 3 - same gap because 5+3+3=11 and 11 <= 12 (maxWeight)
+                // - finally, 2 more entries to complete the gap, at which point the
+                //   entry is split, hence we get two entries weights 11 and 2 respectively.
+                expect(gapCache.toArray()).toEqual([
+                    { firstKey: 'pre/0002', lastKey: 'pre/0005', weight: 11 },
+                    { firstKey: 'pre/0005', lastKey: `pre/0005${VID_SEP}v101`, weight: 2 },
+                ]);
+            } else {
+                // trigger=5|10
+                expect(gapCache.toArray()).toEqual([
+                    { firstKey: 'pre/0002', lastKey: `pre/0004${VID_SEP}v101`, weight: 10 },
+                    { firstKey: `pre/0004${VID_SEP}v101`, lastKey: `pre/0005${VID_SEP}v101`, weight: 3 },
+                ]);
+            }
+        });
+    });
+
+    [1, 2, 3].forEach(triggerSaveGapWeight => {
+        it('should cache a gap of weight more than twice maxWeight in as many chained gaps ' +
+        `as needed (triggerSaveGapWeight=${triggerSaveGapWeight})`, () => {
+            const listing = new DelimiterMaster({}, fakeLogger, 'v0');
+            const gapCache = new GapCacheAsSet(5); // maxWeight=5
+            // minGapWeight=4 prevents the last gap starting at "0008" from being cached
+            listing.refreshGapCache(gapCache, 4, triggerSaveGapWeight);
+
+            filterEntries(listing, 'Vv Ddv Ddvv Ddv Ddv Ddv Vv Ddv', 'as ass asss ass ass ass as ass');
+            // the slight differences in weight between different values of
+            // 'triggerSaveGapWeight' are due to the combination of the trigger
+            // frequency and the 'minGapWeight' value (3), but in all cases a
+            // reasonable splitting job should be obtained.
+            //
+            // NOTE: in practice, the default trigger is half the maximum weight, any value
+            // equal or lower should yield gap weights close enough to the maximum allowed.
+            if (triggerSaveGapWeight === 1) {
+                // a trigger at every key guarantees gaps to maximize their weight
+                expect(gapCache.toArray()).toEqual([
+                    { firstKey: 'pre/0002', lastKey: `pre/0003${VID_SEP}v100`, weight: 5 },
+                    { firstKey: `pre/0003${VID_SEP}v100`, lastKey: `pre/0004${VID_SEP}v101`, weight: 5 },
+                    { firstKey: `pre/0004${VID_SEP}v101`, lastKey: `pre/0006${VID_SEP}v100`, weight: 5 },
+                    { firstKey: `pre/0006${VID_SEP}v100`, lastKey: `pre/0006${VID_SEP}v101`, weight: 1 },
+                ]);
+            } else if (triggerSaveGapWeight === 2) {
+                expect(gapCache.toArray()).toEqual([
+                    { firstKey: 'pre/0002', lastKey: 'pre/0003', weight: 4 },
+                    { firstKey: 'pre/0003', lastKey: 'pre/0004', weight: 4 },
+                    { firstKey: 'pre/0004', lastKey: `pre/0005${VID_SEP}v100`, weight: 4 },
+                    { firstKey: `pre/0005${VID_SEP}v100`, lastKey: `pre/0006${VID_SEP}v101`, weight: 4 },
+                ]);
+            } else {
+                // trigger=3
+                expect(gapCache.toArray()).toEqual([
+                    { firstKey: 'pre/0002', lastKey: 'pre/0003', weight: 4 },
+                    { firstKey: 'pre/0003', lastKey: `pre/0003${VID_SEP}v102`, weight: 3 },
+                    { firstKey: `pre/0003${VID_SEP}v102`, lastKey: `pre/0004${VID_SEP}v101`, weight: 3 },
+                    { firstKey: `pre/0004${VID_SEP}v101`, lastKey: `pre/0005${VID_SEP}v101`, weight: 3 },
+                    { firstKey: `pre/0005${VID_SEP}v101`, lastKey: `pre/0006${VID_SEP}v101`, weight: 3 },
+                ]);
+            }
+        });
+    });
+
+    it('should cut the current gap when seeing a non-deleted object, and start a new ' +
+    'gap on the next deleted object', () => {
+        const listing = new DelimiterMaster({}, fakeLogger, 'v0');
+        const gapCache = new GapCacheAsSet(100);
+        listing.refreshGapCache(gapCache, 2); // minGapWeight=2
+
+        filterEntries(listing, 'Vv Ddv Vv Ddv Vv', 'as ass as ass as');
+        expect(gapCache.toArray()).toEqual([
+            { firstKey: 'pre/0002', lastKey: `pre/0002${VID_SEP}v101`, weight: 3 },
+            { firstKey: 'pre/0004', lastKey: `pre/0004${VID_SEP}v101`, weight: 3 },
+        ]);
+    });
+
+    it('should complete the current gap when returning a result', () => {
+        const listing = new DelimiterMaster({}, fakeLogger, 'v0');
+        const gapCache = new GapCacheAsSet(100);
+        listing.refreshGapCache(gapCache, 2); // ensure the gap above minGapWeight=2 gets saved
+
+        filterEntries(listing, 'Vv Ddv Ddv', 'as ass ass');
+        const result = listing.result();
+        expect(result).toEqual({
+            CommonPrefixes: [],
+            Contents: [
+                { key: 'pre/0001', value: '{"versionId":"v100"}' },
+            ],
+            Delimiter: undefined,
+            IsTruncated: false,
+            NextMarker: undefined,
+        });
+        expect(gapCache.toArray()).toEqual([
+            { firstKey: 'pre/0002', lastKey: `pre/0003${VID_SEP}v101`, weight: 6 },
+        ]);
+    });
+
+    it('should refresh the building params when refreshGapCache() is called in NonBuilding state',
+    () => {
+        const listing = new DelimiterMaster({}, fakeLogger, 'v0');
+        const gapCache = new GapCacheAsSet(100);
+        // ensure the first gap with weight=9 gets saved
+        listing.refreshGapCache(gapCache, 9);
+        let resumeFromState = filterEntries(listing, 'Vv', 'as');
+        // refresh with a different value for minGapWeight (12)
+        listing.refreshGapCache(gapCache, 12);
+
+        resumeFromState = filterEntries(listing, 'Ddv Ddv Ddv Vv', 'ass ass ass as',
+                                        resumeFromState);
+        // for the building gap, minGapWeight should have been updated to 12, hence the
+        // gap should not have been created
+        expect(gapCache.toArray()).toEqual([]);
+        filterEntries(listing, 'Ddv Ddv Ddv Ddv Vv', 'ass ass ass ass as', resumeFromState);
+        // there should now be a new gap with weight=12
+        expect(gapCache.toArray()).toEqual([
+            { firstKey: 'pre/0006', lastKey: `pre/0009${VID_SEP}v101`, weight: 12 },
+        ]);
+    });
+
+    it('should save the refreshed building params when refreshGapCache() is called in Building state',
+    () => {
+        const listing = new DelimiterMaster({}, fakeLogger, 'v0');
+        const gapCache = new GapCacheAsSet(100);
+        // ensure the first gap with weight=9 gets saved
+        listing.refreshGapCache(gapCache, 9);
+
+        let resumeFromState = filterEntries(listing, 'Vv Ddv Ddv', 'as ass ass');
+        // refresh with a different value for minGapWeight (12)
+        listing.refreshGapCache(gapCache, 12);
+        resumeFromState = filterEntries(listing, 'Ddv Vv', 'ass as', resumeFromState);
+        // for the building gap, minGapWeight should still be 9, hence the gap should
+        // have been created
+        expect(gapCache.toArray()).toEqual([
+            { firstKey: 'pre/0002', lastKey: `pre/0004${VID_SEP}v101`, weight: 9 },
+        ]);
+        filterEntries(listing, 'Ddv Ddv Ddv Vv', 'ass ass ass as', resumeFromState);
+        // there should still be only one gap because the next gap's weight is 9 and 9 < 12
+        expect(gapCache.toArray()).toEqual([
+            { firstKey: 'pre/0002', lastKey: `pre/0004${VID_SEP}v101`, weight: 9 },
+        ]);
+    });
+
+    it('should not build a new gap when skipping a prefix', () => {
+        const listing = new DelimiterMaster({
+            delimiter: '/',
+        }, fakeLogger, 'v0');
+        const gapCache = new GapCacheAsSet(100);
+        // force immediate creation of gaps with 1, 1
+        listing.refreshGapCache(gapCache, 1, 1);
+
+        // prefix should be skipped, but no new gap should be created
+        filterEntries(listing, 'Vv Ddv Ddv Ddv', 'as sss sss sss');
+        expect(gapCache.toArray()).toEqual([]);
+    });
+
+    it('should trigger gap lookup and continue filtering without skipping when encountering ' +
+    'a delete marker', () => {
+        const listing = new DelimiterMaster({}, fakeLogger, 'v0');
+        const gapsArray = [
+            { firstKey: 'pre/0002', lastKey: `pre/0003${VID_SEP}v100`, weight: 6 },
+        ];
+        const gapCache = GapCacheAsSet.createFromArray(JSON.parse(
+            JSON.stringify(gapsArray)
+        ), 100);
+        listing.refreshGapCache(gapCache);
+
+        let resumeState = filterEntries(listing, 'Vv', 'as');
+        // state should still be UnknownGap since no delete marker has been seen yet
+        expect(listing._gapCaching.state).toEqual(GapCachingState.UnknownGap);
+
+        resumeState = filterEntries(listing, 'D', 'a', resumeState);
+        // since the lookup is asynchronous (Promise-based), it should now be in progress
+        expect(listing._gapCaching.state).toEqual(GapCachingState.GapLookupInProgress);
+
+        filterEntries(listing, 'dv Ddv Vv Ddv', 'ss ass as ass', resumeState);
+        // the lookup should still be in progress
+        expect(listing._gapCaching.state).toEqual(GapCachingState.GapLookupInProgress);
+
+        // the gap cache shouldn't have been updated
+        expect(gapCache.toArray()).toEqual(gapsArray);
+    });
+
+    it('should cache a gap after lookup completes, and use it to skip over keys ' +
+    'within the gap range', async () => {
+        const listing = new DelimiterMaster({}, fakeLogger, 'v0');
+        const gapsArray = [
+            { firstKey: 'pre/0002', lastKey: `pre/0006${VID_SEP}v101`, weight: 14 },
+        ];
+        const gapCache = GapCacheAsSet.createFromArray(JSON.parse(
+            JSON.stringify(gapsArray)
+        ), 100);
+        listing.refreshGapCache(gapCache);
+
+        let resumeState = filterEntries(listing, 'Vv D', 'as a');
+        // since the lookup is asynchronous (Promise-based), it should now be in progress
+        expect(listing._gapCaching.state).toEqual(GapCachingState.GapLookupInProgress);
+        expect(listing.state.id).toEqual(DelimiterMasterFilterStateId.SkippingVersionsV0);
+        // wait until the lookup completes (should happen in the next
+        // event loop iteration so always quicker than a non-immediate timer)
+        await new Promise(resolve => setTimeout(resolve, 1));
+
+        // the lookup should have completed now and the next gap should be cached
+        expect(listing._gapCaching.state).toEqual(GapCachingState.GapCached);
+        expect(listing.state.id).toEqual(DelimiterMasterFilterStateId.SkippingVersionsV0);
+
+        // the state should stay in SkippingVersionsV0 until filter() is called with
+        // a new master delete marker
+        resumeState = filterEntries(listing, 'dvvv', 'ssss', resumeState);
+        expect(listing.state.id).toEqual(DelimiterMasterFilterStateId.SkippingVersionsV0);
+
+        // here comes the next master delete marker, it should be skipped as it is still within
+        // the cached gap's range (its key is "0003" and version "v100")
+        resumeState = filterEntries(listing, 'D', 's', resumeState);
+        // the listing algorithm should now be actively skipping the gap
+        expect(listing.state.id).toEqual(DelimiterMasterFilterStateId.SkippingGapV0);
+
+        // the skipping() function should return the gap's last key.
+        // NOTE: returning a key to jump to that is the actual gap's last key
+        // (instead of a key just after) allows the listing algorithm to build
+        // a chained gap when the database listing is restarted from that point
+        // and there are more delete markers to skip.
+        expect(listing.skipping()).toEqual(`pre/0006${VID_SEP}v101`);
+
+        // - The next master delete markers with key "0004" and "0005" are still within the
+        //   gap's range, so filter() should return FILTER_SKIP ('s')
+        //
+        // - Master key "0006" is NOT a delete marker, although this means that the update
+        //   happened after the gap was looked up and the listing is allowed to skip it as
+        //   well (it actually doesn't even check so doesn't know what type of key it is).
+        //
+        // - The following master delete marker "0007" is past the gap so returns
+        //   FILTER_ACCEPT ('a') and should have triggered a new cache lookup, and
+        //   the listing state should have been switched back to SkippingVersionsV0.
+        resumeState = filterEntries(listing, 'dv Ddv Ddv Vvvv Ddv', 'ss sss sss ssss ass',
+                                    resumeState);
+        expect(listing._gapCaching.state).toEqual(GapCachingState.GapLookupInProgress);
+        expect(listing.state.id).toEqual(DelimiterMasterFilterStateId.SkippingVersionsV0);
+
+        // the gap cache must not have been updated in the process
+        expect(gapCache.toArray()).toEqual(gapsArray);
+    });
+
+    it('should extend a cached gap forward if current delete markers are listed beyond',
+    async () => {
+        const listing = new DelimiterMaster({}, fakeLogger, 'v0');
+        const gapsArray = [
+            { firstKey: 'pre/0002', lastKey: `pre/0005${VID_SEP}v100`, weight: 12 },
+        ];
+        const gapCache = GapCacheAsSet.createFromArray(JSON.parse(
+            JSON.stringify(gapsArray)
+        ), 100);
+        listing.refreshGapCache(gapCache, 2);
+
+        let resumeState = filterEntries(listing, 'Vv D', 'as a');
+        // wait until the lookup completes (should happen in the next
+        // event loop iteration so always quicker than a non-immediate timer)
+        await new Promise(resolve => setTimeout(resolve, 1));
+
+        // the lookup should have completed now and the next gap should be cached,
+        // continue with filtering
+        resumeState = filterEntries(listing, 'dv Ddv Ddv Ddv Ddv Ddvvv Vv Ddv Vv',
+                                    'ss sss sss sss ass assss as ass as',
+                                    resumeState);
+        // the cached gap should be extended to the last key before the last regular
+        // master version ('V')
+        expect(gapCache.toArray()).toEqual([
+            // this gap has been extended forward up to right before the first non-deleted
+            // current version following the gap, and its weight updated with how many
+            // extra keys are skippable
+            { firstKey: 'pre/0002', lastKey: `pre/0007${VID_SEP}v103`, weight: 21 },
+            // this gap has been created from the next deleted current version
+            { firstKey: 'pre/0009', lastKey: `pre/0009${VID_SEP}v101`, weight: 3 },
+        ]);
+    });
+
+    it('should extend a cached gap backwards if current delete markers are listed ahead, ' +
+    'and forward if more skippable keys are seen', async () => {
+        const listing = new DelimiterMaster({}, fakeLogger, 'v0');
+        const gapsArray = [
+            { firstKey: 'pre/0004', lastKey: `pre/0005${VID_SEP}v100`, weight: 4 },
+        ];
+        const gapCache = GapCacheAsSet.createFromArray(JSON.parse(
+            JSON.stringify(gapsArray)
+        ), 100);
+        listing.refreshGapCache(gapCache, 2);
+
+        let resumeState = filterEntries(listing, 'Vv D', 'as a');
+        // wait until the lookup completes (should happen in the next
+        // event loop iteration so always quicker than a non-immediate timer)
+        await new Promise(resolve => setTimeout(resolve, 1));
+
+        // the lookup should have completed now and the next gap should be cached,
+        // continue with filtering
+        expect(listing._gapCaching.state).toEqual(GapCachingState.GapCached);
+        resumeState = filterEntries(listing, 'dv Ddv Ddv Ddv Vv Ddv Vv',
+                                    'ss ass sss sss as ass as', resumeState);
+        // the cached gap should be extended to the last key before the last regular
+        // master version ('V')
+        expect(gapCache.toArray()).toEqual([
+            // this gap has been extended:
+            // - backwards up to the first listed delete marker
+            // - forward up to the last skippable key
+            // and its weight updated with how many extra keys are skippable
+            { firstKey: 'pre/0002', lastKey: `pre/0005${VID_SEP}v101`, weight: 11 },
+            // this gap has been created from the next deleted current version
+            { firstKey: 'pre/0007', lastKey: `pre/0007${VID_SEP}v101`, weight: 3 },
+        ]);
+    });
+
+    it('should not extend a cached gap forward if extension weight is 0',
+    async () => {
+        const listing = new DelimiterMaster({}, fakeLogger, 'v0');
+        const gapsArray = [
+            { firstKey: 'pre/0002', lastKey: `pre/0005${VID_SEP}v101`, weight: 13 },
+        ];
+        const gapCache = GapCacheAsSet.createFromArray(JSON.parse(
+            JSON.stringify(gapsArray)
+        ), 100);
+        listing.refreshGapCache(gapCache, 2);
+
+        let resumeState = filterEntries(listing, 'Vv D', 'as a');
+        // wait until the lookup completes (should happen in the next
+        // event loop iteration so always quicker than a non-immediate timer)
+        await new Promise(resolve => setTimeout(resolve, 1));
+
+        // the lookup should have completed now and the next gap should
+        // be cached, simulate a concurrent invalidation by removing the
+        // existing gap immediately, then continue with filtering
+        resumeState = filterEntries(listing, 'dv Ddv Ddv Ddv',
+                                    'ss sss sss sss', resumeState);
+        gapCache.removeOverlappingGaps(['pre/0002']);
+        resumeState = filterEntries(listing, 'Vv', 'as', resumeState);
+        // no new gap should have been added
+        expect(gapCache.toArray()).toEqual([]);
+    });
+
+    it('should ignore gap with 0 listed key in it (e.g. due to skipping a prefix)', async () => {
+        const listing = new DelimiterMaster({}, fakeLogger, 'v0');
+        const gapsArray = [
+            { firstKey: 'pre/0004/a', lastKey: 'pre/0004/b', weight: 10 },
+        ];
+        const gapCache = GapCacheAsSet.createFromArray(JSON.parse(
+            JSON.stringify(gapsArray)
+        ), 100);
+        listing.refreshGapCache(gapCache);
+
+        let resumeState = filterEntries(listing, 'Dd Vv Vv', 'as as as');
+        // wait until the lookup completes (should happen in the next
+        // event loop iteration so always quicker than a non-immediate timer)
+        await new Promise(resolve => setTimeout(resolve, 1));
+
+        expect(listing._gapCaching.state).toEqual(GapCachingState.GapCached);
+        expect(gapCache.toArray()).toEqual([
+            { firstKey: 'pre/0004/a', lastKey: 'pre/0004/b', weight: 10 },
+        ]);
+        // "0004" keys are still prior to the gap's first key
+        resumeState = filterEntries(listing, 'Ddv', 'ass', resumeState);
+        expect(listing._gapCaching.state).toEqual(GapCachingState.GapCached);
+
+        // the next delete marker "0005" should trigger a new lookup...
+        resumeState = filterEntries(listing, 'D', 'a', resumeState);
+        expect(listing._gapCaching.state).toEqual(GapCachingState.GapLookupInProgress);
+        await new Promise(resolve => setTimeout(resolve, 1));
+
+        // ...which returns 'null' and sets the state to NoMoreGap
+        expect(listing._gapCaching.state).toEqual(GapCachingState.NoMoreGap);
+        filterEntries(listing, 'dv Vv', 'ss as', resumeState);
+    });
+
+    it('should disable gap fetching and building if using V1 format', async () => {
+        const listing = new DelimiterMaster({}, fakeLogger, 'v1');
+        const gapCache = new GapCacheAsSet(100);
+        listing.refreshGapCache(gapCache);
+
+        expect(listing.getGapBuildingValidityPeriodMs()).toBeNull();
+        expect(listing._gapCaching.state).toEqual(GapCachingState.NoGapCache);
+        // mimic V1 listing of master prefix
+        filterEntries(listing, 'V V', 'a a');
+        expect(listing._gapBuilding.state).toEqual(GapBuildingState.Disabled);
     });
 });

--- a/tests/unit/algos/list/delimiterVersions.spec.js
+++ b/tests/unit/algos/list/delimiterVersions.spec.js
@@ -846,11 +846,11 @@ function getTestListing(mdParams, data, vFormat) {
             }
             if (vFormat === 'v1') {
                 assert.deepStrictEqual(delimiter.skipping(), [
-                    `${DbPrefixes.Master}foo/`,
-                    `${DbPrefixes.Version}foo/`,
+                    `${DbPrefixes.Master}foo0`,
+                    `${DbPrefixes.Version}foo0`,
                 ]);
             } else {
-                assert.strictEqual(delimiter.skipping(), 'foo/');
+                assert.strictEqual(delimiter.skipping(), 'foo0');
             }
         });
 
@@ -871,7 +871,7 @@ function getTestListing(mdParams, data, vFormat) {
                     }),
                     FILTER_SKIP);
                 // ...it should skip the whole replay prefix
-                assert.strictEqual(delimiter.skipping(), DbPrefixes.Replay);
+                assert.strictEqual(delimiter.skipping(), inc(DbPrefixes.Replay));
 
                 // simulate a listing that reaches regular object keys
                 // beyond the replay prefix, ...
@@ -882,7 +882,7 @@ function getTestListing(mdParams, data, vFormat) {
                     }),
                     FILTER_ACCEPT);
                 // ...it should return to skipping by prefix as usual
-                assert.strictEqual(delimiter.skipping(), `${inc(DbPrefixes.Replay)}foo/`);
+                assert.strictEqual(delimiter.skipping(), `${inc(DbPrefixes.Replay)}foo0`);
             });
         }
 
@@ -937,11 +937,11 @@ function getTestListing(mdParams, data, vFormat) {
             assert.strictEqual(delimiter.nextKeyMarker, 'foo/');
 
             if (vFormat === 'v0') {
-                assert.strictEqual(delimiter.skipping(), 'foo/');
+                assert.strictEqual(delimiter.skipping(), 'foo0');
             } else {
                 assert.deepStrictEqual(delimiter.skipping(), [
-                    `${DbPrefixes.Master}foo/`,
-                    `${DbPrefixes.Version}foo/`,
+                    `${DbPrefixes.Master}foo0`,
+                    `${DbPrefixes.Version}foo0`,
                 ]);
             }
         });
@@ -958,11 +958,11 @@ function getTestListing(mdParams, data, vFormat) {
             assert.strictEqual(delimiter.nextKeyMarker, 'foo/');
 
             if (vFormat === 'v0') {
-                assert.strictEqual(delimiter.skipping(), 'foo/');
+                assert.strictEqual(delimiter.skipping(), 'foo0');
             } else {
                 assert.deepStrictEqual(delimiter.skipping(), [
-                    `${DbPrefixes.Master}foo/`,
-                    `${DbPrefixes.Version}foo/`,
+                    `${DbPrefixes.Master}foo0`,
+                    `${DbPrefixes.Version}foo0`,
                 ]);
             }
         });
@@ -1249,11 +1249,11 @@ function getTestListing(mdParams, data, vFormat) {
             }), FILTER_SKIP);
 
             if (vFormat === 'v0') {
-                assert.deepStrictEqual(listing.skipping(), `key${VID_SEP}version3`);
+                assert.deepStrictEqual(listing.skipping(), `key${VID_SEP}version3\0`);
             } else {
                 assert.deepStrictEqual(listing.skipping(), [
-                    `${DbPrefixes.Master}key${VID_SEP}version3`,
-                    `${DbPrefixes.Version}key${VID_SEP}version3`,
+                    `${DbPrefixes.Master}key${VID_SEP}version3\0`,
+                    `${DbPrefixes.Version}key${VID_SEP}version3\0`,
                 ]);
             }
 
@@ -1335,11 +1335,11 @@ function getTestListing(mdParams, data, vFormat) {
             }), FILTER_SKIP);
 
             if (vFormat === 'v0') {
-                assert.deepStrictEqual(listing.skipping(), `key${VID_SEP}version3`);
+                assert.deepStrictEqual(listing.skipping(), `key${VID_SEP}version3\0`);
             } else {
                 assert.deepStrictEqual(listing.skipping(), [
-                    `${DbPrefixes.Master}key${VID_SEP}version3`,
-                    `${DbPrefixes.Version}key${VID_SEP}version3`,
+                    `${DbPrefixes.Master}key${VID_SEP}version3\0`,
+                    `${DbPrefixes.Version}key${VID_SEP}version3\0`,
                 ]);
             }
 

--- a/tests/unit/algos/list/skip.spec.js
+++ b/tests/unit/algos/list/skip.spec.js
@@ -116,7 +116,7 @@ describe('Skip Algorithm', () => {
         // Skipping algo params
         const extension = {
             filter: () => FILTER_SKIP,
-            skipping: () => 'entry0',
+            skipping: () => 'entry1',
         };
         const gte = 'some-other-entry';
         // Setting spy functions
@@ -138,7 +138,7 @@ describe('Skip Algorithm', () => {
         // Skipping algo params
         const extension = {
             filter: () => FILTER_SKIP,
-            skipping: () => ['first-entry-0', 'second-entry-0'],
+            skipping: () => ['first-entry-1', 'second-entry-1'],
         };
         const gte = 'some-other-entry';
         // Setting spy functions
@@ -160,7 +160,7 @@ describe('Skip Algorithm', () => {
         // Skipping algo params
         const extension = {
             filter: () => FILTER_SKIP,
-            skipping: () => 'entry-0',
+            skipping: () => 'entry-1',
         };
         const gte = 'entry-1';
         // Setting spy functions


### PR DESCRIPTION
**Note for reviews**: best to review commits individually.

- change contract of skipping() API

  Instead of returning a "prefix" for the listing task to skip over, directly return the key on which to skip and continue the listing.

  It is both more natural as well as needed to implement skipping over cached "gaps" of deleted objects.

  Note that it could even be more powerful to return the type of query param to apply for the next listing ('gt' or 'gte'), but it would be more complex to implement with little practical benefit, so instead we add a null byte at the end of the returned key to skip to, whenever we want a 'gt' behavior from the returned 'gte' key.

- Implement logic in DelimiterMaster to improve efficiency of listings of buckets in V0 format that have a lot of current delete markers.

  A GapCache instance can be attached to a DelimiterMaster instance which enables the following:

  - Lookups in the cache to be able to restart listing directly beyond the cached gaps. It is done by returning FILTER_SKIP code when listing inside a gap, which hints the caller (RepdServer) that it is allowed to restart a new listing from a specific later key.

  - Building gaps and cache them, when listing inside a series of current delete markers. This allows future listings to benefit from the gap information and skip over them.

  An important caveat is that there is a limited time in which gaps can be built from the current listing: it is a trade-off to guarantee the validity of cached gaps when concurrent operations may invalidate them. This time is set in the GapCache instance as `exposureDelayMs`, and is the time during which concurrent operations are kept in memory
to potentially invalidate future gap creations. Because listings use a snapshot of the database, they return entries that are older than when the listing started. For this reason, in order to be allowed to consistently build new gaps, it is necessary to limit the running time of listings, and potentially redo periodically new listings (based on time or number of listed keys), resuming from where the previous listing stopped, instead of continuing the current listing.
