### PR TITLE
INTEGRATION [PR#2429 > development/8.1] Backport impr(ARSN-475): Add bucketOwnerId field to ObjectMD model

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -31,7 +31,11 @@ export const maximumMetaHeadersSize = 2136;
 export const emptyFileMd5 = 'd41d8cd98f00b204e9800998ecf8427e';
 // Version 2 changes the format of the data location property
 // Version 3 adds the dataStoreName attribute
-export const mdModelVersion = 3;
+// Version 7 adds the "bucketOwnerId" attribute to the object metadata.
+// This is set when the owner of the bucket is different from the owner-id of the object.
+// This can happen in cases of cross-account permissions where the object
+// is uploaded by a different account than the one that owns the bucket.
+export const mdModelVersion = 7;
 /*
  * Splitter is used to build the object name for the overview of a
  * multipart upload and to build the object names for each part of a

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -31,11 +31,12 @@ export const maximumMetaHeadersSize = 2136;
 export const emptyFileMd5 = 'd41d8cd98f00b204e9800998ecf8427e';
 // Version 2 changes the format of the data location property
 // Version 3 adds the dataStoreName attribute
+// Version 3.1 backport of Version 7 on top of 3
 // Version 7 adds the "bucketOwnerId" attribute to the object metadata.
 // This is set when the owner of the bucket is different from the owner-id of the object.
 // This can happen in cases of cross-account permissions where the object
 // is uploaded by a different account than the one that owns the bucket.
-export const mdModelVersion = 7;
+export const mdModelVersion = 3.1;
 /*
  * Splitter is used to build the object name for the overview of a
  * multipart upload and to build the object names for each part of a

--- a/lib/models/ObjectMD.ts
+++ b/lib/models/ObjectMD.ts
@@ -33,6 +33,9 @@ export type ReplicationInfo = {
 
 export type ObjectMDData = {
     'owner-display-name': string;
+    // The canonical Id of the account used to create the object.
+    // This can be different than the bucket owner if cross-account
+    // permissions are used to create the object.
     'owner-id': string;
     'cache-control': string;
     'content-disposition': string;
@@ -73,6 +76,9 @@ export type ObjectMDData = {
     replicationInfo: ReplicationInfo;
     dataStoreName: string;
     originOp: string;
+    // This is the canonical Id for the bucket owner.
+    // This is only set when it differs from `owner-id`.
+    bucketOwnerId?: string;
 };
 
 /**
@@ -1143,5 +1149,31 @@ export default class ObjectMD {
      */
     getValue() {
         return this._data;
+    }
+
+    /**
+     * Set bucket owner id
+     * @param canonicalId - bucket owner id
+     * @return itself
+     */
+    setBucketOwnerId(canonicalId: string) {
+        this._data.bucketOwnerId = canonicalId;
+        return this;
+    }
+
+    /**
+     * Returns bucket owner id
+     * @return bucket owner id
+     */
+    getBucketOwnerId() {
+        return this._data.bucketOwnerId;
+    }
+
+    /**
+     * Returns the model version of the object metadata
+     * @return {number|undefined}
+     */
+    getModelVersion(): number | undefined {
+        return this._data['md-model-version'];
     }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "7.70.46",
+  "version": "7.70.47",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "8.1.158",
+  "version": "8.1.159",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/models/ObjectMD.spec.js
+++ b/tests/unit/models/ObjectMD.spec.js
@@ -117,6 +117,9 @@ describe('ObjectMD class setters/getters', () => {
         ['RetentionMode', 'GOVERNANCE'],
         ['RetentionDate', retainDate.toISOString()],
         ['OriginOp', null, ''],
+        ['BucketOwnerId', null, undefined],
+        ['BucketOwnerId', 'abcdef'],
+        ['ModelVersion', null, constants.mdModelVersion],
     ].forEach(test => {
         const property = test[0];
         const testValue = test[1];


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2429.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/improvement/ARSN-475-backport-bucketownerid`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/improvement/ARSN-475-backport-bucketownerid
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/improvement/ARSN-475-backport-bucketownerid
```

Please always comment pull request #2429 instead of this one.