### PR TITLE
ARSN-499: KMIPCluster Healthcheck report healthy if 1 node is up

### DIFF
--- a/lib/network/KMSInterface.ts
+++ b/lib/network/KMSInterface.ts
@@ -70,8 +70,8 @@ export function makeBackend<T extends KmsType>(
     }
 }
 
-export function isScalityKmsArn(kmsKey: string) {
-    return kmsKey.startsWith(SCAL_KMS_ARN);
+export function isScalityKmsArn(kmsKey?: string | null) {
+    return kmsKey?.startsWith(SCAL_KMS_ARN) ?? false;
 }
 
 /**

--- a/lib/network/kmip/ClusterClient.ts
+++ b/lib/network/kmip/ClusterClient.ts
@@ -270,8 +270,24 @@ export default class ClusterClient implements KMSInterface {
     }
 
     healthcheck(...args: Parameters<Required<KMSInterface>['healthcheck']>) {
-        // for now check health of every member
-        this.clusterHealthcheck.apply(this, args);
+        // healthcheck follow round robin with retries instead of broadcast
+        const originalCallback = args.pop() as ArrayLast<typeof args>;
+        const poppedArgs = args as unknown as ArrayPopped<typeof args>;
+        const logger = args[args.length - 1] as ArrayLast<typeof poppedArgs>;
+
+        if (this.clients.length === 0) {
+            logger.warn('kmip cluster has no healthy hosts');
+            return originalCallback(errorInstances.InternalError.customizeDescription(
+                kmipMsg('Healthcheck', '', `no healthy host in the cluster`)));
+        }
+
+        const client = this.next();
+
+        client.healthcheck(
+            ...poppedArgs,
+            this.callback(client, 'healthcheck', poppedArgs, logger, originalCallback),
+        );
+        return undefined;
     }
 
     stop(cb?: Function) {

--- a/lib/network/kmip/ClusterClient.ts
+++ b/lib/network/kmip/ClusterClient.ts
@@ -188,7 +188,7 @@ export default class ClusterClient implements KMSInterface {
         if (this.clients.length === 0) {
             logger.warn('kmip cluster has no healthy hosts');
             return originalCallback(errorInstances.InternalError.customizeDescription(
-                kmipMsg('Create', args[0], `no healthy host in the cluster`)));
+                kmipMsg('Create', args[0], 'kmip cluster has no healthy hosts')));
         }
 
         const client = this.next();
@@ -208,7 +208,7 @@ export default class ClusterClient implements KMSInterface {
         if (this.clients.length === 0) {
             logger.warn('kmip cluster has no healthy hosts');
             return originalCallback(errorInstances.InternalError.customizeDescription(
-                kmipMsg('Destroy', args[0], `no healthy host in the cluster`)));
+                kmipMsg('Destroy', args[0], 'kmip cluster has no healthy hosts')));
         }
 
         const client = this.next();
@@ -228,7 +228,7 @@ export default class ClusterClient implements KMSInterface {
         if (this.clients.length === 0) {
             logger.warn('kmip cluster has no healthy hosts');
             return originalCallback(errorInstances.InternalError.customizeDescription(
-                kmipMsg('Encrypt', args[1], `no healthy host in the cluster`)));
+                kmipMsg('Encrypt', args[1], 'kmip cluster has no healthy hosts')));
         }
 
         const client = this.next();
@@ -248,7 +248,7 @@ export default class ClusterClient implements KMSInterface {
         if (this.clients.length === 0) {
             logger.warn('kmip cluster has no healthy hosts');
             return originalCallback(errorInstances.InternalError.customizeDescription(
-                kmipMsg('Decrypt', args[1], `no healthy host in the cluster`)));
+                kmipMsg('Decrypt', args[1], 'kmip cluster has no healthy hosts')));
         }
 
         const client = this.next();
@@ -278,7 +278,7 @@ export default class ClusterClient implements KMSInterface {
         if (this.clients.length === 0) {
             logger.warn('kmip cluster has no healthy hosts');
             return originalCallback(errorInstances.InternalError.customizeDescription(
-                kmipMsg('Healthcheck', '', `no healthy host in the cluster`)));
+                kmipMsg('Healthcheck', '', 'kmip cluster has no healthy hosts')));
         }
 
         const client = this.next();

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.70.45",
+  "version": "7.70.46",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/functional/pykmip/ClusterClient.spec.js
+++ b/tests/functional/pykmip/ClusterClient.spec.js
@@ -52,6 +52,7 @@ const dataKey = Buffer.from('a'.repeat(16));
 function promisify(client) {
     return {
         healthcheck: util.promisify(client.healthcheck.bind(client)),
+        clusterHealthcheck: client.clusterHealthcheck && util.promisify(client.clusterHealthcheck.bind(client)),
         createBucketKey: util.promisify(client.createBucketKey.bind(client)),
         destroyBucketKey: util.promisify(client.destroyBucketKey.bind(client)),
         cipherDataKey: util.promisify(client.cipherDataKey.bind(client)),
@@ -82,12 +83,29 @@ function showArsenalErr(err) {
     }
 }
 
-function assertHealthcheck(healthy, unhealthy, spysHealthchecks) {
+function assertClusterHealthcheck(healthy, unhealthy, spysHealthchecks) {
     assert.strictEqual(healthy.actual, healthy.expected);
     assert.strictEqual(unhealthy.actual, unhealthy.expected);
     assert.ok(spysHealthchecks.every(spy => spy.callCount === 1),
         `All ${spysHealthchecks.length} hosts should be healthchecked. Instead got ${
             spysHealthchecks.map(spy => spy.callCount)}`);
+}
+
+function assertHealthcheck(healthy, unhealthy, spysHealthchecks) {
+    // healthy and unhealthy depends on round robin
+    const maxHealthy = healthy.expected + unhealthy.expected;
+    assert.ok(healthy.actual >= healthy.expected && healthy.actual <= spysHealthchecks.length,
+        `There can be between ${healthy.expected} and ${maxHealthy} healthy hosts. Got ${healthy.actual}`);
+    assert.ok(unhealthy.actual <= unhealthy.expected,
+        `There can be up to ${unhealthy.expected} unhealthy. Instead got ${unhealthy.actual}`);
+
+    const callCount = spysHealthchecks.map(spy => spy.callCount);
+    const called = callCount.filter(x => x === 1).length;
+    const expectedCalled = unhealthy.actual + (healthy.actual ? 1 : 0);
+
+    assert.strictEqual(called, expectedCalled,
+        `With round robin and ${unhealthy.actual} unhealthy and ${healthy.actual} healthy.
+        Instead got calls ${callCount}.`);
 }
 
 /** Authorize a approximation of +- 2 executions */
@@ -233,9 +251,18 @@ describe('KMIP ClusterClient with pykmip', () => {
             spys = clusterSpys(client.clients);
         });
 
-        it(`should connect and healthcheck each ${nb} hosts`, async () => {
+        it(`should connect and healthcheck in round robin on ${nb} hosts`, async () => {
             await assert.doesNotReject(promises.healthcheck(logger), showArsenalErr);
             assertHealthcheck(
+                { actual: healthyClients.length, expected: nb },
+                { actual: unhealthyClients.length, expected: 0 },
+                spys.healthchecks,
+            );
+        });
+
+        it(`should connect and clusterHealthcheck each ${nb} hosts`, async () => {
+            await assert.doesNotReject(promises.clusterHealthcheck(logger), showArsenalErr);
+            assertClusterHealthcheck(
                 { actual: healthyClients.length, expected: nb },
                 { actual: unhealthyClients.length, expected: 0 },
                 spys.healthchecks,
@@ -279,9 +306,18 @@ describe('KMIP ClusterClient with pykmip', () => {
             spys = clusterSpys(client.clients);
         });
 
-        it('should fail healthcheck', async () => {
-            await assert.rejects(promises.healthcheck(logger));
+        it('should succeed round robin healthcheck', async () => {
+            await assert.doesNotReject(promises.healthcheck(logger));
             assertHealthcheck(
+                { actual: healthyClients.length, expected: nb },
+                { actual: unhealthyClients.length, expected: 1 },
+                spys.healthchecks,
+            );
+        });
+
+        it('should fail clusterHealthcheck', async () => {
+            await assert.rejects(promises.clusterHealthcheck(logger));
+            assertClusterHealthcheck(
                 // TODO S3C-9763 healthcheck should mark hosts unhealthy
                 { actual: healthyClients.length, expected: nb + 1 },
                 { actual: unhealthyClients.length, expected: 0 },


### PR DESCRIPTION
clusterHealthcheck would broadcast a healthcheck
on every node and fail if 1 node fails.

But we want to succeed if at least 1 node is up
so use the round robin method with retries to keep
it simple