### PR TITLE
bf: ARSN-398 DelimiterMaster: fix when gap building is disabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.70.23",
+  "version": "7.70.24",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/algos/list/delimiterMaster.spec.ts
+++ b/tests/unit/algos/list/delimiterMaster.spec.ts
@@ -1186,6 +1186,11 @@ describe('DelimiterMaster listing algorithm: gap caching and lookup', () => {
         resumeFromState = filterEntries(listing, 'Ddv Ddv Ddv Vvv', 'ass ass ass ass',
                                         resumeFromState);
         expect(gapCache.toArray()).toEqual(gapsArray);
+        // gap building should be in expired state
+        expect(listing._gapBuilding.state).toEqual(GapBuildingState.Expired);
+        // remaining validity period should still be 0 because gap building has expired
+        validityPeriod = listing.getGapBuildingValidityPeriodMs();
+        expect(validityPeriod).toEqual(0);
 
         // we should still be able to skip over the existing cached gaps
         expect(listing._gapCaching.state).toEqual(GapCachingState.GapLookupInProgress);


### PR DESCRIPTION
- Fix the situation where gap building is disabled by `_saveBuildingGap()` but we attempted to reset the building gap state anyway.

- Introduce a new state 'Expired' that can be differentiated from 'Disabled': it makes `getGapBuildingValidityPeriodMs()` return 0 instead of 'null' to hint the listing backend that it should trigger a new listing.
