### PR TITLE
ARSN-487: Use SUR instead of SCUBA for the service name  [7.70]

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v4
       with:
         node-version: '16'
         cache: 'yarn'

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -129,4 +129,4 @@ export const maxCachedBuckets = process.env.METADATA_MAX_CACHED_BUCKETS ?
 export const maxBatchingConcurrentOperations = 5;
 
 /** For policy resource arn check we allow empty account ID to not break compatibility */
-export const policyArnAllowedEmptyAccountId = ['utapi', 'scuba'];
+export const policyArnAllowedEmptyAccountId = ['utapi', 'sur'];

--- a/lib/policyEvaluator/RequestContext.ts
+++ b/lib/policyEvaluator/RequestContext.ts
@@ -12,7 +12,7 @@ import {
     actionMapSSO,
     actionMapSTS,
     actionMapMetadata,
-    actionMapScuba,
+    actionMapSUR,
 } from './utils/actionMaps';
 
 const _actionNeedQuotaCheck = {
@@ -22,25 +22,25 @@ const _actionNeedQuotaCheck = {
 
 function _findAction(service: string, method: string) {
     switch (service) {
-        case 's3':
-            return actionMapRQ[method];
-        case 'iam':
-            return actionMapIAM[method];
-        case 'sso':
-            return actionMapSSO[method];
-        case 'ring':
-            return `ring:${method}`;
-        case 'utapi':
-            // currently only method is ListMetrics
-            return `utapi:${method}`;
-        case 'sts':
-            return actionMapSTS[method];
-        case 'metadata':
-            return actionMapMetadata[method];
-        case 'scuba':
-            return actionMapScuba[method];
-        default:
-            return undefined;
+    case 's3':
+        return actionMapRQ[method];
+    case 'iam':
+        return actionMapIAM[method];
+    case 'sso':
+        return actionMapSSO[method];
+    case 'ring':
+        return `ring:${method}`;
+    case 'utapi':
+        // currently only method is ListMetrics
+        return `utapi:${method}`;
+    case 'sts':
+        return actionMapSTS[method];
+    case 'metadata':
+        return actionMapMetadata[method];
+    case 'sur':
+        return actionMapSUR[method];
+    default:
+        return undefined;
     }
 }
 
@@ -107,13 +107,13 @@ function _buildArn(
             }
             return `arn:scality:metadata::${requesterInfo!.accountid}:` +
             `${generalResource}/`;
-        }
-        case 'scuba': {
-            return `arn:scality:scuba::${requesterInfo!.accountid}:` +
-            `${generalResource}${specificResource ? '/' + specificResource : ''}`;
-        }
-        default:
-            return undefined;
+    }
+    case 'sur': {
+        return `arn:scality:sur::${requesterInfo!.accountid}:` +
+            `${generalResource}${specificResource ? `/${specificResource}` : ''}`;
+    }
+    default:
+        return undefined;
     }
 }
 
@@ -714,7 +714,7 @@ export default class RequestContext {
     /**
      * Get object lock retention days
      *
-     * @returns objectLockRetentionDays - object lock retention days 
+     * @returns objectLockRetentionDays - object lock retention days
      */
     getObjectLockRetentionDays() {
         return this._objectLockRetentionDays;

--- a/lib/policyEvaluator/utils/actionMaps.ts
+++ b/lib/policyEvaluator/utils/actionMaps.ts
@@ -201,7 +201,7 @@ const actionMapMetadata = {
     default: 'metadata:bucketd',
 };
 
-const actionMapScuba = {
+const actionMapSUR = {
     GetMetrics: 'sur:GetMetrics',
     GetMetricsBatch: 'sur:GetMetricsBatch',
     AdminStartIngest: 'sur:AdminStartIngest',
@@ -222,5 +222,5 @@ export {
     actionMapSSO,
     actionMapSTS,
     actionMapMetadata,
-    actionMapScuba,
+    actionMapSUR,
 };

--- a/lib/policyEvaluator/utils/actionMaps.ts
+++ b/lib/policyEvaluator/utils/actionMaps.ts
@@ -202,12 +202,15 @@ const actionMapMetadata = {
 };
 
 const actionMapScuba = {
-    GetMetrics: 'scuba:GetMetrics',
-    GetMetricsBatch: 'scuba:GetMetricsBatch',
-    AdminStartIngest: 'scuba:AdminStartIngest',
-    AdminStopIngest: 'scuba:AdminStopIngest',
-    AdminReadRaftCseq: 'scuba:AdminReadRaftCseq',
-    AdminTriggerRepair: 'scuba:AdminTriggerRepair',
+    GetMetrics: 'sur:GetMetrics',
+    GetMetricsBatch: 'sur:GetMetricsBatch',
+    AdminStartIngest: 'sur:AdminStartIngest',
+    AdminStopIngest: 'sur:AdminStopIngest',
+    AdminReadRaftCseq: 'sur:AdminReadRaftCseq',
+    AdminTriggerRepair: 'sur:AdminTriggerRepair',
+    AdminStartDownsample: 'sur:AdminStartDownsample',
+    AdminStopDownsample: 'sur:AdminStopDownsample',
+    AdminTriggerDownsample: 'sur:AdminTriggerDownsample',
 };
 
 export {

--- a/lib/policyEvaluator/utils/checkArnMatch.ts
+++ b/lib/policyEvaluator/utils/checkArnMatch.ts
@@ -38,7 +38,7 @@ export default function checkArnMatch(
         const requestSegment = caseSensitive ? requestArnArr[j] :
             requestArnArr[j].toLowerCase();
         const policyArnArr = policyArn.split(':');
-        // We want to allow an empty account ID for utapi and scuba service ARNs to not
+        // We want to allow an empty account ID for utapi and SUR service ARNs to not
         // break compatibility.
         if (j === 4 && policyArnAllowedEmptyAccountId.includes(policyArnArr[2])
             && policyArnArr[4] === '') {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.70.41",
+  "version": "7.70.42",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/policyEvaluator/RequestContext.spec.js
+++ b/tests/unit/policyEvaluator/RequestContext.spec.js
@@ -15,7 +15,7 @@ describe('RequestContext', () => {
         'us-east-1', // locationConstraint
         { // requesterInfo
             arn: 'arn:aws:iam::user/johndoe',
-            accountId: 'JOHNACCOUNT',
+            accountid: 'JOHNACCOUNT',
             username: 'John Doe',
             principalType: 'user',
         },
@@ -39,14 +39,14 @@ describe('RequestContext', () => {
         {
             name: 'getRequesterInfo',
             expectedValue: {
-                accountId: 'JOHNACCOUNT',
+                accountid: 'JOHNACCOUNT',
                 arn: 'arn:aws:iam::user/johndoe',
                 username: 'John Doe',
                 principalType: 'user',
             },
         },
         { name: 'getRequesterIp', expectedValueToString: '127.0.0.1' },
-        { name: 'getRequesterAccountId', expectedValue: undefined },
+        { name: 'getRequesterAccountId', expectedValue: 'JOHNACCOUNT' },
         { name: 'getRequesterEndArn', expectedValue: 'arn:aws:iam::user/johndoe' },
         { name: 'getRequesterExternalId', expectedValue: undefined },
         { name: 'getRequesterPrincipalArn', expectedValue: 'arn:aws:iam::user/johndoe' },
@@ -98,7 +98,7 @@ describe('RequestContext', () => {
             q2: 'v2',
         },
         requesterInfo: {
-            accountId: 'JOHNACCOUNT',
+            accountid: 'JOHNACCOUNT',
             arn: 'arn:aws:iam::user/johndoe',
             principalType: 'user',
             username: 'John Doe',
@@ -125,5 +125,72 @@ describe('RequestContext', () => {
         const deserializedRC = RequestContext.deSerialize(serialized);
         const newSerialized = JSON.parse(deserializedRC.serialize());
         assert.deepStrictEqual(newSerialized, SerializedFields);
+    });
+
+    it('should return correct ARN for utapi service', () => {
+        const utapiParams = [...constructorParams];
+        utapiParams[7] = 'utapi';
+        const utapiRC = new RequestContext(...utapiParams);
+        assert.strictEqual(utapiRC.getResource(), 'arn:scality:utapi::JOHNACCOUNT:general-resource/specific-resource');
+    });
+
+    it('should return correct ARN for sts service', () => {
+        const stsParams = [...constructorParams];
+        stsParams[7] = 'sts';
+        const stsRC = new RequestContext(...stsParams);
+        assert.strictEqual(stsRC.getResource(), 'arn:aws:iam::undefined:general-resourcespecific-resource');
+    });
+
+    it('should return correct ARN for metadata service', () => {
+        const metadataParams = [...constructorParams];
+        metadataParams[7] = 'metadata';
+        const metadataRC = new RequestContext(...metadataParams);
+        assert.strictEqual(
+            metadataRC.getResource(),
+            'arn:scality:metadata::JOHNACCOUNT:general-resource/specific-resource',
+        );
+    });
+
+    it('should return correct ARN for SUR service', () => {
+        const surParams = [...constructorParams];
+        surParams[7] = 'sur';
+        const surRC = new RequestContext(...surParams);
+        assert.strictEqual(surRC.getResource(), 'arn:scality:sur::JOHNACCOUNT:general-resource/specific-resource');
+    });
+
+    it('should return correct ARN for ring service', () => {
+        const ringParams = [...constructorParams];
+        ringParams[7] = 'ring';
+        const ringRC = new RequestContext(...ringParams);
+        assert.strictEqual(ringRC.getResource(), 'arn:aws:ring::JOHNACCOUNT:general-resource/specific-resource');
+    });
+
+    it('should return correct ARN for sso service', () => {
+        const ssoParams = [...constructorParams];
+        ssoParams[7] = 'sso';
+        const ssoRC = new RequestContext(...ssoParams);
+        assert.strictEqual(ssoRC.getResource(), 'arn:scality:sso:::general-resource/specific-resource');
+    });
+
+    it('should return correct ARN for s3 service without specific resource', () => {
+        const s3Params = [...constructorParams];
+        s3Params[3] = undefined; // specificResource
+        const s3RC = new RequestContext(...s3Params);
+        assert.strictEqual(s3RC.getResource(), 'arn:aws:s3:::general-resource');
+    });
+
+    it('should return correct ARN for s3 service without general and specific resource', () => {
+        const s3Params = [...constructorParams];
+        s3Params[2] = undefined; // generalResource
+        s3Params[3] = undefined; // specificResource
+        const s3RC = new RequestContext(...s3Params);
+        assert.strictEqual(s3RC.getResource(), 'arn:aws:s3:::');
+    });
+
+    it('should return undefined for unknown service', () => {
+        const unknownParams = [...constructorParams];
+        unknownParams[7] = 'unknown';
+        const unknownRC = new RequestContext(...unknownParams);
+        assert.strictEqual(unknownRC.getResource(), undefined);
     });
 });


### PR DESCRIPTION
Cherry-pick https://github.com/scality/Arsenal/pull/2345 to `development/7.70`.

The bump of the setup-node action is to fix this failure: https://github.com/scality/Arsenal/actions/runs/14513865716/job/40718461569

Issue: ARSN-487