### PR TITLE
ARSN-439: Vaut/authenticateV2(4)Request error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.70.35",
+  "version": "7.70.36",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {


### PR DESCRIPTION
Vaultclient's `verifySignatureV2(4)`  returns an error that contains a `code` and a `description` field.
This error is propagated to the callers of `authenticateV2(4)Request`.

However, callers expect an `ArsenalError`.
This change fixes this specifically for the case of `InvalidAccessKeyId` (when a non-existing access key is given).

Issue: ARSN-439