### PR TITLE
ARSN-476: Perf improvement around arsenal error

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -19,7 +19,7 @@ import SubStreamInterface from './lib/s3middleware/azureHelpers/SubStreamInterfa
 import * as processMpuParts from './lib/s3middleware/processMpuParts';
 import * as retention from './lib/s3middleware/objectRetention';
 import * as lifecycleHelpers from './lib/s3middleware/lifecycleHelpers';
-export { default as errors } from './lib/errors';
+export { default as errors, errorInstances } from './lib/errors';
 export { default as Clustering } from './lib/Clustering';
 export * as ClusterRPC from './lib/clustering/ClusterRPC';
 export * as ipCheck from './lib/ipCheck';

--- a/lib/auth/v2/headerAuthCheck.ts
+++ b/lib/auth/v2/headerAuthCheck.ts
@@ -1,5 +1,5 @@
 import { Logger } from 'werelogs';
-import errors from '../../errors';
+import errors, { errorInstances } from '../../errors';
 import * as constants from '../../constants';
 import constructStringToSign from './constructStringToSign';
 import checkRequestExpiry from './checkRequestExpiry';
@@ -22,7 +22,7 @@ export function check(request: any, log: Logger, data: { [key: string]: string }
     if (!timestamp) {
         log.debug('missing or invalid date header',
         { method: 'auth/v2/headerAuthCheck.check' });
-        return { err: errors.AccessDenied.
+        return { err: errorInstances.AccessDenied.
           customizeDescription('Authentication requires a valid Date or ' +
           'x-amz-date header') };
     }

--- a/lib/auth/v4/headerAuthCheck.ts
+++ b/lib/auth/v4/headerAuthCheck.ts
@@ -1,5 +1,5 @@
 import { Logger } from 'werelogs';
-import errors from '../../../lib/errors';
+import errors, { errorInstances } from '../../../lib/errors';
 import * as constants from '../../constants';
 import constructStringToSign from './constructStringToSign';
 import {
@@ -94,7 +94,7 @@ export function check(
     if (!timestamp) {
         log.debug('missing or invalid date header',
           { method: 'auth/v4/headerAuthCheck.check' });
-        return { err: errors.AccessDenied.
+        return { err: errorInstances.AccessDenied.
           customizeDescription('Authentication requires a valid Date or ' +
           'x-amz-date header') };
     }

--- a/lib/errors/index.ts
+++ b/lib/errors/index.ts
@@ -36,6 +36,16 @@ const createIs = (type: Name): Is => {
     return new Proxy(final, { get });
 };
 
+/**
+ * Is helper object for each of the 189 errors.
+ * It makes 189 * 189 = 35721 booleans in heap at startup.
+ * Adds +1.3 MB of js objects but greatly increase speed when using errors
+ * And avoid gc.
+ */
+const isPreCreated = Object.fromEntries(
+    (Object.keys(rawErrors) as Name[]).map(key => [key, createIs(key)])
+) as Record<Name, Is>;
+
 export class ArsenalError extends Error {
     /** HTTP status code. Example: 401, 403, 500, ... */
     #code: number;
@@ -52,7 +62,7 @@ export class ArsenalError extends Error {
         this.#code = code;
         this.#description = description;
         this.#type = type;
-        this.#is = createIs(type);
+        this.#is = isPreCreated[type];
 
         // This restores the old behavior of errors, to make sure they're now
         // backward-compatible. Fortunately it's handled by TS, but it cannot

--- a/lib/errors/index.ts
+++ b/lib/errors/index.ts
@@ -149,7 +149,17 @@ export class ArsenalError extends Error {
             const error = value[1];
             const { code, description } = error;
             const get = () => new ArsenalError(name, code, description);
-            Object.defineProperty(errors, name, { get });
+            // Perf improvement for the ok error.
+            // As it's used mainly for HTTP response using the code and message only.
+            // Return the same instance as no stack trace or other property are needed
+            if (name === 'ok') {
+                Object.defineProperty(errors, name, { value: get() });
+            } else {
+                // Ideally for other errors caching the instance outside request handling
+                // would be beneficial if .customizeDescription is used or if
+                // no stack trace or additional field is required
+                Object.defineProperty(errors, name, { get });
+            }
         });
         return errors as Errors
     }

--- a/lib/errors/index.ts
+++ b/lib/errors/index.ts
@@ -161,10 +161,34 @@ export class ArsenalError extends Error {
                 Object.defineProperty(errors, name, { get });
             }
         });
-        return errors as Errors
+        return errors as Errors;
     }
+
+        /**
+         * Like errors but generate singleton instances of errors
+         * To use before .customizeDescription to avoid intermediate instance.
+         * Adds +0.2 MB in heap at start
+         */
+        static errorInstances() {
+            const errors = {}
+            Object.entries(rawErrors).forEach((value) => {
+                const name = value[0] as Name;
+                const error = value[1];
+                const { code, description } = error;
+                const instance = new ArsenalError(name, code, description);
+                Object.defineProperty(errors, name, { value: instance });
+            });
+            return errors as Errors;
+        }
 }
 
 /** Mapping of all possible Errors.
  * Use them with errors[error].customizeDescription for any customization. */
 export default ArsenalError.errors();
+
+/**
+ * Same as errors but already instanciated.
+ * To be used like errorInstances[error].customizeDescription or errorInstances.ok.code.
+ * Avoid intermediate instance
+ */
+export const errorInstances = ArsenalError.errorInstances();

--- a/lib/errors/index.ts
+++ b/lib/errors/index.ts
@@ -116,7 +116,11 @@ export class ArsenalError extends Error {
     customizeDescription(description: string): ArsenalError {
         const type = this.#type;
         const code = this.#code;
-        return new ArsenalError(type, code, description);
+        const err = new ArsenalError(type, code, description);
+        if (this.stack) {
+            err.stack = this.stack;
+        }
+        return err;
     }
 
     /** Used to determine the error type. Example: error.is.InternalError */
@@ -176,6 +180,8 @@ export class ArsenalError extends Error {
                 const error = value[1];
                 const { code, description } = error;
                 const instance = new ArsenalError(name, code, description);
+                // stack trace created at startup instead of call time, not useful
+                delete instance.stack;
                 Object.defineProperty(errors, name, { value: instance });
             });
             return errors as Errors;

--- a/lib/models/ARN.ts
+++ b/lib/models/ARN.ts
@@ -1,4 +1,4 @@
-import errors from '../errors'
+import { errorInstances } from '../errors'
 
 const validServices = {
     aws: ['s3', 'iam', 'sts', 'ring'],
@@ -42,30 +42,30 @@ export default class ARN {
             resourceType, resource] = arnStr.split(':');
 
         if (arn !== 'arn') {
-            return { error: errors.InvalidArgument.customizeDescription(
+            return { error: errorInstances.InvalidArgument.customizeDescription(
                 'bad ARN: must start with "arn:"') };
         }
         if (!partition) {
-            return { error: errors.InvalidArgument.customizeDescription(
+            return { error: errorInstances.InvalidArgument.customizeDescription(
                 'bad ARN: must include a partition name, like "aws" in ' +
                     '"arn:aws:..."') };
         }
         if (!service) {
-            return { error: errors.InvalidArgument.customizeDescription(
+            return { error: errorInstances.InvalidArgument.customizeDescription(
                 'bad ARN: must include a service name, like "s3" in ' +
                     '"arn:aws:s3:..."') };
         }
         if (validServices[partition] === undefined) {
-            return { error: errors.InvalidArgument.customizeDescription(
+            return { error: errorInstances.InvalidArgument.customizeDescription(
                 `bad ARN: unknown partition "${partition}", should be a ` +
                     'valid partition name like "aws" in "arn:aws:..."') };
         }
         if (!validServices[partition].includes(service)) {
-            return { error: errors.InvalidArgument.customizeDescription(
+            return { error: errorInstances.InvalidArgument.customizeDescription(
                 `bad ARN: unsupported ${partition} service "${service}"`) };
         }
         if (accountId && !/^([0-9]{12}|[*])$/.test(accountId)) {
-            return { error: errors.InvalidArgument.customizeDescription(
+            return { error: errorInstances.InvalidArgument.customizeDescription(
                 `bad ARN: bad account ID "${accountId}": ` +
                     'must be a 12-digit number or "*"') };
         }

--- a/lib/models/BucketPolicy.ts
+++ b/lib/models/BucketPolicy.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import errors, { ArsenalError } from '../errors';
+import { ArsenalError, errorInstances } from '../errors';
 import { validateResourcePolicy } from '../policy/policyValidator';
 
 /**
@@ -76,7 +76,7 @@ export default class BucketPolicy {
      */
     _getPolicy(): { error: ArsenalError } | any {
         if (!this._json || this._json === '') {
-            return { error: errors.MalformedPolicy.customizeDescription(
+            return { error: errorInstances.MalformedPolicy.customizeDescription(
                 'request json is empty or undefined') };
         }
         const validSchema = validateResourcePolicy(this._json);
@@ -122,7 +122,7 @@ export default class BucketPolicy {
                 (objectResource && !objectAction && !wildcardObjectAction));
         });
         if (invalid) {
-            return { error: errors.MalformedPolicy.customizeDescription(
+            return { error: errorInstances.MalformedPolicy.customizeDescription(
                 'Action does not apply to any resource(s) in statement') };
         }
         return {};

--- a/lib/models/LifecycleConfiguration.ts
+++ b/lib/models/LifecycleConfiguration.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import UUID from 'uuid';
 
-import errors, { ArsenalError } from '../errors';
+import { ArsenalError, errorInstances } from '../errors';
 import LifecycleRule from './LifecycleRule';
 import escapeForXml from '../s3middleware/escapeForXml';
 import type { XMLRule } from './ReplicationConfiguration';
@@ -125,25 +125,25 @@ export default class LifecycleConfiguration {
         this._config.rules = [];
         if (!this._parsedXML || this._parsedXML === '') {
             const msg = 'request xml is undefined or empty';
-            const error = errors.MalformedXML.customizeDescription(msg);
+            const error = errorInstances.MalformedXML.customizeDescription(msg);
             return { error };
         }
         if (!this._parsedXML.LifecycleConfiguration &&
             this._parsedXML.LifecycleConfiguration !== '') {
             const msg = 'request xml does not include LifecycleConfiguration';
-            const error = errors.MalformedXML.customizeDescription(msg);
+            const error = errorInstances.MalformedXML.customizeDescription(msg);
             return { error };
         }
         const lifecycleConf = this._parsedXML.LifecycleConfiguration;
         const rulesArray: any[] = lifecycleConf.Rule;
         if (!rulesArray || !Array.isArray(rulesArray) || rulesArray.length === 0) {
             const msg = 'missing required key \'Rules\' in LifecycleConfiguration';
-            const error = errors.MissingRequiredParameter.customizeDescription(msg);
+            const error = errorInstances.MissingRequiredParameter.customizeDescription(msg);
             return { error };
         }
         if (rulesArray.length > 1000) {
             const msg = 'request xml includes over max limit of 1000 rules';
-            const error = errors.MalformedXML.customizeDescription(msg);
+            const error = errorInstances.MalformedXML.customizeDescription(msg);
             return { error };
         }
         const rules: any = {};
@@ -167,7 +167,7 @@ export default class LifecycleConfiguration {
     _checkPrefix(prefix: string) {
         if (prefix.length > 1024) {
             const msg = 'The maximum size of a prefix is 1024';
-            return errors.InvalidRequest.customizeDescription(msg);
+            return errorInstances.InvalidRequest.customizeDescription(msg);
         }
         return null;
     }
@@ -221,24 +221,24 @@ export default class LifecycleConfiguration {
     _parseRule(rule: XMLRule) {
         if (rule.Transition || rule.NoncurrentVersionTransition) {
             const msg = 'Transition lifecycle action not yet implemented';
-            const error = errors.NotImplemented.customizeDescription(msg);
+            const error = errorInstances.NotImplemented.customizeDescription(msg);
             return { error };
         }
         // Either Prefix or Filter must be included, but can be empty string
         if ((!rule.Filter && rule.Filter !== '') &&
         (!rule.Prefix && rule.Prefix !== '')) {
             const msg = 'Rule xml does not include valid Filter or Prefix';
-            const error = errors.MalformedXML.customizeDescription(msg);
+            const error = errorInstances.MalformedXML.customizeDescription(msg);
             return { error };
         }
         if (rule.Filter && rule.Prefix) {
             const msg = 'Rule xml should not include both Filter and Prefix';
-            const error = errors.MalformedXML.customizeDescription(msg);
+            const error = errorInstances.MalformedXML.customizeDescription(msg);
             return { error };
         }
         if (!rule.Status) {
             const msg = 'Rule xml does not include Status';
-            const error = errors.MissingRequiredParameter.customizeDescription(msg);
+            const error = errorInstances.MissingRequiredParameter.customizeDescription(msg);
             return { error };
         }
         const id = this._parseID(rule.ID!);
@@ -319,7 +319,7 @@ export default class LifecycleConfiguration {
         if (filter.And && (filter.Prefix || filter.Tag) ||
         (filter.Prefix && filter.Tag)) {
             const msg = 'Filter should only include one of And, Prefix, or Tag key';
-            const error = errors.MalformedXML.customizeDescription(msg);
+            const error = errorInstances.MalformedXML.customizeDescription(msg);
             filterObj.error = error;
             return filterObj;
         }
@@ -343,7 +343,7 @@ export default class LifecycleConfiguration {
         if (filter.And) {
             const andF = filter.And[0];
             if (!andF.Tag || (!andF.Prefix && andF.Tag.length < 2)) {
-                filterObj.error = errors.MalformedXML.customizeDescription(
+                filterObj.error = errorInstances.MalformedXML.customizeDescription(
                     'And should include Prefix and Tags or more than one Tag');
                 return filterObj;
             }
@@ -396,25 +396,25 @@ export default class LifecycleConfiguration {
         for (const tag of tags) {
             if (!tag.Key || !tag.Value) {
                 const msg = 'Tag XML does not contain both Key and Value';
-                const err = errors.MissingRequiredParameter.customizeDescription(msg);
+                const err = errorInstances.MissingRequiredParameter.customizeDescription(msg);
                 tagObj.error = err;
                 break;
             }
 
             if (tag.Key[0].length < 1 || tag.Key[0].length > 128) {
-                tagObj.error = errors.InvalidRequest.customizeDescription(
+                tagObj.error = errorInstances.InvalidRequest.customizeDescription(
                     "A Tag's Key must be a length between 1 and 128"
                 );
                 break;
             }
             if (tag.Value[0].length < 0 || tag.Value[0].length > 256) {
-                tagObj.error = errors.InvalidRequest.customizeDescription(
+                tagObj.error = errorInstances.InvalidRequest.customizeDescription(
                     "A Tag's Value must be a length between 0 and 256"
                 );
                 break;
             }
             if (this._tagKeys.includes(tag.Key[0])) {
-                tagObj.error = errors.InvalidRequest.customizeDescription(
+                tagObj.error = errorInstances.InvalidRequest.customizeDescription(
                     'Tag Keys must be unique'
                 );
                 break;
@@ -448,7 +448,7 @@ export default class LifecycleConfiguration {
             | { propName: 'ruleID', ruleID: any } = { propName: 'ruleID' };
         if (id && id[0].length > 255) {
             const msg = 'Rule ID is greater than 255 characters long';
-            const error = errors.InvalidArgument.customizeDescription(msg);
+            const error = errorInstances.InvalidArgument.customizeDescription(msg);
             return { ...idObj, error };
         }
         if (!id || !id[0] || id[0] === '') {
@@ -461,7 +461,7 @@ export default class LifecycleConfiguration {
         // Each ID in a list of rules must be unique.
         if (this._ruleIDs.includes(idObj.ruleID)) {
             const msg = 'Rule ID must be unique';
-            const error = errors.InvalidRequest.customizeDescription(msg);
+            const error = errorInstances.InvalidRequest.customizeDescription(msg);
             return { ...idObj, error };
         }
         this._ruleIDs.push(idObj.ruleID);
@@ -486,7 +486,7 @@ export default class LifecycleConfiguration {
         const validStatuses = ['Enabled', 'Disabled'];
         if (!validStatuses.includes(status)) {
             const msg = 'Status is not valid';
-            const error = errors.MalformedXML.customizeDescription(msg);
+            const error = errorInstances.MalformedXML.customizeDescription(msg);
             return { ...base, error };
         }
         return { ...base, ruleStatus: status }
@@ -513,7 +513,7 @@ export default class LifecycleConfiguration {
         const matches = [...date.matchAll(isoRegex)];
         if (matches.length !== 1) {
             const msg = 'Date must be in ISO 8601 format';
-            return errors.InvalidArgument.customizeDescription(msg);
+            return errorInstances.InvalidArgument.customizeDescription(msg);
         }
         // Check for a timezone in the last match group. If none, add a Z to indicate UTC.
         if (!matches[0][matches[0].length-1]) {
@@ -522,14 +522,14 @@ export default class LifecycleConfiguration {
         const dateObj = new Date(date);
         if (Number.isNaN(dateObj.getTime())) {
             const msg = 'Date is not a valid date';
-            return errors.InvalidArgument.customizeDescription(msg);
+            return errorInstances.InvalidArgument.customizeDescription(msg);
         }
         if (dateObj.getUTCHours() !== 0
             || dateObj.getUTCMinutes() !== 0
             || dateObj.getUTCSeconds() !== 0
             || dateObj.getUTCMilliseconds() !== 0) {
             const msg = '\'Date\' must be at midnight GMT';
-            return errors.InvalidArgument.customizeDescription(msg);
+            return errorInstances.InvalidArgument.customizeDescription(msg);
         }
         return null;
     }
@@ -578,7 +578,7 @@ export default class LifecycleConfiguration {
         });
         if (actionsObj.actions.length === 0) {
             const msg = 'Rule does not include valid action';
-            const error = errors.InvalidRequest.customizeDescription(msg);
+            const error = errorInstances.InvalidRequest.customizeDescription(msg);
             return { ...actionsObj, error };
         }
         actionsObj.actions.forEach(a => {
@@ -622,7 +622,7 @@ export default class LifecycleConfiguration {
             }
         }
         if (filter && filter.Tag) {
-            abortObj.error = errors.InvalidRequest.customizeDescription(
+            abortObj.error = errorInstances.InvalidRequest.customizeDescription(
                 'Tag-based filter cannot be used with ' +
                 'AbortIncompleteMultipartUpload action',
             );
@@ -630,14 +630,14 @@ export default class LifecycleConfiguration {
         }
         const subAbort = rule.AbortIncompleteMultipartUpload[0];
         if (!subAbort.DaysAfterInitiation) {
-            abortObj.error = errors.MalformedXML.customizeDescription(
+            abortObj.error = errorInstances.MalformedXML.customizeDescription(
                 'AbortIncompleteMultipartUpload action does not ' +
                 'include DaysAfterInitiation');
             return abortObj;
         }
         const daysInt = parseInt(subAbort.DaysAfterInitiation[0], 10);
         if (daysInt < 1) {
-            abortObj.error = errors.InvalidArgument.customizeDescription(
+            abortObj.error = errorInstances.InvalidArgument.customizeDescription(
                 'DaysAfterInitiation is not a positive integer');
             return abortObj;
         }
@@ -669,7 +669,7 @@ export default class LifecycleConfiguration {
         const subExp = rule.Expiration[0];
         if (!subExp.Date && !subExp.Days && !subExp.ExpiredObjectDeleteMarker) {
             const msg = 'Expiration action does not include an action time';
-            const error = errors.MalformedXML.customizeDescription(msg);
+            const error = errorInstances.MalformedXML.customizeDescription(msg);
             return { error };
         }
         const eodm = 'ExpiredObjectDeleteMarker';
@@ -677,7 +677,7 @@ export default class LifecycleConfiguration {
             (subExp.Days || subExp[eodm]) ||
             (subExp.Days && subExp[eodm])) {
             const msg = 'Expiration action includes more than one time';
-            const error = errors.MalformedXML.customizeDescription(msg);
+            const error = errorInstances.MalformedXML.customizeDescription(msg);
             return { error };
         }
         if (subExp.Date) {
@@ -691,7 +691,7 @@ export default class LifecycleConfiguration {
         if (subExp.Days) {
             const daysInt = parseInt(subExp.Days[0], 10);
             if (daysInt < 1) {
-                expObj.error = errors.InvalidArgument.customizeDescription(
+                expObj.error = errorInstances.InvalidArgument.customizeDescription(
                     'Expiration days is not a positive integer');
             } else {
                 expObj.days = daysInt;
@@ -707,14 +707,14 @@ export default class LifecycleConfiguration {
                 }
             }
             if (filter && filter.Tag) {
-                expObj.error = errors.InvalidRequest.customizeDescription(
+                expObj.error = errorInstances.InvalidRequest.customizeDescription(
                     'Tag-based filter cannot be used with ' +
                     'ExpiredObjectDeleteMarker action');
                 return expObj;
             }
             const validValues = ['true', 'false'];
             if (!validValues.includes(subExp.ExpiredObjectDeleteMarker[0])) {
-                expObj.error = errors.MalformedXML.customizeDescription(
+                expObj.error = errorInstances.MalformedXML.customizeDescription(
                     'ExpiredObjDeleteMarker is not true or false');
             } else {
                 expObj.deleteMarker = subExp.ExpiredObjectDeleteMarker[0];
@@ -739,7 +739,7 @@ export default class LifecycleConfiguration {
     _parseNoncurrentVersionExpiration(rule: any) {
         const subNVExp = rule.NoncurrentVersionExpiration[0];
         if (!subNVExp.NoncurrentDays) {
-            const error = errors.MalformedXML.customizeDescription(
+            const error = errorInstances.MalformedXML.customizeDescription(
                 'NoncurrentVersionExpiration action does not include ' +
                 'NoncurrentDays');
             return { error };
@@ -757,7 +757,7 @@ export default class LifecycleConfiguration {
         const daysInt = parseInt(subNVExp.NoncurrentDays[0], 10);
         if (daysInt < 1) {
             const msg = 'NoncurrentDays is not a positive integer';
-            const error = errors.InvalidArgument.customizeDescription(msg);
+            const error = errorInstances.InvalidArgument.customizeDescription(msg);
             return { error };
         } else {
             actionParams.days = daysInt;
@@ -768,7 +768,7 @@ export default class LifecycleConfiguration {
 
             if (Number.isNaN(newerVersionsInt) || newerVersionsInt < 1) {
                 const msg = 'NewerNoncurrentVersions is not a positive integer';
-                const error = errors.InvalidArgument.customizeDescription(msg);
+                const error = errorInstances.InvalidArgument.customizeDescription(msg);
                 return { error };
             }
 

--- a/lib/models/NotificationConfiguration.ts
+++ b/lib/models/NotificationConfiguration.ts
@@ -5,7 +5,7 @@ import {
     supportedNotificationEvents,
     notificationArnPrefix,
 } from '../constants';
-import errors, { ArsenalError } from '../errors';
+import { ArsenalError, errorInstances } from '../errors';
 
 /**
  * Format of xml request:
@@ -87,12 +87,12 @@ export default class NotificationConfiguration {
      */
     _parseNotificationConfig() {
         if (!this._parsedXml || this._parsedXml === '') {
-            return errors.MalformedXML.customizeDescription(
+            return errorInstances.MalformedXML.customizeDescription(
                 'request xml is undefined or empty');
         }
         const notificationConfig = this._parsedXml.NotificationConfiguration;
         if (!notificationConfig || notificationConfig === '') {
-            return errors.MalformedXML.customizeDescription(
+            return errorInstances.MalformedXML.customizeDescription(
                 'request xml does not include NotificationConfiguration');
         }
         const queueConfig = notificationConfig.QueueConfiguration;
@@ -146,7 +146,7 @@ export default class NotificationConfiguration {
     _parseEvents(events: any[]) {
         if (!events || !events[0]) {
             const msg = 'each queue configuration must contain an event';
-            const error = errors.MalformedXML.customizeDescription(msg);
+            const error = errorInstances.MalformedXML.customizeDescription(msg);
             return { error };
         }
         const eventsObj: { error?: ArsenalError, events: any[] } = {
@@ -155,7 +155,7 @@ export default class NotificationConfiguration {
         for (const e of events) {
             if (!supportedNotificationEvents.has(e)) {
                 const msg = 'event array contains invalid or unsupported event';
-                const error = errors.MalformedXML.customizeDescription(msg);
+                const error = errorInstances.MalformedXML.customizeDescription(msg);
                 return { error };
             } else {
                 eventsObj.events.push(e);
@@ -174,12 +174,12 @@ export default class NotificationConfiguration {
             return { filterRules: undefined };
         }
         if (!filter[0].S3Key || !filter[0].S3Key[0]) {
-            return { error: errors.MalformedXML.customizeDescription(
+            return { error: errorInstances.MalformedXML.customizeDescription(
                 'if included, queue configuration filter must contain S3Key') };
         }
         const filterRules = filter[0].S3Key[0];
         if (!filterRules.FilterRule || !filterRules.FilterRule[0]) {
-            return { error: errors.MalformedXML.customizeDescription(
+            return { error: errorInstances.MalformedXML.customizeDescription(
                 'if included, queue configuration filter must contain a rule') };
         }
         const filterObj: { filterRules: { name: string; value: string }[] } = {
@@ -191,11 +191,11 @@ export default class NotificationConfiguration {
                 || !ruleArray[i].Name[0]
                 || !ruleArray[i].Value
                 || !ruleArray[i].Value[0]) {
-                return { error: errors.MalformedXML.customizeDescription(
+                return { error: errorInstances.MalformedXML.customizeDescription(
                     'each included filter must contain a name and value') };
             }
             if (!['Prefix', 'Suffix'].includes(ruleArray[i].Name[0])) {
-                return { error: errors.MalformedXML.customizeDescription(
+                return { error: errorInstances.MalformedXML.customizeDescription(
                     'filter Name must be one of Prefix or Suffix') };
             }
             filterObj.filterRules.push({
@@ -213,7 +213,7 @@ export default class NotificationConfiguration {
      */
     _parseId(id: string) {
         if (id && id[0].length > 255) {
-            return { error: errors.InvalidArgument.customizeDescription(
+            return { error: errorInstances.InvalidArgument.customizeDescription(
                 'queue configuration ID is greater than 255 characters long') };
         }
         let validId: string;
@@ -226,7 +226,7 @@ export default class NotificationConfiguration {
         }
         // Each ID in a list of rules must be unique.
         if (this._ids.has(validId)) {
-            return { error: errors.InvalidRequest.customizeDescription(
+            return { error: errorInstances.InvalidRequest.customizeDescription(
                 'queue configuration ID must be unique') };
         }
         this._ids.add(validId);
@@ -240,14 +240,14 @@ export default class NotificationConfiguration {
      */
     _parseArn(arn: string) {
         if (!arn || !arn[0]) {
-            return { error: errors.MalformedXML.customizeDescription(
+            return { error: errorInstances.MalformedXML.customizeDescription(
                 'each queue configuration must contain a queue arn'),
             };
         }
         const splitArn = arn[0].split(':');
         const slicedArn = arn[0].slice(0, 23);
         if (splitArn.length !== 6 || slicedArn !== notificationArnPrefix) {
-            return { error: errors.MalformedXML.customizeDescription(
+            return { error: errorInstances.MalformedXML.customizeDescription(
                 'queue arn is invalid') };
         }
         // remaining 3 parts of arn are evaluated in cloudserver

--- a/lib/models/ObjectLockConfiguration.ts
+++ b/lib/models/ObjectLockConfiguration.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import errors, { ArsenalError } from '../errors';
+import { ArsenalError, errorInstances } from '../errors';
 
 export type Config = any;
 export type LockMode = 'GOVERNANCE' | 'COMPLIANCE';
@@ -68,17 +68,17 @@ export default class ObjectLockConfiguration {
         const expectedModes = ['GOVERNANCE', 'COMPLIANCE'];
         if (!mode || !mode[0]) {
             const msg = 'request xml does not contain Mode';
-            const error = errors.MalformedXML.customizeDescription(msg);
+            const error = errorInstances.MalformedXML.customizeDescription(msg);
             return { error };
         }
         if (mode.length > 1) {
             const msg = 'request xml contains more than one Mode';
-            const error = errors.MalformedXML.customizeDescription(msg);
+            const error = errorInstances.MalformedXML.customizeDescription(msg);
             return { error };
         }
         if (!expectedModes.includes(mode[0])) {
             const msg = 'Mode request xml must be one of "GOVERNANCE", "COMPLIANCE"';
-            const error = errors.MalformedXML.customizeDescription(msg);
+            const error = errorInstances.MalformedXML.customizeDescription(msg);
             return { error };
         }
         return { mode: mode[0] };
@@ -92,35 +92,35 @@ export default class ObjectLockConfiguration {
     _parseTime(dr: DefaultRetention): ParsedRetention {
         if ('Days' in dr && 'Years' in dr) {
             const msg = 'request xml contains both Days and Years';
-            const error = errors.MalformedXML.customizeDescription(msg);
+            const error = errorInstances.MalformedXML.customizeDescription(msg);
             return { error };
         }
         const timeType = 'Days' in dr ? 'Days' : 'Years';
         if (!dr[timeType] || !dr[timeType][0]) {
             const msg = 'request xml does not contain Days or Years';
-            const error = errors.MalformedXML.customizeDescription(msg);
+            const error = errorInstances.MalformedXML.customizeDescription(msg);
             return { error };
         }
         if (dr[timeType].length > 1) {
             const msg = 'request xml contains more than one retention period';
-            const error = errors.MalformedXML.customizeDescription(msg);
+            const error = errorInstances.MalformedXML.customizeDescription(msg);
             return { error };
         }
         const timeValue = Number.parseInt(dr[timeType][0], 10);
         if (Number.isNaN(timeValue)) {
             const msg = 'request xml does not contain valid retention period';
-            const error = errors.MalformedXML.customizeDescription(msg);
+            const error = errorInstances.MalformedXML.customizeDescription(msg);
             return { error };
         }
         if (timeValue < 1) {
             const msg = 'retention period must be a positive integer';
-            const error = errors.InvalidArgument.customizeDescription(msg);
+            const error = errorInstances.InvalidArgument.customizeDescription(msg);
             return { error };
         }
         if ((timeType === 'Days' && timeValue > 36500) ||
         (timeType === 'Years' && timeValue > 100)) {
             const msg = 'retention period is too large';
-            const error = errors.InvalidArgument.customizeDescription(msg);
+            const error = errorInstances.InvalidArgument.customizeDescription(msg);
             return { error };
         }
         return {
@@ -137,39 +137,39 @@ export default class ObjectLockConfiguration {
         const validConfig: { error?: ArsenalError } = {};
         if (!this._parsedXml || this._parsedXml === '') {
             const msg = 'request xml is undefined or empty';
-            const error = errors.MalformedXML.customizeDescription(msg);
+            const error = errorInstances.MalformedXML.customizeDescription(msg);
             return { error };
         }
         const objectLockConfig = this._parsedXml.ObjectLockConfiguration;
         if (!objectLockConfig || objectLockConfig === '') {
             const msg = 'request xml does not include ObjectLockConfiguration';
-            const error = errors.MalformedXML.customizeDescription(msg);
+            const error = errorInstances.MalformedXML.customizeDescription(msg);
             return { error };
         }
         const objectLockEnabled = objectLockConfig.ObjectLockEnabled;
         if (!objectLockEnabled || objectLockEnabled[0] !== 'Enabled') {
             const msg = 'request xml does not include valid ObjectLockEnabled';
-            const error = errors.MalformedXML.customizeDescription(msg);
+            const error = errorInstances.MalformedXML.customizeDescription(msg);
             return { error };
         }
         const ruleArray = objectLockConfig.Rule;
         if (ruleArray) {
             if (ruleArray.length > 1) {
                 const msg = 'request xml contains more than one rule';
-                const error = errors.MalformedXML.customizeDescription(msg);
+                const error = errorInstances.MalformedXML.customizeDescription(msg);
                 return { error };
             }
             const drArray = ruleArray[0].DefaultRetention;
             if (!drArray || !drArray[0] || drArray[0] === '') {
                 const msg = 'Rule request xml does not contain DefaultRetention';
-                const error = errors.MalformedXML.customizeDescription(msg);
+                const error = errorInstances.MalformedXML.customizeDescription(msg);
                 return { error };
             }
             if (!drArray[0].Mode || (!drArray[0].Days && !drArray[0].Years)) {
                 const msg =
                     'DefaultRetention request xml does not contain Mode or ' +
                     'retention period (Days or Years)';
-                const error = errors.MalformedXML.customizeDescription(msg);
+                const error = errorInstances.MalformedXML.customizeDescription(msg);
                 return { error };
             }
             const validMode = this._parseMode(drArray[0].Mode);

--- a/lib/models/ReplicationConfiguration.ts
+++ b/lib/models/ReplicationConfiguration.ts
@@ -4,7 +4,7 @@ import UUID from 'uuid';
 import { RequestLogger } from 'werelogs';
 
 import escapeForXml from '../s3middleware/escapeForXml';
-import errors from '../errors';
+import errors, { errorInstances } from '../errors';
 import { isValidBucketName } from '../s3routes/routesUtils';
 import { Status } from './LifecycleRule';
 
@@ -181,20 +181,20 @@ export default class ReplicationConfiguration {
         const role: string = parsedRole[0];
         const rolesArr = role.split(',');
         if (this._hasScalityDestination && rolesArr.length !== 2) {
-            return errors.InvalidArgument.customizeDescription(
+            return errorInstances.InvalidArgument.customizeDescription(
                 'Invalid Role specified in replication configuration: ' +
                     'Role must be a comma-separated list of two IAM roles'
             );
         }
         if (!this._hasScalityDestination && rolesArr.length > 1) {
-            return errors.InvalidArgument.customizeDescription(
+            return errorInstances.InvalidArgument.customizeDescription(
                 'Invalid Role specified in replication configuration: ' +
                     'Role may not contain a comma separator'
             );
         }
         const invalidRole = rolesArr.find((r) => !this._isValidRoleARN(r));
         if (invalidRole !== undefined) {
-            return errors.InvalidArgument.customizeDescription(
+            return errorInstances.InvalidArgument.customizeDescription(
                 'Invalid Role specified in replication configuration: ' +
                     `'${invalidRole}'`
             );
@@ -213,7 +213,7 @@ export default class ReplicationConfiguration {
             return errors.MalformedXML;
         }
         if (Rule.length > MAX_RULES) {
-            return errors.InvalidRequest.customizeDescription(
+            return errorInstances.InvalidRequest.customizeDescription(
                 'Number of defined replication rules cannot exceed 1000'
             );
         }
@@ -268,7 +268,7 @@ export default class ReplicationConfiguration {
             return errors.MalformedXML;
         }
         if (prefix.length > 1024) {
-            return errors.InvalidArgument.customizeDescription(
+            return errorInstances.InvalidArgument.customizeDescription(
                 'Rule prefix ' +
                     'cannot be longer than maximum allowed key length of 1024'
             );
@@ -279,7 +279,7 @@ export default class ReplicationConfiguration {
         for (let i = 0; i < this._configPrefixes.length; i++) {
             const used = this._configPrefixes[i];
             if (prefix.startsWith(used) || used.startsWith(prefix)) {
-                return errors.InvalidRequest.customizeDescription(
+                return errorInstances.InvalidRequest.customizeDescription(
                     'Found ' + `overlapping prefixes '${used}' and '${prefix}'`
                 );
             }
@@ -295,13 +295,13 @@ export default class ReplicationConfiguration {
     _parseID(rule: XMLRule) {
         const id = rule.ID && rule.ID[0];
         if (id && id.length > RULE_ID_LIMIT) {
-            return errors.InvalidArgument.customizeDescription(
+            return errorInstances.InvalidArgument.customizeDescription(
                 'Rule Id cannot be greater than 255'
             );
         }
         // Each ID in a list of rules must be unique.
         if (id && this._configIDs.includes(id)) {
-            return errors.InvalidRequest.customizeDescription(
+            return errorInstances.InvalidRequest.customizeDescription(
                 'Rule Id must be unique'
             );
         }
@@ -372,7 +372,7 @@ export default class ReplicationConfiguration {
         }
         const bucketARN = parsedBucketARN[0];
         if (!bucketARN) {
-            return errors.InvalidArgument.customizeDescription(
+            return errorInstances.InvalidArgument.customizeDescription(
                 'Destination bucket cannot be null or empty'
             );
         }
@@ -384,18 +384,18 @@ export default class ReplicationConfiguration {
             arr[3] === '' &&
             arr[4] === '';
         if (!isValidARN) {
-            return errors.InvalidArgument.customizeDescription(
+            return errorInstances.InvalidArgument.customizeDescription(
                 'Invalid bucket ARN'
             );
         }
         if (!isValidBucketName(arr[5], [])) {
-            return errors.InvalidArgument.customizeDescription(
+            return errorInstances.InvalidArgument.customizeDescription(
                 'The specified bucket is not valid'
             );
         }
         // We can replicate objects only to one destination bucket.
         if (this._destination && this._destination !== bucketARN) {
-            return errors.InvalidRequest.customizeDescription(
+            return errorInstances.InvalidRequest.customizeDescription(
                 'The destination bucket must be same for all rules'
             );
         }

--- a/lib/network/http/server.ts
+++ b/lib/network/http/server.ts
@@ -5,7 +5,7 @@ import * as net from 'net';
 import assert from 'assert';
 import { dhparam } from '../../https/dh2048';
 import { ciphers } from '../../https/ciphers';
-import errors from '../../errors';
+import { errorInstances } from '../../errors';
 import { checkSupportIPv6 } from './utils';
 import { Logger } from 'werelogs';
 
@@ -205,7 +205,7 @@ export default class Server {
      */
     _noHandlerCb(_req: http.IncomingMessage, res: http.ServerResponse) {
         // if no handler on the Server, send back an internal error
-        const err = errors.InternalError;
+        const err = errorInstances.InternalError;
         const msg = `${err.message}: No handler in Server`;
         res.writeHead(err.code, {
             'Content-Type': 'text/plain',

--- a/lib/network/probe/ProbeServer.ts
+++ b/lib/network/probe/ProbeServer.ts
@@ -1,7 +1,7 @@
 import * as http from 'http';
 import httpServer from '../http/server';
 import * as werelogs from 'werelogs';
-import errors from '../../errors';
+import { errorInstances } from '../../errors';
 
 export const DEFAULT_LIVE_ROUTE = '/_/live';
 export const DEFAULT_READY_ROUTE = '/_/live';
@@ -81,12 +81,12 @@ export class ProbeServer extends httpServer {
         log.debug('request received', { method: req.method, url: req.url });
 
         if (req.method !== 'GET') {
-            errors.MethodNotAllowed.writeResponse(res);
+            errorInstances.MethodNotAllowed.writeResponse(res);
             return;
         }
 
         if (!this._handlers.has(req.url!)) {
-            errors.InvalidURI.writeResponse(res);
+            errorInstances.InvalidURI.writeResponse(res);
             return;
         }
 

--- a/lib/network/rest/RESTServer.ts
+++ b/lib/network/rest/RESTServer.ts
@@ -6,7 +6,7 @@ import httpServer from '../http/server';
 import * as constants from '../../constants';
 import * as utils from './utils';
 import * as httpUtils from '../http/utils';
-import errors, { ArsenalError } from '../../errors';
+import errors, { ArsenalError, errorInstances } from '../../errors';
 
 function setContentLength(response: http.ServerResponse, contentLength: number) {
     response.setHeader('Content-Length', contentLength.toString());
@@ -54,11 +54,11 @@ function parseURL(urlStr: string, expectKey: boolean) {
     const urlObj = url.parse(urlStr);
     const pathInfo = utils.explodePath(urlObj.path!);
     if (pathInfo.service !== constants.dataFileURL) {
-        throw errors.InvalidAction.customizeDescription(
+        throw errorInstances.InvalidAction.customizeDescription(
             `unsupported service '${pathInfo.service}'`);
     }
     if (expectKey && pathInfo.key === undefined) {
-        throw errors.MissingParameter.customizeDescription(
+        throw errorInstances.MissingParameter.customizeDescription(
             'URL is missing key');
     }
     if (!expectKey && pathInfo.key !== undefined) {
@@ -68,7 +68,7 @@ function parseURL(urlStr: string, expectKey: boolean) {
         // atomicity of the update (we would just remove the old
         // object when the new one has been written entirely in this
         // case, saving a request over an equivalent PUT + DELETE).
-        throw errors.InvalidURI.customizeDescription(
+        throw errorInstances.InvalidURI.customizeDescription(
             'PUT url cannot contain a key');
     }
     return pathInfo;
@@ -188,7 +188,7 @@ export default class RESTServer extends httpServer {
             }
             size = Number.parseInt(contentLength, 10);
             if (Number.isNaN(size)) {
-                throw errors.InvalidInput.customizeDescription(
+                throw errorInstances.InvalidInput.customizeDescription(
                     'bad Content-Length');
             }
         } catch (err: any) {

--- a/lib/network/rest/utils.ts
+++ b/lib/network/rest/utils.ts
@@ -1,4 +1,4 @@
-import errors from '../../errors';
+import { errorInstances } from '../../errors';
 
 export function explodePath(path: string) {
     const pathMatch = /^(\/[a-zA-Z0-9]+)(\/([0-9a-f]*))?$/.exec(path);
@@ -9,5 +9,5 @@ export function explodePath(path: string) {
                 pathMatch[3] : undefined),
         };
     }
-    throw errors.InvalidURI.customizeDescription('malformed URI');
+    throw errorInstances.InvalidURI.customizeDescription('malformed URI');
 };

--- a/lib/network/rpc/rpc.ts
+++ b/lib/network/rpc/rpc.ts
@@ -6,7 +6,7 @@ import async from 'async';
 import assert from 'assert';
 import { EventEmitter } from 'events';
 import { flattenError, reconstructError } from './utils';
-import errors, { ArsenalError } from '../../errors';
+import errors, { ArsenalError, errorInstances } from '../../errors';
 import * as jsutil from '../../jsutil';
 import { Logger } from 'werelogs';
 
@@ -438,7 +438,7 @@ export class BaseService {
                 return cb(flattenError(err));
             }
         } else {
-            return cb(errors.InvalidArgument.customizeDescription(
+            return cb(errorInstances.InvalidArgument.customizeDescription(
                 `Unknown remote call ${remoteCall} ` +
                     `in namespace ${this.namespace}`));
         }
@@ -697,7 +697,7 @@ export function RESTServer(params: { logger: Logger }) {
     const httpServer = http.createServer((req, res) => {
         if (req.method !== 'POST') {
             return sendHTTPError(
-                res, errors.MethodNotAllowed.customizeDescription(
+                res, errorInstances.MethodNotAllowed.customizeDescription(
                     'only POST requests are supported for RPC calls'));
         }
         // @ts-expect-errors
@@ -706,7 +706,7 @@ export function RESTServer(params: { logger: Logger }) {
             service => req.url === service.namespace);
         if (!matchingService) {
             return sendHTTPError(
-                res, errors.InvalidArgument.customizeDescription(
+                res, errorInstances.InvalidArgument.customizeDescription(
                     `unknown service in URL ${req.url}`));
         }
         const reqBody: any = [];
@@ -720,7 +720,7 @@ export function RESTServer(params: { logger: Logger }) {
             try {
                 const jsonReq = JSON.parse(reqBody);
                 if (!jsonReq.call) {
-                    throw errors.InvalidArgument.customizeDescription(
+                    throw errorInstances.InvalidArgument.customizeDescription(
                         'missing "call" JSON attribute');
                 }
                 const args = jsonReq.args || {};

--- a/lib/network/utils.ts
+++ b/lib/network/utils.ts
@@ -1,4 +1,4 @@
-import errors from '../errors';
+import { errorInstances } from '../errors';
 
 /**
  * Normalize errors according to arsenal definitions with a custom prefix
@@ -8,7 +8,7 @@ import errors from '../errors';
  */
 function _normalizeArsenalError(err: string | Error, messagePrefix: string) {
     if (typeof err === 'string') {
-        return errors.InternalError
+        return errorInstances.InternalError
             .customizeDescription(`${messagePrefix} ${err}`);
     } else if (
         err instanceof Error ||
@@ -17,10 +17,10 @@ function _normalizeArsenalError(err: string | Error, messagePrefix: string) {
         // @ts-expect-error
         (err && typeof err.message === 'string')
     ) {
-        return errors.InternalError
+        return errorInstances.InternalError
             .customizeDescription(`${messagePrefix} ${err.message}`);
     }
-    return errors.InternalError
+    return errorInstances.InternalError
         .customizeDescription(`${messagePrefix} Unspecified error`);
 }
 

--- a/lib/s3middleware/azureHelpers/mpuUtils.ts
+++ b/lib/s3middleware/azureHelpers/mpuUtils.ts
@@ -8,7 +8,7 @@ import ResultsCollector from './ResultsCollector';
 import SubStreamInterface from './SubStreamInterface';
 import * as objectUtils from '../objectUtils';
 import MD5Sum from '../MD5Sum';
-import errors from '../../errors';
+import errors, { errorInstances } from '../../errors';
 
 export const splitter = '|';
 export const overviewMpuKey = 'azure_mpu';
@@ -142,7 +142,7 @@ export const putSinglePart = (
                     if (err.code === 'Md5Mismatch') {
                         return cb(errors.BadDigest);
                     }
-                    return cb(errors.InternalError.customizeDescription(
+                    return cb(errorInstances.InternalError.customizeDescription(
                         `Error returned from Azure: ${err.message}`),
                     );
                 }
@@ -207,7 +207,7 @@ export const putSubParts = (
         if (err.code === 'ContainerNotFound') {
             return cb(errors.NoSuchBucket);
         }
-        return cb(errors.InternalError.customizeDescription(
+        return cb(errorInstances.InternalError.customizeDescription(
             `Error returned from Azure: ${err}`));
     });
 
@@ -218,7 +218,7 @@ export const putSubParts = (
             if (err.code === 'ContainerNotFound') {
                 return cb(errors.NoSuchBucket);
             }
-            return cb(errors.InternalError.customizeDescription(
+            return cb(errorInstances.InternalError.customizeDescription(
                 `Error returned from Azure: ${err}`));
         }
         const numberSubParts = results.length;

--- a/lib/s3middleware/objectLegalHold.ts
+++ b/lib/s3middleware/objectLegalHold.ts
@@ -1,5 +1,5 @@
 import { parseString } from 'xml2js';
-import errors, { ArsenalError } from '../errors';
+import errors, { ArsenalError, errorInstances } from '../errors';
 import * as werelogs from 'werelogs';
 
 /*
@@ -17,17 +17,17 @@ function _validateStatus(status?: string[]) {
     const expectedValues = new Set(['OFF', 'ON']);
     if (!status || status[0] === '') {
         const desc = 'request xml does not contain Status';
-        const error = errors.MalformedXML.customizeDescription(desc);
+        const error = errorInstances.MalformedXML.customizeDescription(desc);
         return { error };
     }
     if (status.length > 1) {
         const desc = 'request xml contains more than one Status';
-        const error = errors.MalformedXML.customizeDescription(desc);
+        const error = errorInstances.MalformedXML.customizeDescription(desc);
         return { error };
     }
     if (!expectedValues.has(status[0])) {
         const desc = 'Status request xml must be one of "ON", "OFF"';
-        const error = errors.MalformedXML.customizeDescription(desc);
+        const error = errorInstances.MalformedXML.customizeDescription(desc);
         return { error };
     }
     return { status: status[0] as 'OFF' | 'ON' }
@@ -41,12 +41,12 @@ function _validateStatus(status?: string[]) {
 function _validateLegalHold(parsedXml?: { LegalHold: { Status: string[] } }) {
     if (!parsedXml) {
         const desc = 'request xml is undefined or empty';
-        const error = errors.MalformedXML.customizeDescription(desc);
+        const error = errorInstances.MalformedXML.customizeDescription(desc);
         return { error };
     }
     if (!parsedXml.LegalHold) {
         const desc = 'request xml does not contain LegalHold';
-        const error = errors.MalformedXML.customizeDescription(desc);
+        const error = errorInstances.MalformedXML.customizeDescription(desc);
         return { error };
     }
     const validatedStatus = _validateStatus(parsedXml.LegalHold.Status);

--- a/lib/s3middleware/objectRetention.ts
+++ b/lib/s3middleware/objectRetention.ts
@@ -1,5 +1,5 @@
 import { parseString } from 'xml2js';
-import errors, { ArsenalError } from '../errors';
+import errors, { ArsenalError, errorInstances } from '../errors';
 import * as werelogs from 'werelogs';
 
 /*
@@ -19,17 +19,17 @@ function validateMode(mode?: string[]) {
     const expectedModes = new Set(['GOVERNANCE', 'COMPLIANCE']);
     if (!mode || !mode[0]) {
         const desc = 'request xml does not contain Mode';
-        const error = errors.MalformedXML.customizeDescription(desc);
+        const error = errorInstances.MalformedXML.customizeDescription(desc);
         return { error };
     }
     if (mode.length > 1) {
         const desc = 'request xml contains more than one Mode';
-        const error = errors.MalformedXML.customizeDescription(desc);
+        const error = errorInstances.MalformedXML.customizeDescription(desc);
         return { error };
     }
     if (!expectedModes.has(mode[0])) {
         const desc = 'Mode request xml must be one of "GOVERNANCE", "COMPLIANCE"';
-        const error = errors.MalformedXML.customizeDescription(desc);
+        const error = errorInstances.MalformedXML.customizeDescription(desc);
         return { error };
     }
     return { mode: mode[0] as 'GOVERNANCE' | 'COMPLIANCE' }
@@ -43,19 +43,19 @@ function validateMode(mode?: string[]) {
 function validateRetainDate(retainDate?: string[]) {
     if (!retainDate || !retainDate[0]) {
         const desc = 'request xml does not contain RetainUntilDate';
-        const error = errors.MalformedXML.customizeDescription(desc);
+        const error = errorInstances.MalformedXML.customizeDescription(desc);
         return { error };
     }
     const retentionDate = Date.parse(retainDate[0]);
     if (isNaN(retentionDate)) {
         const desc = 'RetainUntilDate is not a valid timestamp';
-        const error = errors.InvalidRequest.customizeDescription(desc);
+        const error = errorInstances.InvalidRequest.customizeDescription(desc);
         return { error };
     }
     const date = new Date(retentionDate);
     if (date < new Date()) {
         const desc = 'RetainUntilDate must be in the future';
-        const error = errors.InvalidRequest.customizeDescription(desc);
+        const error = errorInstances.InvalidRequest.customizeDescription(desc);
         return { error };
     }
     return { date: retainDate[0] };
@@ -70,13 +70,13 @@ function validateRetainDate(retainDate?: string[]) {
 function validateRetention(parsedXml?: any) {
     if (!parsedXml) {
         const desc = 'request xml is undefined or empty';
-        const error = errors.MalformedXML.customizeDescription(desc);
+        const error = errorInstances.MalformedXML.customizeDescription(desc);
         return { error };
     }
     const retention = parsedXml.Retention;
     if (!retention) {
         const desc = 'request xml does not contain Retention';
-        const error = errors.MalformedXML.customizeDescription(desc);
+        const error = errorInstances.MalformedXML.customizeDescription(desc);
         return { error };
     }
     const modeObj = validateMode(retention.Mode);

--- a/lib/s3middleware/tagging.ts
+++ b/lib/s3middleware/tagging.ts
@@ -1,13 +1,13 @@
 import { parseString } from 'xml2js';
 import * as werelogs from 'werelogs';
-import errors, { ArsenalError } from '../errors';
+import errors, { ArsenalError, errorInstances } from '../errors';
 import escapeForXml from './escapeForXml';
 
-const errorInvalidArgument = () => errors.InvalidArgument
+const errorInvalidArgument = () => errorInstances.InvalidArgument
     .customizeDescription('The header \'x-amz-tagging\' shall be ' +
   'encoded as UTF-8 then URLEncoded URL query parameters without ' +
   'tag name duplicates.');
-const errorBadRequestLimit50 = () => errors.BadRequest
+const errorBadRequestLimit50 = () => errorInstances.BadRequest
     .customizeDescription('Object tags cannot be greater than 50');
 
 /*
@@ -47,11 +47,11 @@ export const _validator = {
 
     validateKeyValue: (key: string, value: any) => {
         if (key.length > 128) {
-            return errors.InvalidTag.customizeDescription('The TagKey you ' +
+            return errorInstances.InvalidTag.customizeDescription('The TagKey you ' +
               'have provided is too long, max 128');
         }
         if (value.length > 256) {
-            return errors.InvalidTag.customizeDescription('The TagValue you ' +
+            return errorInstances.InvalidTag.customizeDescription('The TagValue you ' +
               'have provided is too long, max 256');
         }
         return true;
@@ -83,7 +83,7 @@ function _validateTags(tags: Array<{ Key: string[], Value: string[] }>) {
         const value = tag.Value[0];
 
         if (!key) {
-            return errors.InvalidTag.customizeDescription('The TagKey you ' +
+            return errorInstances.InvalidTag.customizeDescription('The TagKey you ' +
             'have provided is invalid');
         }
 
@@ -100,7 +100,7 @@ function _validateTags(tags: Array<{ Key: string[], Value: string[] }>) {
     }
     // not repeating keys
     if (tags.length > Object.keys(tagsResult).length) {
-        return errors.InvalidTag.customizeDescription('Cannot provide ' +
+        return errorInstances.InvalidTag.customizeDescription('Cannot provide ' +
         'multiple Tags with the same key');
     }
     return tagsResult;

--- a/lib/s3routes/routes.ts
+++ b/lib/s3routes/routes.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 
 import { RequestLogger } from 'werelogs';
 
-import errors from '../errors';
+import errors, { errorInstances } from '../errors';
 import routeGET from './routes/routeGET';
 import routePUT from './routes/routePUT';
 import routeDELETE from './routes/routeDELETE';
@@ -51,7 +51,7 @@ function checkBucketAndKey(
     if (!bucketName && !(method === 'GET' && !objectKey)) {
         log.debug('empty bucket name', { method: 'routes' });
         return (method !== 'OPTIONS') ?
-            errors.MethodNotAllowed : errors.AccessForbidden
+            errors.MethodNotAllowed : errorInstances.AccessForbidden
                 .customizeDescription('CORSResponse: Bucket not found');
     }
     if (bucketName !== undefined && routesUtils.isValidBucketName(bucketName,
@@ -67,13 +67,13 @@ function checkBucketAndKey(
             blacklistedPrefixes.object);
         if (!result.isValid) {
             log.debug('invalid object key', { objectKey });
-            return errors.InvalidArgument.customizeDescription('Object key ' +
+            return errorInstances.InvalidArgument.customizeDescription('Object key ' +
             `must not start with "${result.invalidPrefix}".`);
         }
     }
     if ((reqQuery.partNumber || reqQuery.uploadId)
         && objectKey === undefined) {
-        return errors.InvalidRequest
+        return errorInstances.InvalidRequest
             .customizeDescription('A key must be specified');
     }
     return undefined;
@@ -244,7 +244,7 @@ export default function routes(
     } catch (err: any) {
         log.debug('could not normalize request', { error: err.stack });
         return routesUtils.responseXMLBody(
-            errors.InvalidURI.customizeDescription('Could not parse the ' +
+            errorInstances.InvalidURI.customizeDescription('Could not parse the ' +
                 'specified URI. Check your restEndpoints configuration.'),
             null, res, log);
     }

--- a/lib/s3routes/routes/routeDELETE.ts
+++ b/lib/s3routes/routes/routeDELETE.ts
@@ -1,7 +1,7 @@
 import { RequestLogger } from 'werelogs';
 
 import * as routesUtils from '../routesUtils';
-import errors from '../../errors';
+import { errorInstances } from '../../errors';
 import StatsClient from '../../metrics/StatsClient';
 import * as http from 'http';
 
@@ -24,7 +24,7 @@ export default function routeDELETE(
     if (query?.uploadId) {
         if (objectKey === undefined) {
             const message = 'A key must be specified';
-            const err = errors.InvalidRequest.customizeDescription(message);
+            const err = errorInstances.InvalidRequest.customizeDescription(message);
             return routesUtils.responseNoBody(err, null, response, 200, log);
         }
         return call('multipartDelete');

--- a/lib/s3routes/routes/routeOPTIONS.ts
+++ b/lib/s3routes/routes/routeOPTIONS.ts
@@ -1,7 +1,7 @@
 import { RequestLogger } from 'werelogs';
 
 import * as routesUtils from '../routesUtils';
-import errors from '../../errors';
+import { errorInstances } from '../../errors';
 import * as http from 'http';
 import StatsClient from '../../metrics/StatsClient';
 
@@ -18,13 +18,13 @@ export default function routeOPTIONS(
 
     if (!request.headers.origin) {
         const msg = 'Insufficient information. Origin request header needed.';
-        const err = errors.BadRequest.customizeDescription(msg);
+        const err = errorInstances.BadRequest.customizeDescription(msg);
         log.debug('missing origin', { method: 'routeOPTIONS', error: err });
         return routesUtils.responseXMLBody(err, null, response, log);
     }
     if (['GET', 'PUT', 'HEAD', 'POST', 'DELETE'].indexOf(corsMethod ?? '') < 0) {
         const msg = `Invalid Access-Control-Request-Method: ${corsMethod}`;
-        const err = errors.BadRequest.customizeDescription(msg);
+        const err = errorInstances.BadRequest.customizeDescription(msg);
         log.debug('invalid Access-Control-Request-Method',
             { method: 'routeOPTIONS', error: err });
         return routesUtils.responseXMLBody(err, null, response, log);

--- a/lib/storage/data/DataWrapper.js
+++ b/lib/storage/data/DataWrapper.js
@@ -5,6 +5,7 @@ const assert = require('assert');
 const { Logger } = require('werelogs');
 
 const errors = require('../../errors').default;
+const errorInstances = require('../../errors').errorInstances;
 const MD5Sum = require('../../s3middleware/MD5Sum').default;
 const NullStream = require('../../s3middleware/nullStream').default;
 const RelayMD5Sum = require('./utils/RelayMD5Sum');
@@ -597,7 +598,7 @@ class DataWrapper {
                             log.debug(externalVersioningErrorMessage,
                                 { method: 'initiateMultipartUpload',
                                     error: errors.NotImplemented });
-                            return callback(errors.NotImplemented
+                            return callback(errorInstances.NotImplemented
                                 .customizeDescription(
                                     externalVersioningErrorMessage),
                             null, isVersionedObj);

--- a/lib/storage/data/MultipleBackendGateway.js
+++ b/lib/storage/data/MultipleBackendGateway.js
@@ -1,6 +1,7 @@
 const async = require('async');
 
 const errors = require('../../errors').default;
+const errorInstances = require('../../errors').errorInstances;
 const { parseTagFromQuery } = require('../../s3middleware/tagging');
 const { externalBackendHealthCheckInterval } = require('../../constants');
 const DataFileBackend = require('./file/DataFileInterface');
@@ -326,7 +327,7 @@ class MultipleBackendGateway {
                         });
                 });
         }
-        return cb(errors.NotImplemented
+        return cb(errorInstances.NotImplemented
             .customizeDescription('Can not copy object from ' +
             `${client.clientType} to ${client.clientType}`));
     }
@@ -339,7 +340,7 @@ class MultipleBackendGateway {
                 sourceLocationConstraintName, config,
                 log, cb);
         }
-        return cb(errors.NotImplemented.customizeDescription(
+        return cb(errorInstances.NotImplemented.customizeDescription(
             'Can not copy object from ' +
           `${client.clientType} to ${client.clientType}`));
     }

--- a/lib/storage/data/external/AwsClient.js
+++ b/lib/storage/data/external/AwsClient.js
@@ -2,6 +2,7 @@ const AWS = require('aws-sdk');
 const werelogs = require('werelogs');
 
 const errors = require('../../../errors').default;
+const errorInstances = require('../../../errors').errorInstances;
 const MD5Sum = require('../../../s3middleware/MD5Sum').default;
 const getMetaHeaders =
     require('../../../s3middleware/userMetadata').getMetaHeaders;
@@ -9,7 +10,7 @@ const { prepareStream } = require('../../../s3middleware/prepareStream');
 const { createLogger, logHelper, removeQuotes, trimXMetaPrefix } =
     require('./utils');
 
-const missingVerIdInternalError = errors.InternalError.customizeDescription(
+const missingVerIdInternalError = errorInstances.InternalError.customizeDescription(
     'Invalid state. Please ensure versioning is enabled ' +
     'in AWS for the location constraint and try again.',
 );
@@ -92,7 +93,7 @@ class AwsClient {
             if (err) {
                 logHelper(log, 'error', 'err from data backend',
                     err, this._dataStoreName, this.clientType);
-                return callback(errors.ServiceUnavailable
+                return callback(errorInstances.ServiceUnavailable
                     .customizeDescription('Error returned from ' +
                   `${this.type}: ${err.message}`),
                 );
@@ -160,7 +161,7 @@ class AwsClient {
                     retError = errors.LocationNotFound;
                 } else {
                     logLevel = 'error';
-                    retError = errors.ServiceUnavailable.customizeDescription(
+                    retError = errorInstances.ServiceUnavailable.customizeDescription(
                         `Error returned from ${this.type}: ${err.message}`);
                 }
                 logHelper(log, logLevel, 'error heading object ' +
@@ -231,7 +232,7 @@ class AwsClient {
                     // sent back to client anyway, so no need to return err
                     return callback();
                 }
-                return callback(errors.ServiceUnavailable
+                return callback(errorInstances.ServiceUnavailable
                     .customizeDescription('Error returned from ' +
                   `${this.type}: ${err.message}`),
                 );
@@ -305,7 +306,7 @@ class AwsClient {
             if (err) {
                 logHelper(log, 'error', 'err from data backend',
                     err, this._dataStoreName, this.clientType);
-                return callback(errors.ServiceUnavailable
+                return callback(errorInstances.ServiceUnavailable
                     .customizeDescription('Error returned from ' +
                   `${this.type}: ${err.message}`),
                 );
@@ -333,7 +334,7 @@ class AwsClient {
             if (err) {
                 logHelper(log, 'error', 'err from data backend ' +
                     'on uploadPart', err, this._dataStoreName, this.clientType);
-                return callback(errors.ServiceUnavailable
+                return callback(errorInstances.ServiceUnavailable
                     .customizeDescription('Error returned from ' +
                     `${this.type}: ${err.message}`),
                 );
@@ -361,7 +362,7 @@ class AwsClient {
             if (err) {
                 logHelper(log, 'error', 'err from data backend on listPart',
                     err, this._dataStoreName, this.clientType);
-                return callback(errors.ServiceUnavailable
+                return callback(errorInstances.ServiceUnavailable
                     .customizeDescription('Error returned from ' +
                   `${this.type}: ${err.message}`),
                 );
@@ -433,7 +434,7 @@ class AwsClient {
                     }
                     logHelper(log, 'error', 'err from data backend on ' +
                 'completeMPU', err, this._dataStoreName, this.clientType);
-                    return callback(errors.ServiceUnavailable
+                    return callback(errorInstances.ServiceUnavailable
                         .customizeDescription('Error returned from ' +
                   `${this.type}: ${err.message}`),
                     );
@@ -451,7 +452,7 @@ class AwsClient {
                         if (err) {
                             logHelper(log, 'trace', 'err from data backend on ' +
                     'headObject', err, this._dataStoreName, this.clientType);
-                            return callback(errors.ServiceUnavailable
+                            return callback(errorInstances.ServiceUnavailable
                                 .customizeDescription('Error returned from ' +
                       `${this.type}: ${err.message}`),
                             );
@@ -479,7 +480,7 @@ class AwsClient {
                 'the MPU on AWS S3. You should abort directly on AWS S3 ' +
                 'using the same uploadId.', err, this._dataStoreName,
                 this.clientType);
-                return callback(errors.ServiceUnavailable
+                return callback(errorInstances.ServiceUnavailable
                     .customizeDescription('Error returned from ' +
                   `${this.type}: ${err.message}`),
                 );
@@ -508,7 +509,7 @@ class AwsClient {
                 logHelper(log, 'error', 'error from data backend on ' +
                   'putObjectTagging', err,
                 this._dataStoreName, this.clientType);
-                return callback(errors.ServiceUnavailable
+                return callback(errorInstances.ServiceUnavailable
                     .customizeDescription('Error returned from ' +
                   `${this.type}: ${err.message}`),
                 );
@@ -531,7 +532,7 @@ class AwsClient {
                 logHelper(log, 'error', 'error from data backend on ' +
                 'deleteObjectTagging', err,
                 this._dataStoreName, this.clientType);
-                return callback(errors.ServiceUnavailable
+                return callback(errorInstances.ServiceUnavailable
                     .customizeDescription('Error returned from ' +
                   `${this.type}: ${err.message}`),
                 );
@@ -568,14 +569,14 @@ class AwsClient {
                     logHelper(log, 'error', 'Unable to access ' +
                     `${sourceAwsBucketName} ${this.type} bucket`, err,
                     this._dataStoreName, this.clientType);
-                    return callback(errors.AccessDenied
+                    return callback(errorInstances.AccessDenied
                         .customizeDescription('Error: Unable to access ' +
                       `${sourceAwsBucketName} ${this.type} bucket`),
                     );
                 }
                 logHelper(log, 'error', 'error from data backend on ' +
                 'copyObject', err, this._dataStoreName, this.clientType);
-                return callback(errors.ServiceUnavailable
+                return callback(errorInstances.ServiceUnavailable
                     .customizeDescription('Error returned from ' +
                   `${this.type}: ${err.message}`),
                 );
@@ -627,14 +628,14 @@ class AwsClient {
                     logHelper(log, 'error', 'Unable to access ' +
                     `${sourceAwsBucketName} AWS bucket`, err,
                     this._dataStoreName, this.clientType);
-                    return callback(errors.AccessDenied
+                    return callback(errorInstances.AccessDenied
                         .customizeDescription('Error: Unable to access ' +
                       `${sourceAwsBucketName} AWS bucket`),
                     );
                 }
                 logHelper(log, 'error', 'error from data backend on ' +
                 'uploadPartCopy', err, this._dataStoreName, this.clientType);
-                return callback(errors.ServiceUnavailable
+                return callback(errorInstances.ServiceUnavailable
                     .customizeDescription('Error returned from ' +
                   `${this.type}: ${err.message}`),
                 );

--- a/lib/storage/data/external/AzureClient.js
+++ b/lib/storage/data/external/AzureClient.js
@@ -2,6 +2,7 @@ const url = require('url');
 
 const azure = require('azure-storage');
 const errors = require('../../../errors').default;
+const errorInstances = require('../../../errors').errorInstances;
 const azureMpuUtils = require('../../../s3middleware/azureHelpers/mpuUtils');
 const { validateAndFilterMpuParts } =
     require('../../../s3middleware/processMpuParts');
@@ -149,7 +150,7 @@ class AzureClient {
                                 if (err) {
                                     logHelper(log, 'error', 'err from Azure PUT data ' +
                                 'backend', err, this._dataStoreName);
-                                    return callback(errors.ServiceUnavailable
+                                    return callback(errorInstances.ServiceUnavailable
                                         .customizeDescription('Error returned from ' +
                                 `Azure: ${err.message}`));
                                 }
@@ -162,7 +163,7 @@ class AzureClient {
                             if (err) {
                                 logHelper(log, 'error', 'err from Azure PUT data ' +
                             'backend', err, this._dataStoreName);
-                                return callback(errors.ServiceUnavailable
+                                return callback(errorInstances.ServiceUnavailable
                                     .customizeDescription('Error returned from ' +
                             `Azure: ${err.message}`));
                             }
@@ -185,7 +186,7 @@ class AzureClient {
                             retError = errors.LocationNotFound;
                         } else {
                             logLevel = 'error';
-                            retError = errors.ServiceUnavailable
+                            retError = errorInstances.ServiceUnavailable
                                 .customizeDescription(
                                     `Error returned from Azure: ${err.message}`);
                         }
@@ -242,7 +243,7 @@ class AzureClient {
                         const log = createLogger(reqUids);
                         logHelper(log, 'error', 'error deleting object from ' +
                         'Azure datastore', err, this._dataStoreName);
-                        return callback(errors.ServiceUnavailable
+                        return callback(errorInstances.ServiceUnavailable
                             .customizeDescription('Error returned from ' +
                         `Azure: ${err.message}`));
                     }
@@ -349,7 +350,7 @@ class AzureClient {
                     if (err) {
                         logHelper(log, 'error', 'err completing MPU on Azure ' +
                         'datastore', err, this._dataStoreName);
-                        return callback(errors.ServiceUnavailable
+                        return callback(errorInstances.ServiceUnavailable
                             .customizeDescription('Error returned from ' +
                         `Azure: ${err.message}`));
                     }
@@ -420,14 +421,14 @@ class AzureClient {
                         logHelper(log, 'error', 'Unable to access ' +
                         `${sourceContainerName} Azure Container`, err,
                         this._dataStoreName);
-                        return callback(errors.AccessDenied
+                        return callback(errorInstances.AccessDenied
                             .customizeDescription('Error: Unable to access ' +
                         `${sourceContainerName} Azure Container`),
                         );
                     }
                     logHelper(log, 'error', 'error from data backend on ' +
                     'copyObject', err, this._dataStoreName);
-                    return callback(errors.ServiceUnavailable
+                    return callback(errorInstances.ServiceUnavailable
                         .customizeDescription('Error returned from ' +
                     `AWS: ${err.message}`),
                     );
@@ -441,12 +442,12 @@ class AzureClient {
                             if (err) {
                                 logHelper(log, 'error', 'error from data backend ' +
                             'on abortCopyBlob', err, this._dataStoreName);
-                                return callback(errors.ServiceUnavailable
+                                return callback(errorInstances.ServiceUnavailable
                                     .customizeDescription('Error returned from ' +
                             `AWS on abortCopyBlob: ${err.message}`),
                                 );
                             }
-                            return callback(errors.InvalidObjectState
+                            return callback(errorInstances.InvalidObjectState
                                 .customizeDescription('Error: Azure copy status was ' +
                         'pending. It has been aborted successfully'),
                             );

--- a/lib/storage/data/external/GCP/GcpApis/abortMPU.js
+++ b/lib/storage/data/external/GCP/GcpApis/abortMPU.js
@@ -1,4 +1,4 @@
-const errors = require('../../../../../errors').default;
+const errorInstances = require('../../../../../errors').errorInstances;
 const MpuHelper = require('./mpuHelper');
 const { createMpuKey, logger } = require('../GcpUtils');
 const { logHelper } = require('../../utils');
@@ -16,7 +16,7 @@ const { logHelper } = require('../../utils');
 function abortMPU(params, callback) {
     if (!params || !params.Key || !params.UploadId ||
         !params.Bucket || !params.MPU) {
-        const error = errors.InvalidRequest
+        const error = errorInstances.InvalidRequest
             .customizeDescription('Missing required parameter');
         logHelper(logger, 'error', 'error in abortMultipartUpload', error);
         return callback(error);

--- a/lib/storage/data/external/GCP/GcpApis/completeMPU.js
+++ b/lib/storage/data/external/GCP/GcpApis/completeMPU.js
@@ -1,5 +1,6 @@
 const async = require('async');
 const errors = require('../../../../../errors').default;
+const errorInstances = require('../../../../../errors').errorInstances;
 const MpuHelper = require('./mpuHelper');
 const { createMpuKey, logger } = require('../GcpUtils');
 const { logHelper } = require('../../utils');
@@ -20,7 +21,7 @@ function completeMPU(params, callback) {
     if (!params || !params.MultipartUpload ||
         !params.MultipartUpload.Parts || !params.UploadId ||
         !params.Bucket || !params.Key) {
-        const error = errors.InvalidRequest
+        const error = errorInstances.InvalidRequest
             .customizeDescription('Missing required parameter');
         logHelper(logger, 'error', 'error in completeMultipartUpload', error);
         return callback(error);
@@ -28,7 +29,7 @@ function completeMPU(params, callback) {
     const partList = params.MultipartUpload.Parts;
     // verify that the part list is in order
     if (params.MultipartUpload.Parts.length === 0) {
-        const error = errors.InvalidRequest
+        const error = errorInstances.InvalidRequest
             .customizeDescription('You must specify at least one part');
         logHelper(logger, 'error', 'error in completeMultipartUpload', error);
         return callback(error);

--- a/lib/storage/data/external/GCP/GcpApis/createMPU.js
+++ b/lib/storage/data/external/GCP/GcpApis/createMPU.js
@@ -1,5 +1,5 @@
 const uuid = require('uuid/v4');
-const errors = require('../../../../../errors').default;
+const errorInstances = require('../../../../../errors').errorInstances;
 const { createMpuKey, logger, getPutTagsMetadata } = require('../GcpUtils');
 const { logHelper } = require('../../utils');
 
@@ -23,7 +23,7 @@ function createMPU(params, callback) {
     // create an empty 'init' object that will temporarily store the
     // object metadata and return an upload ID to mimic an AWS MPU
     if (!params || !params.Bucket || !params.Key) {
-        const error = errors.InvalidRequest
+        const error = errorInstances.InvalidRequest
             .customizeDescription('Missing required parameter');
         logHelper(logger, 'error', 'error in createMultipartUpload', error);
         return callback(error);

--- a/lib/storage/data/external/GCP/GcpApis/listParts.js
+++ b/lib/storage/data/external/GCP/GcpApis/listParts.js
@@ -1,4 +1,4 @@
-const errors = require('../../../../../errors').default;
+const errorInstances = require('../../../../../errors').errorInstances;
 const { createMpuKey, logger } = require('../GcpUtils');
 const { logHelper } = require('../../utils');
 
@@ -13,13 +13,13 @@ const { logHelper } = require('../../utils');
  */
 function listParts(params, callback) {
     if (!params || !params.UploadId || !params.Bucket || !params.Key) {
-        const error = errors.InvalidRequest
+        const error = errorInstances.InvalidRequest
             .customizeDescription('Missing required parameter');
         logHelper(logger, 'error', 'error in listParts', error);
         return callback(error);
     }
     if (params.PartNumberMarker && params.PartNumberMarker < 0) {
-        return callback(errors.InvalidArgument
+        return callback(errorInstances.InvalidArgument
             .customizeDescription('The request specified an invalid marker'));
     }
     const mpuParams = {

--- a/lib/storage/data/external/GCP/GcpApis/uploadPart.js
+++ b/lib/storage/data/external/GCP/GcpApis/uploadPart.js
@@ -1,4 +1,4 @@
-const errors = require('../../../../../errors').default;
+const errorInstances = require('../../../../../errors').errorInstances;
 const { getPartNumber, createMpuKey, logger } = require('../GcpUtils');
 const { logHelper } = require('../../utils');
 
@@ -12,14 +12,14 @@ const { logHelper } = require('../../utils');
  */
 function uploadPart(params, callback) {
     if (!params || !params.UploadId || !params.Bucket || !params.Key) {
-        const error = errors.InvalidRequest
+        const error = errorInstances.InvalidRequest
             .customizeDescription('Missing required parameter');
         logHelper(logger, 'error', 'error in uploadPart', error);
         return callback(error);
     }
     const partNumber = getPartNumber(params.PartNumber);
     if (!partNumber) {
-        const error = errors.InvalidArgument
+        const error = errorInstances.InvalidArgument
             .customizeDescription('PartNumber is invalid');
         logHelper(logger, 'debug', 'error in uploadPart', error);
         return callback(error);

--- a/lib/storage/data/external/GCP/GcpApis/uploadPartCopy.js
+++ b/lib/storage/data/external/GCP/GcpApis/uploadPartCopy.js
@@ -1,4 +1,4 @@
-const errors = require('../../../../../errors').default;
+const errorInstances = require('../../../../../errors').errorInstances;
 const { getPartNumber, createMpuKey, logger } = require('../GcpUtils');
 const { logHelper } = require('../../utils');
 
@@ -14,14 +14,14 @@ const { logHelper } = require('../../utils');
 function uploadPartCopy(params, callback) {
     if (!params || !params.UploadId || !params.Bucket || !params.Key ||
         !params.CopySource) {
-        const error = errors.InvalidRequest
+        const error = errorInstances.InvalidRequest
             .customizeDescription('Missing required parameter');
         logHelper(logger, 'error', 'error in uploadPartCopy', error);
         return callback(error);
     }
     const partNumber = getPartNumber(params.PartNumber);
     if (!partNumber) {
-        const error = errors.InvalidArgument
+        const error = errorInstances.InvalidArgument
             .customizeDescription('PartNumber is not a number');
         logHelper(logger, 'debug', 'error in uploadPartCopy', error);
         return callback(error);

--- a/lib/storage/data/external/GCP/GcpManagedUpload.js
+++ b/lib/storage/data/external/GCP/GcpManagedUpload.js
@@ -1,7 +1,7 @@
 const async = require('async');
 const assert = require('assert');
 const stream = require('stream');
-const errors = require('../../../../errors').default;
+const errorInstances = require('../../../../errors').errorInstances;
 const { minimumAllowedPartSize, gcpMaximumAllowedPartCount } =
     require('../../../../constants');
 const { createMpuList, logger } = require('./GcpUtils');
@@ -64,19 +64,19 @@ class GcpManagedUpload {
      */
     validateBody() {
         this.body = this.params.Body;
-        assert(this.body, errors.MissingRequestBodyError.customizeDescription(
+        assert(this.body, errorInstances.MissingRequestBodyError.customizeDescription(
             'Missing request body'));
         this.totalBytes = this.params.ContentLength;
         if (this.body instanceof stream) {
             assert.strictEqual(typeof this.totalBytes, 'number',
-                errors.MissingContentLength.customizeDescription(
+                errorInstances.MissingContentLength.customizeDescription(
                     'If body is a stream, ContentLength must be provided'));
         } else {
             if (typeof this.body === 'string') {
                 this.body = Buffer.from(this.body);
             }
             this.totalBytes = this.body.byteLength;
-            assert(this.totalBytes, errors.InternalError.customizeDescription(
+            assert(this.totalBytes, errorInstances.InternalError.customizeDescription(
                 'Unable to perform upload'));
         }
     }

--- a/lib/storage/data/external/GCP/GcpService.js
+++ b/lib/storage/data/external/GCP/GcpService.js
@@ -1,7 +1,7 @@
 const AWS = require('aws-sdk');
 const Service = AWS.Service;
 
-const errors = require('../../../../errors').default;
+const errorInstances = require('../../../../errors').errorInstances;
 const GcpApis = require('./GcpApis');
 const GcpServiceSetup = require('./GcpServiceSetup');
 const GcpManagedUpload = require('./GcpManagedUpload');
@@ -35,94 +35,94 @@ Object.assign(GCP.prototype, GcpServiceSetup, {
     // TO-DO: Implement the following APIs
     // Service API
     listBuckets(params, callback) {
-        return callback(errors.NotImplemented
+        return callback(errorInstances.NotImplemented
             .customizeDescription('GCP: listBuckets not implemented'));
     },
 
     // Bucket APIs
     getBucketLocation(params, callback) {
-        return callback(errors.NotImplemented
+        return callback(errorInstances.NotImplemented
             .customizeDescription('GCP: getBucketLocation not implemented'));
     },
 
     deleteBucket(params, callback) {
-        return callback(errors.NotImplemented
+        return callback(errorInstances.NotImplemented
             .customizeDescription('GCP: deleteBucket not implemented'));
     },
 
     listObjectVersions(params, callback) {
-        return callback(errors.NotImplemented
+        return callback(errorInstances.NotImplemented
             .customizeDescription('GCP: listObjectVersions not implemented'));
     },
 
     createBucket(params, callback) {
-        return callback(errors.NotImplemented
+        return callback(errorInstances.NotImplemented
             .customizeDescription('GCP: createBucket not implemented'));
     },
 
     putBucket(params, callback) {
-        return callback(errors.NotImplemented
+        return callback(errorInstances.NotImplemented
             .customizeDescription('GCP: putBucket not implemented'));
     },
 
     getBucketAcl(params, callback) {
-        return callback(errors.NotImplemented
+        return callback(errorInstances.NotImplemented
             .customizeDescription('GCP: getBucketAcl not implemented'));
     },
 
     putBucketAcl(params, callback) {
-        return callback(errors.NotImplemented
+        return callback(errorInstances.NotImplemented
             .customizeDescription('GCP: putBucketAcl not implemented'));
     },
 
     putBucketWebsite(params, callback) {
-        return callback(errors.NotImplemented
+        return callback(errorInstances.NotImplemented
             .customizeDescription('GCP: putBucketWebsite not implemented'));
     },
 
     getBucketWebsite(params, callback) {
-        return callback(errors.NotImplemented
+        return callback(errorInstances.NotImplemented
             .customizeDescription('GCP: getBucketWebsite not implemented'));
     },
 
     deleteBucketWebsite(params, callback) {
-        return callback(errors.NotImplemented
+        return callback(errorInstances.NotImplemented
             .customizeDescription('GCP: deleteBucketWebsite not implemented'));
     },
 
     putBucketCors(params, callback) {
-        return callback(errors.NotImplemented
+        return callback(errorInstances.NotImplemented
             .customizeDescription('GCP: putBucketCors not implemented'));
     },
 
     getBucketCors(params, callback) {
-        return callback(errors.NotImplemented
+        return callback(errorInstances.NotImplemented
             .customizeDescription('GCP: getBucketCors not implemented'));
     },
 
     deleteBucketCors(params, callback) {
-        return callback(errors.NotImplemented
+        return callback(errorInstances.NotImplemented
             .customizeDescription('GCP: deleteBucketCors not implemented'));
     },
 
     // Object APIs
     putObjectTagging(params, callback) {
-        return callback(errors.NotImplemented
+        return callback(errorInstances.NotImplemented
             .customizeDescription('GCP: putObjectTagging not implemented'));
     },
 
     deleteObjectTagging(params, callback) {
-        return callback(errors.NotImplemented
+        return callback(errorInstances.NotImplemented
             .customizeDescription('GCP: deleteObjectTagging not implemented'));
     },
 
     putObjectAcl(params, callback) {
-        return callback(errors.NotImplemented
+        return callback(errorInstances.NotImplemented
             .customizeDescription('GCP: putObjectAcl not implemented'));
     },
 
     getObjectAcl(params, callback) {
-        return callback(errors.NotImplemented
+        return callback(errorInstances.NotImplemented
             .customizeDescription('GCP: getObjectAcl not implemented'));
     },
 });

--- a/lib/storage/data/external/GCP/GcpUtils.js
+++ b/lib/storage/data/external/GCP/GcpUtils.js
@@ -1,6 +1,6 @@
 const werelogs = require('werelogs');
 
-const errors = require('../../../../errors').default;
+const errorInstances = require('../../../../errors').errorInstances;
 const { parseTagFromQuery } = require('../../../../s3middleware/tagging');
 const { gcpTaggingPrefix } = require('../../../../constants');
 
@@ -85,7 +85,7 @@ function createMpuList(params, level, size) {
 
 function processTagSet(tagSet = []) {
     if (tagSet.length > 10) {
-        return errors.BadRequest
+        return errorInstances.BadRequest
             .customizeDescription('Object tags cannot be greater than 10');
     }
     let error = undefined;
@@ -94,19 +94,19 @@ function processTagSet(tagSet = []) {
     tagSet.every(tag => {
         const { Key: key, Value: value } = tag;
         if (key.length > 128) {
-            error = errors.InvalidTag
+            error = errorInstances.InvalidTag
                 .customizeDescription(
                     `The TagKey provided is too long, ${key.length}`);
             return false;
         }
         if (value.length > 256) {
-            error = errors.InvalidTag
+            error = errorInstances.InvalidTag
                 .customizeDescription(
                     `The TagValue provided is too long, ${value.length}`);
             return false;
         }
         if (taggingDict[key]) {
-            error = errors.InvalidTag
+            error = errorInstances.InvalidTag
                 .customizeDescription(
                     'Cannot provide multiple Tags with the same key');
             return false;

--- a/lib/storage/data/external/GcpClient.js
+++ b/lib/storage/data/external/GcpClient.js
@@ -1,6 +1,7 @@
 const async = require('async');
 
 const errors = require('../../../errors').default;
+const errorInstances = require('../../../errors').errorInstances;
 const MD5Sum = require('../../../s3middleware/MD5Sum').default;
 const { GCP, GcpUtils } = require('./GCP');
 const { createMpuKey } = GcpUtils;
@@ -8,7 +9,7 @@ const AwsClient = require('./AwsClient');
 const { prepareStream } = require('../../../s3middleware/prepareStream');
 const { logHelper, removeQuotes } = require('./utils');
 
-const missingVerIdInternalError = errors.InternalError.customizeDescription(
+const missingVerIdInternalError = errorInstances.InternalError.customizeDescription(
     'Invalid state. Please ensure versioning is enabled ' +
     'in GCP for the location constraint and try again.');
 
@@ -85,7 +86,7 @@ class GcpClient extends AwsClient {
             mpu: done => checkBucketHealth(this._mpuBucketName, done),
         }, (err, result) => {
             if (err) {
-                return callback(errors.InternalFailure
+                return callback(errorInstances.InternalFailure
                     .customizeDescription('Unable to perform health check'));
             }
 
@@ -121,7 +122,7 @@ class GcpClient extends AwsClient {
             if (err) {
                 logHelper(log, 'error', 'err from data backend',
                     err, this._dataStoreName, this.clientType);
-                return callback(errors.ServiceUnavailable
+                return callback(errorInstances.ServiceUnavailable
                     .customizeDescription('Error returned from ' +
                   `GCP: ${err.message}`),
                 );
@@ -166,7 +167,7 @@ class GcpClient extends AwsClient {
                 if (err) {
                     logHelper(log, 'error', 'err from data backend on ' +
                 'completeMPU', err, this._dataStoreName, this.clientType);
-                    return callback(errors.ServiceUnavailable
+                    return callback(errorInstances.ServiceUnavailable
                         .customizeDescription('Error returned from ' +
                   `GCP: ${err.message}`),
                     );
@@ -208,7 +209,7 @@ class GcpClient extends AwsClient {
             if (err) {
                 logHelper(log, 'error', 'err from data backend ' +
                   'on uploadPart', err, this._dataStoreName, this.clientType);
-                return callback(errors.ServiceUnavailable
+                return callback(errorInstances.ServiceUnavailable
                     .customizeDescription('Error returned from ' +
                   `GCP: ${err.message}`),
                 );
@@ -240,7 +241,7 @@ class GcpClient extends AwsClient {
         const copySourceRange = request.headers['x-amz-copy-source-range'];
 
         if (copySourceRange) {
-            return callback(errors.NotImplemented
+            return callback(errorInstances.NotImplemented
                 .customizeDescription('Error returned from ' +
                 `${this.clientType}: copySourceRange not implemented`),
             );
@@ -259,14 +260,14 @@ class GcpClient extends AwsClient {
                     logHelper(log, 'error', 'Unable to access ' +
                     `${sourceGcpBucketName} GCP bucket`, err,
                     this._dataStoreName, this.clientType);
-                    return callback(errors.AccessDenied
+                    return callback(errorInstances.AccessDenied
                         .customizeDescription('Error: Unable to access ' +
                       `${sourceGcpBucketName} GCP bucket`),
                     );
                 }
                 logHelper(log, 'error', 'error from data backend on ' +
                 'uploadPartCopy', err, this._dataStoreName);
-                return callback(errors.ServiceUnavailable
+                return callback(errorInstances.ServiceUnavailable
                     .customizeDescription('Error returned from ' +
                   `GCP: ${err.message}`),
                 );
@@ -289,7 +290,7 @@ class GcpClient extends AwsClient {
             if (err) {
                 logHelper(log, 'error', 'err from data backend ' +
                     'on abortMPU', err, this._dataStoreName, this.clientType);
-                return callback(errors.ServiceUnavailable
+                return callback(errorInstances.ServiceUnavailable
                     .customizeDescription('Error returned from ' +
                     `GCP: ${err.message}`),
                 );

--- a/lib/storage/data/file/DataFileStore.js
+++ b/lib/storage/data/file/DataFileStore.js
@@ -8,6 +8,7 @@ const diskusage = require('diskusage');
 const werelogs = require('werelogs');
 
 const errors = require('../../../errors').default;
+const errorInstances = require('../../../errors').errorInstances;
 const stringHash = require('../../../stringHash').default;
 const jsutil = require('../../../jsutil');
 const storageUtils = require('../../utils');
@@ -151,7 +152,7 @@ class DataFileStore {
             return;
         }
         if (this.isReadOnly) {
-            callback(errors.InternalError.customizeDescription(
+            callback(errorInstances.InternalError.customizeDescription(
                 'unable to write in ReadOnly mode'));
             return;
         }
@@ -167,7 +168,7 @@ class DataFileStore {
             if (err) {
                 log.error('error opening filePath',
                     { method: 'put', key, filePath, error: err });
-                return callback(errors.InternalError.customizeDescription(
+                return callback(errorInstances.InternalError.customizeDescription(
                     `filesystem error: open() returned ${err.code}`));
             }
             const cbOnce = jsutil.once(callback);
@@ -233,7 +234,7 @@ class DataFileStore {
                             { method: 'put', key, filePath,
                                 error: err });
                         return cbOnce(
-                            errors.InternalError.customizeDescription(
+                            errorInstances.InternalError.customizeDescription(
                                 'filesystem error: fsync() returned ' +
                                     `${err.code}`));
                     }
@@ -245,7 +246,7 @@ class DataFileStore {
                     { method: 'put', key, filePath, error: err });
                 // destroying the write stream forces a close(fd)
                 fileStream.destroy();
-                return cbOnce(errors.InternalError.customizeDescription(
+                return cbOnce(errorInstances.InternalError.customizeDescription(
                     `write stream error: ${err.code}`));
             });
             dataStream.resume();
@@ -257,7 +258,7 @@ class DataFileStore {
                 fileStream.destroy();
                 // we need to unlink the file ourselves
                 fs.unlinkSync(filePath);
-                return cbOnce(errors.InternalError.customizeDescription(
+                return cbOnce(errorInstances.InternalError.customizeDescription(
                     `read stream error: ${err.code}`));
             });
             return undefined;
@@ -287,7 +288,7 @@ class DataFileStore {
                 }
                 log.error('error on \'stat\' of file',
                     { key, filePath, error: err });
-                return callback(errors.InternalError.customizeDescription(
+                return callback(errorInstances.InternalError.customizeDescription(
                     `filesystem error: stat() returned ${err.code}`));
             }
             const info = { objectSize: stat.size };
@@ -333,7 +334,7 @@ class DataFileStore {
                     { method: 'DataFileStore.get', key, filePath,
                         error: err });
                 return cbOnce(
-                    errors.InternalError.customizeDescription(
+                    errorInstances.InternalError.customizeDescription(
                         `filesystem read error: ${err.code}`));
             })
             .on('open', () => { cbOnce(null, rs); })
@@ -362,7 +363,7 @@ class DataFileStore {
      */
     delete(key, log, callback) {
         if (this.isReadOnly) {
-            return callback(errors.InternalError.customizeDescription(
+            return callback(errorInstances.InternalError.customizeDescription(
                 'unable to delete in ReadOnly mode'));
         }
         const filePath = this.getFilePath(key);
@@ -378,7 +379,7 @@ class DataFileStore {
                 log.error('error deleting file', { method: 'delete',
                     key, filePath,
                     error: err });
-                return callback(errors.InternalError.customizeDescription(
+                return callback(errorInstances.InternalError.customizeDescription(
                     `filesystem error: unlink() returned ${err.code}`));
             }
             return callback();

--- a/lib/storage/metadata/mongoclient/MongoClientInterface.js
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.js
@@ -15,6 +15,7 @@ const constants = require('../../../constants');
 
 const { reshapeExceptionError } = require('../../../errorUtils');
 const errors = require('../../../errors').default;
+const errorInstances = require('../../../errors').errorInstances;
 const BucketInfo = require('../../../models/BucketInfo').default;
 const ObjectMD = require('../../../models/ObjectMD').default;
 const jsutil = require('../../../jsutil');
@@ -977,11 +978,11 @@ class MongoClientInterface {
         const c = this.getCollection(bucketName);
         let vFormat = null;
         if (!Array.isArray(objects)) {
-            return callback(errors.InternalError.customizeDescription('objects must be an array'));
+            return callback(errorInstances.InternalError.customizeDescription('objects must be an array'));
         }
         // We do not accept more than 1000 keys in a single request
         if (objects.length > 1000) {
-            return callback(errors.InternalError.customizeDescription('cannot get more than 1000 objects'));
+            return callback(errorInstances.InternalError.customizeDescription('cannot get more than 1000 objects'));
         }
         // Function to process each document
         const processDoc = (doc, objName, params, key, cb) => {
@@ -1725,7 +1726,7 @@ class MongoClientInterface {
             if (vFormat !== BUCKET_VERSIONS.v1) {
                 log.error('not supported bucket format version',
                     { method: 'listLifecycleObject', bucket: bucketName, vFormat });
-                return cb(errors.NotImplemented.customizeDescription('Not supported bucket format version'));
+                return cb(errorInstances.NotImplemented.customizeDescription('Not supported bucket format version'));
             }
 
             const extName = params.listingType;
@@ -1776,7 +1777,7 @@ class MongoClientInterface {
         log.error('disconnected from mongodb');
         resp[implName] = {
             error: errors.ServiceUnavailable,
-            code: errors.ServiceUnavailable.code,
+            code: errorInstances.ServiceUnavailable.code,
         };
         return cb(null, resp);
     }

--- a/lib/storage/metadata/proxy/utils.js
+++ b/lib/storage/metadata/proxy/utils.js
@@ -1,6 +1,7 @@
 const url = require('url');
 const querystring = require('querystring');
 const errors = require('../../../errors').default;
+const errorInstances = require('../../../errors').errorInstances;
 
 /**
  * Extracts components from URI.
@@ -143,8 +144,8 @@ function sendResponse(req, res, log, err, data) {
         statusCode = err.code;
         statusMessage = err.message;
     } else {
-        statusCode = errors.ok.code;
-        statusMessage = errors.ok.message;
+        statusCode = errorInstances.ok.code;
+        statusMessage = errorInstances.ok.message;
     }
 
     if (data) {

--- a/lib/stream/readJSONStreamObject.ts
+++ b/lib/stream/readJSONStreamObject.ts
@@ -1,4 +1,4 @@
-import errors from '../errors';
+import { errorInstances } from '../errors';
 import * as stream from 'stream';
 import joi from 'joi';
 
@@ -31,7 +31,7 @@ export default async function readJSONStreamObject<Data = any>(
                 return resolve(parsedContents);
             } catch (err: any) {
                 return reject(
-                    errors.InvalidArgument.customizeDescription(
+                    errorInstances.InvalidArgument.customizeDescription(
                         `invalid input: ${err.message}`
                     )
                 );

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.70.38",
+  "version": "7.70.39",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/auth/v4/headerAuthCheck.spec.js
+++ b/tests/unit/auth/v4/headerAuthCheck.spec.js
@@ -4,6 +4,7 @@ const assert = require('assert');
 const fakeTimers = require('@sinonjs/fake-timers');
 
 const errors = require('../../../../index').errors;
+const errorInstances = require('../../../../index').errorInstances;
 
 const createAlteredRequest = require('../../helpers').createAlteredRequest;
 const headerAuthCheck =
@@ -142,7 +143,7 @@ describe('v4 headerAuthCheck', () => {
         const alteredRequest = createAlteredRequest({
             'x-amz-date': undefined }, 'headers', request, headers);
         const res = headerAuthCheck(alteredRequest, log);
-        assert.deepStrictEqual(res.err, errors.AccessDenied.
+        assert.deepStrictEqual(res.err, errorInstances.AccessDenied.
             customizeDescription('Authentication requires a valid Date or ' +
           'x-amz-date header'));
         done();
@@ -170,7 +171,7 @@ describe('v4 headerAuthCheck', () => {
                 '0064d22eacd6ccb85c06befa15f' +
                 '4a789b0bae19307bc' }, 'headers', request, headers);
         const res = headerAuthCheck(alteredRequest, log);
-        assert.deepStrictEqual(res.err, errors.AccessDenied.
+        assert.deepStrictEqual(res.err, errorInstances.AccessDenied.
             customizeDescription('Authentication requires a valid Date or ' +
         'x-amz-date header'));
         done();

--- a/tests/unit/errors.spec.ts
+++ b/tests/unit/errors.spec.ts
@@ -1,5 +1,5 @@
 import * as rawErrors from '../../lib/errors/arsenalErrors';
-import { errors } from '../../index';
+import { errors, errorInstances } from '../../index';
 import { ArsenalError } from '../../lib/errors';
 
 describe('Errors: ', () => {
@@ -24,13 +24,13 @@ describe('Errors: ', () => {
 
     it('can be used as an http response', () => {
         // @ts-expect-errors
-        errors.NoSuchEntity.writeResponse({
+        errorInstances.NoSuchEntity.writeResponse({
             writeHead(statusCode: number) {
                 expect(statusCode).toEqual(404);
                 return this;
             },
             end(msg: any) {
-                const asStr = errors.NoSuchEntity.toString();
+                const asStr = errorInstances.NoSuchEntity.toString();
                 expect(msg).toEqual(asStr);
                 return this;
             },

--- a/tests/unit/errors.spec.ts
+++ b/tests/unit/errors.spec.ts
@@ -37,6 +37,23 @@ describe('Errors: ', () => {
         });
     });
 
+    it('should use the original stack trace with customizeDescription', () => {
+        const err = errors.AccessDenied;
+        function thisShouldNotAppearInStackTrace() {
+            return err.customizeDescription('custom');
+        }
+        const errCustom = thisShouldNotAppearInStackTrace();
+        expect(errCustom.stack).toBe(err.stack);
+    });
+
+    it('should not use the original stack trace of pre instanciated errors', () => {
+        function makeErr() {
+            return errorInstances.AccessDenied.customizeDescription('custom');
+        }
+        const errCustom = makeErr();
+        expect(errCustom.stack).toMatch(/makeErr/);
+    });
+
     it('errors.AccessDenied.is should be the same instance for perf', () => {
         const first = errors.AccessDenied;
         const second = errors.AccessDenied;

--- a/tests/unit/errors.spec.ts
+++ b/tests/unit/errors.spec.ts
@@ -36,6 +36,33 @@ describe('Errors: ', () => {
             },
         });
     });
+
+    it('errors.AccessDenied.is should be the same instance for perf', () => {
+        const first = errors.AccessDenied;
+        const second = errors.AccessDenied;
+        expect(first).not.toBe(second);
+        expect(first.is).toBe(second.is);
+    })
+
+    it ('errors.ok should return the same instance for perf', () => {
+        const first = errors.ok;
+        const second = errors.ok;
+        expect(first).toBe(second);
+        // don't modify instance, the use case is for errors.ok.[code | message]
+        Error.captureStackTrace(first);
+        // don't use stacktrace of ok error
+        expect(first.stack).toEqual(second.stack);
+    });
+
+    it ('errorInstances should return the same instance for perf', () => {
+        const first = errorInstances.AccessDenied;
+        const second = errorInstances.AccessDenied;
+        expect(first).toBe(second);
+        // don't modify, the use case is for errorInstance.x.[customizeDescription | code | message]
+        Error.captureStackTrace(first);
+        // don't use errorInstances if you need stacktrace
+        expect(first.stack).toEqual(second.stack);
+    });
 });
 
 describe('Backward compatibility flag', () => {

--- a/tests/unit/s3routes/routesUtils/redirectRequestOnError.spec.js
+++ b/tests/unit/s3routes/routesUtils/redirectRequestOnError.spec.js
@@ -4,7 +4,7 @@ const sinon = require('sinon');
 const DummyRequestLogger = require('../../storage/metadata/mongoclient/utils/DummyRequestLogger');
 const HttpResponseMock = require('../../../utils/HttpResponseMock');
 const routesUtils = require('../../../../lib/s3routes/routesUtils');
-const { errors } = require('../../../../index');
+const { errors, errorInstances } = require('../../../../index');
 const DataWrapper = require('../../../../lib/storage/data/DataWrapper');
 
 const corsHeaders = {
@@ -22,8 +22,8 @@ describe('routesUtils.redirectRequestOnError', () => {
     describe('from request on folder containing ' +
     'index without trailing /', () => {
         const errorHeaders = {
-            'x-amz-error-code': errors.Found.type,
-            'x-amz-error-message': errors.Found.description,
+            'x-amz-error-code': errorInstances.Found.type,
+            'x-amz-error-message': errorInstances.Found.description,
         };
 
         it('should redirect 302 with body on GET', () => {
@@ -75,8 +75,8 @@ describe('routesUtils.redirectRequestOnError', () => {
             const routing = { withError: true,
                 location: 'http://scality.com/test' };
             const errorHeaders = {
-                'x-amz-error-code': errors.AccessDenied.type,
-                'x-amz-error-message': errors.AccessDenied.description,
+                'x-amz-error-code': errorInstances.AccessDenied.type,
+                'x-amz-error-message': errorInstances.AccessDenied.description,
             };
             dataWrapperGetStub = sinon.stub(DataWrapper.prototype, 'get');
 


### PR DESCRIPTION
## Best to review by commit

See Jira ticket (https://scality.atlassian.net/browse/ARSN-476) for profilings in cloudserver, vault, bucketd, metadata.

- Instanciate the `Is` object only once at startup
- Instanciate all errors to use for cases like `errors.AccessDenied.code` or `errors.AccessDenied.customizeDescription` and avoid an useless intermediate instance when instance fields like stack trace are not needed.
