### PR TITLE
support getCanonicalIdsByAccountIds in vault helper class

### DIFF
--- a/lib/auth/AuthInfo.ts
+++ b/lib/auth/AuthInfo.ts
@@ -32,6 +32,18 @@ export type AuthV4Results = {
     accountQuota: AccountQuota,
 };
 
+export type AccountCanonicalInfo = {
+    accountId: string;
+    canonicalId: string;
+    name: string;
+}
+
+export type AccountCanonicalInfoResults = {
+    message: {
+        body: AccountCanonicalInfo[],
+    },
+};
+
 /**
  * Class containing requester's information received from Vault
  * @param {object} info from Vault including arn, canonicalID,

--- a/lib/auth/Vault.ts
+++ b/lib/auth/Vault.ts
@@ -1,6 +1,8 @@
 import { RequestLogger } from 'werelogs';
 import errors from '../errors';
-import AuthInfo, { AccountInfos, AuthInfoType, AuthorizationResults, AuthV4Results } from './AuthInfo';
+import AuthInfo, { AccountInfos, AuthInfoType, AuthorizationResults,
+    AuthV4Results, AccountCanonicalInfo } from './AuthInfo';
+import { ArsenalCallback } from '../types';
 import RequestContext from '../policyEvaluator/RequestContext';
 
 /** vaultSignatureCb parses message from Vault and instantiates
@@ -354,6 +356,36 @@ export default class Vault {
                 });
                 return callback(null, result);
             });
+    }
+
+    /**
+     * A getter for account canonical IDs given a list of account IDs
+     * @param accountIds - list of account IDs
+     * @param log - log object
+     * @param callback - callback function
+     * @returns callback with either error or an object from Vault
+     * containing canonicalID and display name for each account ID
+     */
+    getCanonicalIdsByAccountIds(
+        accountIds: string[],
+        log: RequestLogger,
+        callback: ArsenalCallback<AccountCanonicalInfo[]>,
+    ) {
+        log.trace('getting canonicalIDs from Vault based on accountIDs');
+        const options = {
+            reqUid: log.getSerializedUids(),
+            logger: log,
+        };
+        this.client.getCanonicalIdsByAccountIds(accountIds, options, (err, res) => {
+            if (err) {
+                log.debug('received error message from vault', {
+                    error: err,
+                    accountIds,
+                });
+                return callback(err);
+            }
+            return callback(null, res.message.body);
+        });
     }
 
     /** checkPolicies -- call Vault to evaluate policies

--- a/lib/auth/backends/ChainBackend.ts
+++ b/lib/auth/backends/ChainBackend.ts
@@ -1,7 +1,10 @@
 import assert from 'assert';
 import async from 'async';
+import { RequestLogger } from 'werelogs';
 import errors from '../../errors';
 import BaseBackend from './base';
+import { AccountCanonicalInfoResults } from '../AuthInfo';
+import { ArsenalCallback } from '../../types';
 
 /**
  * Class that provides an authentication backend that will verify signatures
@@ -91,6 +94,14 @@ export default class ChainBackend extends BaseBackend {
             {});
     }
 
+    static _mergeObjArraysByKey(arrayResponses: any, key: string) {
+        const resultByKey = new Map();
+        arrayResponses.forEach(res => {
+            res.message.body.forEach(item => resultByKey.set(item[key], item));
+        });
+        return Array.from(resultByKey.values());
+    }
+
     getCanonicalIds(emailAddresses: string[], options: any, callback: any) {
         this._forEachClient(
             (client, done) => client.getCanonicalIds(emailAddresses, options, done),
@@ -117,6 +128,33 @@ export default class ChainBackend extends BaseBackend {
                 return callback(null, {
                     message: {
                         body: ChainBackend._mergeObjects(res),
+                    },
+                });
+            });
+    }
+
+    /**
+     * A getter for account canonical IDs given a list of account IDs
+     * @param accountIds - list of account IDs
+     * @param options - additional arguments
+     * @param callback - callback function
+     * @returns callback with either error or an object from Vault
+     * containing canonicalID and display name for each account ID
+     */
+    getCanonicalIdsByAccountIds(
+        accountIds: string[],
+        options: { reqUid: string, logger: RequestLogger },
+        callback: ArsenalCallback<AccountCanonicalInfoResults>,
+    ) {
+        this._forEachClient(
+            (client, done) => client.getCanonicalIdsByAccountIds(accountIds, options, done),
+            (err, res) => {
+                if (err) {
+                    return callback(err);
+                }
+                return callback(null, {
+                    message: {
+                        body: ChainBackend._mergeObjArraysByKey(res, 'accountId'),
                     },
                 });
             });

--- a/lib/auth/backends/base.ts
+++ b/lib/auth/backends/base.ts
@@ -1,4 +1,7 @@
 import errors from '../../errors';
+import { RequestLogger } from 'werelogs';
+import { AccountCanonicalInfoResults } from '../AuthInfo';
+import { ArsenalCallback } from '../../types';
 
 /**
  * Base backend class
@@ -83,6 +86,22 @@ export default class BaseBackend {
      * as each object key and an email address as the value (or "NotFound")
      */
     getEmailAddresses(canonicalIDs: string[], options: any, callback: any) {
+        return callback(errors.AuthMethodNotImplemented);
+    }
+
+    /**
+     * A getter for account canonical IDs given a list of account IDs
+     * @param accountIds - list of account IDs
+     * @param options - additional arguments
+     * @param callback - callback function
+     * @returns callback with either error or an object from Vault
+     * containing canonicalID and display name for each account ID
+     */
+    getCanonicalIdsByAccountIds(
+        accountIds: string[],
+        options: { reqUid: string, logger: RequestLogger },
+        callback: ArsenalCallback<AccountCanonicalInfoResults>,
+    ) {
         return callback(errors.AuthMethodNotImplemented);
     }
 

--- a/lib/auth/backends/in_memory/Backend.ts
+++ b/lib/auth/backends/in_memory/Backend.ts
@@ -5,7 +5,9 @@ import { calculateSigningKey, hashSignature } from './vaultUtilities';
 import Indexer from './Indexer';
 import BaseBackend from '../base';
 import { Accounts } from './types';
-import { AuthInfoType, AuthV4Results } from '../../AuthInfo';
+import { AuthInfoType, AuthV4Results,
+    AccountCanonicalInfo, AccountCanonicalInfoResults } from '../../AuthInfo';
+import { ArsenalCallback } from '../../../types';
 
 function _formatResponse(userInfo: AuthInfoType): { message: { body: AuthV4Results } } {
     return {
@@ -167,6 +169,38 @@ class InMemoryBackend extends BaseBackend {
             },
         };
         return cb(null, vaultReturnObject);
+    }
+
+    /**
+     * A getter for account canonical IDs given a list of account IDs
+     * @param accountIds - list of account IDs
+     * @param options - additional arguments
+     * @param callback - callback function
+     * @returns callback with either error or an object from Vault
+     * containing canonicalID and display name for each account ID
+     */
+    getCanonicalIdsByAccountIds(
+        accountIds: string[],
+        options: {},
+        callback: ArsenalCallback<AccountCanonicalInfoResults>,
+    ) {
+        const results: AccountCanonicalInfo[] = [];
+        accountIds.forEach(accountId => {
+            const foundEntity = this.indexer.getEntityByShortId(accountId);
+            if (foundEntity) {
+                results.push({
+                    accountId,
+                    canonicalId: foundEntity.canonicalID,
+                    name : foundEntity.accountDisplayName,
+                });
+            }
+        });
+        const vaultReturnObject = {
+            message: {
+                body: results,
+            },
+        };
+        return callback(null, vaultReturnObject);
     }
 
     report(log: Logger, callback: any) {

--- a/lib/auth/backends/in_memory/Indexer.ts
+++ b/lib/auth/backends/in_memory/Indexer.ts
@@ -9,6 +9,7 @@ import { Accounts, Account, Entity } from './types';
 export default class Indexer {
     accountsBy: {
         canId: { [id: string]: Entity | undefined },
+        shortId: { [id: string]: Entity | undefined },
         accessKey: { [id: string]: Entity | undefined },
         email: { [id: string]: Entity | undefined },
     };
@@ -16,6 +17,7 @@ export default class Indexer {
     constructor(authdata?: Accounts) {
         this.accountsBy = {
             canId: {},
+            shortId: {},
             accessKey: {},
             email: {},
         };
@@ -43,6 +45,7 @@ export default class Indexer {
         };
         this.accountsBy.canId[accountData.canonicalID] = accountData;
         this.accountsBy.email[accountData.email] = accountData;
+        this.accountsBy.shortId[accountData.shortid] = accountData;
         if (account.keys !== undefined) {
             account.keys.forEach(key => {
                 accountData.keys.push(key);
@@ -60,6 +63,11 @@ export default class Indexer {
     /** This method returns the account associated to a canonical ID. */
     getEntityByCanId(canId: string): Entity | undefined {
         return this.accountsBy.canId[canId];
+    }
+
+    /** This method returns the account associated to a short ID. */
+    getEntityByShortId(shortId: string): Entity | undefined {
+        return this.accountsBy.shortId[shortId];
     }
 
     /**

--- a/lib/storage/metadata/mongoclient/MongoClientInterface.ts
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.ts
@@ -19,6 +19,7 @@ import errors, { ArsenalError, errorInstances } from '../../../errors';
 import BucketInfo, { BucketMetadata, Capabilities } from '../../../models/BucketInfo';
 import ObjectMD, { ObjectMDData } from '../../../models/ObjectMD';
 import * as jsutil from '../../../jsutil';
+import { ArsenalCallback } from '../../../types';
 
 import { MongoClient, Long, Db, MongoClientOptions,
     ReadPreferenceMode, WithId, Collection, AnyBulkWriteOperation,
@@ -230,12 +231,6 @@ export type ObjectMDStats = {
     buckets?: number;
     bucketWithQuotaCount?: number;
     stalled: number;
-};
-
-interface ArsenalCallback<T> {
-    (err: null, result: T): void;
-    (err: void): void;
-    (err: ArsenalError): void;
 };
 
 /**

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,7 @@
+import { ArsenalError } from './errors';
+
+export interface ArsenalCallback<T> {
+    (err: null, result: T): void;
+    (err: void): void;
+    (err: ArsenalError): void;
+};

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=20"
   },
-  "version": "8.2.7",
+  "version": "8.2.8",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/auth/Vault.spec.js
+++ b/tests/unit/auth/Vault.spec.js
@@ -76,6 +76,7 @@ describe('Vault class', () => {
             getCanonicalIds: sandbox.stub(),
             getEmailAddresses: sandbox.stub(),
             getAccountIds: sandbox.stub(),
+            getCanonicalIdsByAccountIds: sandbox.stub(),
             checkPolicies: sandbox.stub(),
             getOrCreateEncryptionKeyId: sandbox.stub(),
         };
@@ -437,6 +438,33 @@ describe('Vault class', () => {
             vault.getAccountIds(mockIds, log, (err, data) => {
                 assert.strictEqual(err, null);
                 assert.deepStrictEqual(data, {});
+                done();
+            });
+        });
+    });
+
+    describe('getCanonicalIdsByAccountIds', () => {
+        it('should return canonical IDs for valid account IDs', done => {
+            const mockIds = ['account123'];
+            const mockResponse = {
+                message: { body: [{ account123: 'canonical123' }] },
+            };
+            mockClient.getCanonicalIdsByAccountIds.callsFake((_, __, cb) => cb(null, mockResponse));
+
+            vault.getCanonicalIdsByAccountIds(mockIds, log, (err, data) => {
+                assert.strictEqual(err, null);
+                assert.deepStrictEqual(data, [{ account123: 'canonical123' }]);
+                done();
+            });
+        });
+
+        it('should return error when client fails', done => {
+            const mockIds = ['account123'];
+            const mockError = new Error('Client error');
+            mockClient.getCanonicalIdsByAccountIds.callsFake((_, __, cb) => cb(mockError));
+
+            vault.getCanonicalIdsByAccountIds(mockIds, log, (err) => {
+                assert.strictEqual(err, mockError);
                 done();
             });
         });

--- a/tests/unit/auth/chainBackend.spec.js
+++ b/tests/unit/auth/chainBackend.spec.js
@@ -11,6 +11,7 @@ const backendWithAllMethods = {
     verifySignatureV4: () => {},
     getCanonicalIds: () => {},
     getEmailAddresses: () => {},
+    getCanonicalIdsByAccountIds: () => {},
     checkPolicies: () => {},
     healthcheck: () => {},
 };
@@ -41,6 +42,10 @@ class TestBackend extends BaseBackend {
     }
 
     getEmailAddresses(canonicalIDs, options, callback) {
+        return callback(this._error, this._result);
+    }
+
+    getCanonicalIdsByAccountIds(accountIds, options, callback) {
         return callback(this._error, this._result);
     }
 
@@ -188,6 +193,41 @@ describe('Auth Backend: Chain Backend', () => {
             });
         }));
 
+    describe('::getCanonicalIdsByAccountIds', () => {
+        it('should return an error if any of the clients fails', done => {
+            const backend = new ChainBackend('chain', [
+                new TestBackend('test1', null, { message: { body: { test1: 'aaa' } } }),
+                new TestBackend('test2', testError, null),
+                new TestBackend('test3', null, { message: { body: { test2: 'bbb' } } }),
+            ]);
+
+            backend.getCanonicalIdsByAccountIds(['1234345'], null, err => {
+                assert.deepStrictEqual(err, testError);
+                done();
+            });
+        });
+
+        it('should merge results from clients into a single response object', done => {
+            const backend = new ChainBackend('chain', [
+                new TestBackend('test1', null, { message: { body: [{ accountId: 'aaa' }] } }),
+                new TestBackend('test2', null, { message: { body: [{ accountId: 'bbb' }] } }),
+            ]);
+
+            backend.getCanonicalIdsByAccountIds(['1234345'], null, (err, res) => {
+                assert.ifError(err);
+                assert.deepStrictEqual(res, {
+                    message: {
+                        body: [
+                            { accountId: 'aaa' },
+                            { accountId: 'bbb' },
+                        ],
+                    }, 
+                });
+                done();
+            });
+        });
+    });
+
     describe('::checkPolicies', () => {
         it('should return an error if any of the clients fails', done => {
             const backend = new ChainBackend('chain', [
@@ -257,6 +297,66 @@ describe('Auth Backend: Chain Backend', () => {
                     // id4 should be overwritten
                     id4: 'email5@test.com',
                 },
+            );
+        });
+    });
+
+    describe('::_mergeObjArraysByKey', () => {
+        it('should correctly merge reponses', () => {
+            const arrayResps = [
+                {
+                    message: {
+                        body: [],
+                    },
+                },
+                {
+                    message: {
+                        body: [{
+                            accountId: "820584278927",
+                            canonicalId: "0b7738d4630bba4df490a30f35c94dc1ba01c47a9cb6342c8a50df6a78e11fe9",
+                            name: "account3",
+                        }],
+                        code: 200,
+                        message: "Attributes retrieved",
+                    }
+                },
+                {
+                    message: {
+                        body: [
+                            {
+                                accountId: "988542727028",
+                                canonicalId: "8c9800244adbc7ea8cab0491061befa15f45c3b63db677f3a3cf7094493dd10a",
+                                name: "account1",
+                            }, {
+                                accountId: "809872782425",
+                                canonicalId: "bcf336c310145dab60b3b67c7d4c14a074a07ae2d99eb4c8a4385a809f1ffd90",
+                                name: "account2",
+                            }
+                        ],
+                        code: 200,
+                        message: "Attributes retrieved",
+                    }
+                },
+            ];
+            assert.deepStrictEqual(
+                ChainBackend._mergeObjArraysByKey(arrayResps, 'accountId'),
+                [
+                    {
+                      accountId: '820584278927',
+                      canonicalId: '0b7738d4630bba4df490a30f35c94dc1ba01c47a9cb6342c8a50df6a78e11fe9',
+                      name: 'account3'
+                    },
+                    {
+                      accountId: '988542727028',
+                      canonicalId: '8c9800244adbc7ea8cab0491061befa15f45c3b63db677f3a3cf7094493dd10a',
+                      name: 'account1'
+                    },
+                    {
+                      accountId: '809872782425',
+                      canonicalId: 'bcf336c310145dab60b3b67c7d4c14a074a07ae2d99eb4c8a4385a809f1ffd90',
+                      name: 'account2'
+                    }
+                ],
             );
         });
     });

--- a/tests/unit/auth/in_memory/backend.spec.js
+++ b/tests/unit/auth/in_memory/backend.spec.js
@@ -12,6 +12,8 @@ const obj2 = JSON.parse(JSON.stringify(ref2));
 const searchEmail = 'sampleaccount1@sampling.com';
 const expectCanId =
     '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be';
+const searchAccountId = '123456789012';
+const expectedName = 'Bart';
 
 const searchEmail2 = 'sampleaccount4@sampling.com';
 const expectCanId2 = 'newCanId';
@@ -65,6 +67,25 @@ describe('S3 in_memory auth backend', () => {
         backend.refreshAuthData(obj2);
         backend.getCanonicalIds([searchEmail2], log, (err, res) => {
             assert.strictEqual(res.message.body[searchEmail2], expectCanId2);
+            done();
+        });
+    });
+
+    it('should return cannonicalId by accountId', done => {
+        const backend = new Backend(JSON.parse(JSON.stringify(ref)));
+        backend.getCanonicalIdsByAccountIds([searchAccountId], log, (err, res) => {
+            assert.strictEqual(res.message.body.length, 1);
+            assert.strictEqual(res.message.body[0].accountId, searchAccountId);
+            assert.strictEqual(res.message.body[0].canonicalId, expectCanId);
+            assert.strictEqual(res.message.body[0].name, expectedName);
+            done();
+        });
+    });
+
+    it('should return empty array if accountId not found', done => {
+        const backend = new Backend(JSON.parse(JSON.stringify(ref)));
+        backend.getCanonicalIdsByAccountIds([invalidAccountId], log, (err, res) => {
+            assert.strictEqual(res.message.body.length, 0);
             done();
         });
     });

--- a/tests/unit/auth/in_memory/indexer.spec.js
+++ b/tests/unit/auth/in_memory/indexer.spec.js
@@ -35,6 +35,13 @@ describe('S3 AuthData Indexer', () => {
         done();
     });
 
+    it('Should return account from shortID', done => {
+        const res = index.getEntityByShortId(obj.accounts[0].shortid);
+        assert.strictEqual(typeof res, 'object');
+        assert.strictEqual(res.arn, obj.accounts[0].arn);
+        done();
+    });
+
     it('should index account without keys', done => {
         should._exec = () => {
             index = new Indexer(obj);


### PR DESCRIPTION
Support `getCanonicalIdsByAccountIds` in Vault helper class. This API is needed for Cloudserver to replace Account info in the metadata of CRR replicated objects.

In S3C this used to be called directly by Backbeat of the replication source, but in Zenko the Vault admin API is not exposed so we delegate the task to the replication destination's Cloudserver.

Linked PR: https://github.com/scality/cloudserver/pull/5762

Issue: ARSN-478