### PR TITLE
ARSN-485: Prefix KMS Keys with an arn (HF cldsrv 9.2.0.12)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     services:
       # Label used to access the service container
       redis:
@@ -25,8 +25,8 @@ jobs:
           - 6379:6379
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+      uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
         node-version: '16'
         cache: 'yarn'
@@ -50,12 +50,12 @@ jobs:
   compile:
     name: Compile and upload build artifacts
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install NodeJS
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: '16'
         cache: yarn

--- a/lib/auth/in_memory/Backend.ts
+++ b/lib/auth/in_memory/Backend.ts
@@ -3,6 +3,7 @@ import errors from '../../errors';
 import { calculateSigningKey, hashSignature } from './vaultUtilities';
 import Indexer from './Indexer';
 import { Accounts } from './types';
+import { KmsType, KmsProtocol, makeScalityArnPrefix } from '../../network/KMSInterface';
 
 function _formatResponse(userInfoToSend: any) {
     return {
@@ -201,11 +202,13 @@ class Backend {
             _options: any, 
             cb: (err: null, data: { message: { body: { canonicalId: string, encryptionKeyId: string, action: string } } }) => void
         ): void {
+            const kmsProtocol = process.env.S3KMS === 'file' ? KmsProtocol.file : KmsProtocol.mem;
+            const arnPrefix = makeScalityArnPrefix(KmsType.int, kmsProtocol, 'scality');
             return cb(null, {
                 message: {
                     body: {
                         canonicalId,
-                        encryptionKeyId: 'account-level-master-encryption-key',
+                        encryptionKeyId: `${arnPrefix}account-level-master-encryption-key`,
                         action: 'retrieved',
                     }
                 }

--- a/lib/network/KMSInterface.ts
+++ b/lib/network/KMSInterface.ts
@@ -1,0 +1,167 @@
+import errors from "../errors";
+
+export const SCAL_KMS_ARN = 'arn:scality:kms:';
+
+export enum KmsType {
+    /** Internal scality provider */
+    int = 'int',
+    /** External provider */
+    ext = 'ext',
+};
+
+export enum KmsProtocol {
+    /** For tests & dev */
+    mem = 'mem',
+    /** Default if no provider */
+    file = 'file',
+    /** (SafeNet from Gemalto/Thales using scality-kms) */
+    scality = 'scality',
+    aws_kms = 'aws_kms',
+    kmip = 'kmip',
+};
+
+const kmsTypeProtocolMapping = {
+    [KmsType.int]: [KmsProtocol.mem, KmsProtocol.file] as const,
+    [KmsType.ext]: [KmsProtocol.scality, KmsProtocol.aws_kms, KmsProtocol.kmip] as const,
+} as const;
+export type KmsProtocolByType<T extends KmsType> = typeof kmsTypeProtocolMapping[T][number];
+
+/**
+ * Possible arn are:
+ *
+ * - `arn:scality:kms:int:mem:scality:key/$keyId` (tests & dev)
+ * - `arn:scality:kms:int:file:scality:key/$keyId` (default if no provider)
+ * - `arn:scality:kms:ext:scality:safenet:key/$keyId` (deprecated provider)
+ * - `arn:scality:kms:ext:aws_kms:aws:key/$keyIdOrArn`
+ * - `arn:scality:kms:ext:aws_kms:custom:alias/$keyIdOrArn`
+ * - `arn:scality:kms:ext:kmip:thales:key/$keyId`
+ * - `arn:scality:kms:ext:kmip:hashicorp:key/$keyId`
+ * - `arn:scality:kms:ext:kmip:hytrust:key/$keyId`
+ */
+export type AwsLikeKmsArnPrefix<T extends KmsType = KmsType> =
+    `${typeof SCAL_KMS_ARN}${T}:${KmsProtocolByType<T>}:${string}:${'key' | 'alias'}/`;
+/** Scality arn prefixing KMS KeyId to keep track of KMS backend */
+export type AwsLikeKmsArn<T extends KmsType = KmsType> = `${AwsLikeKmsArnPrefix<T>}${string}`;
+
+export interface KmsBackend<T extends KmsType> {
+    readonly type: T;
+    readonly protocol: KmsProtocolByType<T>;
+    readonly provider: string;
+    readonly arnPrefix: AwsLikeKmsArnPrefix<T>;
+}
+
+export function makeScalityArnPrefix<T extends KmsType>(
+    type: T, protocol: KmsProtocolByType<T>, provider: string
+): AwsLikeKmsArnPrefix<T> {
+    return `${SCAL_KMS_ARN}${type}:${protocol}:${provider}:key/`;
+}
+
+export function makeBackend<T extends KmsType>(
+    type: T, protocol: KmsProtocolByType<T>, provider: string
+): KmsBackend<T> {
+    return {
+        type,
+        protocol,
+        provider,
+        arnPrefix: makeScalityArnPrefix(type, protocol, provider),
+    }
+}
+
+export function isScalityKmsArn(kmsKey: string) {
+    return kmsKey.startsWith(SCAL_KMS_ARN);
+}
+
+/**
+ * Drop scality arn prefix from a KMS Key so it can be sent to the backend KMS.
+ * This is used in KMS clients as a safety but the key should be passed
+ * without arnPrefix as it should be extract by a KMS wrapper using `extractDetailFromArn`.
+ * For old key without arnPrefix this does nothing.
+ * Can be used to return KeyId in HTTP headers as well.
+ * @param kmsKeyIdOrArn KMS key coming from object metadata
+ * @returns KeyId extracted from scality arn (for AWS can still be an aws arn)
+ */
+export function getKeyIdFromArn(kmsKeyIdOrArn: AwsLikeKmsArn | string) {
+    if (isScalityKmsArn(kmsKeyIdOrArn)) {
+        // Do not use full arnPrefix to allow for different providerName
+        return kmsKeyIdOrArn.substring(kmsKeyIdOrArn.indexOf('/') + 1)
+    }
+    return kmsKeyIdOrArn;
+}
+
+// Functions used to validate configuration
+const kmsTypes = Object.values(KmsType);
+export function isValidType(type: KmsType | string): type is KmsType {
+    return kmsTypes.includes(type as KmsType);
+}
+export function isValidProtocol<T extends KmsType = KmsType>(
+    type: T, protocol: KmsProtocol | string
+): protocol is KmsProtocolByType<T> {
+    return (kmsTypeProtocolMapping[type] as unknown as KmsProtocol[] | undefined)
+        ?.includes(protocol as KmsProtocol) || false;
+}
+/** must be lowercase alphanumeric */
+export function isValidProvider(provider: string) {
+    return /^[a-z0-9]+$/.test(provider);
+}
+// end of functions to validate configuration
+
+export interface KmsArnDetail {
+    type: KmsType,
+    protocol: KmsProtocol,
+    provider: string,
+    arnType: 'key' | 'alias', // we don't support alias yet
+    id: string,
+}
+type NotValidatedKmsArnDetail = { [Key in keyof KmsArnDetail]?: KmsArnDetail[Key] | string };
+
+/**
+ * Split the scality arn to extract KMS backend identifiers.
+ * @param keyArn KMS Key prefixed with scality arn
+ * @returns KMS Key id with KMS backend identifiers
+ */
+export function extractDetailFromArn(keyArn: AwsLikeKmsArn): NotValidatedKmsArnDetail {
+    if (!isScalityKmsArn(keyArn)) {
+        return { id: keyArn };
+    }
+
+    const [arnPrefix, ...keyIdOrArn] = keyArn.split('/');
+    const [,,,type, protocol, provider, arnType] = arnPrefix.split(':');
+
+    return {
+        type,
+        protocol,
+        provider,
+        arnType,
+        id: keyIdOrArn?.join('/')
+    }
+}
+
+/**
+ * Validate arn detail provided as input from PutObject or retrieved from GetObject
+ * List of backends should include the currently configured KMS.
+ * Optionally the sseMigration can be included in backends for Get requests pulling key from DB
+ * @returns error or null
+ */
+export function validateKeyDetail(keyDetail: NotValidatedKmsArnDetail, backends: KmsBackend<KmsType>[]) {
+    const isValidBackend = backends.some(backend =>
+        keyDetail.type === backend.type
+        && keyDetail.protocol === backend.protocol
+        && keyDetail.provider === backend.provider
+    )
+    // Produce error description to end user with detail of backend configuration for troubleshooting
+    if (!isValidBackend) {
+        return errors.InvalidArgument.customizeDescription(
+            `KMS Scality KeyArn doesn't match any configured providers. Possible arn are: "${
+                backends.map(b => b.arnPrefix).join('", "')}"`
+        )
+    }
+    if (keyDetail.arnType !== 'key') {
+        return errors.InvalidArgument.customizeDescription(
+            `Invalid KMS Scality KeyArn, expected "key" instead of "${keyDetail.arnType}"`);
+    }
+    if (!keyDetail.id) {
+        return errors.InvalidArgument.customizeDescription(`Invalid KMS Scality KeyArn, missing KeyId`);
+    }
+
+    return null;
+}

--- a/lib/network/kmip/Client.ts
+++ b/lib/network/kmip/Client.ts
@@ -7,6 +7,7 @@ import TlsTransport from './transport/tls';
 import KMIP from '.';
 import * as werelogs from 'werelogs';
 import { arsenalErrorKMIP } from '../utils'
+import { getKeyIdFromArn, KmsBackend, KmsProtocol, KmsType, makeBackend } from '../KMSInterface';
 
 const CRYPTOGRAPHIC_OBJECT_TYPE = 'Symmetric Key';
 const CRYPTOGRAPHIC_ALGORITHM = 'AES';
@@ -219,11 +220,13 @@ export default class Client {
     vendorIdentification: string;
     serverInformation: any[];
     kmip: KMIP;
+    public readonly backend: KmsBackend<KmsType.ext>;
 
     /**
      * Construct a high level KMIP driver suitable for cloudserver
      * @param options - Instance options
      * @param options.kmip - Low level driver options
+     * @param options.kmip.providerName - Name of kmip provider
      * @param options.kmip.client - This high level driver options
      * @param options.kmip.client.compoundCreateActivate -
      *                 Depends on the server's ability. False offers the best
@@ -244,6 +247,7 @@ export default class Client {
     constructor(
         options: {
             kmip: {
+                providerName: string;
                 codec: any;
                 transport: any;
                 client: {
@@ -264,6 +268,8 @@ export default class Client {
         this.kmip.registerHandshakeFunction((logger, cb) => {
             this._kmipHandshake(logger, cb);
         });
+
+        this.backend = makeBackend(KmsType.ext, KmsProtocol.kmip, options.kmip.providerName);
     }
 
     /**
@@ -302,11 +308,12 @@ export default class Client {
      * Activate a cryptographic key managed by the server,
      * for a specific bucket. This is a required action to perform after
      * the key creation.
-     * @param keyIdentifier - The bucket key Id
+     * @param keyIdentifierOrArn - The bucket key Id
      * @param logger - Werelog logger object
-     * @param cb - The callback(err: Error)
+     * @param cb - The callback(err: Error, bucketKeyId: String, bucketKeyArn: String)
      */
-    _activateBucketKey(keyIdentifier: string, logger: werelogs.Logger, cb: any) {
+    _activateBucketKey(keyIdentifierOrArn: string, logger: werelogs.Logger, cb: any) {
+        const keyIdentifier = getKeyIdFromArn(keyIdentifierOrArn);
         return this.kmip.request(logger, 'Activate', [
             KMIP.TextString('Unique Identifier', keyIdentifier),
         ], (err, response) => {
@@ -326,7 +333,7 @@ export default class Client {
                     { error, uniqueIdentifier });
                 return cb(error);
             }
-            return cb(null, keyIdentifier);
+            return cb(null, keyIdentifier, `${this.backend.arnPrefix}${keyIdentifier}`);
         });
     }
 
@@ -335,7 +342,7 @@ export default class Client {
      * for a specific bucket
      * @param bucketName - The bucket name
      * @param logger - Werelog logger object
-     * @param cb - The callback(err: Error, bucketKeyId: String)
+     * @param cb - The callback(err: Error, bucketKeyId: String, bucketKeyArn: String)
      */
     createBucketKey(bucketName: string, logger: werelogs.Logger, cb: any) {
         const attributes: any = [];
@@ -384,7 +391,7 @@ export default class Client {
             if (!this.options.compoundCreateActivate) {
                 return this._activateBucketKey(uniqueIdentifier, logger, cb);
             }
-            return cb(null, uniqueIdentifier);
+            return cb(null, uniqueIdentifier, `${this.backend.arnPrefix}${uniqueIdentifier}`);
         });
     }
 
@@ -392,11 +399,12 @@ export default class Client {
      * Revoke a cryptographic key managed by the server, for a specific bucket.
      * This is a required action to perform before being able to destroy the
      * managed key.
-     * @param bucketKeyId - The bucket key Id
+     * @param bucketKeyIdOrArn - The bucket key Id
      * @param logger - Werelog logger object
      * @param cb - The callback(err: Error)
      */
-    _revokeBucketKey(bucketKeyId: string, logger: werelogs.Logger, cb: any) {
+    _revokeBucketKey(bucketKeyIdOrArn: string, logger: werelogs.Logger, cb: any) {
+        const bucketKeyId = getKeyIdFromArn(bucketKeyIdOrArn);
         // maybe revoke first
         return this.kmip.request(logger, 'Revoke', [
             KMIP.TextString('Unique Identifier', bucketKeyId),
@@ -429,11 +437,12 @@ export default class Client {
 
     /**
      * Destroy a cryptographic key managed by the server, for a specific bucket.
-     * @param bucketKeyId - The bucket key Id
+     * @param bucketKeyIdOrArn - The bucket key Id
      * @param logger - Werelog logger object
      * @param cb - The callback(err: Error)
      */
-    destroyBucketKey(bucketKeyId: string, logger: werelogs.Logger, cb: any) {
+    destroyBucketKey(bucketKeyIdOrArn: string, logger: werelogs.Logger, cb: any) {
+        const bucketKeyId = getKeyIdFromArn(bucketKeyIdOrArn);
         return this._revokeBucketKey(bucketKeyId, logger, err => {
             if (err) {
                 const error = arsenalErrorKMIP(err);
@@ -469,7 +478,7 @@ export default class Client {
     /**
      *
      * @param cryptoScheme - crypto scheme version number
-     * @param masterKeyId - key to retrieve master key
+     * @param masterKeyIdOrArn - key to retrieve master key
      * @param plainTextDataKey - data key
      * @param logger - werelog logger object
      * @param cb - callback
@@ -477,11 +486,12 @@ export default class Client {
      */
     cipherDataKey(
         cryptoScheme: number,
-        masterKeyId: string,
+        masterKeyIdOrArn: string,
         plainTextDataKey: Buffer,
         logger: werelogs.Logger,
         cb: any,
     ) {
+        const masterKeyId = getKeyIdFromArn(masterKeyIdOrArn);
         return this.kmip.request(logger, 'Encrypt', [
             KMIP.TextString('Unique Identifier', masterKeyId),
             KMIP.Structure('Cryptographic Parameters', [
@@ -519,7 +529,7 @@ export default class Client {
     /**
      *
      * @param cryptoScheme - crypto scheme version number
-     * @param masterKeyId - key to retrieve master key
+     * @param masterKeyIdOrArn - key to retrieve master key
      * @param cipheredDataKey - data key
      * @param logger - werelog logger object
      * @param cb - callback
@@ -527,11 +537,12 @@ export default class Client {
      */
     decipherDataKey(
         cryptoScheme: number,
-        masterKeyId: string,
+        masterKeyIdOrArn: string,
         cipheredDataKey: Buffer,
         logger: werelogs.Logger,
         cb: any,
     ) {
+        const masterKeyId = getKeyIdFromArn(masterKeyIdOrArn);
         return this.kmip.request(logger, 'Decrypt', [
             KMIP.TextString('Unique Identifier', masterKeyId),
             KMIP.Structure('Cryptographic Parameters', [

--- a/lib/network/kmsAWS/Client.ts
+++ b/lib/network/kmsAWS/Client.ts
@@ -7,10 +7,13 @@ import { Agent } from 'https';
 import { KMS, AWSError } from 'aws-sdk';
 import * as werelogs from 'werelogs';
 import assert from 'assert';
+import { KmsBackend, getKeyIdFromArn, KmsProtocol, KmsType, makeBackend } from '../KMSInterface';
 
 type TLSVersion = 'TLSv1.3' | 'TLSv1.2' | 'TLSv1.1' | 'TLSv1';
 
 interface KMSOptions {
+    /** To be included in KMS key arn */
+    providerName: string;
     region?: string;
     endpoint?: string;
     ak?: string;
@@ -23,6 +26,18 @@ interface KMSOptions {
         maxVersion?: TLSVersion;
         key?: Buffer | Buffer[];
     };
+    /**
+     * Do not use AWS KMS Key arn but id (to keep backward compatibility).
+     *
+     * Some providers (okms) might not have accountId in their arn and don't need cross-account.
+     *
+     * Not set or false by default to use arn to be future-proof (multi account, region).
+     *
+     * Difference in kms key returned:
+     *  - `arn:scality:kms:ext:aws_kms:custom:key/arn:aws:kms:region:accountId:key/cbd69d33-ba8e-4b56-8cfe-ae0844f69966`
+     *  - `arn:scality:kms:ext:aws_kms:custom:key/cbd69d33-ba8e-4b56-8cfe-ae0844f69966`
+     */
+    noAwsArn?: boolean;
 }
 
 interface ClientOptions {
@@ -32,10 +47,12 @@ interface ClientOptions {
 export default class Client {
     private _supportsDefaultKeyPerAccount: boolean;
     private client: KMS;
+    public readonly backend: KmsBackend<KmsType.ext>;
+    public readonly noAwsArn?: boolean;
 
     constructor(options: ClientOptions) {
         this._supportsDefaultKeyPerAccount = true;
-        const { tls, ak, sk, region, endpoint } = options.kmsAWS;
+        const { providerName, tls, ak, sk, region, endpoint, noAwsArn } = options.kmsAWS;
 
         const httpOptions = tls ? {
             agent: new Agent({
@@ -61,6 +78,8 @@ export default class Client {
             httpOptions,
             ...credentials,
         });
+        this.backend = makeBackend(KmsType.ext, KmsProtocol.aws_kms, providerName);
+        this.noAwsArn = noAwsArn;
     }
 
     get supportsDefaultKeyPerAccount(): boolean {
@@ -86,12 +105,12 @@ export default class Client {
     // createBucketKey is a method used by CloudServer to create a default master encryption key per bucket.
     // New KMS backends like AWS KMS now allow the customer to use the default master encryption key per account.
     // To achieve this, Vault will call createMasterKey and store the master encryption ID in the account metadata.
-    createBucketKey(bucketName: string, logger: werelogs.Logger, cb: (err: Error | null, keyId?: string) => void): void {
+    createBucketKey(bucketName: string, logger: werelogs.Logger, cb: (err: Error | null, keyId?: string, keyArn?: string) => void): void {
         logger.debug("AWS KMS: creating encryption key managed at the bucket level", { bucketName });
         this.createMasterKey(logger, cb);
     }
 
-    createMasterKey(logger: werelogs.Logger, cb: (err: Error | null, keyId?: string) => void): void {
+    createMasterKey(logger: werelogs.Logger, cb: (err: Error | null, keyId?: string, keyArn?: string) => void): void {
         logger.debug("AWS KMS: creating master encryption key");
         this.client.createKey({}, (err: AWSError, data) => {
             if (err) {
@@ -100,21 +119,37 @@ export default class Client {
                 cb(error);
                 return;
             }
-            logger.debug("AWS KMS: master encryption key created", { KeyMetadata: data?.KeyMetadata });
-            cb(null, data?.KeyMetadata?.KeyId);
+            const keyMetadata = data?.KeyMetadata;
+            logger.debug("AWS KMS: master encryption key created", { KeyMetadata: keyMetadata });
+            let keyId: string;
+            if (this.noAwsArn) {
+                // Use KeyId when ARN is not wanted
+                keyId = keyMetadata?.KeyId!;
+            } else {
+                // Prefer ARN, but fall back to KeyId if ARN is missing
+                keyId = keyMetadata?.Arn ?? keyMetadata?.KeyId!;
+            }
+            // May produce double arn prefix: scality arn + aws arn
+            // arn:scality:kms:ext:aws_kms:custom:key/arn:aws:kms:region:accountId:key/cbd69d33-ba8e-4b56-8cfe-ae0844f69966
+            // If this is a problem, a config flag should be used to hide the scality arn when returning the KMS KeyId
+            // or aws arn when creating the KMS Key
+            const arn = `${this.backend.arnPrefix}${keyId}`;
+            cb(null, keyId, arn);
         });
     }
 
     // destroyBucketKey is a method used by CloudServer to remove the default master encryption key for a bucket.
     // New KMS backends like AWS KMS allow customers to delete the default master encryption key at the account level.
     // To achieve this, Vault will call deleteMasterKey before deleting the account.
-    destroyBucketKey(bucketKeyId: string, logger: werelogs.Logger, cb: (err: Error | null) => void): void {
-        logger.debug("AWS KMS: deleting encryption key managed at the bucket level", { bucketKeyId });
+    destroyBucketKey(bucketKeyIdOrArn: string, logger: werelogs.Logger, cb: (err: Error | null) => void): void {
+        const bucketKeyId = getKeyIdFromArn(bucketKeyIdOrArn);
+        logger.debug("AWS KMS: deleting encryption key managed at the bucket level", { bucketKeyId, bucketKeyIdOrArn });
         this.deleteMasterKey(bucketKeyId, logger, cb);
     }
 
-    deleteMasterKey(masterKeyId: string, logger: werelogs.Logger, cb: (err: Error | null) => void): void {
-        logger.debug("AWS KMS: deleting master encryption key", { masterKeyId });
+    deleteMasterKey(masterKeyIdOrArn: string, logger: werelogs.Logger, cb: (err: Error | null) => void): void {
+        const masterKeyId = getKeyIdFromArn(masterKeyIdOrArn);
+        logger.debug("AWS KMS: deleting master encryption key", { masterKeyId, masterKeyIdOrArn });
         const params = {
             KeyId: masterKeyId,
             PendingWindowInDays: 7,
@@ -147,11 +182,12 @@ export default class Client {
 
     generateDataKey(
         cryptoScheme: number,
-        masterKeyId: string,
+        masterKeyIdOrArn: string,
         logger: werelogs.Logger,
         cb: (err: Error | null, plainTextDataKey?: Buffer, cipheredDataKey?: Buffer) => void
     ): void {
-        logger.debug("AWS KMS: generating data key", { cryptoScheme, masterKeyId });
+        const masterKeyId = getKeyIdFromArn(masterKeyIdOrArn);
+        logger.debug("AWS KMS: generating data key", { cryptoScheme, masterKeyId, masterKeyIdOrArn });
         assert.strictEqual(cryptoScheme, 1);
 
         const params = {
@@ -183,12 +219,14 @@ export default class Client {
 
     cipherDataKey(
         cryptoScheme: number,
-        masterKeyId: string,
+        masterKeyIdOrArn: string,
         plainTextDataKey: Buffer,
         logger: werelogs.Logger,
         cb: (err: Error | null, cipheredDataKey?: Buffer) => void
     ): void {
-        logger.debug("AWS KMS: ciphering data key", { cryptoScheme, masterKeyId });
+        const masterKeyId = getKeyIdFromArn(masterKeyIdOrArn);
+
+        logger.debug("AWS KMS: ciphering data key", { cryptoScheme, masterKeyId, masterKeyIdOrArn });
         assert.strictEqual(cryptoScheme, 1);
 
         const params = {
@@ -219,12 +257,14 @@ export default class Client {
 
     decipherDataKey(
         cryptoScheme: number,
-        masterKeyId: string,
+        masterKeyIdOrArn: string,
         cipheredDataKey: Buffer,
         logger: werelogs.Logger,
         cb: (err: Error | null, plainTextDataKey?: Buffer) => void
     ): void {
-        logger.debug("AWS KMS: deciphering data key", { cryptoScheme, masterKeyId });
+        const masterKeyId = getKeyIdFromArn(masterKeyIdOrArn);
+
+        logger.debug("AWS KMS: deciphering data key", { cryptoScheme, masterKeyId, masterKeyIdOrArn });
         assert.strictEqual(cryptoScheme, 1);
 
         const params = {

--- a/lib/storage/data/DataWrapper.js
+++ b/lib/storage/data/DataWrapper.js
@@ -382,13 +382,13 @@ class DataWrapper {
      * dataStoreContext.uploadId: uploadId
      * dataStoreContext.partNumber: request.query.partNumber
      * @param {function} lcCheckFn: locationConstraintCheck function
+     * @param {object} serverSideEncryption - server side encryption configuration
      * @param {function} callback - callback
      * @returns {function} cb - callback
      */
     uploadPartCopy(request, log, destBucketMD, sourceLocationConstraintName,
         destLocationConstraintName, dataLocator, dataStoreContext, lcCheckFn,
-        callback) {
-        const serverSideEncryption = destBucketMD.getServerSideEncryption();
+        serverSideEncryption, callback) {
         const lastModified = new Date().toJSON();
 
         // skip if 0 byte object
@@ -767,7 +767,7 @@ class DataWrapper {
 
     /**
      * _dataCopyPut - put used for copying object with and without encryption
-     * @param {string} serverSideEncryption - Server side encryption
+     * @param {object} serverSideEncryption - Server side encryption configuration
      * @param {object} stream - stream containing the data
      * @param {object} part - element of dataLocator array
      * @param {object} dataStoreContext - information of the destination object

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.70.4-2",
+  "version": "7.70.4-3-outscale-cldsrv",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/functional/kmip/highlevel.spec.js
+++ b/tests/functional/kmip/highlevel.spec.js
@@ -27,6 +27,7 @@ describe('KMIP High Level Driver', () => {
         [false, true].forEach(compoundCreateActivate => {
             const options = {
                 kmip: {
+                    providerName: 'tests',
                     client: {
                         bucketNameAttributeName,
                         compoundCreateActivate,
@@ -49,11 +50,13 @@ describe('KMIP High Level Driver', () => {
                 const plaintext = Buffer.from(crypto.randomBytes(32));
                 async.waterfall([
                     next => kmipClient.createBucketKey('plop', logger, next),
-                    (id, next) =>
+                    (id, arn, next) => {
+                        assert.match(arn, /arn:scality:kms:ext:kmip:tests:key\//);
                         kmipClient.cipherDataKey(1, id, plaintext,
                             logger, (err, ciphered) => {
                                 next(err, id, ciphered);
-                            }),
+                            });
+                    },
                     (id, ciphered, next) =>
                         kmipClient.decipherDataKey(
                             1, id, ciphered, logger, (err, deciphered) => {
@@ -70,6 +73,7 @@ describe('KMIP High Level Driver', () => {
     it('should succeed healthcheck with working KMIP client and server', done => {
         const options = {
             kmip: {
+                providerName: 'tests',
                 client: {
                     bucketNameAttributeName: null,
                     compoundCreateActivate: false,
@@ -94,6 +98,7 @@ describe('KMIP High Level Driver', () => {
     it('should fail healthcheck with KMIP server not running', done => {
         const options = {
             kmip: {
+                providerName: 'tests',
                 client: {
                     bucketNameAttributeName: null,
                     compoundCreateActivate: false,

--- a/tests/functional/kmsAWS/highlevel.spec.js
+++ b/tests/functional/kmsAWS/highlevel.spec.js
@@ -20,6 +20,7 @@ describe('KmsAWSClient', () => {
     beforeEach(() => {
         client = new Client({
             kmsAWS: {
+                providerName: 'tests',
                 region: 'us-east-1',
                 ak: 'ak',
                 sk: 'sk',
@@ -48,6 +49,10 @@ describe('KmsAWSClient', () => {
         assert.strictEqual(client.supportsDefaultKeyPerAccount, true);
     });
 
+    it('should be configured with noAwsArn falsy (undefined) by default', () => {
+        assert.strictEqual(client.noAwsArn, undefined);
+    });
+
     it('should create a new master encryption key', done => {
         const mockResponse = {
             KeyMetadata: {
@@ -56,9 +61,85 @@ describe('KmsAWSClient', () => {
         };
         createKeyStub.yields(null, mockResponse);
 
-        client.createMasterKey(logger, (err, keyId) => {
+        client.createMasterKey(logger, (err, keyId, keyArn) => {
             assert.ifError(err);
             assert.strictEqual(keyId, 'mock-key-id');
+            assert.strictEqual(keyArn, 'arn:scality:kms:ext:aws_kms:tests:key/mock-key-id');
+            assert(createKeyStub.calledOnce);
+            done();
+        });
+    });
+
+    it('should create a new master encryption key when configured to use Arn but fallback to KeyId', done => {
+        client = new Client({
+            kmsAWS: {
+                providerName: 'tests',
+                region: 'us-east-1',
+                ak: 'ak',
+                sk: 'sk',
+                noAwsArn: false, // ignore default enforce using aws arn
+            },
+        });
+        createKeyStub = sinon.stub(client.client, 'createKey');
+        const mockResponse = {
+            KeyMetadata: {
+                KeyId: 'mock-key-id',
+            },
+        };
+        createKeyStub.yields(null, mockResponse);
+
+        client.createMasterKey(logger, (err, keyId, keyArn) => {
+            assert.ifError(err);
+            assert.strictEqual(keyId, 'mock-key-id');
+            assert.strictEqual(keyArn, 'arn:scality:kms:ext:aws_kms:tests:key/mock-key-id');
+            assert(createKeyStub.calledOnce);
+            done();
+        });
+    });
+
+    it('should create a new master encryption key with aws arn', done => {
+        const mockResponse = {
+            KeyMetadata: {
+                KeyId: 'mock-key-id',
+                Arn: 'arn:aws:kms:region:accountId:key/mock-key-id',
+            },
+        };
+        createKeyStub.yields(null, mockResponse);
+
+        client.createMasterKey(logger, (err, keyId, keyArn) => {
+            assert.ifError(err);
+            assert.strictEqual(keyId, 'arn:aws:kms:region:accountId:key/mock-key-id');
+            assert.strictEqual(keyArn,
+                'arn:scality:kms:ext:aws_kms:tests:key/arn:aws:kms:region:accountId:key/mock-key-id');
+            assert(createKeyStub.calledOnce);
+            done();
+        });
+    });
+
+    it('should create a new master encryption key without aws arn', done => {
+        client = new Client({
+            kmsAWS: {
+                providerName: 'tests',
+                region: 'us-east-1',
+                ak: 'ak',
+                sk: 'sk',
+                noAwsArn: true,
+            },
+        });
+        createKeyStub = sinon.stub(client.client, 'createKey');
+        const mockResponse = {
+            KeyMetadata: {
+                KeyId: 'mock-key-id',
+                Arn: 'arn:aws:kms:region:accountId:key/mock-key-id',
+            },
+        };
+        createKeyStub.yields(null, mockResponse);
+
+        client.createMasterKey(logger, (err, keyId, keyArn) => {
+            assert.ifError(err);
+            assert.strictEqual(keyId, 'mock-key-id');
+            assert.strictEqual(keyArn,
+                'arn:scality:kms:ext:aws_kms:tests:key/mock-key-id');
             assert(createKeyStub.calledOnce);
             done();
         });
@@ -83,9 +164,10 @@ describe('KmsAWSClient', () => {
         };
         createKeyStub.yields(null, mockResponse);
 
-        client.createBucketKey('bucketName', logger, (err, keyId) => {
+        client.createBucketKey('bucketName', logger, (err, keyId, keyArn) => {
             assert.ifError(err);
             assert.strictEqual(keyId, 'mock-bucket-key-id');
+            assert.strictEqual(keyArn, 'arn:scality:kms:ext:aws_kms:tests:key/mock-bucket-key-id');
             assert(createKeyStub.calledOnce);
             done();
         });
@@ -205,6 +287,25 @@ describe('KmsAWSClient', () => {
             assert.strictEqual(plainText.toString(), 'plaintext');
             assert.strictEqual(cipherText.toString(), 'ciphertext');
             assert(generateDataKeyStub.calledOnce);
+            done();
+        });
+    });
+
+    it('should extract key from arn input to call generate a data key', done => {
+        const arnPrefix = 'arn:scality:kms:ext:aws_kms:tests:key/';
+        const awsArn = 'arn:aws:kms:region:accountId:key/mock-key-id';
+        const key = `${arnPrefix}${awsArn}`;
+        const mockResponse = {
+            Plaintext: Buffer.from('plaintext'),
+            CiphertextBlob: Buffer.from('ciphertext'),
+            KeyId: 'mocked-kms-key-id',
+        };
+        generateDataKeyStub.yields(null, mockResponse);
+
+        client.generateDataKey(1, key, logger, (err) => {
+            assert.ifError(err);
+            assert(generateDataKeyStub.calledOnce);
+            assert.strictEqual(generateDataKeyStub.getCall(0).firstArg.KeyId, awsArn);
             done();
         });
     });

--- a/tests/unit/network/KMSInterface.spec.js
+++ b/tests/unit/network/KMSInterface.spec.js
@@ -1,0 +1,225 @@
+const assert = require('assert');
+const {
+    SCAL_KMS_ARN,
+    KmsType,
+    KmsProtocol,
+    makeScalityArnPrefix,
+    makeBackend,
+    isScalityKmsArn,
+    getKeyIdFromArn,
+    isValidType,
+    isValidProtocol,
+    isValidProvider,
+    validateKeyDetail,
+    extractDetailFromArn,
+} = require('../../../lib/network/KMSInterface');
+
+const awsArn = 'arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab';
+
+describe('KMSInterface', () => {
+    const backends = [
+        { type: KmsType.int, protocol: KmsProtocol.mem, provider: 'mtests' },
+        { type: KmsType.int, protocol: KmsProtocol.file, provider: 'ftests' },
+        { type: KmsType.ext, protocol: KmsProtocol.scality, provider: 'safenet' },
+        { type: KmsType.ext, protocol: KmsProtocol.kmip, provider: 'ktests' },
+        { type: KmsType.ext, protocol: KmsProtocol.aws_kms, provider: 'atests' },
+        { type: KmsType.ext, protocol: KmsProtocol.aws_kms, provider: 'aws', key: awsArn },
+    ];
+
+    describe('makeScalityArnPrefix', () => {
+        backends.forEach(({ type, protocol, provider }) => it(
+            `should succeed for ${type}:${protocol}:${provider}`, () => {
+                const res = makeScalityArnPrefix(type, protocol, provider);
+                assert.strictEqual(res, `${SCAL_KMS_ARN}${type}:${protocol}:${provider}:key/`);
+            }));
+    });
+
+    describe('makeBackend', () => {
+        backends.forEach(({ type, protocol, provider }) => it(
+            `should succeed for ${type}:${protocol}:${provider}`, () => {
+                const res = makeBackend(type, protocol, provider);
+                assert.strictEqual(res.type, type);
+                assert.strictEqual(res.protocol, protocol);
+                assert.strictEqual(res.provider, provider);
+                assert.strictEqual(res.arnPrefix, `${SCAL_KMS_ARN}${type}:${protocol}:${provider}:key/`);
+            }));
+    });
+
+    describe('isScalityKmsArn', () => {
+        backends.forEach(({ type, protocol, provider, key }) => it(
+            `should return true for ${type}:${protocol}:${provider}`, () => {
+                const arn = `${makeScalityArnPrefix(type, protocol, provider)}${key || '12345'}`;
+                const res = isScalityKmsArn(arn);
+                assert.strictEqual(res, true);
+            }));
+
+        it('should return false for non arn', () => {
+            assert.strictEqual(isScalityKmsArn('12345'), false);
+        });
+        it('should return false for aws arn', () => {
+            assert.strictEqual(isScalityKmsArn(awsArn), false);
+        });
+    });
+
+    describe('getKeyIdFromArn', () => {
+        backends.forEach(({ type, protocol, provider, key }) => it(
+            `should return KeyId for ${type}:${protocol}:${provider}`, () => {
+                const arn = `${makeScalityArnPrefix(type, protocol, provider)}${key || '12345'}`;
+                const res = getKeyIdFromArn(arn);
+                assert.strictEqual(res, key || '12345');
+            }));
+
+        it('should return KeyId for non arn', () => {
+            assert.strictEqual(getKeyIdFromArn('12345'), '12345');
+        });
+        it('should return aws arn', () => {
+            assert.strictEqual(getKeyIdFromArn(awsArn), awsArn);
+        });
+    });
+
+    describe('isValidType', () => {
+        it('should return true for int', () => assert.strictEqual(isValidType(KmsType.int), true));
+        it('should return true for ext', () => assert.strictEqual(isValidType(KmsType.ext), true));
+        it('should return false for anything', () => assert.strictEqual(isValidType('nope'), false));
+    });
+
+    describe('isValidProtocol', () => {
+        backends.forEach(({ type, protocol, provider }) => it(
+            `should return true for ${type}:${protocol}:${provider}`, () => {
+                assert.strictEqual(isValidProtocol(type, protocol), true);
+            }));
+
+        it('should return false for mismatching type and protocol', () => {
+            assert.strictEqual(isValidProtocol(KmsType.int, KmsProtocol.kmip), false);
+        });
+        it('should return false for bad protocol', () => {
+            assert.strictEqual(isValidProtocol(KmsType.int, 'bad protocol'), false);
+        });
+        it('should return false for bad type', () => {
+            assert.strictEqual(isValidProtocol('bad type', KmsProtocol.file), false);
+        });
+    });
+
+    describe('isValidProvider', () => {
+        it('should return true for lowercase alphanumeric', () => {
+            assert.strictEqual(isValidProvider('scality01'), true);
+        });
+        it('should return false not lowercase alphanumeric', () => {
+            assert.strictEqual(isValidProvider('A BAD PROVIDER !!!'), false);
+        });
+    });
+
+    describe('extractDetailFromArn', () => {
+        backends.forEach(({ type, protocol, provider, key }) => it(
+            `should return detail for ${type}:${protocol}:${provider}`, () => {
+                const arn = `${makeScalityArnPrefix(type, protocol, provider)}${key || '12345'}`;
+                const detail = extractDetailFromArn(arn);
+
+                assert.strictEqual(detail.type, type);
+                assert.strictEqual(detail.protocol, protocol);
+                assert.strictEqual(detail.provider, provider);
+                assert.strictEqual(detail.arnType, 'key');
+                assert.strictEqual(detail.id, key || '12345');
+            }));
+
+        it('should return only id for non arn', () => {
+            const detail = extractDetailFromArn('12345');
+
+            assert.strictEqual(detail.type, undefined);
+            assert.strictEqual(detail.protocol, undefined);
+            assert.strictEqual(detail.provider, undefined);
+            assert.strictEqual(detail.arnType, undefined);
+            assert.strictEqual(detail.id, '12345');
+        });
+
+        it('should return only id (aws arn) for aws arn', () => {
+            const detail = extractDetailFromArn(awsArn);
+
+            assert.strictEqual(detail.type, undefined);
+            assert.strictEqual(detail.protocol, undefined);
+            assert.strictEqual(detail.provider, undefined);
+            assert.strictEqual(detail.arnType, undefined);
+            assert.strictEqual(detail.id, awsArn);
+        });
+    });
+
+    describe('validateKeyDetail', () => {
+        backends.forEach(({ type, protocol, provider, key }) => it(
+            `should return no error ${type}:${protocol}:${provider}`, () => {
+                const arn = `${makeScalityArnPrefix(type, protocol, provider)}${key || '12345'}`;
+                const detail = extractDetailFromArn(arn);
+                const backend = makeBackend(type, protocol, provider);
+
+                assert.strictEqual(validateKeyDetail(detail, [backend]), null);
+            }));
+
+        it('should return an error for non arn key', () => {
+            const b1 = backends[1];
+            const detail = extractDetailFromArn('12345');
+            const backend = makeBackend(b1.type, b1.protocol, b1.provider);
+
+            const err = validateKeyDetail(detail, [backend]);
+            assert.notStrictEqual(err, null);
+            assert.strictEqual(err.InvalidArgument, true);
+            assert.strictEqual(err.description,
+                `KMS Scality KeyArn doesn\'t match any configured providers. Possible arn are: \"${
+                    backend.arnPrefix}\"`,
+            );
+        });
+
+        it('should return an error for aws arn', () => {
+            const b1 = backends[1];
+            const detail = extractDetailFromArn(awsArn);
+            const backend = makeBackend(b1.type, b1.protocol, b1.provider);
+
+            const err = validateKeyDetail(detail, [backend]);
+            assert.notStrictEqual(err, null);
+            assert.strictEqual(err.InvalidArgument, true);
+            assert.strictEqual(err.description,
+                `KMS Scality KeyArn doesn\'t match any configured providers. Possible arn are: \"${
+                    backend.arnPrefix}\"`,
+            );
+        });
+
+        it('should return an error for mismatching key and provider', () => {
+            const b0 = backends[0];
+            const b1 = backends[1];
+            const arn = `${makeScalityArnPrefix(b0.type, b0.protocol, b0.provider)}12345`;
+            const detail = extractDetailFromArn(arn);
+            const backend = makeBackend(b1.type, b1.protocol, b1.provider);
+
+            const err = validateKeyDetail(detail, [backend]);
+            assert.notStrictEqual(err, null);
+            assert.strictEqual(err.InvalidArgument, true);
+            assert.strictEqual(err.description,
+                `KMS Scality KeyArn doesn\'t match any configured providers. Possible arn are: \"${
+                    backend.arnPrefix}\"`,
+            );
+        });
+
+        it('should return an error for invalid arnType', () => {
+            const b0 = backends[0];
+            const arn = `${SCAL_KMS_ARN}${b0.type}:${b0.protocol}:${b0.provider}:wrongResourceType/1234`;
+            const detail = extractDetailFromArn(arn);
+            const backend = makeBackend(b0.type, b0.protocol, b0.provider);
+
+            const err = validateKeyDetail(detail, [backend]);
+            assert.notStrictEqual(err, null);
+            assert.strictEqual(err.InvalidArgument, true);
+            assert.strictEqual(err.description,
+                'Invalid KMS Scality KeyArn, expected "key" instead of "wrongResourceType"');
+        });
+
+        it('should return an error for missing KeyId after arnPrefix', () => {
+            const b0 = backends[0];
+            const arn = `${SCAL_KMS_ARN}${b0.type}:${b0.protocol}:${b0.provider}:key/`;
+            const detail = extractDetailFromArn(arn);
+            const backend = makeBackend(b0.type, b0.protocol, b0.provider);
+
+            const err = validateKeyDetail(detail, [backend]);
+            assert.notStrictEqual(err, null);
+            assert.strictEqual(err.InvalidArgument, true);
+            assert.strictEqual(err.description, 'Invalid KMS Scality KeyArn, missing KeyId');
+        });
+    });
+});


### PR DESCRIPTION
To keep track of backend provider

For AWS use key Arn instead of KeyId by default
to allow for cross-account

___

See https://scality.atlassian.net/browse/S3C-9949
This hotfix to handle SSE with both internal and external KMS. Needed to built a custom image of cloudserver & vault.

Cherry-pick for vault: https://github.com/scality/Arsenal/pull/2350

It will then be cherry-picked into latest development for 9.5