### PR TITLE
Improvement/Fixup on buckets creations

### DIFF
--- a/lib/models/Veeam.ts
+++ b/lib/models/Veeam.ts
@@ -4,6 +4,7 @@
  * The capcity-related field accept numbers, but will be treated as
  * bigints internally.
  */
+import { Long } from 'mongodb';
 export type VeeamSOSApiSchema = {
     SystemInfo?: {
         ProtocolVersion: string,
@@ -26,9 +27,9 @@ export type VeeamSOSApiSchema = {
         LastModified?: string,
     },
     CapacityInfo?: {
-        Capacity: bigint | number,
-        Available: bigint | number,
-        Used: bigint | number,
+        Capacity: bigint,
+        Available: bigint,
+        Used: bigint,
         LastModified?: string,
     },
 };
@@ -52,7 +53,12 @@ export type VeeamSOSApiSerializable = Omit<VeeamSOSApiSchema, 'CapacityInfo'> & 
  * ability to use the proprietary SOSAPI feature.
  */
 export class VeeamCapacityInfo {
-    static serialize(capacity: VeeamSOSApiSchema['CapacityInfo']): VeeamSOSApiSerializable['CapacityInfo'] {
+    static serialize(capacity: {
+        Capacity: bigint | number | Long,
+        Available: bigint | number | Long,
+        Used: bigint | number | Long,
+        LastModified?: string,
+    }): VeeamSOSApiSerializable['CapacityInfo'] {
         return {
             Capacity: capacity?.Capacity?.toString() || '0',
             Available: capacity?.Available?.toString() || '0',

--- a/lib/storage/metadata/mongoclient/MongoClientInterface.ts
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.ts
@@ -19,7 +19,7 @@ import errors, { ArsenalError, errorInstances } from '../../../errors';
 import BucketInfo, { BucketMetadata, Capabilities } from '../../../models/BucketInfo';
 import ObjectMD, { ObjectMDData } from '../../../models/ObjectMD';
 import * as jsutil from '../../../jsutil';
-import { ArsenalCallback } from '../../../types';
+import { ArsenalCallback, NestedOmit } from '../../../types';
 
 import { MongoClient, UpdateFilter, Long, MongoServerError } from 'mongodb';
 import type {
@@ -45,7 +45,7 @@ import { Transform } from 'stream';
 import { Version } from '../../../versioning/Version';
 
 import { formatMasterKey, formatVersionKey } from './utils';
-import { VeeamCapacityInfo, VeeamSOSApiSchema } from '../../../models/Veeam';
+import { VeeamCapacityInfo } from '../../../models/Veeam';
 import { BucketVersioningFormat } from '../../../versioning/constants';
 
 const VID_NONE = '';
@@ -108,20 +108,19 @@ export type MongoDBClientInterfaceParameters = {
     shardCollections: boolean,
 };
 
-export type CapabilitiesMongoDB = Capabilities & {
-    VeeamSOSApi?: Omit<VeeamSOSApiSchema, 'CapacityInfo'> & {
-        CapacityInfo?: {
-            Capacity: Long,
-            Available: Long,
-            Used: Long,
-        },
-    },
-}
-
 export type BucketMetadataMongoDB = Omit<Omit<BucketMetadata, 'quotaMax'>, 'capabilities'> & {
-    // Old buckets might not have a quotaMax
-    quotaMax?: Long,
-    capabilities?: CapabilitiesMongoDB,
+    // Old buckets might not have a quotaMax 
+    quotaMax?: Long;
+    capabilities?: NestedOmit<Capabilities, 'VeeamSOSApi.CapacityInfo'> & {
+        VeeamSOSApi?: {
+            CapacityInfo?: {
+                Capacity: Long;
+                Available: Long;
+                Used: Long;
+                LastModified?: string;
+            };
+        };
+    };
 };
 
 export interface BucketMetastoreDocument extends Document {
@@ -411,7 +410,18 @@ class MongoClientInterface {
                 value: {
                     ...newBucketMD,
                     quotaMax: new Long(newBucketMD.quotaMax || '0'),
-                    capabilities: undefined,
+                    capabilities: newBucketMD.capabilities && {
+                        ...newBucketMD.capabilities,
+                        VeeamSOSApi: newBucketMD.capabilities.VeeamSOSApi && {
+                            ...newBucketMD.capabilities.VeeamSOSApi,
+                            CapacityInfo: newBucketMD.capabilities.VeeamSOSApi.CapacityInfo && {
+                                Capacity: new Long(newBucketMD.capabilities.VeeamSOSApi.CapacityInfo.Capacity || '0'),
+                                Available: new Long(newBucketMD.capabilities.VeeamSOSApi.CapacityInfo.Available || '0'),
+                                Used: new Long(newBucketMD.capabilities.VeeamSOSApi.CapacityInfo.Used || '0'),
+                                LastModified: (newBucketMD.capabilities.VeeamSOSApi.CapacityInfo as any).LastModified,
+                            },
+                        },
+                    },
                 },
                 vFormat: this.defaultBucketKeyFormat,
             },

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,3 +5,18 @@ export interface ArsenalCallback<T> {
     (err: void): void;
     (err: ArsenalError): void;
 };
+
+type Primitive = string | number | boolean | symbol | null | undefined | bigint;
+
+type StripKey<K extends PropertyKey, P extends PropertyKey> =
+    K extends `${Exclude<P, symbol>}.${infer R}` ? R : never;
+
+export type NestedOmit<T, K extends PropertyKey> =
+    T extends Primitive | Function
+        ? T
+        : T extends Array<infer U>
+            ? Array<NestedOmit<U, K>>
+            : {
+                [P in keyof T as P extends Extract<K, string> ? never : P]:
+                    NestedOmit<T[P], StripKey<K, P>>;
+            };

--- a/tests/unit/storage/metadata/mongoclient/MongoClientInterface.spec.js
+++ b/tests/unit/storage/metadata/mongoclient/MongoClientInterface.spec.js
@@ -578,6 +578,77 @@ describe('MongoClientInterface, tests', () => {
             next => client.deleteBucket(bucketName, logger, err => next(err)),
         ], done);
     });
+
+    it('should create a bucket with VeeamSOSApi CapacityInfo and retrieve it correctly', done => {
+        const bucketName = 'test-bucket-veeam-capacity';
+        const veeamCapacity = {
+            Capacity: '1000000000000000000',
+            Available: '500000000000000000',
+            Used: '500000000000000000',
+            LastModified: new Date().toISOString(),
+        };
+        const expectedACL = {
+            Canned: 'private',
+            FULL_CONTROL: [],
+            WRITE: [],
+            WRITE_ACP: [],
+            READ: [],
+            READ_ACP: [],
+        };
+
+        async.waterfall([
+            next => {
+                const bucketMD = BucketInfo.fromObj({
+                    _name: bucketName,
+                    _owner: 'testowner',
+                    _ownerDisplayName: 'testdisplayname',
+                    _creationDate: new Date().toJSON(),
+                    _acl: expectedACL,
+                    _mdBucketModelVersion: 10,
+                    _transient: false,
+                    _deleted: false,
+                    _serverSideEncryption: null,
+                    _versioningConfiguration: null,
+                    _locationConstraint: 'us-east-1',
+                    _capabilities: {
+                        VeeamSOSApi: {
+                            SOSApiMode: 'enabled',
+                            CapacityInfo: veeamCapacity,
+                        },
+                    },
+                    _quotaMax: '0',
+                });
+                client.createBucket(bucketName, bucketMD, logger, err => next(err));
+            },
+            next => {
+                client.getBucketAttributes(bucketName, logger, (err, bucketInfo) => {
+                    next(err, bucketInfo);
+                });
+            },
+        ], (err, bucketInfo) => {
+            assert.ifError(err);
+            assert.ok(bucketInfo, 'BucketInfo should be retrieved');
+
+            const retrievedCapabilities = bucketInfo.getCapabilities();
+            assert.ok(retrievedCapabilities, 'Capabilities should exist');
+            assert.ok(retrievedCapabilities.VeeamSOSApi, 'VeeamSOSApi capabilities should exist');
+
+            const retrievedCapacityInfo = retrievedCapabilities.VeeamSOSApi.CapacityInfo;
+            assert.ok(retrievedCapacityInfo, 'VeeamSOSApi.CapacityInfo should exist');
+
+            assert.strictEqual(typeof retrievedCapacityInfo.Capacity, 'bigint', 'Capacity should be a bigint');
+            assert.strictEqual(retrievedCapacityInfo.Capacity.toString(), veeamCapacity.Capacity, 'Capacity value mismatch');
+
+            assert.strictEqual(typeof retrievedCapacityInfo.Available, 'bigint', 'Available should be a bigint');
+            assert.strictEqual(retrievedCapacityInfo.Available.toString(), veeamCapacity.Available, 'Available value mismatch');
+
+            assert.strictEqual(typeof retrievedCapacityInfo.Used, 'bigint', 'Used should be a bigint');
+            assert.strictEqual(retrievedCapacityInfo.Used.toString(), veeamCapacity.Used, 'Used value mismatch');
+
+            assert.strictEqual(retrievedCapacityInfo.LastModified, veeamCapacity.LastModified, 'LastModified value mismatch');
+            done();
+        });
+    });
 });
 
 describe('MongoClientInterface, updateDeleteMaster', () => {


### PR DESCRIPTION
with the migration to typescript the bucket creation has been changed always passing the capabilities as `undefined` , which is now breaking s3utils as we’re not able to retrieve the capabilities in order to update them

Issue: ARSN-492 