### PR TITLE
bf: ARSN-393 infinite loop in GapSet._coalesceGapChain()

### DIFF
--- a/lib/algos/cache/GapSet.ts
+++ b/lib/algos/cache/GapSet.ts
@@ -270,6 +270,10 @@ export default class GapSet implements GapSetInterface, Iterable<GapSetEntry> {
                         return resolve(coalescedGap);
                     }
                     const chainedGap = chainedGapIt.pointer;
+                    if (chainedGap.firstKey === chainedGap.lastKey) {
+                        // found a single-key gap: chain is complete
+                        return resolve(coalescedGap);
+                    }
                     coalescedGap.lastKey = chainedGap.lastKey;
                     coalescedGap.weight += chainedGap.weight;
                 }

--- a/tests/unit/algos/cache/GapSet.spec.ts
+++ b/tests/unit/algos/cache/GapSet.spec.ts
@@ -792,6 +792,25 @@ describe('GapSet', () => {
             const coalescedGap = await thousandGapsSet._coalesceGapChain(gap);
             expect(coalescedGap).toEqual({ firstKey: '0000', lastKey: '1000', weight: 10000 });
         });
+
+        it('should coalesce a single-key gap', async () => {
+            const singleKeyGapSet = GapSet.createFromArray([
+                { firstKey: '0000', lastKey: '0000', weight: 1 },
+            ], 100);
+            const gap = { firstKey: '0000', lastKey: '0000', weight: 1 };
+            const coalescedGap = await singleKeyGapSet._coalesceGapChain(gap);
+            expect(coalescedGap).toEqual({ firstKey: '0000', lastKey: '0000', weight: 1 });
+        });
+
+        it('should coalesce a chain of two gaps ending with a single-key gap', async () => {
+            const singleKeyGapSet = GapSet.createFromArray([
+                { firstKey: '0000', lastKey: '0003', weight: 9 },
+                { firstKey: '0003', lastKey: '0003', weight: 1 },
+            ], 100);
+            const gap = { firstKey: '0000', lastKey: '0003', weight: 9 };
+            const coalescedGap = await singleKeyGapSet._coalesceGapChain(gap);
+            expect(coalescedGap).toEqual({ firstKey: '0000', lastKey: '0003', weight: 9 });
+        });
     });
 
     describe('GapSet::lookupGap()', () => {


### PR DESCRIPTION
The `GapSet._coalesceGapChain()` helper could infinite loop when encountering a single-key gap (typically as an unchained single gap).