### PR TITLE
remove supportedLifecycleRules from constants

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -159,13 +159,6 @@ export const notificationArnPrefix = 'arn:scality:bucketnotif';
 // http.Agent.
 export const httpServerKeepAliveTimeout = 60000;
 export const httpClientFreeSocketTimeout = 55000;
-export const supportedLifecycleRules = [
-    'expiration',
-    'noncurrentVersionExpiration',
-    'abortIncompleteMultipartUpload',
-    'transitions',
-    'noncurrentVersionTransition',
-];
 // Maximum number of buckets to cache (bucket metadata)
 export const maxCachedBuckets = process.env.METADATA_MAX_CACHED_BUCKETS ?
     Number(process.env.METADATA_MAX_CACHED_BUCKETS) : 1000;

--- a/lib/s3middleware/lifecycleHelpers/LifecycleUtils.ts
+++ b/lib/s3middleware/lifecycleHelpers/LifecycleUtils.ts
@@ -1,22 +1,19 @@
 import assert from 'assert';
 
 import LifecycleDateTime from './LifecycleDateTime';
-import { supportedLifecycleRules } from '../../constants';
 
 export default class LifecycleUtils {
     _supportedRules: string[];
     _datetime: LifecycleDateTime;
 
-    constructor(supportedRules?: string[], datetime?: LifecycleDateTime) {
-        if (supportedRules) {
-            assert(Array.isArray(supportedRules));
-        }
+    constructor(supportedRules: string[], datetime?: LifecycleDateTime) {
+        assert(Array.isArray(supportedRules));
 
         if (datetime) {
             assert(datetime instanceof LifecycleDateTime);
         }
 
-        this._supportedRules = supportedRules || supportedLifecycleRules;
+        this._supportedRules = supportedRules;
         this._datetime = datetime || new LifecycleDateTime();
     }
 

--- a/tests/unit/s3middleware/LifecycleUtils.spec.js
+++ b/tests/unit/s3middleware/LifecycleUtils.spec.js
@@ -31,17 +31,29 @@ function getRuleIDs(rules) {
     return rules.map(rule => rule.ID).sort();
 }
 
+const supportedLifecycleRules = [
+    'expiration',
+    'noncurrentVersionExpiration',
+    'abortIncompleteMultipartUpload',
+    'transitions',
+    'noncurrentVersionTransition',
+];
+
+describe('LifecycleUtils::constructor', () => {
+    it('should throw when not given supported lifecycle rules', () => {
+        assert.throws(() => new LifecycleUtils());
+    });
+
+    it('should throw when supported lifecycle rules is not an array', () => {
+        assert.throws(() => new LifecycleUtils('rules'));
+    });
+});
+
 describe('LifecycleUtils::getApplicableRules', () => {
     let lutils;
 
     beforeAll(() => {
-        lutils = new LifecycleUtils([
-            'expiration',
-            'noncurrentVersionExpiration',
-            'abortIncompleteMultipartUpload',
-            'transitions',
-            'noncurrentVersionTransition',
-        ]);
+        lutils = new LifecycleUtils(supportedLifecycleRules);
     });
 
     it('should return earliest applicable expirations', () => {
@@ -708,12 +720,11 @@ describe('LifecycleUtils::getApplicableRules', () => {
     });
 });
 
-
 describe('LifecycleUtils::filterRules', () => {
     let lutils;
 
     beforeAll(() => {
-        lutils = new LifecycleUtils();
+        lutils = new LifecycleUtils(supportedLifecycleRules);
     });
 
     it('should filter out Status disabled rules', () => {
@@ -898,7 +909,7 @@ describe('LifecycleUtils::getApplicableTransition', () => {
     let lutils;
 
     beforeAll(() => {
-        lutils = new LifecycleUtils();
+        lutils = new LifecycleUtils(supportedLifecycleRules);
     });
 
     describe('using Days time type', () => {
@@ -1071,7 +1082,7 @@ describe('LifecycleUtils::getApplicableNCVTransition', () => {
     let lutils;
 
     beforeAll(() => {
-        lutils = new LifecycleUtils();
+        lutils = new LifecycleUtils(supportedLifecycleRules);
     });
 
     describe('using NoncurrentDays time type', () => {
@@ -1175,7 +1186,7 @@ describe('LifecycleUtils::compareTransitions', () => {
     let lutils;
 
     beforeAll(() => {
-        lutils = new LifecycleUtils();
+        lutils = new LifecycleUtils(supportedLifecycleRules);
     });
 
     it('should return undefined if no rules given', () => {
@@ -1274,7 +1285,7 @@ describe('LifecycleUtils::getApplicableNCVTransition', () => {
     let lutils;
 
     beforeAll(() => {
-        lutils = new LifecycleUtils();
+        lutils = new LifecycleUtils(supportedLifecycleRules);
     });
 
     describe('using NoncurrentDays time type', () => {


### PR DESCRIPTION
supportedLifecycleRules' value is different between the 7.x and 8.x branches. We should define the rules directly in the config of the Zenko components.

Issue: ARSN-435