### PR TITLE
ARSN-412: add support for `exists` condition for transactions

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -148,7 +148,7 @@ export class IndexTransaction {
                 'missing condition for conditional put'
             );
         }
-        if (typeof condition.notExists !== 'string') {
+        if (typeof condition.notExists !== 'string' && typeof condition.exists !== 'string') {
             throw propError(
                 'unsupportedConditionalOperation',
                 'missing key or supported condition'

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.70.30",
+  "version": "7.70.31",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/db.spec.js
+++ b/tests/unit/db.spec.js
@@ -53,7 +53,7 @@ function checkKeyNotExistsInDB(db, key, cb) {
             return cb(err);
         }
         if (value) {
-            return cb(errors.PreconditionFailed);
+            return cb(errors.EntityAlreadyExists);
         }
         return cb();
     });
@@ -437,7 +437,7 @@ describe('IndexTransaction', () => {
                 value: value3,
             });
             return transaction.commit(err => {
-                if (!err || !err.is.PreconditionFailed) {
+                if (!err || !err.is.EntityAlreadyExists) {
                     return done(new Error('should not be able to conditional put for duplicate key'));
                 }
                 return async.parallel([

--- a/tests/unit/db.spec.js
+++ b/tests/unit/db.spec.js
@@ -59,6 +59,15 @@ function checkKeyNotExistsInDB(db, key, cb) {
     });
 }
 
+function checkKeyExistsInDB(db, key, callback) {
+    return db.get(key, err => {
+        if (err) {
+            return callback(err.notFound ? errors.NoSuchEntity : err);
+        }
+        return callback();
+    });
+}
+
 class ConditionalLevelDB {
     constructor() {
         this.db = createDb();
@@ -69,6 +78,9 @@ class ConditionalLevelDB {
             switch (true) {
             case ('notExists' in cond):
                 checkKeyNotExistsInDB(this.db, cond.notExists, asyncCallback);
+                break;
+            case ('exists' in cond):
+                checkKeyExistsInDB(this.db, cond.exists, asyncCallback);
                 break;
             default:
                 asyncCallback(new Error('unsupported conditional operation'));
@@ -457,11 +469,87 @@ describe('IndexTransaction', () => {
     it('should not allow batch operation with unsupported condition', done => {
         const transaction = new IndexTransaction();
         try {
-            transaction.addCondition({ exists: key1 });
+            transaction.addCondition({ like: key1 });
             done(new Error('should fail for unsupported condition, currently supported - notExists'));
         } catch (err) {
             assert.strictEqual(err.unsupportedConditionalOperation, true);
             done();
         }
+    });
+
+    it('should allow batch operation with key specified in exists condition is present in db', done => {
+        const db = new ConditionalLevelDB();
+        const { client } = db;
+        let transaction = new IndexTransaction(db);
+        transaction.put(key1, value1);
+        return async.series([
+            next => transaction.commit(next),
+            next => client.get(key1, next),
+        ], err => {
+            assert.ifError(err);
+            // create new transaction as previous transaction is already committed
+            transaction = new IndexTransaction(db);
+            transaction.addCondition({ exists: key1 });
+            transaction.push({
+                type: 'put',
+                key: key1,
+                value: value2,
+            });
+            return async.series([
+                next => transaction.commit(next),
+                next => client.get(key1, next),
+            ], (err, res) => {
+                assert.ifError(err);
+                assert.strictEqual(res[1], value2);
+                return done();
+            });
+        });
+    });
+
+    it('should not allow batch operation with key specified in exists condition is not in db', done => {
+        const db = new ConditionalLevelDB();
+        const { client } = db;
+        const transaction = new IndexTransaction(db);
+        transaction.addCondition({ exists: key1 });
+        transaction.push({
+            type: 'put',
+            key: key1,
+            value: value1,
+        });
+        return transaction.commit(err => {
+            assert.strictEqual(err && err.NoSuchEntity, true);
+            return checkKeyNotExistsInDB(client, key1, done);
+        });
+    });
+
+    it('should handle batch operations with multiple conditions correctly', done => {
+        const db = new ConditionalLevelDB();
+        const { client } = db;
+        let transaction = new IndexTransaction(db);
+        transaction.put(key1, value1);
+        return async.series([
+            next => transaction.commit(next),
+            next => client.get(key1, next),
+        ], err => {
+            assert.ifError(err);
+            // create new transaction as previous transaction is already committed
+            transaction = new IndexTransaction(db);
+            transaction.addCondition({ exists: key1 });
+            transaction.addCondition({ notExists: key2 });
+            transaction.push({
+                type: 'put',
+                key: key1,
+                value: value2,
+            });
+
+            return async.series([
+                next => transaction.commit(next),
+                next => client.get(key1, next),
+            ], (err, res) => {
+                assert.ifError(err);
+                assert.strictEqual(res[1], value2);
+                return done();
+            });
+        });
     });
 });


### PR DESCRIPTION
**Motivation**:
We arte using the improvement for [this Vault PR](https://github.com/scality/Vault/pull/2163) and specifically [here](https://github.com/scality/Vault/pull/2163/commits/1465e88472c269ee9a94682d503e3a52c13b5ea1#diff-41150607980ec4c24c5af31dcac8f3d0dfe6df8b8e462cc9a0e802e1f4c76213R261)
We're enhancing data integrity in our IAM systems to prevent accidental deletions of mutable yet key-constrained entities. Introducing key existence checks before batch operations will help avoid conflicts and ensure data accuracy.

**Details of the Code Being Merged**:

- **Commit # 1**: Adds a new `exists` condition to transaction processing to verify key presence before operations, ensuring accuracy in entity management.

- **Commit # 2**: Implements unit tests to validate the functionality of the `exists` condition.

- **Commit # 3**: Revises the error response for the `notExists` condition from `PreConditionFailed` to `EntityAlreadyExists`, aligning with the `exists` condition which uses `NoSuchEntity`. This change will also be applied in Metadata and Vault.

- **Commit # 4**: Version bump in `package.json`.