### PR TITLE
ARSN-512: Fix GCP createMPU merge mistake

### DIFF
--- a/lib/storage/data/external/GCP/GcpApis/createMPU.js
+++ b/lib/storage/data/external/GCP/GcpApis/createMPU.js
@@ -1,6 +1,6 @@
 const { v4: uuid } = require('uuid');
-const errors = require('../../../../../errors').default;
 const errorInstances = require('../../../../../errors').errorInstances;
+const { createMpuKey, logger, getPutTagsMetadata } = require('../GcpUtils');
 const { logHelper } = require('../../utils');
 
 /**

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=20"
   },
-  "version": "8.2.26",
+  "version": "8.2.27",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {


### PR DESCRIPTION
Merge mistake in integration branch:
https://github.com/scality/Arsenal/pull/2323/commits/5f82c8d1e1592977ca299fbad6ec545b9a349aea#diff-52c79ca036023bc2900f3585f751607ed025bffa666f3c9193689daa6c28bc24L3

GCP createMPU broken since March

Impacted versions: 8.2.7 - 8.2.25

since cloudserver 9.0.6 (https://github.com/scality/cloudserver/commit/5d5c660432d0c6675a60757774f8108a0d0cb488)
in Zenko since 2.11.4 (https://github.com/scality/Zenko/commit/296fa7df9db8bc035bd0f1c24311a11fd536c4c9)