### PR TITLE
Update description for BucketAlreadyOwnedByYou error

### DIFF
--- a/lib/errors/arsenalErrors.ts
+++ b/lib/errors/arsenalErrors.ts
@@ -42,7 +42,7 @@ export const BucketAlreadyOwnedByYou: ErrorFormat = {
     code: 409,
 
     description:
-        'A bucket with this name exists and is already owned by you',
+        'Your previous request to create the named bucket succeeded and you already own it.',
 };
 
 export const BucketNotEmpty: ErrorFormat = {


### PR DESCRIPTION
Updated the error description for the CreateBucket operation when the bucket is already owned by the user. The new message is compliant with AWS error description.

Issue: ARSN-451

AWS behavior:
```
# aws s3 mb s3://anurag-bkt-notif
make_bucket failed: s3://anurag-bkt-notif An error occurred (BucketAlreadyOwnedByYou) when calling the CreateBucket operation: Your previous request to create the named bucket succeeded and you already own it.
```

in S3C 9.3.08 we see same behavior as AWS but description is different
```
aws s3 mb s3://aws  --endpoint-url http://16.16.245.20:9000/ --profile aws_lab
make_bucket failed: s3://aws An error occurred (BucketAlreadyOwnedByYou) when calling the CreateBucket operation: A bucket with this name exists and is already owned by you
```