### PR TITLE
ft: ARSN-397 GapCache.clear()

### DIFF
--- a/lib/algos/cache/GapCache.ts
+++ b/lib/algos/cache/GapCache.ts
@@ -343,4 +343,18 @@ export default class GapCache implements GapCacheInterface {
     toArray(): GapSetEntry[] {
         return this._exposedGaps.toArray();
     }
+
+    /**
+     * Clear all exposed and staging gaps from the cache.
+     *
+     * Note: retains invalidating updates from removeOverlappingGaps()
+     * for correctness of gaps inserted afterwards.
+     *
+     * @return {undefined}
+     */
+    clear(): void {
+        this._stagingUpdates.newGaps = new GapSet(this.maxGapWeight);
+        this._frozenUpdates.newGaps = new GapSet(this.maxGapWeight);
+        this._exposedGaps = new GapSet(this.maxGapWeight);
+    }
 }


### PR DESCRIPTION
Add a clear() method to clear exposed and staging gaps. Retains invalidating updates for gaps inserted after the call to clear().