### PR TITLE
ARSN-458: Add action scuba:GetMetricsBatch

### DIFF
--- a/lib/policyEvaluator/utils/actionMaps.ts
+++ b/lib/policyEvaluator/utils/actionMaps.ts
@@ -203,6 +203,7 @@ const actionMapMetadata = {
 
 const actionMapScuba = {
     GetMetrics: 'scuba:GetMetrics',
+    GetMetricsBatch: 'scuba:GetMetricsBatch',
     AdminStartIngest: 'scuba:AdminStartIngest',
     AdminStopIngest: 'scuba:AdminStopIngest',
     AdminReadRaftCseq: 'scuba:AdminReadRaftCseq',

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.70.37",
+  "version": "7.70.38",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {


### PR DESCRIPTION
GetMetricsBatch action is used by identisee

branch 7.70 for vault
and 8.1 for scuba