### PR TITLE
ARSN-477: Perf of ipCheck parseIp

### DIFF
--- a/lib/ipCheck.ts
+++ b/lib/ipCheck.ts
@@ -34,14 +34,21 @@ export function checkIPinRangeOrMatch(
  * @return parsedIp - Object representation of parsed IP
  */
 export function parseIp(ip: string): ipaddr.IPv4 | ipaddr.IPv6 | {} {
-    if (ipaddr.IPv4.isValid(ip)) {
-        return ipaddr.parse(ip);
+    try {
+        return ipaddr.IPv4.parse(ip);
+    } catch {
+        try {
+            const addr = ipaddr.IPv6.parse(ip);
+            // Copy ipaddr.process to bypass a duplicate Ipv6 parsing for isValid
+            if (addr.kind() === 'ipv6' && addr.isIPv4MappedAddress()) {
+                return addr.toIPv4Address();
+            } else {
+                return addr;
+            }
+        } catch {
+            return {};
+        }
     }
-    if (ipaddr.IPv6.isValid(ip)) {
-        // also parses IPv6 mapped IPv4 addresses into IPv4 representation
-        return ipaddr.process(ip);
-    }
-    return {};
 }
 
 /**


### PR DESCRIPTION
isValid is a parse encapsulated in try catch
ipaddr.parse use isValid before using Ipv4|6 parse

So there was actually 3 parsing of the ip:
  - IPv4.isValid -> IPv4.parser
  - ipaddr.parse -> IPv6.isValid (perf opti) & IPv4.isValid -> IPv4.parser
  - IPv4.parse -> IPv4.parser

This will ensure IPv4 is parsed first and no duplicate parsing


![Untitled Diagram drawio](https://github.com/user-attachments/assets/81e697dc-7c2f-4b9f-8cd0-03d923913184)
See Jira ticket https://scality.atlassian.net/browse/ARSN-477 for full profiling