### PR TITLE
bf: ARSN-494 exception when parsing replication config without endpoint

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v4
       with:
         node-version: '16'
         cache: 'yarn'

--- a/lib/models/ReplicationConfiguration.ts
+++ b/lib/models/ReplicationConfiguration.ts
@@ -322,14 +322,13 @@ export default class ReplicationConfiguration {
             replicationEndpoints[0];
         // StorageClass is optional.
         if (destination.StorageClass === undefined) {
-            this._hasScalityDestination = defaultEndpoint.type === undefined;
+            this._hasScalityDestination = (defaultEndpoint && defaultEndpoint.type === undefined);
             return undefined;
         }
         const storageClasses = destination.StorageClass[0].split(',');
         const isValidStorageClass = storageClasses.every((storageClass) => {
             if (validStorageClasses.includes(storageClass)) {
-                this._hasScalityDestination =
-                    defaultEndpoint.type === undefined;
+                this._hasScalityDestination = (defaultEndpoint && defaultEndpoint.type === undefined);
                 return true;
             }
             const endpoint = replicationEndpoints.find(
@@ -342,7 +341,7 @@ export default class ReplicationConfiguration {
                 if (!this._hasScalityDestination) {
                     // If any endpoint does not have a type, then we know it is
                     // a Scality destination.
-                    this._hasScalityDestination = endpoint.type === undefined;
+                    this._hasScalityDestination = (endpoint.type === undefined);
                 }
                 return true;
             }
@@ -424,6 +423,11 @@ export default class ReplicationConfiguration {
         const err = this._parseRules();
         if (err) {
             return err;
+        }
+        const { replicationEndpoints } = this._config;
+        if (replicationEndpoints.length === 0) {
+            return errors.InvalidRequest.customizeDescription(
+                'No configured replication endpoint');
         }
         return this._parseRole();
     }

--- a/lib/models/ReplicationConfiguration.ts
+++ b/lib/models/ReplicationConfiguration.ts
@@ -195,8 +195,7 @@ export default class ReplicationConfiguration {
         const invalidRole = rolesArr.find((r) => !this._isValidRoleARN(r));
         if (invalidRole !== undefined) {
             return errors.InvalidArgument.customizeDescription(
-                'Invalid Role specified in replication configuration: ' +
-                    `'${invalidRole}'`
+                `Invalid Role specified in replication configuration: '${invalidRole}'`
             );
         }
         this._role = role;
@@ -269,8 +268,7 @@ export default class ReplicationConfiguration {
         }
         if (prefix.length > 1024) {
             return errors.InvalidArgument.customizeDescription(
-                'Rule prefix ' +
-                    'cannot be longer than maximum allowed key length of 1024'
+                'Rule prefix cannot be longer than maximum allowed key length of 1024'
             );
         }
         // Each Prefix in a list of rules must not overlap. For example, two
@@ -280,7 +278,7 @@ export default class ReplicationConfiguration {
             const used = this._configPrefixes[i];
             if (prefix.startsWith(used) || used.startsWith(prefix)) {
                 return errors.InvalidRequest.customizeDescription(
-                    'Found ' + `overlapping prefixes '${used}' and '${prefix}'`
+                    `Found overlapping prefixes '${used}' and '${prefix}'`
                 );
             }
         }
@@ -296,13 +294,13 @@ export default class ReplicationConfiguration {
         const id = rule.ID && rule.ID[0];
         if (id && id.length > RULE_ID_LIMIT) {
             return errors.InvalidArgument.customizeDescription(
-                'Rule Id cannot be greater than 255'
+                'Rule ID length cannot be greater than 255'
             );
         }
         // Each ID in a list of rules must be unique.
         if (id && this._configIDs.includes(id)) {
             return errors.InvalidRequest.customizeDescription(
-                'Rule Id must be unique'
+                'Duplicate Rule ID'
             );
         }
         if (id !== undefined) {
@@ -396,7 +394,7 @@ export default class ReplicationConfiguration {
         // We can replicate objects only to one destination bucket.
         if (this._destination && this._destination !== bucketARN) {
             return errors.InvalidRequest.customizeDescription(
-                'The destination bucket must be same for all rules'
+                'The destination bucket must be the same for all rules'
             );
         }
         this._destination = bucketARN;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.10.66",
+  "version": "7.10.67",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/models/ReplicationConfiguration.spec.ts
+++ b/tests/unit/models/ReplicationConfiguration.spec.ts
@@ -306,4 +306,39 @@ describe('ReplicationConfiguration.parseConfiguration()', () => {
         const result = instance.parseConfiguration();
         expect(result).toEqual(errors.InvalidRequest);
     });
+
+    it('should return InvalidRequest if StorageClass not provided and cloudserver config has no replication endpoint', () => {
+        const repConfig = {
+            Role: [TEST_ROLE],
+            Rule: [{
+                Prefix: [''],
+                Status: ['Enabled'],
+                Destination: [{
+                    Bucket: ['arn:aws:s3:::crr-dest'],
+                }],
+            }],
+        };
+        const instance = new ReplicationConfiguration({ ReplicationConfiguration: repConfig },
+            null, { replicationEndpoints: [] });
+        const result = instance.parseConfiguration();
+        expect(result).toEqual(errors.InvalidRequest);
+    });
+
+    it('should return InvalidRequest if StorageClass provided and cloudserver config has no replication endpoint', () => {
+        const repConfig = {
+            Role: [TEST_ROLE],
+            Rule: [{
+                Prefix: [''],
+                Status: ['Enabled'],
+                Destination: [{
+                    Bucket: ['arn:aws:s3:::crr-dest'],
+                    StorageClass: ['STANDARD'],
+                }],
+            }],
+        };
+        const instance = new ReplicationConfiguration({ ReplicationConfiguration: repConfig },
+            null, { replicationEndpoints: [] });
+        const result = instance.parseConfiguration();
+        expect(result).toEqual(errors.InvalidRequest);
+    });
 });

--- a/tests/unit/models/ReplicationConfiguration.spec.ts
+++ b/tests/unit/models/ReplicationConfiguration.spec.ts
@@ -1,0 +1,309 @@
+import { errors } from '../../../index';
+
+const { default: ReplicationConfiguration } = require('../../../lib/models/ReplicationConfiguration');
+
+const mockS3ServerConfig = {
+    replicationEndpoints: [{
+        site: 'zenko',
+        servers: ['127.0.0.1:8000'],
+        default: true,
+    }],
+};
+
+const TEST_ROLE =
+      'arn:aws:iam::942839175607:role/crr-trust-role,arn:aws:iam::989181102323:role/crr-trust-role';
+
+describe('ReplicationConfiguration.parseConfiguration()', () => {
+    // --- Valid Configurations ---
+
+    it('should succeed for a minimal valid configuration without storage class', () => {
+        const repConfig = {
+            Role: [TEST_ROLE],
+            Rule: [{
+                Prefix: [''],
+                Status: ['Enabled'],
+                Destination: [{
+                    Bucket: ['arn:aws:s3:::crr-dest'],
+                }],
+            }],
+        };
+        const instance = new ReplicationConfiguration({ ReplicationConfiguration: repConfig },
+            null, mockS3ServerConfig);
+        const result = instance.parseConfiguration();
+        expect(result).toBeUndefined();
+        expect(instance.getRole()).toEqual(TEST_ROLE);
+        expect(instance.getDestination()).toEqual('arn:aws:s3:::crr-dest');
+        const rules = instance.getRules();
+        expect(rules.length).toEqual(1);
+        expect(rules[0].enabled).toBe(true);
+        // should have generated a new random ID
+        expect(typeof rules[0].id).toBe('string');
+        expect(rules[0].prefix).toEqual('');
+    });
+
+    it('should succeed for a minimal valid configuration including Rule ID and destination StorageClass', () => {
+        const repConfig = {
+            Role: [TEST_ROLE],
+            Rule: [{
+                ID: ['RuleID'],
+                Prefix: [''],
+                Status: ['Enabled'],
+                Destination: [{
+                    Bucket: ['arn:aws:s3:::crr-dest'],
+                    StorageClass: ['STANDARD'],
+                }],
+            }],
+        };
+        const instance = new ReplicationConfiguration({ ReplicationConfiguration: repConfig },
+            null, mockS3ServerConfig);
+        const result = instance.parseConfiguration();
+        expect(result).toBeUndefined();
+        expect(instance.getRules()).toEqual([
+            {
+                enabled: true,
+                id: 'RuleID',
+                prefix: '',
+                storageClass: 'STANDARD',
+            },
+        ]);
+    });
+
+    it('should succeed for multiple valid rules with non-overlapping prefixes', () => {
+        const repConfig = {
+            Role: [TEST_ROLE],
+            Rule: [
+                {
+                    ID: ['ImagesRule'],
+                    Prefix: ['main/images/'],
+                    Status: ['Enabled'],
+                    Destination: [{ Bucket: ['arn:aws:s3:::crr-dest'] }],
+                },
+                {
+                    ID: ['DocsAndProjects'],
+                    Prefix: ['main/documents/'],
+                    Status: ['Disabled'],
+                    Destination: [{ Bucket: ['arn:aws:s3:::crr-dest'] }],
+                },
+            ],
+        };
+        const instance = new ReplicationConfiguration({ ReplicationConfiguration: repConfig },
+            null, mockS3ServerConfig);
+        const result = instance.parseConfiguration();
+        expect(result).toBeUndefined();
+        expect(instance.getRole()).toEqual(TEST_ROLE);
+        expect(instance.getDestination()).toEqual('arn:aws:s3:::crr-dest');
+        expect(instance.getRules()).toEqual([
+            {
+                enabled: true,
+                id: 'ImagesRule',
+                prefix: 'main/images/',
+            },
+            {
+                enabled: false,
+                id: 'DocsAndProjects',
+                prefix: 'main/documents/',
+            },
+        ]);
+    });
+
+    // --- Invalid Configurations ---
+
+    it('should return MalformedXML when config is missing a Role array', () => {
+        const repConfig = {
+            Rule: [{
+                Prefix: [''],
+                Status: ['Enabled'],
+                Destination: [{
+                    Bucket: ['arn:aws:s3:::crr-dest'],
+                }],
+            }],
+        };
+        const instance = new ReplicationConfiguration({ ReplicationConfiguration: repConfig },
+            null, mockS3ServerConfig);
+        const result = instance.parseConfiguration();
+        expect(result).toEqual(errors.MalformedXML);
+    });
+
+    it('should return InvalidArgument when Scality destination has a single role', () => {
+        const repConfig = {
+            Role: ['arn:aws:iam::942839175607:role/crr-trust-role'],
+            Rule: [{
+                Prefix: [''],
+                Status: ['Enabled'],
+                Destination: [{
+                    Bucket: ['arn:aws:s3:::crr-dest'],
+                }],
+            }],
+        };
+        const instance = new ReplicationConfiguration({ ReplicationConfiguration: repConfig },
+            null, mockS3ServerConfig);
+        const result = instance.parseConfiguration();
+        expect(result).toEqual(errors.InvalidArgument);
+    });
+
+    // eslint-disable-next-line max-len
+    it('should return InvalidArgument when Scality destination has two comma-separated roles but one is invalid', () => {
+        const repConfig = {
+            Role: [`invalidarn:${TEST_ROLE}`],
+            Rule: [{
+                Prefix: [''],
+                Status: ['Enabled'],
+                Destination: [{
+                    Bucket: ['arn:aws:s3:::crr-dest'],
+                }],
+            }],
+        };
+        const instance = new ReplicationConfiguration({ ReplicationConfiguration: repConfig },
+            null, mockS3ServerConfig);
+        const result = instance.parseConfiguration();
+        expect(result).toEqual(errors.InvalidArgument);
+    });
+
+    it('should return MalformedXML when config has an empty Rule array', () => {
+        const repConfig = {
+            Role: [TEST_ROLE],
+            Rule: [],
+        };
+        const instance = new ReplicationConfiguration({ ReplicationConfiguration: repConfig },
+            null, mockS3ServerConfig);
+        const result = instance.parseConfiguration();
+        expect(result).toEqual(errors.MalformedXML);
+    });
+
+    it('should return InvalidArgument if a Rule ID exceeds 255 characters', () => {
+        const repConfig = {
+            Role: [TEST_ROLE],
+            Rule: [{
+                ID: [new Array(256).fill('X').join('')],
+                Prefix: [''],
+                Status: ['Enabled'],
+                Destination: [{
+                    Bucket: ['arn:aws:s3:::crr-dest'],
+                }],
+            }],
+        };
+        const instance = new ReplicationConfiguration({ ReplicationConfiguration: repConfig },
+            null, mockS3ServerConfig);
+        const result = instance.parseConfiguration();
+        expect(result).toEqual(errors.InvalidArgument);
+    });
+
+    it('should return InvalidRequest when config has duplicate Rule IDs', () => {
+        const repConfig = {
+            Role: [TEST_ROLE],
+            Rule: [
+                {
+                    ID: ['rule1'],
+                    Prefix: ['a/'],
+                    Status: ['Enabled'],
+                    Destination: [{ Bucket: ['arn:aws:s3:::crr-dest'] }],
+                },
+                {
+                    ID: ['rule1'],
+                    Prefix: ['b/'],
+                    Status: ['Enabled'],
+                    Destination: [{ Bucket: ['arn:aws:s3:::crr-dest'] }],
+                },
+            ],
+        };
+        const instance = new ReplicationConfiguration({ ReplicationConfiguration: repConfig },
+            null, mockS3ServerConfig);
+        const result = instance.parseConfiguration();
+        expect(result).toEqual(errors.InvalidRequest);
+    });
+
+    it('should return MalformedXML when config has a rule with an invalid Status value', () => {
+        const repConfig = {
+            Role: [TEST_ROLE],
+            Rule: [{
+                Prefix: [''],
+                Status: ['Invalid'],
+                Destination: [{ Bucket: ['arn:aws:s3:::crr-dest'] }],
+            }],
+        };
+        const instance = new ReplicationConfiguration({ ReplicationConfiguration: repConfig },
+            null, mockS3ServerConfig);
+        const result = instance.parseConfiguration();
+        expect(result).toEqual(errors.MalformedXML);
+    });
+
+    it('should return InvalidRequest when config has multiple rules with overlapping prefixes', () => {
+        const repConfig = {
+            Role: [TEST_ROLE],
+            Rule: [
+                {
+                    ID: ['rule1'],
+                    Prefix: ['prefix/'],
+                    Status: ['Enabled'],
+                    Destination: [{ Bucket: ['arn:aws:s3:::crr-dest'] }],
+                },
+                {
+                    ID: ['rule2'],
+                    Prefix: ['prefix/subprefix/'],
+                    Status: ['Enabled'],
+                    Destination: [{ Bucket: ['arn:aws:s3:::crr-dest'] }],
+                },
+            ],
+        };
+        const instance = new ReplicationConfiguration({ ReplicationConfiguration: repConfig },
+            null, mockS3ServerConfig);
+        const result = instance.parseConfiguration();
+        expect(result).toEqual(errors.InvalidRequest);
+    });
+
+    it('should return InvalidArgument if a prefix is longer than 1024 characters', () => {
+        const repConfig = {
+            Role: [TEST_ROLE],
+            Rule: [{
+                Prefix: [new Array(1025).fill('X').join('')],
+                Status: ['Enabled'],
+                Destination: [{
+                    Bucket: ['arn:aws:s3:::crr-dest'],
+                }],
+            }],
+        };
+        const instance = new ReplicationConfiguration({ ReplicationConfiguration: repConfig },
+            null, mockS3ServerConfig);
+        const result = instance.parseConfiguration();
+        expect(result).toEqual(errors.InvalidArgument);
+    });
+
+    it('should return MalformedXML when the provided storage class is invalid', () => {
+        const repConfig = {
+            Role: [TEST_ROLE],
+            Rule: [{
+                Prefix: [''],
+                Status: ['Enabled'],
+                Destination: [{
+                    Bucket: ['arn:aws:s3:::crr-dest'],
+                    StorageClass: ['INVALID'],
+                }],
+            }],
+        };
+        const instance = new ReplicationConfiguration({ ReplicationConfiguration: repConfig },
+            null, mockS3ServerConfig);
+        const result = instance.parseConfiguration();
+        expect(result).toEqual(errors.MalformedXML);
+    });
+
+    it('should return InvalidRequest with a config containing more than 1000 rules', () => {
+        const repConfig = {
+            Role: [TEST_ROLE],
+            Rule: [] as any[],
+        };
+        for (let i = 0; i < 1001; ++i) {
+            repConfig.Rule.push({
+                ID: [`rule${i}`],
+                Prefix: [`prefix${i}/`],
+                Status: ['Enabled'],
+                Destination: [{
+                    Bucket: ['arn:aws:s3:::crr-dest'],
+                }],
+            });
+        };
+        const instance = new ReplicationConfiguration({ ReplicationConfiguration: repConfig },
+            null, mockS3ServerConfig);
+        const result = instance.parseConfiguration();
+        expect(result).toEqual(errors.InvalidRequest);
+    });
+});


### PR DESCRIPTION
Fix an exception that occurs when parsing a ReplicationConfiguration (provided from a `PutBucketReplication` API call) where no replication endpoint is configured in Cloudserver.

In such case, return an InvalidRequest error.

Also added new test cases for ReplicationConfiguration, which lacked unit test coverage.
