### PR TITLE
bf: ARSN-394 GapCache: invalidate staging gaps

### DIFF
--- a/lib/algos/cache/GapCache.ts
+++ b/lib/algos/cache/GapCache.ts
@@ -121,20 +121,23 @@ export default class GapCache implements GapCacheInterface {
     }
 
     /**
-     * Internal helper to remove gaps in the frozen set overlapping
-     * with previously updated keys, right before the frozen gaps get
-     * exposed.
+     * Internal helper to remove gaps in the staging and frozen sets
+     * overlapping with previously updated keys, right before the
+     * frozen gaps get exposed.
      *
      * @return {undefined}
      */
     _removeOverlappingGapsBeforeExpose(): void {
-        // simple optimization to avoid looping over all updates if
-        // there is no gap in the frozen set
-        if (this._frozenUpdates.newGaps.size === 0) {
-            return;
-        }
-        for (const updateSet of [this._stagingUpdates, this._frozenUpdates]) {
-            this._frozenUpdates.newGaps.removeOverlappingGaps(updateSet.updatedKeys);
+        for (const { updatedKeys } of [this._stagingUpdates, this._frozenUpdates]) {
+            if (updatedKeys.size() === 0) {
+                continue;
+            }
+            for (const { newGaps } of [this._stagingUpdates, this._frozenUpdates]) {
+                if (newGaps.size === 0) {
+                    continue;
+                }
+                newGaps.removeOverlappingGaps(updatedKeys);
+            }
         }
     }
 

--- a/tests/unit/algos/cache/GapCache.spec.ts
+++ b/tests/unit/algos/cache/GapCache.spec.ts
@@ -128,6 +128,11 @@ describe('GapCache', () => {
 
     it('removeOverlappingGaps() should invalidate gaps created later by setGap() but ' +
     'within the exposure delay', async () => {
+        // wait for 80ms (slightly less than exposure delay of 100ms)
+        // before calling removeOverlappingGaps(), so that the next
+        // exposure timer kicks in before the call to setGap()
+        await new Promise(resolve => setTimeout(resolve, 80));
+
         // there is no exposed gap yet, so expect 0 gap removed
         expect(gapCache.removeOverlappingGaps(['dog'])).toEqual(0);
 


### PR DESCRIPTION
In the `GapCache._removeOverlappingGapsBeforeExpose()` helper, remove the gaps from the *staging* set that overlap with any of the staging or frozen updates, in addition to removing the gaps from the frozen set.

Without this extra invalidation, it's still possible to have gaps created within the exposure delay that miss some invalidation, resulting in stale gaps in the cache.

Modify an existing unit test to cover this case by adding extra wait time to ensure `_removeOverlappingGapsBeforeExpose()` is called once after the invalidating update but before the `setGap()` call.