### PR TITLE
Ensure getBucketInfos acces only mongo collections

### DIFF
--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -2099,7 +2099,7 @@ class MongoClientInterface {
         let bucketCount = 0;
         const bucketInfos = [];
 
-        this.db.listCollections().toArray().then(collInfos =>
+        this.db.listCollections({ filter: { type: 'collection' } }).toArray().then(collInfos =>
             async.eachLimit(collInfos, 10, (value, next) => {
                 if (this._isSpecialCollection(value.name)) {
                     // skip

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "8.1.135",
+  "version": "8.1.136",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {


### PR DESCRIPTION
This is especially needed after PRA bootstrap was executed, as we
started using views in that context.

Issue: ARSN-432
