### PR TITLE
ARSN-430 Add new KMS backend with account-level default encryption key management

### DIFF
--- a/lib/auth/Vault.ts
+++ b/lib/auth/Vault.ts
@@ -384,4 +384,45 @@ export default class Vault {
             return callback(null, respBody);
         });
     }
+
+    /**
+     * Calls Vault to retrieve the default encryption key id of the account, or creates it if it doesn't exist.
+     *
+     * @param {string} canonicalID - The canonical id of the account for which 
+     * the encryption key id is being retrieved or created.
+     * @param {Logger} log - logger
+     * @param {(err: Error | null, data?: { 
+     *    canonicalId: string, 
+     *    encryptionKeyId: string, 
+     *    action: 'retrieved' | 'created' 
+     * }) => void}
+     *   - canonicalId: The canonical id of the account.
+     *   - encryptionKeyId: The retrieved or newly created encryption key id.
+     *   - action: Describes if the key was 'retrieved' or 'created'.
+     *
+     * @returns {void}
+    */
+    getOrCreateEncryptionKeyId(
+        canonicalID: string,
+        log: Logger,
+        callback: (err: Error | null, data?: { 
+            canonicalId: string, 
+            encryptionKeyId: string, 
+            action: 'retrieved' | 'created' 
+        }) => void
+    ) {
+        log.trace('sending request context params to vault to get or create encryption key id');
+        this.client.getOrCreateEncryptionKeyId(canonicalID, {
+            // @ts-ignore
+            reqUid: log.getSerializedUids(),
+        }, (err: Error | null, info?: any) => {
+            if (err) {
+                log.debug('received error message from auth provider',
+                    { error: err });
+                return callback(err);
+            }
+            const result = info.message.body;
+            return callback(null, result);
+        });
+    }
 }

--- a/lib/auth/in_memory/Backend.ts
+++ b/lib/auth/in_memory/Backend.ts
@@ -179,6 +179,38 @@ class Backend {
         };
         return cb(null, vaultReturnObject);
     }
+
+        /**
+         * Retrieves or creates an encryption key id for the specified canonical id.
+         *
+         * @param {string} canonicalId - The canonical id of the account for which to retrieve or create the encryption key.
+         * @param {any} _options - An options object, currently unused.
+         * @param {(err: Error | null, data?: { 
+         *    canonicalId: string, 
+         *    encryptionKeyId: string, 
+         *    action: 'retrieved' | 'created' 
+         * }) => void}
+         *   - canonicalId: The canonical id of the account.
+         *   - encryptionKeyId: The retrieved or newly created encryption key id.
+         *   - action: Describes if the key was 'retrieved' or 'created'.
+         *
+         * @returns {void}
+         */
+        getOrCreateEncryptionKeyId(
+            canonicalId: string, 
+            _options: any, 
+            cb: (err: null, data: { message: { body: { canonicalId: string, encryptionKeyId: string, action: string } } }) => void
+        ): void {
+            return cb(null, {
+                message: {
+                    body: {
+                        canonicalId,
+                        encryptionKeyId: 'account-level-master-encryption-key',
+                        action: 'retrieved',
+                    }
+                }
+            });
+        }
 }
 
 class S3AuthBackend extends Backend {

--- a/lib/models/BucketInfo.ts
+++ b/lib/models/BucketInfo.ts
@@ -28,6 +28,7 @@ export type SSE = {
     masterKeyId: string;
     configuredMasterKeyId: string;
     mandatory: boolean;
+    isAccountEncryptionEnabled: boolean;
 };
 
 export type VersioningConfiguration = {
@@ -153,10 +154,13 @@ export default class BucketInfo {
                 configuredMasterKeyId, mandatory } = serverSideEncryption;
             assert.strictEqual(typeof cryptoScheme, 'number');
             assert.strictEqual(typeof algorithm, 'string');
-            assert.strictEqual(typeof masterKeyId, 'string');
             assert.strictEqual(typeof mandatory, 'boolean');
+            assert.ok(masterKeyId !== undefined || configuredMasterKeyId !== undefined, 'At least one of masterKeyId or configuredMasterKeyId must be defined');
+            if (masterKeyId !== undefined) {
+                assert.strictEqual(typeof masterKeyId, 'string', 'masterKeyId must be a string');
+            }
             if (configuredMasterKeyId !== undefined) {
-                assert.strictEqual(typeof configuredMasterKeyId, 'string');
+                assert.strictEqual(typeof configuredMasterKeyId, 'string', 'configuredMasterKeyId must be a string');
             }
         }
         if (versioningConfiguration) {
@@ -545,6 +549,21 @@ export default class BucketInfo {
             return null;
         }
         return this._serverSideEncryption.masterKeyId;
+    }
+
+    /**
+     * Checks if the default encryption is set at the account level instead of the legacy bucket level.
+     * This method helps to prevent deletion of the account-level master encryption key when deleting buckets. 
+     *
+     * @returns {boolean} - Returns true if account-level default encryption is enabled, 
+     * false if it uses the legacy bucket level.
+     */
+    isAccountEncryptionEnabled() {
+        if (!this._serverSideEncryption) {
+            return false;
+        }
+
+        return this._serverSideEncryption.isAccountEncryptionEnabled;
     }
     /**
     * Get bucket name.

--- a/lib/network/index.ts
+++ b/lib/network/index.ts
@@ -11,6 +11,6 @@ export const probe = { ProbeServer };
 export { default as RoundRobin } from './RoundRobin';
 export { default as kmip } from './kmip';
 export { default as kmipClient } from './kmip/Client';
-export { default as awsClient } from './kmsAWS/Client';
+export { default as KmsAWSClient } from './kmsAWS/Client';
 export * as rpc from './rpc/rpc';
 export * as level from './rpc/level-net';

--- a/lib/network/index.ts
+++ b/lib/network/index.ts
@@ -11,5 +11,6 @@ export const probe = { ProbeServer };
 export { default as RoundRobin } from './RoundRobin';
 export { default as kmip } from './kmip';
 export { default as kmipClient } from './kmip/Client';
+export { default as awsClient } from './kmsAWS/Client';
 export * as rpc from './rpc/rpc';
 export * as level from './rpc/level-net';

--- a/lib/network/kmsAWS/Client.ts
+++ b/lib/network/kmsAWS/Client.ts
@@ -1,0 +1,276 @@
+'use strict'; // eslint-disable-line
+/* eslint new-cap: "off" */
+
+import errors from '../../errors';
+import { Agent } from "https";
+import { SecureVersion } from "tls";
+import * as werelogs from 'werelogs';
+import { KMSClient, CreateKeyCommand, ScheduleKeyDeletionCommand, EncryptCommand, DecryptCommand, GenerateDataKeyCommand, DataKeySpec } from "@aws-sdk/client-kms";
+import { NodeHttpHandler } from "@smithy/node-http-handler";
+import { AwsCredentialIdentity } from "@smithy/types";
+import assert from 'assert';
+
+/**
+ * Normalize errors according to arsenal definitions
+ * @param err - an Error instance or a message string
+ * @returns - arsenal error
+ *
+ * @note Copied from the KMIP implementation
+ */
+function _arsenalError(err: string | Error) {
+    const messagePrefix = 'AWS_KMS:';
+    if (typeof err === 'string') {
+        return errors.InternalError
+            .customizeDescription(`${messagePrefix} ${err}`);
+    } else if (
+        err instanceof Error ||
+        // INFO: The second part is here only for Jest, to remove when we'll be
+        //   fully migrated to TS
+        // @ts-expect-error
+        (err && typeof err.message === 'string')
+    ) {
+        return errors.InternalError
+            .customizeDescription(`${messagePrefix} ${err.message}`);
+    }
+    return errors.InternalError
+        .customizeDescription(`${messagePrefix} Unspecified error`);
+}
+
+export default class Client {
+    client: KMSClient;
+    options: any;
+
+    /**
+     * Construct a high level KMIP driver suitable for cloudserver
+     * @param options - Instance options
+     * @param options.kmsAWS - AWS client options
+     * @param options.kmsAWS.region - KMS region
+     * @param options.kmsAWS.endpoint - Endpoint URL of the KMS service
+     * @param options.kmsAWS.ak - Application Key
+     * @param options.kmsAWS.sk - Secret Key
+     * @param options.kmsAWS.tls.rejectUnauthorized - default to true, reject unauthenticated TLS connections (set to false to accept auto-signed certificates, useful in development ONLY)
+     * @param options.kmsAWS.tls.ca - override CA definition(s)
+     * @param options.kmsAWS.tls.cert - certificate or list of certificates
+     * @param options.kmsAWS.tls.minVersion - min TLS version accepted, One of 'TLSv1.3', 'TLSv1.2', 'TLSv1.1', or 'TLSv1' (see https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions)
+     * @param options.kmsAWS.tls.maxVersion - max TLS version accepted, One of 'TLSv1.3', 'TLSv1.2', 'TLSv1.1', or 'TLSv1' (see https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions)
+     * @param options.kmsAWS.tls.key - private key or list of private keys
+     * 
+     * This client also looks in the standard AWS configuration files (https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html).
+     * If no option is passed to this constructor, the client will try to get it from the configuration file.
+     * 
+     * TLS configuration options are those of nodejs, you can refere to https://nodejs.org/api/tls.html#tlsconnectoptions and https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions
+     */
+    constructor(
+        options: {
+            kmsAWS: {
+                region?: string,
+                endpoint?: string,
+                ak?: string,
+                sk?: string,
+                tls?: {
+                    rejectUnauthorized?: boolean,
+                    ca?: [Buffer] | Buffer,
+                    cert?: [Buffer] | Buffer,
+                    minVersion?: string,
+                    maxVersion?: string,
+                    key?: [Buffer] | Buffer,
+                }
+            }
+        },
+    ) {
+        let requestHandler: {requestHandler: NodeHttpHandler} | null = null;
+        const tlsOpts = options.kmsAWS.tls;
+        if (tlsOpts) {
+            const agent = new Agent({
+                rejectUnauthorized: tlsOpts?.rejectUnauthorized,
+                ca: tlsOpts?.ca,
+                cert: tlsOpts?.cert,
+                minVersion: <SecureVersion>tlsOpts?.minVersion,
+                maxVersion: <SecureVersion>tlsOpts?.maxVersion,
+                key: tlsOpts?.key,
+            });
+
+            requestHandler = {requestHandler: new NodeHttpHandler({
+                httpAgent: agent,
+                httpsAgent: agent,
+            })}
+        }
+
+        let credentials: {credentials: AwsCredentialIdentity} | null = null;
+        if (options.kmsAWS.ak && options.kmsAWS.sk) {
+            credentials = {credentials: {
+                accessKeyId: options.kmsAWS.ak,
+                secretAccessKey: options.kmsAWS.sk,
+            }};
+        }
+
+        this.client = new KMSClient({
+            region: options.kmsAWS.region,
+            endpoint: options.kmsAWS.endpoint,
+            ...credentials,
+            ...requestHandler
+        });
+    }
+
+    /**
+     * Create a new cryptographic key managed by the server,
+     * for a specific bucket
+     * @param bucketName - The bucket name
+     * @param logger - Werelog logger object
+     * @param cb - The callback(err: Error, bucketKeyId: String)
+     */
+    createBucketKey(bucketName: string, logger: werelogs.Logger, cb: any) {
+        logger.debug("AWS KMS: createBucketKey", {bucketName});
+
+        const command = new CreateKeyCommand({});
+        this.client.send(command, (err, data) => {
+            if (err) {
+                const error = _arsenalError(err);
+                logger.error("AWS_KMS::createBucketKey", {err, bucketName});
+                cb (error);
+            } else {
+                logger.debug("AWS KMS: createBucketKey", {bucketName, KeyMetadata: data?.KeyMetadata});
+                cb(null, data?.KeyMetadata?.KeyId);
+            }
+          });
+    }
+
+    /**
+     * Destroy a cryptographic key managed by the server, for a specific bucket.
+     * @param bucketKeyId - The bucket key Id
+     * @param logger - Werelog logger object
+     * @param cb - The callback(err: Error)
+     */
+    destroyBucketKey(bucketKeyId: string, logger: werelogs.Logger, cb: any) {
+        logger.debug("AWS KMS: destroyBucketKey", {bucketKeyId: bucketKeyId});
+
+        // Schedule a deletion in 7 days (the minimum value on this API)
+        const command = new ScheduleKeyDeletionCommand({KeyId: bucketKeyId, PendingWindowInDays: 7});
+        this.client.send(command, (err, data) => {
+            if (err) {
+                const error = _arsenalError(err);
+                logger.error("AWS_KMS::destroyBucketKey", {err});
+                cb (error);
+            } else {
+                // Sanity check
+                if (data?.KeyState != "PendingDeletion") {
+                    const error = _arsenalError("Key is not in PendingDeletion state")
+                    logger.error("AWS_KMS::destroyBucketKey", {err, data});
+                    cb(error);
+                } else {
+                    cb();
+                }
+            }
+        });
+    }
+
+    /**
+     * @param cryptoScheme - crypto scheme version number
+     * @param masterKeyId - key to retrieve master key
+     * @param logger - werelog logger object
+     * @param cb - callback
+     * @callback called with (err, plainTextDataKey: Buffer, cipheredDataKey: Buffer)
+     */
+    generateDataKey(
+        cryptoScheme: number,
+        masterKeyId: string,
+        logger: werelogs.Logger,
+        cb: any,
+    ) {
+        logger.debug("AWS KMS: generateDataKey", {cryptoScheme, masterKeyId});
+
+        // Only support cryptoScheme v1
+        assert.strictEqual (cryptoScheme, 1);
+
+        const command = new GenerateDataKeyCommand({KeyId: masterKeyId, KeySpec: DataKeySpec.AES_256});
+        this.client.send(command, (err, data) => {
+            if (err) {
+                const error = _arsenalError(err);
+                logger.error("AWS_KMS::generateDataKey", {err});
+                cb (error);
+            } else if (!data) {
+                const error = _arsenalError("generateDataKey: empty response");
+                logger.error("AWS_KMS::generateDataKey empty reponse");
+                cb (error);
+            } else {
+                // Convert to a buffer. This allows the wrapper to use .toString("base64")
+                cb(null, Buffer.from(data.Plaintext!), Buffer.from(data.CiphertextBlob!));
+            }
+        });
+    }
+
+    /**
+     *
+     * @param cryptoScheme - crypto scheme version number
+     * @param masterKeyId - key to retrieve master key
+     * @param plainTextDataKey - data key
+     * @param logger - werelog logger object
+     * @param cb - callback
+     * @callback called with (err, cipheredDataKey: Buffer)
+     */
+    cipherDataKey(
+        cryptoScheme: number,
+        masterKeyId: string,
+        plainTextDataKey: Buffer,
+        logger: werelogs.Logger,
+        cb: any,
+    ) {
+        logger.debug("AWS KMS: cipherDataKey", {cryptoScheme, masterKeyId});
+
+        // Only support cryptoScheme v1
+        assert.strictEqual (cryptoScheme, 1);
+
+        const command = new EncryptCommand({KeyId: masterKeyId, Plaintext: plainTextDataKey});
+        this.client.send(command, (err, data) => {
+            if (err) {
+                const error = _arsenalError(err);
+                logger.error("AWS_KMS::cipherDataKey", {err});
+                cb (error);
+            } else if (!data) {
+                const error = _arsenalError("cipherDataKey: empty response");
+                logger.error("AWS_KMS::cipherDataKey empty reponse");
+                cb (error);
+            } else {
+                // Convert to a buffer. This allows the wrapper to use .toString("base64")
+                cb(null, Buffer.from(data.CiphertextBlob!));
+            }
+        });
+    }
+
+    /**
+     *
+     * @param cryptoScheme - crypto scheme version number
+     * @param masterKeyId - key to retrieve master key
+     * @param cipheredDataKey - data key
+     * @param logger - werelog logger object
+     * @param cb - callback
+     * @callback called with (err, plainTextDataKey: Buffer)
+     */
+    decipherDataKey(
+        cryptoScheme: number,
+        masterKeyId: string,
+        cipheredDataKey: Buffer,
+        logger: werelogs.Logger,
+        cb: any,
+    ) {
+        logger.debug("AWS KMS: decipherDataKey", {cryptoScheme, masterKeyId});
+
+        // Only support cryptoScheme v1
+        assert.strictEqual (cryptoScheme, 1);
+
+        const command = new DecryptCommand({CiphertextBlob: cipheredDataKey});
+        this.client.send(command, (err, data) => {
+            if (err) {
+                const error = _arsenalError(err);
+                logger.error("AWS_KMS::decipherDataKey", {err});
+                cb (error);
+            } else if (!data) {
+                const error = _arsenalError("decipherDataKey: empty response");
+                logger.error("AWS_KMS::decipherDataKey empty reponse");
+                cb (error);
+            } else {
+                cb(null, Buffer.from(data?.Plaintext!));
+            }
+        });
+    }
+}

--- a/lib/network/kmsAWS/Client.ts
+++ b/lib/network/kmsAWS/Client.ts
@@ -2,275 +2,282 @@
 /* eslint new-cap: "off" */
 
 import errors from '../../errors';
-import { Agent } from "https";
-import { SecureVersion } from "tls";
+import { arsenalErrorAWSKMS } from '../utils'
+import { Agent } from 'https';
+import { KMS, AWSError } from 'aws-sdk';
 import * as werelogs from 'werelogs';
-import { KMSClient, CreateKeyCommand, ScheduleKeyDeletionCommand, EncryptCommand, DecryptCommand, GenerateDataKeyCommand, DataKeySpec } from "@aws-sdk/client-kms";
-import { NodeHttpHandler } from "@smithy/node-http-handler";
-import { AwsCredentialIdentity } from "@smithy/types";
 import assert from 'assert';
 
-/**
- * Normalize errors according to arsenal definitions
- * @param err - an Error instance or a message string
- * @returns - arsenal error
- *
- * @note Copied from the KMIP implementation
- */
-function _arsenalError(err: string | Error) {
-    const messagePrefix = 'AWS_KMS:';
-    if (typeof err === 'string') {
-        return errors.InternalError
-            .customizeDescription(`${messagePrefix} ${err}`);
-    } else if (
-        err instanceof Error ||
-        // INFO: The second part is here only for Jest, to remove when we'll be
-        //   fully migrated to TS
-        // @ts-expect-error
-        (err && typeof err.message === 'string')
-    ) {
-        return errors.InternalError
-            .customizeDescription(`${messagePrefix} ${err.message}`);
-    }
-    return errors.InternalError
-        .customizeDescription(`${messagePrefix} Unspecified error`);
+type TLSVersion = 'TLSv1.3' | 'TLSv1.2' | 'TLSv1.1' | 'TLSv1';
+
+interface KMSOptions {
+    region?: string;
+    endpoint?: string;
+    ak?: string;
+    sk?: string;
+    tls?: {
+        rejectUnauthorized?: boolean;
+        ca?: Buffer | Buffer[];
+        cert?: Buffer | Buffer[];
+        minVersion?: TLSVersion;
+        maxVersion?: TLSVersion;
+        key?: Buffer | Buffer[];
+    };
+}
+
+interface ClientOptions {
+    kmsAWS: KMSOptions;
 }
 
 export default class Client {
-    client: KMSClient;
-    options: any;
+    private _supportsDefaultKeyPerAccount: boolean;
+    private client: KMS;
 
-    /**
-     * Construct a high level KMIP driver suitable for cloudserver
-     * @param options - Instance options
-     * @param options.kmsAWS - AWS client options
-     * @param options.kmsAWS.region - KMS region
-     * @param options.kmsAWS.endpoint - Endpoint URL of the KMS service
-     * @param options.kmsAWS.ak - Application Key
-     * @param options.kmsAWS.sk - Secret Key
-     * @param options.kmsAWS.tls.rejectUnauthorized - default to true, reject unauthenticated TLS connections (set to false to accept auto-signed certificates, useful in development ONLY)
-     * @param options.kmsAWS.tls.ca - override CA definition(s)
-     * @param options.kmsAWS.tls.cert - certificate or list of certificates
-     * @param options.kmsAWS.tls.minVersion - min TLS version accepted, One of 'TLSv1.3', 'TLSv1.2', 'TLSv1.1', or 'TLSv1' (see https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions)
-     * @param options.kmsAWS.tls.maxVersion - max TLS version accepted, One of 'TLSv1.3', 'TLSv1.2', 'TLSv1.1', or 'TLSv1' (see https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions)
-     * @param options.kmsAWS.tls.key - private key or list of private keys
-     * 
-     * This client also looks in the standard AWS configuration files (https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html).
-     * If no option is passed to this constructor, the client will try to get it from the configuration file.
-     * 
-     * TLS configuration options are those of nodejs, you can refere to https://nodejs.org/api/tls.html#tlsconnectoptions and https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions
-     */
-    constructor(
-        options: {
-            kmsAWS: {
-                region?: string,
-                endpoint?: string,
-                ak?: string,
-                sk?: string,
-                tls?: {
-                    rejectUnauthorized?: boolean,
-                    ca?: [Buffer] | Buffer,
-                    cert?: [Buffer] | Buffer,
-                    minVersion?: string,
-                    maxVersion?: string,
-                    key?: [Buffer] | Buffer,
-                }
-            }
-        },
-    ) {
-        let requestHandler: {requestHandler: NodeHttpHandler} | null = null;
-        const tlsOpts = options.kmsAWS.tls;
-        if (tlsOpts) {
-            const agent = new Agent({
-                rejectUnauthorized: tlsOpts?.rejectUnauthorized,
-                ca: tlsOpts?.ca,
-                cert: tlsOpts?.cert,
-                minVersion: <SecureVersion>tlsOpts?.minVersion,
-                maxVersion: <SecureVersion>tlsOpts?.maxVersion,
-                key: tlsOpts?.key,
-            });
+    constructor(options: ClientOptions) {
+        this._supportsDefaultKeyPerAccount = true;
+        const { tls, ak, sk, region, endpoint } = options.kmsAWS;
 
-            requestHandler = {requestHandler: new NodeHttpHandler({
-                httpAgent: agent,
-                httpsAgent: agent,
-            })}
-        }
+        const httpOptions = tls ? {
+            agent: new Agent({
+                rejectUnauthorized: tls.rejectUnauthorized,
+                ca: tls.ca,
+                cert: tls.cert,
+                minVersion: tls.minVersion,
+                maxVersion: tls.maxVersion,
+                key: tls.key,
+            }),
+        } : undefined;
 
-        let credentials: {credentials: AwsCredentialIdentity} | null = null;
-        if (options.kmsAWS.ak && options.kmsAWS.sk) {
-            credentials = {credentials: {
-                accessKeyId: options.kmsAWS.ak,
-                secretAccessKey: options.kmsAWS.sk,
-            }};
-        }
+        const credentials = (ak && sk) ? {
+            credentials: {
+                accessKeyId: ak,
+                secretAccessKey: sk,
+            },
+        } : undefined;
 
-        this.client = new KMSClient({
-            region: options.kmsAWS.region,
-            endpoint: options.kmsAWS.endpoint,
+        this.client = new KMS({
+            region,
+            endpoint,
+            httpOptions,
             ...credentials,
-            ...requestHandler
         });
     }
 
-    /**
-     * Create a new cryptographic key managed by the server,
-     * for a specific bucket
-     * @param bucketName - The bucket name
-     * @param logger - Werelog logger object
-     * @param cb - The callback(err: Error, bucketKeyId: String)
-     */
-    createBucketKey(bucketName: string, logger: werelogs.Logger, cb: any) {
-        logger.debug("AWS KMS: createBucketKey", {bucketName});
-
-        const command = new CreateKeyCommand({});
-        this.client.send(command, (err, data) => {
-            if (err) {
-                const error = _arsenalError(err);
-                logger.error("AWS_KMS::createBucketKey", {err, bucketName});
-                cb (error);
-            } else {
-                logger.debug("AWS KMS: createBucketKey", {bucketName, KeyMetadata: data?.KeyMetadata});
-                cb(null, data?.KeyMetadata?.KeyId);
-            }
-          });
+    get supportsDefaultKeyPerAccount(): boolean {
+        return this._supportsDefaultKeyPerAccount;
     }
 
     /**
-     * Destroy a cryptographic key managed by the server, for a specific bucket.
-     * @param bucketKeyId - The bucket key Id
-     * @param logger - Werelog logger object
-     * @param cb - The callback(err: Error)
+     * Safely handles the plaintext buffer by copying it to an isolated buffer
+     * and zeroing out the original buffer to prevent unauthorized access.
+     *
+     * @param plaintext - The original plaintext buffer from AWS KMS.
+     * @returns A new Buffer containing the isolated plaintext data.
      */
-    destroyBucketKey(bucketKeyId: string, logger: werelogs.Logger, cb: any) {
-        logger.debug("AWS KMS: destroyBucketKey", {bucketKeyId: bucketKeyId});
+    private safePlaintext(plaintext: Buffer): Buffer {
+        // allocate a new buffer and initialize it directly with plaintext data
+        const isolatedPlaintext = Buffer.alloc(plaintext.length, plaintext);
+        // zero out the original plaintext buffer to prevent data leakage
+        plaintext.fill(0);
+    
+        return isolatedPlaintext;
+    }
 
-        // Schedule a deletion in 7 days (the minimum value on this API)
-        const command = new ScheduleKeyDeletionCommand({KeyId: bucketKeyId, PendingWindowInDays: 7});
-        this.client.send(command, (err, data) => {
+    // createBucketKey is a method used by CloudServer to create a default master encryption key per bucket.
+    // New KMS backends like AWS KMS now allow the customer to use the default master encryption key per account.
+    // To achieve this, Vault will call createMasterKey and store the master encryption ID in the account metadata.
+    createBucketKey(bucketName: string, logger: werelogs.Logger, cb: (err: Error | null, keyId?: string) => void): void {
+        logger.debug("AWS KMS: creating encryption key managed at the bucket level", { bucketName });
+        this.createMasterKey(logger, cb);
+    }
+
+    createMasterKey(logger: werelogs.Logger, cb: (err: Error | null, keyId?: string) => void): void {
+        logger.debug("AWS KMS: creating master encryption key");
+        this.client.createKey({}, (err: AWSError, data) => {
             if (err) {
-                const error = _arsenalError(err);
-                logger.error("AWS_KMS::destroyBucketKey", {err});
-                cb (error);
-            } else {
-                // Sanity check
-                if (data?.KeyState != "PendingDeletion") {
-                    const error = _arsenalError("Key is not in PendingDeletion state")
-                    logger.error("AWS_KMS::destroyBucketKey", {err, data});
-                    cb(error);
-                } else {
-                    cb();
-                }
+                const error = arsenalErrorAWSKMS(err);
+                logger.error("AWS KMS: failed to create master encryption key", { err });
+                cb(error);
+                return;
             }
+            logger.debug("AWS KMS: master encryption key created", { KeyMetadata: data?.KeyMetadata });
+            cb(null, data?.KeyMetadata?.KeyId);
         });
     }
 
-    /**
-     * @param cryptoScheme - crypto scheme version number
-     * @param masterKeyId - key to retrieve master key
-     * @param logger - werelog logger object
-     * @param cb - callback
-     * @callback called with (err, plainTextDataKey: Buffer, cipheredDataKey: Buffer)
-     */
+    // destroyBucketKey is a method used by CloudServer to remove the default master encryption key for a bucket.
+    // New KMS backends like AWS KMS allow customers to delete the default master encryption key at the account level.
+    // To achieve this, Vault will call deleteMasterKey before deleting the account.
+    destroyBucketKey(bucketKeyId: string, logger: werelogs.Logger, cb: (err: Error | null) => void): void {
+        logger.debug("AWS KMS: deleting encryption key managed at the bucket level", { bucketKeyId });
+        this.deleteMasterKey(bucketKeyId, logger, cb);
+    }
+
+    deleteMasterKey(masterKeyId: string, logger: werelogs.Logger, cb: (err: Error | null) => void): void {
+        logger.debug("AWS KMS: deleting master encryption key", { masterKeyId });
+        const params = {
+            KeyId: masterKeyId,
+            PendingWindowInDays: 7,
+        };
+        this.client.scheduleKeyDeletion(params, (err: AWSError, data) => {
+            if (err) {
+                const error = arsenalErrorAWSKMS(err);
+                logger.error("AWS KMS: failed to delete master encryption key", { err });
+                cb(error);
+                return;
+            }
+
+            if (data?.KeyState && data.KeyState !== "PendingDeletion") {
+                const error = arsenalErrorAWSKMS("key is not in PendingDeletion state");
+                logger.error("AWS KMS: failed to delete master encryption key", { err, data });
+                cb(error);
+                return;
+            }
+
+            cb(null);
+        });
+    }
+
     generateDataKey(
         cryptoScheme: number,
         masterKeyId: string,
         logger: werelogs.Logger,
-        cb: any,
-    ) {
-        logger.debug("AWS KMS: generateDataKey", {cryptoScheme, masterKeyId});
+        cb: (err: Error | null, plainTextDataKey?: Buffer, cipheredDataKey?: Buffer) => void
+    ): void {
+        logger.debug("AWS KMS: generating data key", { cryptoScheme, masterKeyId });
+        assert.strictEqual(cryptoScheme, 1);
 
-        // Only support cryptoScheme v1
-        assert.strictEqual (cryptoScheme, 1);
+        const params = {
+            KeyId: masterKeyId,
+            KeySpec: 'AES_256',
+        };
 
-        const command = new GenerateDataKeyCommand({KeyId: masterKeyId, KeySpec: DataKeySpec.AES_256});
-        this.client.send(command, (err, data) => {
+        this.client.generateDataKey(params, (err: AWSError, data) => {
             if (err) {
-                const error = _arsenalError(err);
-                logger.error("AWS_KMS::generateDataKey", {err});
-                cb (error);
-            } else if (!data) {
-                const error = _arsenalError("generateDataKey: empty response");
-                logger.error("AWS_KMS::generateDataKey empty reponse");
-                cb (error);
-            } else {
-                // Convert to a buffer. This allows the wrapper to use .toString("base64")
-                cb(null, Buffer.from(data.Plaintext!), Buffer.from(data.CiphertextBlob!));
+                const error = arsenalErrorAWSKMS(err);
+                logger.error("AWS KMS: failed to generate data key", { err });
+                cb(error);
+                return;
             }
+
+            if (!data) {
+                const error = arsenalErrorAWSKMS("failed to generate data key: empty response");
+                logger.error("AWS KMS: failed to generate data key: empty response");
+                cb(error);
+                return;
+            }
+
+            const isolatedPlaintext = this.safePlaintext(data.Plaintext as Buffer);
+
+            logger.debug("AWS KMS: data key generated");
+            cb(null, isolatedPlaintext, Buffer.from(data.CiphertextBlob as Uint8Array));
         });
     }
 
-    /**
-     *
-     * @param cryptoScheme - crypto scheme version number
-     * @param masterKeyId - key to retrieve master key
-     * @param plainTextDataKey - data key
-     * @param logger - werelog logger object
-     * @param cb - callback
-     * @callback called with (err, cipheredDataKey: Buffer)
-     */
     cipherDataKey(
         cryptoScheme: number,
         masterKeyId: string,
         plainTextDataKey: Buffer,
         logger: werelogs.Logger,
-        cb: any,
-    ) {
-        logger.debug("AWS KMS: cipherDataKey", {cryptoScheme, masterKeyId});
+        cb: (err: Error | null, cipheredDataKey?: Buffer) => void
+    ): void {
+        logger.debug("AWS KMS: ciphering data key", { cryptoScheme, masterKeyId });
+        assert.strictEqual(cryptoScheme, 1);
 
-        // Only support cryptoScheme v1
-        assert.strictEqual (cryptoScheme, 1);
+        const params = {
+            KeyId: masterKeyId,
+            Plaintext: plainTextDataKey,
+        };
 
-        const command = new EncryptCommand({KeyId: masterKeyId, Plaintext: plainTextDataKey});
-        this.client.send(command, (err, data) => {
+        this.client.encrypt(params, (err: AWSError, data) => {
             if (err) {
-                const error = _arsenalError(err);
-                logger.error("AWS_KMS::cipherDataKey", {err});
-                cb (error);
-            } else if (!data) {
-                const error = _arsenalError("cipherDataKey: empty response");
-                logger.error("AWS_KMS::cipherDataKey empty reponse");
-                cb (error);
-            } else {
-                // Convert to a buffer. This allows the wrapper to use .toString("base64")
-                cb(null, Buffer.from(data.CiphertextBlob!));
+                const error = arsenalErrorAWSKMS(err);
+                logger.error("AWS KMS: failed to cipher data key", { err });
+                cb(error);
+                return;
             }
+
+            if (!data) {
+                const error = arsenalErrorAWSKMS("failed to cipher data key: empty response");
+                logger.error("AWS KMS: failed to cipher data key: empty response");
+                cb(error);
+                return;
+            }
+
+            logger.debug("AWS KMS: data key ciphered");
+            cb(null, Buffer.from(data.CiphertextBlob as Uint8Array));
+            return;
         });
     }
 
-    /**
-     *
-     * @param cryptoScheme - crypto scheme version number
-     * @param masterKeyId - key to retrieve master key
-     * @param cipheredDataKey - data key
-     * @param logger - werelog logger object
-     * @param cb - callback
-     * @callback called with (err, plainTextDataKey: Buffer)
-     */
     decipherDataKey(
         cryptoScheme: number,
         masterKeyId: string,
         cipheredDataKey: Buffer,
         logger: werelogs.Logger,
-        cb: any,
-    ) {
-        logger.debug("AWS KMS: decipherDataKey", {cryptoScheme, masterKeyId});
+        cb: (err: Error | null, plainTextDataKey?: Buffer) => void
+    ): void {
+        logger.debug("AWS KMS: deciphering data key", { cryptoScheme, masterKeyId });
+        assert.strictEqual(cryptoScheme, 1);
 
-        // Only support cryptoScheme v1
-        assert.strictEqual (cryptoScheme, 1);
+        const params = {
+            CiphertextBlob: cipheredDataKey,
+        };
 
-        const command = new DecryptCommand({CiphertextBlob: cipheredDataKey});
-        this.client.send(command, (err, data) => {
+        this.client.decrypt(params, (err: AWSError, data) => {
             if (err) {
-                const error = _arsenalError(err);
-                logger.error("AWS_KMS::decipherDataKey", {err});
-                cb (error);
-            } else if (!data) {
-                const error = _arsenalError("decipherDataKey: empty response");
-                logger.error("AWS_KMS::decipherDataKey empty reponse");
-                cb (error);
-            } else {
-                cb(null, Buffer.from(data?.Plaintext!));
+                const error = arsenalErrorAWSKMS(err);
+                logger.error("AWS KMS: failed to decipher data key", { err });
+                cb(error);
+                return;
             }
+
+            if (!data) {
+                const error = arsenalErrorAWSKMS("failed to decipher data key: empty response");
+                logger.error("AWS KMS: failed to decipher data key: empty response");
+                cb(error);
+                return;
+            }
+
+            const isolatedPlaintext = this.safePlaintext(data.Plaintext as Buffer);
+
+            logger.debug("AWS KMS: data key deciphered");
+            cb(null, isolatedPlaintext);
         });
     }
+
+    /**
+     * NOTE1: S3C-4833 KMS healthcheck is disabled in CloudServer
+     * NOTE2: The best approach for implementing the AWS KMS health check is still under consideration.
+     * In the meantime, this method is commented out to prevent potential issues related to costs or permissions.
+     *
+     * Reasons for commenting out:
+     * - frequent API calls can lead to increased expenses.
+     * - access key secret key used must have `kms:ListKeys` permissions
+     *
+     * Future potential actions:
+     * - implement caching mechanisms to reduce the number of API calls.
+     * - differentiate between error types (e.g., 500 vs. 403) for more effective error handling.
+     */
+    /*
+    healthcheck(logger: werelogs.Logger, cb: (err: Error | null) => void): void {
+        logger.debug("AWS KMS: performing healthcheck");
+    
+        const params = {
+            Limit: 1,
+        };
+    
+        this.client.listKeys(params, (err, data) => {
+            if (err) {
+                const error = arsenalErrorAWSKMS(err);
+                logger.error("AWS KMS healthcheck: failed to list keys", { err });
+                cb(error);
+                return;
+            }
+    
+            logger.debug("AWS KMS healthcheck: list keys succeeded");
+            cb(null);
+        });
+    }
+    */
 }

--- a/lib/network/kmsAWS/README.md
+++ b/lib/network/kmsAWS/README.md
@@ -1,0 +1,66 @@
+# AWS KMS Connector
+
+Allows using AWS KMS backend for object encryption. Currently supports AK+SK
+for authentication. mTLS can be used for additional security.
+
+## Configuration
+
+Configuration is done using the configuration file.
+
+Supported parameters:
+
+| Config File        | Description                                             |
+|--------------------|---------------------------------------------------------|
+| kmsAWS.region      | AWS region to use                                       |
+| kmsAWS.endpoint    | Endpoint URL                                            |
+| kmsAWS.ak          | Credentials, Access Key                                 |
+| kmsAWS.sk          | Credentials, Secret Key                                 |
+| kmsAWS.tls         | TLS configuration (Object, see below)                   |
+
+TLS configuration attributes:
+
+| Config File         | Description                                            |
+|---------------------|--------------------------------------------------------|
+| rejectUnauthorized  | `false` to disable TLS cert checks (useful in          |
+|                     | development, **DON'T** disable in production)          |
+| minVersion          | Min TLS version: 'TLSv1.3', 'TLSv1.2', 'TLSv1.1', or   |
+|                     | 'TLSv1' (See [Node.js TLS](https://nodejs.org/api/tls) |
+| maxVersion          | Max TLS version: 'TLSv1.3', 'TLSv1.2', 'TLSv1.1', or   |
+|                     | 'TLSv1' (See [Node.js TLS](https://nodejs.org/api/tls) |
+| ca                  | Filename or array of filenames for CA(s)               |
+| cert                | Filename or array of filenames for certificate(s)      |
+| key                 | Filename or array of filenames for private key(s)      |
+
+All TLS attributes follow Node.js definitions. See
+[Node.js TLS Connect Options](https://nodejs.org/api/tls.html#tlsconnectoptions)
+and
+[Node.js TLS Secure Context](https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions).
+
+### Configuration Example
+
+```json
+{
+    "kmsAWS": {
+        "region": "us-east-1",
+        "endpoint": "https://kms.us-east-1.amazonaws.com",
+        "ak": "xxxxxxx",
+        "sk": "xxxxxxx"
+    }
+}
+
+With TLS configuration:
+
+```json
+    "kmsAWS": {
+        "region": "us-east-1",
+        "endpoint": "https://kms.us-east-1.amazonaws.com",
+        "ak": "xxxxxxx",
+        "sk": "xxxxxxx",
+        "tls": {
+            "rejectUnauthorized": false,
+            "cert": "mtls.crt.pem",
+            "key": "mtls.key.pem",
+            "minVersion": "TLSv1.3"
+        }
+    },
+```

--- a/lib/network/kmsAWS/README.md
+++ b/lib/network/kmsAWS/README.md
@@ -47,6 +47,7 @@ and
         "sk": "xxxxxxx"
     }
 }
+```
 
 With TLS configuration:
 

--- a/lib/network/utils.ts
+++ b/lib/network/utils.ts
@@ -1,0 +1,33 @@
+import errors from '../errors';
+
+/**
+ * Normalize errors according to arsenal definitions with a custom prefix
+ * @param err - an Error instance or a message string
+ * @param messagePrefix - prefix for the error message
+ * @returns - arsenal error
+ */
+function _normalizeArsenalError(err: string | Error, messagePrefix: string) {
+    if (typeof err === 'string') {
+        return errors.InternalError
+            .customizeDescription(`${messagePrefix} ${err}`);
+    } else if (
+        err instanceof Error ||
+        // INFO: The second part is here only for Jest, to remove when we'll be
+        //   fully migrated to TS
+        // @ts-expect-error
+        (err && typeof err.message === 'string')
+    ) {
+        return errors.InternalError
+            .customizeDescription(`${messagePrefix} ${err.message}`);
+    }
+    return errors.InternalError
+        .customizeDescription(`${messagePrefix} Unspecified error`);
+}
+
+export function arsenalErrorKMIP(err: string | Error) {
+    return _normalizeArsenalError(err, 'KMIP:');
+}
+
+export function arsenalErrorAWSKMS(err: string | Error) {
+    return _normalizeArsenalError(err, 'AWS_KMS:');
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.70.32",
+  "version": "7.70.33",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {
@@ -17,7 +17,6 @@
   },
   "homepage": "https://github.com/scality/Arsenal#readme",
   "dependencies": {
-    "@aws-sdk/client-kms": "^3.485.0",
     "@js-sdsl/ordered-set": "^4.4.2",
     "@types/async": "^3.2.12",
     "@types/utf8": "^3.0.1",
@@ -64,7 +63,6 @@
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.21",
     "@types/xml2js": "^0.4.11",
-    "aws-sdk-client-mock": "^3.0.1",
     "eslint": "^8.12.0",
     "eslint-config-airbnb": "6.2.0",
     "eslint-config-scality": "scality/Guidelines#7.10.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/scality/Arsenal#readme",
   "dependencies": {
+    "@aws-sdk/client-kms": "^3.485.0",
     "@js-sdsl/ordered-set": "^4.4.2",
     "@types/async": "^3.2.12",
     "@types/utf8": "^3.0.1",
@@ -63,6 +64,7 @@
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.21",
     "@types/xml2js": "^0.4.11",
+    "aws-sdk-client-mock": "^3.0.1",
     "eslint": "^8.12.0",
     "eslint-config-airbnb": "6.2.0",
     "eslint-config-scality": "scality/Guidelines#7.10.2",

--- a/tests/functional/kmsAWS/highlevel.spec.js
+++ b/tests/functional/kmsAWS/highlevel.spec.js
@@ -1,0 +1,264 @@
+'use strict'; // eslint-disable-line strict
+
+// Mocking official nodejs aws client
+const { mockClient } = require('aws-sdk-client-mock');
+const { KMSClient, CreateKeyCommand, ScheduleKeyDeletionCommand, GenerateDataKeyCommand,
+    EncryptCommand, DecryptCommand } = require('@aws-sdk/client-kms');
+
+const KmsAWSClient = require('../../../lib/network/kmsAWS/Client').default;
+
+const logger = {
+    info: () => {},
+    debug: () => {},
+    warn: () => {},
+    error: () => {},
+};
+
+describe('KMS AWS Client', () => {
+    const options = {
+        kmsAWS: {
+            region: 'test-region-1',
+            endpoint: 'http://mocked.doesnt.matter',
+        },
+    };
+
+    const kmsClient = new KmsAWSClient(options);
+
+    // Mock the AWS client
+    const mockedAwsClient = mockClient(KMSClient);
+
+    // Mock the send method to allow using callbacks
+    // Note: we cannot replace the whole aws client with its mocked version
+    // because the current mocking implementation doesn't support callbacks
+    // See https://github.com/m-radzikowski/aws-sdk-client-mock/issues/6
+    kmsClient.client.send = function mockedSend(cmd, cbOrOption, cb = null) {
+        let callback = cb;
+        if (! cb && typeof(cbOrOption) === 'function') {
+            callback = cbOrOption;
+        }
+
+        const mockedCall = mockedAwsClient.send(cmd);
+
+        // mockedCall is undefined when parameters doesn't match those expected.
+        expect(mockedCall).toBeDefined();
+
+        let gotError = false;
+        mockedCall.catch((err) => {
+            gotError = true;
+            callback(err);
+        })
+            // Order is important here: the catch is done before
+            // so it doesn't catch exceptions raised by Jest in case of
+            // test failure
+            .then((data) => {
+                // Looks like this "then" statement is alway run after
+                // a catch. We check for errors handled in the catch to
+                // avoid a double invocation of the callback.
+                if (!gotError) {
+                    callback(null, data);
+                }
+            });
+    };
+
+    beforeEach(() => {
+        mockedAwsClient.reset();
+    });
+
+    it('should create a new key on bucket creation', done => {
+        mockedAwsClient.on(CreateKeyCommand).resolves({
+            KeyMetadata: {
+                KeyId: 'mocked-kms-key-id',
+            },
+        });
+
+        kmsClient.createBucketKey('plop', logger, (err, bucketKeyId) => {
+            // Check the result
+            expect(err).toBeNull();
+            expect(bucketKeyId).toEqual('mocked-kms-key-id');
+
+            // Check that the CreateKey of the aws client have been used to create the key
+            expect(mockedAwsClient.commandCalls(CreateKeyCommand).length).toEqual(1);
+
+            done();
+        });
+    });
+
+    it('should handle errors creating the key on bucket creation', done => {
+        mockedAwsClient.on(CreateKeyCommand).rejects('Error');
+
+        kmsClient.createBucketKey('plop', logger, (err, bucketKeyId) => {
+            // Check the result
+            expect(bucketKeyId).toBeUndefined();
+            expect(err).toEqual(Error('InternalError'));
+
+            // Check that the CreateKey of the aws client have been used to create the key
+            expect(mockedAwsClient.commandCalls(CreateKeyCommand).length).toEqual(1);
+
+            done();
+        });
+    });
+
+    it('should delete an existing key on bucket deletion', done => {
+        mockedAwsClient.on(ScheduleKeyDeletionCommand, {
+            KeyId: 'mocked-kms-key-id',
+            PendingWindowInDays: 7, // Should be set to 7 (the minimum accepted value on this operation)
+        }).resolves({
+            KeyId: 'mocked-kms-key-id',
+            KeyState: 'PendingDeletion',
+            PendingWindowInDays: 7,
+        });
+
+        kmsClient.destroyBucketKey('mocked-kms-key-id', logger, (err) => {
+            // Check the result
+            expect(err).toBeUndefined();
+
+            // Check that the ScheduleKeyDeletion of the aws client have been invoked
+            expect(mockedAwsClient.commandCalls(ScheduleKeyDeletionCommand).length).toEqual(1);
+
+            done();
+        });
+    });
+
+    it('should handle errors deleting an existing key on bucket deletion', done => {
+        mockedAwsClient.on(ScheduleKeyDeletionCommand, {
+            KeyId: 'mocked-kms-key-id',
+            PendingWindowInDays: 7, // Should be set to 7 (the minimum accepted value on this operation)
+        }).rejects('Error');
+
+        kmsClient.destroyBucketKey('mocked-kms-key-id', logger, (err) => {
+            // Check the result
+            expect(err).toEqual(Error('InternalError'));
+
+            // Check that the ScheduleKeyDeletion of the aws client have been invoked
+            expect(mockedAwsClient.commandCalls(ScheduleKeyDeletionCommand).length).toEqual(1);
+
+            done();
+        });
+    });
+
+    it('should generate a datakey for ciphering', done => {
+        mockedAwsClient.on(GenerateDataKeyCommand).resolves({
+            CiphertextBlob: 'encryptedDataKey',
+            Plaintext: 'dataKey',
+            KeyId: 'mocked-kms-key-id',
+        });
+
+        kmsClient.generateDataKey(1, 'mocked-kms-key-id', logger, (err, plaintextDataKey, cipheredDataKey) => {
+            // Check the result
+            expect(err).toBeNull();
+            expect(plaintextDataKey).toEqual(Buffer.from('dataKey'));
+            expect(cipheredDataKey).toEqual(Buffer.from('encryptedDataKey'));
+
+            // Check that the the aws client have been used to create the data key
+            expect(mockedAwsClient.commandCalls(GenerateDataKeyCommand).length).toEqual(1);
+
+            done();
+        });
+    });
+
+    it('should handle errors generating a datakey', done => {
+        mockedAwsClient.on(GenerateDataKeyCommand).rejects('Error');
+
+        kmsClient.generateDataKey(1, 'mocked-kms-key-id', logger, (err, plaintextDataKey, cipheredDataKey) => {
+            // Check the result
+            expect(plaintextDataKey).toBeUndefined();
+            expect(cipheredDataKey).toBeUndefined();
+            expect(err).toEqual(Error('InternalError'));
+
+            // Check that the the aws client have been used to create the data key
+            expect(mockedAwsClient.commandCalls(GenerateDataKeyCommand).length).toEqual(1);
+
+            done();
+        });
+    });
+
+    it('should allow ciphering a datakey', done => {
+        mockedAwsClient.on(EncryptCommand, {
+            KeyId: 'mocked-kms-key-id',
+            Plaintext: 'dataKey-value',
+            EncryptionContext: undefined,
+            GrantTokens: undefined,
+            EncryptionAlgorithm: undefined,
+        }).resolves({
+            CiphertextBlob: 'encryptedDataKey-value',
+            KeyId: 'mocked-kms-key-id',
+        });
+
+        kmsClient.cipherDataKey(1, 'mocked-kms-key-id', 'dataKey-value', logger, (err, cipheredDataKey) => {
+            // Check the result
+            expect(err).toBeNull();
+            expect(cipheredDataKey).toEqual(Buffer.from('encryptedDataKey-value'));
+
+            // Check that the Encrypt of the aws client has been used
+            expect(mockedAwsClient.commandCalls(EncryptCommand).length).toEqual(1);
+
+            done();
+        });
+    });
+
+    it('should handle errors ciphering a datakey', done => {
+        mockedAwsClient.on(EncryptCommand, {
+            KeyId: 'mocked-kms-key-id',
+            Plaintext: 'dataKey-value',
+            EncryptionContext: undefined,
+            GrantTokens: undefined,
+            EncryptionAlgorithm: undefined,
+        }).rejects('Error');
+
+        kmsClient.cipherDataKey(1, 'mocked-kms-key-id', 'dataKey-value', logger, (err, cipheredDataKey) => {
+            // Check the result
+            expect(cipheredDataKey).toBeUndefined();
+            expect(err).toEqual(Error('InternalError'));
+
+            // Check that the Encrypt of the aws client have been used
+            expect(mockedAwsClient.commandCalls(EncryptCommand).length).toEqual(1);
+
+            done();
+        });
+    });
+
+    it('should allow deciphering a datakey', done => {
+        mockedAwsClient.on(DecryptCommand, {
+            KeyId: undefined, // Key id is embedded in the CiphertextBlob
+            CiphertextBlob: 'encryptedDataKey-value',
+            EncryptionContext: undefined,
+            GrantTokens: undefined,
+            EncryptionAlgorithm: undefined,
+        }).resolves({
+            Plaintext: 'dataKey-value',
+            KeyId: 'mocked-kms-key-id',
+        });
+
+        kmsClient.decipherDataKey(1, 'mocked-kms-key-id', 'encryptedDataKey-value', logger, (err, plainTextDataKey) => {
+            // Check the result
+            expect(err).toBeNull();
+            expect(plainTextDataKey).toEqual(Buffer.from('dataKey-value'));
+
+            // Check that the Decrypt of the aws client have been used
+            expect(mockedAwsClient.commandCalls(DecryptCommand).length).toEqual(1);
+
+            done();
+        });
+    });
+
+    it('should handle errors deciphering a datakey', done => {
+        mockedAwsClient.on(DecryptCommand, {
+            KeyId: undefined, // Key id is embedded in the CiphertextBlob
+            CiphertextBlob: 'encryptedDataKey-value',
+            EncryptionContext: undefined,
+            GrantTokens: undefined,
+            EncryptionAlgorithm: undefined,
+        }).rejects('Error');
+
+        kmsClient.decipherDataKey(1, 'mocked-kms-key-id', 'encryptedDataKey-value', logger, (err, plainTextDataKey) => {
+            // Check the result
+            expect(plainTextDataKey).toBeUndefined();
+            expect(err).toEqual(Error('InternalError'));
+
+            // Check that the Decrypt of the aws client have been used
+            expect(mockedAwsClient.commandCalls(DecryptCommand).length).toEqual(1);
+
+            done();
+        });
+    });
+});


### PR DESCRIPTION
Context:

- Introduce a new KMS backend that supports the AWS KMS protocol.
- Implement a more efficient approach to managing default encryption keys. Instead of creating a master encryption key per bucket, a single default master encryption key is associated with the account. This simplifies key management. The default key id will be stored in the account metadata.

Changes in this PR:
- `Vault.getOrCreateEncryptionKeyId()`: this method fetches the default encryption key ID for the account from Vault. If no key exists, it creates a new one.
- `isAccountEncryptionEnabled()`: this function checks if the account-level default encryption is enabled. This prevents the deletion of the account-level master encryption key when a bucket is deleted.
- A new KMS client has been added to interact with the AWS KMS compatible service and manage encryption operations.