### PR TITLE
Fixes for cloudserver unification

### DIFF
--- a/lib/models/BucketInfo.ts
+++ b/lib/models/BucketInfo.ts
@@ -322,7 +322,7 @@ export default class BucketInfo implements BucketMetadata {
             READ_ACP: [],
         };
 
-        if (tags === undefined) {
+        if (!tags) {
             tags = [] as BucketTag[];
         }
         assert.strictEqual(areTagsValid(tags), true);

--- a/lib/models/LifecycleConfiguration.ts
+++ b/lib/models/LifecycleConfiguration.ts
@@ -94,6 +94,7 @@ export default class LifecycleConfiguration {
     _ruleIDs: string[];
     _tagKeys: string[];
     _storageClasses: string[];
+    _supportedLifecycleRules: string[];
     _config: {
         error?: ArsenalError;
         rules?: any[];
@@ -105,13 +106,23 @@ export default class LifecycleConfiguration {
      * @param config - the CloudServer config
      * @return - LifecycleConfiguration instance
      */
-    constructor(xml: any, config: { replicationEndpoints: { site: string }[] }) {
+    constructor(xml: any, config: { replicationEndpoints: { site: string }[], supportedLifecycleRules: string[] }) {
         this._parsedXML = xml;
         this._storageClasses =
             config.replicationEndpoints.map(endpoint => endpoint.site);
+        this._supportedLifecycleRules = this._buildSupportedLifecycleRules(config.supportedLifecycleRules);
         this._ruleIDs = [];
         this._tagKeys = [];
         this._config = {};
+    }
+
+    _buildSupportedLifecycleRules(ruleNames) {
+        return ruleNames.map(rule => {
+            if (rule === 'noncurrentVersionTransition') {
+                return 'NoncurrentVersionTransitions';
+            }
+            return rule.charAt(0).toUpperCase() + rule.slice(1);
+        });
     }
 
     /**
@@ -229,6 +240,13 @@ export default class LifecycleConfiguration {
      * }
      */
     _parseRule(rule: XMLRule) {
+        const isRuleSupported = Object.keys(rule)
+            .some(key => this._supportedLifecycleRules.includes(key));
+        if (!isRuleSupported) {
+            const msg = 'lifecycle action not implemented';
+            const error = errorInstances.NotImplemented.customizeDescription(msg);
+            return { error };
+        }
         // Either Prefix or Filter must be included, but can be empty string
         if ((!rule.Filter && rule.Filter !== '') &&
         (!rule.Prefix && rule.Prefix !== '')) {

--- a/lib/models/LifecycleConfiguration.ts
+++ b/lib/models/LifecycleConfiguration.ts
@@ -5,7 +5,6 @@ import errors, { errorInstances } from '../errors';
 import type { ArsenalError } from '../errors';
 import LifecycleRule from './LifecycleRule';
 import escapeForXml from '../s3middleware/escapeForXml';
-import type { XMLRule } from './ReplicationConfiguration';
 import { Status } from './LifecycleRule';
 
 const MAX_DAYS = 2147483647; // Max 32-bit signed binary integer.
@@ -89,6 +88,18 @@ export type LifecycleConfigurationMetadata = {
     rules: Rule[],
 };
 
+export type LifecycleXMLRule = {
+    Prefix: string[];
+    Status: Status[];
+    ID?: string[];
+    Filter?: string;
+    Transition?: any[];
+    NoncurrentVersionTransition?: any[];
+    Expiration?: any[];
+    NoncurrentVersionExpiration?: any[];
+    AbortIncompleteMultipartUploads?: any[];
+};
+
 export default class LifecycleConfiguration {
     _parsedXML: any;
     _ruleIDs: string[];
@@ -110,19 +121,36 @@ export default class LifecycleConfiguration {
         this._parsedXML = xml;
         this._storageClasses =
             config.replicationEndpoints.map(endpoint => endpoint.site);
-        this._supportedLifecycleRules = this._buildSupportedLifecycleRules(config.supportedLifecycleRules);
+        this._supportedLifecycleRules = LifecycleConfiguration._buildSupportedLifecycleRules(
+            config.supportedLifecycleRules,
+        );
         this._ruleIDs = [];
         this._tagKeys = [];
         this._config = {};
     }
 
-    _buildSupportedLifecycleRules(ruleNames) {
-        return ruleNames.map(rule => {
+    // Memoize the supported lifecycle rules to avoid recalculating them
+    // We expect a single set of supported lifecycle rules to ever be used (typically from config),
+    // so a length of 1 is enough.
+    static _cachedSupportedLifecycleRules = {
+        names: [] as string[],
+        rules: [] as string[],
+    };
+
+    static _buildSupportedLifecycleRules(names) {
+        if (LifecycleConfiguration._cachedSupportedLifecycleRules.names === names) {
+            return LifecycleConfiguration._cachedSupportedLifecycleRules.rules;
+        }
+
+        const rules = names.map(rule => {
             if (rule === 'noncurrentVersionTransition') {
                 return 'NoncurrentVersionTransitions';
             }
             return rule.charAt(0).toUpperCase() + rule.slice(1);
         });
+
+        LifecycleConfiguration._cachedSupportedLifecycleRules = { names, rules };
+        return rules;
     }
 
     /**
@@ -239,17 +267,9 @@ export default class LifecycleConfiguration {
      *      ]
      * }
      */
-    _parseRule(rule: XMLRule) {
-        const isRuleSupported = Object.keys(rule)
-            .some(key => this._supportedLifecycleRules.includes(key));
-        if (!isRuleSupported) {
-            const msg = 'lifecycle action not implemented';
-            const error = errorInstances.NotImplemented.customizeDescription(msg);
-            return { error };
-        }
+    _parseRule(rule: LifecycleXMLRule) {
         // Either Prefix or Filter must be included, but can be empty string
-        if ((!rule.Filter && rule.Filter !== '') &&
-        (!rule.Prefix && rule.Prefix !== '')) {
+        if ((!rule.Filter && rule.Filter !== '') && (!rule.Prefix && rule.Prefix !== '')) {
             const msg = 'Rule xml does not include valid Filter or Prefix';
             const error = errorInstances.MalformedXML.customizeDescription(msg);
             return { error };
@@ -917,11 +937,20 @@ export default class LifecycleConfiguration {
             'NoncurrentVersionTransition',
             'Transition',
         ];
-        validActions.forEach(a => {
-            if (rule[a]) {
-                actionsObj.actions.push({ actionName: `${a}` });
+        for (const action of validActions) {
+            if (!rule[action]) {
+                continue;
             }
-        });
+
+            const isRuleSupported = this._supportedLifecycleRules.includes(action);
+            if (!isRuleSupported) {
+                const msg = `${action} lifecycle action not implemented`;
+                const error = errorInstances.NotImplemented.customizeDescription(msg);
+                return { ...actionsObj, error };
+            }
+
+            actionsObj.actions.push({ actionName: action });
+        }
         if (actionsObj.actions.length === 0) {
             const msg = 'Rule does not include valid action';
             const error = errorInstances.InvalidRequest.customizeDescription(msg);

--- a/lib/s3routes/routesUtils.ts
+++ b/lib/s3routes/routesUtils.ts
@@ -525,7 +525,7 @@ function _computeContentLengthFromLocation(
                 return sum + parseInt(location.size, 10);
             }
         }
-        return sum;
+        return undefined;
     }, 0);
 }
 

--- a/lib/s3routes/routesUtils.ts
+++ b/lib/s3routes/routesUtils.ts
@@ -23,6 +23,22 @@ export type CallApiMethod = (
 ) => void;
 
 /**
+ * Convert an error to an ArsenalError instance
+ * @param err - Error to convert
+ * @returns ArsenalError instance
+ */
+export function toArsenalError(err: ArsenalError | Error): ArsenalError {
+    if (err instanceof ArsenalError) {
+        return err;
+    }
+
+    // If it's a known error type, use the error instance, otherwise wrap
+    // it in an InternalError
+    return errorInstances[err.message] ||
+        errorInstances.InternalError.customizeDescription(err.message);
+}
+
+/**
  * setCommonResponseHeaders - Set HTTP response headers
  * @param headers - key and value of new headers to add
  * @param response - http response object
@@ -117,13 +133,9 @@ export const XMLResponseBackend = {
         log: RequestLogger,
         corsHeaders?: Record<string, string> | null,
     ) {
+        const error = toArsenalError(errCode);
         setCommonResponseHeaders(corsHeaders, response, log);
-        let error: ArsenalError;
-        if (errCode instanceof ArsenalError) {
-            error = errCode;
-        } else {
-            error = errorInstances.InternalError.customizeDescription(errCode.message);
-        }
+
         // early return to avoid extra headers and XML data
         if (error.code === 304) {
             response.writeHead(error.code);
@@ -213,13 +225,9 @@ export const JSONResponseBackend = {
         log: RequestLogger,
         corsHeaders?: Record<string, string> | null,
     ) {
+        const error = toArsenalError(errCode);
         log.trace('sending error json response', { errCode });
-        let error: ArsenalError;
-        if (errCode instanceof ArsenalError) {
-            error = errCode;
-        } else {
-            error = errorInstances.InternalError.customizeDescription(errCode.message);
-        }
+
         /*
         {
             "code": "NoSuchKey",
@@ -710,12 +718,7 @@ export function streamUserErrorPage(
     corsHeaders: Record<string, string>,
     log: RequestLogger,
 ) {
-    let error: ArsenalError;
-    if (err instanceof ArsenalError) {
-        error = err;
-    } else {
-        error = errorInstances.InternalError.customizeDescription(err.message);
-    }
+    const error = toArsenalError(err);
     // Prepare the headers, but do not send them
     // as errors might still happen when retrieving the data
     setCommonResponseHeaders(corsHeaders, response, log);
@@ -742,15 +745,8 @@ export function errorHtmlResponse(
     corsHeaders: Record<string, string> | null,
     log: RequestLogger,
 ) {
-    let error;
-    if (err instanceof ArsenalError) {
-        error = err;
-    } else {
-        error = errorInstances.InternalError.customizeDescription(err.message);
-    }
-
-    log.trace('sending generic html error page',
-        { error });
+    const error = toArsenalError(err);
+    log.trace('sending generic html error page', { error });
     setCommonResponseHeaders(corsHeaders, response, log);
     response.writeHead(error.code, { 'Content-type': 'text/html' });
     const html: string[] = [];
@@ -813,14 +809,8 @@ export function errorHeaderResponse(
     corsHeaders: Record<string, string>,
     log: RequestLogger,
 ) {
-    let error: ArsenalError;
-    if (err instanceof ArsenalError) {
-        error = err;
-    } else {
-        error = errorInstances.InternalError.customizeDescription(err.message);
-    }
-    log.trace('sending error header response',
-        { error });
+    const error = toArsenalError(err);
+    log.trace('sending error header response', { error });
     setCommonResponseHeaders(corsHeaders, response, log);
     response.setHeader('x-amz-error-code', error.message);
     response.setHeader('x-amz-error-message', error.description);
@@ -948,14 +938,8 @@ export function redirectRequestOnError(
     corsHeaders: Record<string, string>,
     log: RequestLogger,
 ) {
+    const error = toArsenalError(err);
     response.setHeader('Location', routingInfo.location);
-
-    let error: ArsenalError;
-    if (err instanceof ArsenalError) {
-        error = err;
-    } else {
-        error = errorInstances.InternalError.customizeDescription(err.message);
-    }
 
     if (!dataLocations && error.is.Found) {
         if (method === 'HEAD') {

--- a/tests/unit/models/BucketInfo.spec.js
+++ b/tests/unit/models/BucketInfo.spec.js
@@ -747,6 +747,62 @@ describe('uid default', () => {
     });
 });
 
+describe('tags validation', () => {
+    it('should set empty array if tags is undefined', () => {
+        const dummyBucket = new BucketInfo(
+            bucketName, owner, ownerDisplayName, testDate,
+            BucketInfo.currentModelVersion(), acl[emptyAcl],
+            false, false, {
+                cryptoScheme: 1,
+                algorithm: 'sha1',
+                masterKeyId: 'somekey',
+                mandatory: true,
+            },
+        );
+        assert.deepStrictEqual(dummyBucket._tags, []);
+    });
+
+    it('should set empty array if tags is null', () => {
+        const dummyBucket = new BucketInfo(
+            bucketName, owner, ownerDisplayName, testDate,
+            BucketInfo.currentModelVersion(), acl[emptyAcl],
+            false, false, {
+                cryptoScheme: 1,
+                algorithm: 'sha1',
+                masterKeyId: 'somekey',
+                mandatory: true,
+            },
+            undefined, undefined, undefined, undefined,
+            undefined, undefined, undefined, undefined,
+            undefined, undefined, undefined, undefined,
+            undefined, undefined, undefined, null);
+        assert.deepStrictEqual(dummyBucket._tags, []);
+    });
+
+    it('should throw assertion error if tags are invalid', () => {
+        const invalidTags = [
+            { Key: 'key1' }, // missing Value
+            { Value: 'value1' }, // missing Key
+            { Key: '', Value: 'value1' }, // empty Key
+        ];
+        assert.throws(() => {
+            new BucketInfo(
+                bucketName, owner, ownerDisplayName, testDate,
+                BucketInfo.currentModelVersion(), acl[emptyAcl],
+                false, false, {
+                    cryptoScheme: 1,
+                    algorithm: 'sha1',
+                    masterKeyId: 'somekey',
+                    mandatory: true,
+                },
+                undefined, undefined, undefined, undefined,
+                undefined, undefined, undefined, undefined,
+                undefined, undefined, undefined, undefined,
+                undefined, undefined, undefined, invalidTags);
+        }, /AssertionError/);
+    });
+});
+
 describe('ingest', () => {
     it('should enable ingestion if ingestion param sent on bucket creation',
         () => {

--- a/tests/unit/models/LifecycleConfiguration.spec.js
+++ b/tests/unit/models/LifecycleConfiguration.spec.js
@@ -19,6 +19,13 @@ const mockConfig = {
             site: 'b',
         },
     ],
+    supportedLifecycleRules: [
+        'expiration',
+        'noncurrentVersionExpiration',
+        'abortIncompleteMultipartUpload',
+        'transition',
+        'noncurrentVersionTransition',
+    ],
 };
 
 const MAX_DAYS = 2147483647; // Max 32-bit signed binary integer.
@@ -385,6 +392,57 @@ describe('LifecycleConfiguration class getLifecycleConfiguration', () => {
                 getLifecycleConfiguration();
             assert.strictEqual(expectedPrefix,
                 lcConfig.rules[0].filter.rulePrefix);
+            done();
+        });
+    });
+
+    it('should return NotImplemented error when rule action is not supported', done => {
+        mockConfig.supportedLifecycleRules = ['expiration']; // Only support expiration
+        const xml = `
+            <LifecycleConfiguration>
+                <Rule>
+                    <ID>test-rule</ID>
+                    <Status>Enabled</Status>
+                    <Filter></Filter>
+                    <Transition>
+                        <Days>1</Days>
+                        <StorageClass>a</StorageClass>
+                    </Transition>
+                </Rule>
+            </LifecycleConfiguration>`;
+        parseString(xml, (err, parsedXml) => {
+            assert.equal(err, null, 'Error parsing xml');
+            const lcConfig = new LifecycleConfiguration(parsedXml, mockConfig)
+                .getLifecycleConfiguration();
+            assert.strictEqual(lcConfig.error.is.NotImplemented, true);
+            assert.strictEqual(lcConfig.error.description, 'Transition lifecycle action not implemented');
+            done();
+        });
+    });
+
+    it('should return NotImplemented error when some rule action are not supported', done => {
+        mockConfig.supportedLifecycleRules = ['expiration']; // Only support expiration
+        const xml = `
+            <LifecycleConfiguration>
+                <Rule>
+                    <ID>test-rule</ID>
+                    <Status>Enabled</Status>
+                    <Filter></Filter>
+                    <Expiration>
+                        <Days>2</Days>
+                    </Expiration>
+                    <Transition>
+                        <Days>1</Days>
+                        <StorageClass>a</StorageClass>
+                    </Transition>
+                </Rule>
+            </LifecycleConfiguration>`;
+        parseString(xml, (err, parsedXml) => {
+            assert.equal(err, null, 'Error parsing xml');
+            const lcConfig = new LifecycleConfiguration(parsedXml, mockConfig)
+                .getLifecycleConfiguration();
+            assert.strictEqual(lcConfig.error.is.NotImplemented, true);
+            assert.strictEqual(lcConfig.error.description, 'Transition lifecycle action not implemented');
             done();
         });
     });
@@ -1288,4 +1346,56 @@ describe('LifecycleConfiguration::getConfigJson', () => {
                 expected,
             );
         }));
+});
+
+describe('::_buildSupportedLifecycleRules', () => {
+    beforeEach(() => {
+        LifecycleConfiguration._cachedSupportedLifecycleRules = {
+            names: undefined,
+            rules: undefined,
+        };
+    });
+
+    it('should capitalize first letter of each rule name', () => {
+        const names = ['expiration', 'transition'];
+        const result = LifecycleConfiguration._buildSupportedLifecycleRules(names);
+        assert.deepStrictEqual(result, ['Expiration', 'Transition']);
+    });
+
+    it('should handle special case for noncurrentVersionTransition', () => {
+        const names = ['noncurrentVersionTransition'];
+        const result = LifecycleConfiguration._buildSupportedLifecycleRules(names);
+        assert.deepStrictEqual(result, ['NoncurrentVersionTransitions']);
+    });
+
+    it('should memoize results for subsequent calls with same input', () => {
+        const names = ['expiration', 'transition'];
+        const result1 = LifecycleConfiguration._buildSupportedLifecycleRules(names);
+        const result2 = LifecycleConfiguration._buildSupportedLifecycleRules(names);
+
+        assert.deepStrictEqual(result1, ['Expiration', 'Transition']);
+        assert.strictEqual(result1, result2); // Should be same instance
+    });
+
+    it('should recalculate for different input', () => {
+        const names1 = ['expiration'];
+        const names2 = ['transition'];
+
+        const result1 = LifecycleConfiguration._buildSupportedLifecycleRules(names1);
+        const result2 = LifecycleConfiguration._buildSupportedLifecycleRules(names2);
+
+        assert.deepStrictEqual(result1, ['Expiration']);
+        assert.deepStrictEqual(result2, ['Transition']);
+        assert.notStrictEqual(result1, result2); // Should be different instances
+    });
+
+    it('should handle mixed rule names including special cases', () => {
+        const names = ['expiration', 'noncurrentVersionTransition', 'transition'];
+        const result = LifecycleConfiguration._buildSupportedLifecycleRules(names);
+        assert.deepStrictEqual(result, [
+            'Expiration',
+            'NoncurrentVersionTransitions',
+            'Transition',
+        ]);
+    });
 });

--- a/tests/unit/s3middleware/tagging.spec.js
+++ b/tests/unit/s3middleware/tagging.spec.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const { _validator } = require('../../../lib/s3middleware/tagging');
+const { areTagsValid, _validator } = require('../../../lib/s3middleware/tagging');
 
 describe('tagging validator', () => {
     it('validates keys and values are less than 128 and 256', () => {
@@ -17,5 +17,79 @@ describe('tagging validator', () => {
     it('allows any utf8 string in keys and values', () => {
         const result = _validator.validateKeyValue('あいう', '😀😄');
         assert.strictEqual(result, true);
+    });
+});
+
+describe('areTagsValid', () => {
+    it('should return true for empty array', () => {
+        const result = areTagsValid([]);
+        assert.strictEqual(result, true);
+    });
+
+    it('should return true for valid tags', () => {
+        const validTags = [
+            { Key: 'key1', Value: 'value1' },
+            { Key: 'key2', Value: 'value2' }
+        ];
+        const result = areTagsValid(validTags);
+        assert.strictEqual(result, true);
+    });
+
+    it('should return false if number of tags exceed 50', () => {
+        const tags = Array(51).fill(0).map((_, i) => ({
+            Key: `key${i}`,
+            Value: `value${i}`
+        }));
+        const result = areTagsValid(tags);
+        assert.strictEqual(result, false);
+    });
+
+    it('should return false for tags with missing Key', () => {
+        const invalidTags = [
+            { Value: 'value1' }
+        ];
+        const result = areTagsValid(invalidTags);
+        assert.strictEqual(result, false);
+    });
+
+    it('should return false for tags with missing Value', () => {
+        const invalidTags = [
+            { Key: 'key1' }
+        ];
+        const result = areTagsValid(invalidTags);
+        assert.strictEqual(result, false);
+    });
+
+    it('should return false for tags with empty Key', () => {
+        const invalidTags = [
+            { Key: '', Value: 'value1' }
+        ];
+        const result = areTagsValid(invalidTags);
+        assert.strictEqual(result, false);
+    });
+
+    it('should return false for tags with duplicate keys', () => {
+        const invalidTags = [
+            { Key: 'key1', Value: 'value1' },
+            { Key: 'key1', Value: 'value2' }
+        ];
+        const result = areTagsValid(invalidTags);
+        assert.strictEqual(result, false);
+    });
+
+    it('should return false for tags with Key longer than 128 characters', () => {
+        const invalidTags = [
+            { Key: 'a'.repeat(129), Value: 'value1' }
+        ];
+        const result = areTagsValid(invalidTags);
+        assert.strictEqual(result, false);
+    });
+
+    it('should return false for tags with Value longer than 256 characters', () => {
+        const invalidTags = [
+            { Key: 'key1', Value: 'a'.repeat(257) }
+        ];
+        const result = areTagsValid(invalidTags);
+        assert.strictEqual(result, false);
     });
 });

--- a/tests/unit/s3routes/routesUtils/responseBody.spec.ts
+++ b/tests/unit/s3routes/routesUtils/responseBody.spec.ts
@@ -5,7 +5,7 @@ import * as werelogs from 'werelogs';
 const logger = new werelogs.Logger('test:routesUtils.responseStreamData');
 
 describe('responseXMLBody: ', () => {
-    it('Should include invalid arguments in reponse body', done => {
+    it('Should include invalid arguments in response body', done => {
         const invalidArgument1 = { ArgumentName: 'argumentName1', ArgumentValue: 'argumentValue1' };
         const invalidArgument2 = { ArgumentName: 'argumentName2', ArgumentValue: 'argumentValue2' };
         const error = errorInstances.InvalidArgument.addMetadataEntry('invalidArguments',
@@ -34,7 +34,7 @@ describe('responseXMLBody: ', () => {
         }, logger.newRequestLogger());
     });
 
-    it('Should not include invalid arguments in reponse body', done => {
+    it('Should not include invalid arguments in response body', done => {
         const error = errors.InvalidArgument;
         responseXMLBody(error, '', {
             // @ts-ignore
@@ -60,7 +60,7 @@ describe('responseXMLBody: ', () => {
 });
 
 describe('JSONResponseBackend: ', () => {
-    it('Should include invalid arguments in reponse body', done => {
+    it('Should include invalid arguments in response body', done => {
         const invalidArgument1 = { ArgumentName: 'argumentName1', ArgumentValue: 'argumentValue1' };
         const invalidArgument2 = { ArgumentName: 'argumentName2', ArgumentValue: 'argumentValue2' };
         const error = errorInstances.InvalidArgument.addMetadataEntry('invalidArguments',
@@ -90,7 +90,7 @@ describe('JSONResponseBackend: ', () => {
         }, logger.newRequestLogger());
     });
 
-    it('Should not include invalid arguments in reponse body', done => {
+    it('Should not include invalid arguments in response body', done => {
         const error = errors.InvalidArgument;
         responseJSONBody(error, '', {
             // @ts-ignore

--- a/tests/unit/s3routes/routesUtils/responseStreamData.spec.js
+++ b/tests/unit/s3routes/routesUtils/responseStreamData.spec.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const http = require('http');
+const sinon = require('sinon');
 
 const werelogs = require('werelogs');
 const logger = new werelogs.Logger('test:routesUtils.responseStreamData');
@@ -14,6 +15,118 @@ werelogs.configure({
 });
 
 describe('routesUtils.responseStreamData', () => {
+    describe('content length validation', () => {
+        let response;
+        let log;
+        let sandbox;
+        const mockClient = {
+            get: (info, range, uid, cb) => cb(null, new DummyObjectStream(0, 15)),
+        };
+
+        beforeEach(() => {
+            sandbox = sinon.createSandbox();
+            response = {
+                setHeader: sandbox.stub(),
+                writeHead: sandbox.stub(),
+                on: sandbox.stub(),
+                once: sandbox.stub(),
+                emit: sandbox.stub(),
+                write: sandbox.stub().returns(true),
+                end: sandbox.stub(),
+                socket: { destroy: sandbox.stub() },
+            };
+            log = logger.newRequestLogger();
+        });
+
+        afterEach(() => {
+            sandbox.restore();
+        });
+
+        it('should succeed when content length matches data locations total size', () => {
+            const resHeaders = { 'Content-Length': '15' };
+            const dataLocations = [
+                { size: 10, key: 'value1' },
+                { size: 5, key: 'value2' },
+            ];
+
+            responseStreamData(
+                null,
+                {},
+                resHeaders,
+                dataLocations,
+                { client: mockClient },
+                response,
+                undefined,
+                log,
+            );
+
+            sinon.assert.calledWith(response.writeHead, 200);
+        });
+
+        it('should fail when content length does not match total size', () => {
+            const resHeaders = { 'Content-Length': '20' };
+            const dataLocations = [
+                { size: 10, key: 'value1' },
+                { size: 5, key: 'value2' },
+            ];
+
+            responseStreamData(
+                null,
+                {},
+                resHeaders,
+                dataLocations,
+                { client: mockClient },
+                response,
+                undefined,
+                log,
+            );
+
+            sinon.assert.calledWith(response.writeHead, 500);
+        });
+
+        it('should succeed when data locations do not specify size', () => {
+            const resHeaders = { 'Content-Length': '15' };
+            const dataLocations = [
+                { key: 'value1' },
+                { key: 'value2' },
+            ];
+
+            responseStreamData(
+                null,
+                {},
+                resHeaders,
+                dataLocations,
+                { client: mockClient },
+                response,
+                undefined,
+                log,
+            );
+
+            sinon.assert.calledWith(response.writeHead, 200);
+        });
+
+        it('should succeed when Content-Length header is not set', () => {
+            const resHeaders = {}; // No Content-Length header
+            const dataLocations = [
+                { size: 10, key: 'key1' },
+                { size: 5, key: 'key2' },
+            ];
+
+            responseStreamData(
+                null,
+                {},
+                resHeaders,
+                dataLocations,
+                { client: mockClient },
+                response,
+                undefined,
+                log,
+            );
+
+            sinon.assert.calledWith(response.writeHead, 200);
+        });
+    });
+
     const awsAgent = new http.Agent({
         keepAlive: true,
     });

--- a/tests/unit/s3routes/routesUtils/toArsenalError.spec.ts
+++ b/tests/unit/s3routes/routesUtils/toArsenalError.spec.ts
@@ -1,0 +1,24 @@
+import { ArsenalError, errorInstances } from '../../../../lib/errors';
+import { toArsenalError } from '../../../../lib/s3routes/routesUtils';
+
+describe('toArsenalError', () => {
+    it('should return the same error if input is already an ArsenalError', () => {
+        const originalError = errorInstances.NoSuchBucket;
+        const result = toArsenalError(originalError);
+        expect(result).toBe(originalError);
+    });
+
+    it('should use existing error instance if error message matches known error type', () => {
+        const error = new Error('NoSuchBucket');
+        const result = toArsenalError(error);
+        expect(result).toBe(errorInstances.NoSuchBucket);
+    });
+
+    it('should wrap unknown error in InternalError with custom description', () => {
+        const error = new Error('Unknown error occurred');
+        const result = toArsenalError(error);
+        expect(result).toBeInstanceOf(ArsenalError);
+        expect(result.message).toBe('InternalError');
+        expect(result.description).toBe('Unknown error occurred');
+    });
+});


### PR DESCRIPTION
- accept lifecycle config only if all rules are supported
- return arsenal error of same type when available
- Fix crash on buckets created with 7.70 branch
- Fix validation of unsupported rules
- Fix compute ContentLength from location

Issue: ARSN-490
