### PR TITLE
ARSN-403 Set nullVersionId to master when replacing a null version.

### DIFF
--- a/lib/versioning/VersioningRequestProcessor.ts
+++ b/lib/versioning/VersioningRequestProcessor.ts
@@ -402,7 +402,10 @@ export default class VersioningRequestProcessor {
                     if (masterVersionId) {
                         // => create a new version key from the master version
                         const masterVersionKey = formatVersionKey(key, masterVersionId);
-                        value = Version.updateOrAppendNullVersionId(request.value, masterVersionId);
+                        // => set the nullVersionId to the master version if put version on top of null version.
+                        if (versionIdFromMaster !== versionId) {
+                            value = Version.updateOrAppendNullVersionId(request.value, masterVersionId);
+                        }
                         masterVersion.setNullVersion();
                         ops.push({ key: masterVersionKey,
                                    value: masterVersion.toString() });

--- a/tests/unit/versioning/VersioningRequestProcessor.spec.js
+++ b/tests/unit/versioning/VersioningRequestProcessor.spec.js
@@ -380,7 +380,7 @@ describe('test VSP', () => {
             const request = {
                 db: 'foo',
                 key: 'bar',
-                value: '{"qux":"quz2","isNull":true}',
+                value: `{"qux":"quz2","isNull":true,"versionId":"${nullVersionId}"}`,
                 options: {
                     versioning: true,
                     versionId: nullVersionId,
@@ -396,7 +396,7 @@ describe('test VSP', () => {
                 // NOTE: should not set nullVersionId to the master version if updating a null version.
                 {
                     key: 'bar',
-                    value: '{"qux":"quz2","isNull":true}',
+                    value: `{"qux":"quz2","isNull":true,"versionId":"${nullVersionId}"}`,
                 },
                 {
                     key: `bar\x00${nullVersionId}`,
@@ -415,6 +415,7 @@ describe('test VSP', () => {
             const expectedGet = {
                 qux: 'quz2',
                 isNull: true,
+                versionId: nullVersionId,
             };
             assert.deepStrictEqual(JSON.parse(res), expectedGet);
             next();


### PR DESCRIPTION
- Should set `nullVersionId` to the master version if putting a version on top of a null version.

- Should not set `nullVersionId` to the master version if updating a null version.