### PR TITLE
ARSN-413 Replicating null version fails

### DIFF
--- a/lib/models/ObjectMD.ts
+++ b/lib/models/ObjectMD.ts
@@ -1,5 +1,6 @@
 import * as constants from '../constants';
 import * as VersionIDUtils from '../versioning/VersionID';
+import { VersioningConstants } from '../versioning/constants';
 import ObjectMDLocation, {
     ObjectMDLocationData,
     Location,
@@ -797,6 +798,9 @@ export default class ObjectMD {
      * @return The object versionId
      */
     getVersionId() {
+        if (this.getIsNull()) {
+            return VersioningConstants.ExternalNullVersionId;
+        }
         return this._data.versionId;
     }
 
@@ -804,13 +808,16 @@ export default class ObjectMD {
      * Get metadata versionId value in encoded form (the one visible
      * to the S3 API user)
      *
-     * @return The encoded object versionId
+     * @return {undefined|string} The encoded object versionId
      */
     getEncodedVersionId() {
         const versionId = this.getVersionId();
-        if (versionId) {
+        if (versionId === VersioningConstants.ExternalNullVersionId) {
+            return versionId;
+        } else if (versionId) {
             return VersionIDUtils.encode(versionId);
         }
+        return undefined;
     }
 
     /**

--- a/lib/versioning/constants.ts
+++ b/lib/versioning/constants.ts
@@ -15,4 +15,5 @@ export const VersioningConstants = {
         v1mig: 'v1mig',
         v1: 'v1',
     },
+    ExternalNullVersionId: 'null',
 };

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.70.29",
+  "version": "7.70.30",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/models/ObjectMD.spec.js
+++ b/tests/unit/models/ObjectMD.spec.js
@@ -1,6 +1,8 @@
 const assert = require('assert');
 const ObjectMD = require('../../../lib/models/ObjectMD').default;
 const constants = require('../../../lib/constants');
+const ExternalNullVersionId = require('../../../lib/versioning/constants')
+    .VersioningConstants.ExternalNullVersionId;
 
 const retainDate = new Date();
 retainDate.setDate(retainDate.getDate() + 1);
@@ -581,5 +583,46 @@ describe('ObjectMD::getReducedLocations', () => {
                 dataStoreETag: '4:afa655158ca025aa00a818b6b81f9e4d',
             },
         ]);
+    });
+});
+
+describe('ObjectMD::getVersionId', () => {
+    let objMd = null;
+    const versionId = '98451712418844999999RG001  22019.0';
+    beforeEach(() => {
+        objMd = new ObjectMD();
+    });
+    it('should return undefined when object is non versioned', () => {
+        assert.strictEqual(objMd.getVersionId(), undefined);
+    });
+    it('should return versionId when object versioned', () => {
+        objMd.setVersionId(versionId);
+        assert.strictEqual(objMd.getVersionId(), versionId);
+    });
+    it('should return "null" when object is in versioning suspended mode', () => {
+        objMd.setVersionId(versionId);
+        objMd.setIsNull(true);
+        assert.strictEqual(objMd.getVersionId(), ExternalNullVersionId);
+    });
+});
+
+describe('ObjectMD::getEncodedVersionId', () => {
+    let objMd = null;
+    const versionId = '98451712418844999999RG001  22019.0';
+    const encodedVersionId = '39383435313731323431383834343939393939395247303031202032323031392e30';
+    beforeEach(() => {
+        objMd = new ObjectMD();
+    });
+    it('should return undefined when object is non versioned', () => {
+        assert.strictEqual(objMd.getEncodedVersionId(), undefined);
+    });
+    it('should return versionId when object versioned', () => {
+        objMd.setVersionId(versionId);
+        assert.strictEqual(objMd.getEncodedVersionId(), encodedVersionId);
+    });
+    it('should return "null" when object is in versioning suspended mode', () => {
+        objMd.setVersionId(versionId);
+        objMd.setIsNull(true);
+        assert.strictEqual(objMd.getEncodedVersionId(), ExternalNullVersionId);
     });
 });


### PR DESCRIPTION
**This PR contains only cherry-picked code.**

_NOTE: Null versions are not being replicated unless triggered by CrrExistingObject s3utils script (or OOB Ingested in Zenko/Artesca)_

For "null" versions that are created before bucket versioning is configured, CloudServer/Arsenal generates a "null" version ID (`99999999999999999999RG001`) used **only** internally by metadata.

However, Backbeat tries to decode this internal version ID using `ObjectMD.getEncodedVersionId()` with no success and so fails to retrieve the "null" version.