### PR TITLE
ARSN-400: Add scuba admin actions

### DIFF
--- a/lib/policyEvaluator/RequestContext.ts
+++ b/lib/policyEvaluator/RequestContext.ts
@@ -110,7 +110,7 @@ function _buildArn(
         }
         case 'scuba': {
             return `arn:scality:scuba::${requesterInfo!.accountid}:` +
-            `${generalResource}/${specificResource || ''}`;
+            `${generalResource}${specificResource ? '/' + specificResource : ''}`;
         }
         default:
             return undefined;

--- a/lib/policyEvaluator/utils/actionMaps.ts
+++ b/lib/policyEvaluator/utils/actionMaps.ts
@@ -208,6 +208,10 @@ const actionMapMetadata = {
 
 const actionMapScuba = {
     GetMetrics: 'scuba:GetMetrics',
+    AdminStartIngest: 'scuba:AdminStartIngest',
+    AdminStopIngest: 'scuba:AdminStopIngest',
+    AdminReadRaftCseq: 'scuba:AdminReadRaftCseq',
+    AdminTriggerRepair: 'scuba:AdminTriggerRepair',
 };
 
 export {


### PR DESCRIPTION
For admin access, a policy like that should be set:

```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "scuba:AdminStartIngest",
                "scuba:AdminStopIngest",
                "scuba:AdminReadRaftCseq",
                "scuba:AdminTriggerRepair"
            ],
            "Resource": [
                "arn:scality:scuba:::admin"
            ]
        }
    ]
}
```