### PR TITLE
bf: ARSN-425 listing crash if key contains "undefined"

### DIFF
--- a/lib/algos/list/delimiter.ts
+++ b/lib/algos/list/delimiter.ts
@@ -196,6 +196,9 @@ export class Delimiter extends Extension {
     }
 
     getCommonPrefix(key: string): string | undefined {
+        if (!this.delimiter) {
+            return undefined;
+        }
         const baseIndex = this.prefix ? this.prefix.length : 0;
         const delimiterIndex = key.indexOf(this.delimiter, baseIndex);
         if (delimiterIndex === -1) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.10.62",
+  "version": "7.10.63",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/algos/list/delimiterMaster.spec.js
+++ b/tests/unit/algos/list/delimiterMaster.spec.js
@@ -465,6 +465,25 @@ function getListingKey(key, vFormat) {
                             `${inc(DbPrefixes.Replay)}foo/bar${VID_SEP}`);
                 });
             });
+
+            it('should not crash if key contains "undefined" with no delimiter', () => {
+                const delimiter = new DelimiterMaster({}, fakeLogger, vFormat);
+                const listingKey = getListingKey('undefinedfoo', vFormat);
+                assert.strictEqual(
+                    delimiter.filter({
+                        key: listingKey,
+                        value: '{}',
+                    }),
+                    FILTER_ACCEPT);
+
+                assert.deepStrictEqual(delimiter.result(), {
+                    CommonPrefixes: [],
+                    Contents: [{ key: 'undefinedfoo', value: '{}' }],
+                    IsTruncated: false,
+                    NextMarker: undefined,
+                    Delimiter: undefined,
+                });
+            });
         }
     });
 });

--- a/tests/unit/algos/list/delimiterVersions.spec.js
+++ b/tests/unit/algos/list/delimiterVersions.spec.js
@@ -933,6 +933,26 @@ function getTestListing(test, data, vFormat) {
             });
         });
 
+        it('should not crash if key contains "undefined" with no delimiter', () => {
+            const delimiter = new DelimiterVersions({}, logger, vFormat);
+            const value = '';
+
+            const listingKey = getListingKey('undefinedfoo', vFormat);
+            assert.strictEqual(delimiter.filter({ key: listingKey, value }), FILTER_ACCEPT);
+            assert.deepStrictEqual(delimiter.result(), {
+                CommonPrefixes: [],
+                Delimiter: undefined,
+                Versions: [{
+                    key: 'undefinedfoo',
+                    value: '',
+                    versionId: 'null',
+                }],
+                IsTruncated: false,
+                NextKeyMarker: undefined,
+                NextVersionIdMarker: undefined,
+            });
+        });
+
         it('should accept a PHD version as first input', () => {
             const delimiter = new DelimiterVersions({}, logger, vFormat);
             const keyPHD = 'keyPHD';


### PR DESCRIPTION
Fix a crash in DelimiterMaster listing without a delimiter, when a key contains the string "undefined".

Note: a similar fix was done in ARSN-330 for DelimiterVersions. I ported the existing unit test there to the development/7.10 branch to enhance regression testing, even though this bug on DelimiterVersions
only existed on 7.70.
