### PR TITLE
ARSN-401: Add PRIMARY communication in cluster RPC

### DIFF
--- a/lib/network/kmip/codec/ttlv.ts
+++ b/lib/network/kmip/codec/ttlv.ts
@@ -20,7 +20,7 @@ function _ttlvPadVector(vec: any[]) {
     return vec;
 }
 
-function _throwError(logger: werelogs.Logger, msg: string, data?: LogDictionnary) {
+function _throwError(logger: werelogs.Logger, msg: string, data?: LogDictionary) {
     logger.error(msg, data);
     throw Error(msg);
 }

--- a/lib/network/rest/RESTServer.ts
+++ b/lib/network/rest/RESTServer.ts
@@ -104,7 +104,6 @@ export default class RESTServer extends httpServer {
     }) {
         assert(params.port);
 
-        // @ts-expect-error
         werelogs.configure({
             level: params.log.logLevel,
             dump: params.log.dumpLevel,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.70.26",
+  "version": "7.70.28",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "sproxydclient": "github:scality/sproxydclient#8.0.4",
     "utf8": "2.1.2",
     "uuid": "^3.0.1",
-    "werelogs": "scality/werelogs#8.1.0",
+    "werelogs": "scality/werelogs#8.1.1",
     "xml2js": "~0.4.23"
   },
   "optionalDependencies": {

--- a/tests/functional/clustering/ClusterRPC-test-server.js
+++ b/tests/functional/clustering/ClusterRPC-test-server.js
@@ -309,7 +309,7 @@ if (cluster.isPrimary) {
                     res.writeHead(500);
                     res.end(serializedErr);
                 } else {
-                    res.writeHead(err.code);
+                    res.writeHead(err.code || 500);
                     res.end(err.message);
                 }
             });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5636,7 +5636,7 @@ safe-json-stringify@1.0.3:
   resolved "https://registry.yarnpkg.com/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz#3cb6717660a086d07cb5bd9b7a6875bcf67bd05e"
   integrity sha1-PLZxdmCghtB8tb2bemh1vPZ70F4=
 
-safe-json-stringify@^1.0.3:
+safe-json-stringify@^1.0.3, safe-json-stringify@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz#356e44bc98f1f93ce45df14bcd7c01cda86e0afd"
   integrity sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==
@@ -6489,6 +6489,12 @@ werelogs@scality/werelogs#8.1.0:
   resolved "https://codeload.github.com/scality/werelogs/tar.gz/e8f828725642c54c511cdbe580b18f43d3589313"
   dependencies:
     safe-json-stringify "1.0.3"
+
+werelogs@scality/werelogs#8.1.1:
+  version "8.1.1"
+  resolved "https://codeload.github.com/scality/werelogs/tar.gz/240be22c47f1cae30df0c3c965cd701e6300bd18"
+  dependencies:
+    safe-json-stringify "^1.2.0"
 
 werelogs@scality/werelogs#GA7.2.0.5:
   version "7.2.0"


### PR DESCRIPTION
Adds:

- Communication with `PRIMARY` only
- Propagate werelogs config (logLevel) from dependant project
- `errorCode` in error communication (for HTTP)

This is used by scuba https://github.com/scality/scuba/pull/79
