### PR TITLE
properly forward VaultClient errors

### DIFF
--- a/lib/s3routes/routesUtils.ts
+++ b/lib/s3routes/routesUtils.ts
@@ -22,20 +22,29 @@ export type CallApiMethod = (
     callback: (err: ArsenalError | Error | null, ...data: any[]) => void,
 ) => void;
 
+interface VaultClientError {
+    code: string | number;
+    description: string;
+}
+
 /**
  * Convert an error to an ArsenalError instance
  * @param err - Error to convert
  * @returns ArsenalError instance
  */
-export function toArsenalError(err: ArsenalError | Error): ArsenalError {
+export function toArsenalError(err: ArsenalError | VaultClientError | Error): ArsenalError {
     if (err instanceof ArsenalError) {
         return err;
     }
-
-    // If it's a known error type, use the error instance, otherwise wrap
-    // it in an InternalError
-    return errorInstances[err.message] ||
-        errorInstances.InternalError.customizeDescription(err.message);
+    // For known error types, return the error instance as-is; otherwise, wrap it in an InternalError.
+    // - VaultClient errors identify their type via the `code` property.
+    // - ArsenalErrors received from external services (e.g., Metadata) use the `message` property for the error type.
+    return errorInstances[(err as Error).message || (err as VaultClientError).code] ||
+        errorInstances.InternalError.customizeDescription(
+            (err as Error).message ||
+            (err as VaultClientError).description ||
+            errorInstances.InternalError.description,
+        );
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=20"
   },
-  "version": "8.2.20",
+  "version": "8.2.21",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/s3routes/routesUtils/toArsenalError.spec.ts
+++ b/tests/unit/s3routes/routesUtils/toArsenalError.spec.ts
@@ -14,11 +14,29 @@ describe('toArsenalError', () => {
         expect(result).toBe(errorInstances.NoSuchBucket);
     });
 
+    it('should use existing error instance if error code matches known error type', () => {
+        const error = {
+            code: 'InvalidAccessKeyId',
+            description: 'The AWS access key Id you provided does not exist in our records.',
+            InvalidAccessKeyId: true
+        };
+        const result = toArsenalError(error);
+        expect(result).toBe(errorInstances.InvalidAccessKeyId);
+    });
+
     it('should wrap unknown error in InternalError with custom description', () => {
         const error = new Error('Unknown error occurred');
         const result = toArsenalError(error);
         expect(result).toBeInstanceOf(ArsenalError);
         expect(result.message).toBe('InternalError');
         expect(result.description).toBe('Unknown error occurred');
+    });
+
+    it('should wrap unknown error in InternalError', () => {
+        const error = new Error();
+        const result = toArsenalError(error);
+        expect(result).toBeInstanceOf(ArsenalError);
+        expect(result.message).toBe('InternalError');
+        expect(result.description).toBe('We encountered an internal error. Please try again.');
     });
 });


### PR DESCRIPTION
VaultClient errors have the error type in the "code" property which is not properly handled in toArsenalError()

Issue: ARSN-501