### PR TITLE
ARSN-436 Add error handling for KMS key deletion

### DIFF
--- a/lib/network/kmsAWS/Client.ts
+++ b/lib/network/kmsAWS/Client.ts
@@ -127,6 +127,13 @@ export default class Client {
         };
         this.client.scheduleKeyDeletion(params, (err: AWSError, data) => {
             if (err) {
+                if (err.code === 'NotFoundException' || err.code === 'KMSInvalidStateException') {
+                    // master key does not exist or is already pending deletion
+                    logger.info('AWS KMS: key does not exist or is already pending deletion', { masterKeyId, error: err });
+                    cb(null);
+                    return;
+                }
+
                 const error = arsenalErrorAWSKMS(err);
                 logger.error("AWS KMS: failed to delete master encryption key", { err });
                 cb(error);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.70.34",
+  "version": "7.70.35",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/functional/kmsAWS/highlevel.spec.js
+++ b/tests/functional/kmsAWS/highlevel.spec.js
@@ -4,6 +4,7 @@ const Client = require('../../../lib/network/kmsAWS/Client').default;
 
 describe('KmsAWSClient', () => {
     const logger = {
+        info: () => {},
         debug: () => {},
         error: () => {},
     };
@@ -160,6 +161,32 @@ describe('KmsAWSClient', () => {
 
         client.deleteMasterKey('mock-key-id', logger, err => {
             assert.strictEqual(err.message, 'InternalError');
+            assert(scheduleKeyDeletionStub.calledOnce);
+            done();
+        });
+    });
+
+    it('should handle NotFoundException when deleting master key', done => {
+        const mockError = new Error('NotFoundException');
+        mockError.code = 'NotFoundException';
+
+        scheduleKeyDeletionStub.yields(mockError, null);
+
+        client.deleteMasterKey('mock-key-id', logger, err => {
+            assert.ifError(err);
+            assert(scheduleKeyDeletionStub.calledOnce);
+            done();
+        });
+    });
+
+    it('should handle KMSInvalidStateException when deleting master key', done => {
+        const mockError = new Error('KMSInvalidStateException');
+        mockError.code = 'KMSInvalidStateException';
+
+        scheduleKeyDeletionStub.yields(mockError, null);
+
+        client.deleteMasterKey('mock-key-id', logger, err => {
+            assert.ifError(err);
             assert(scheduleKeyDeletionStub.calledOnce);
             done();
         });


### PR DESCRIPTION
Don't return an error if the key is already deleted or in the process of being deleted.
- 'NotFoundException': The key doesn't exist (already deleted).
- 'KMSInvalidStateException': The key is in an invalid state, possibly already pending deletion.