### PR TITLE
ARSN-512: Fix bytesReceived being always 0

### DIFF
--- a/lib/s3routes/routes.ts
+++ b/lib/s3routes/routes.ts
@@ -216,7 +216,7 @@ export default function routes(
         // @ts-ignore
         objectKey: req.objectKey,
         // @ts-ignore
-        bytesReceived: req.parsedContentLength || 0,
+        bytesReceived: req.parsedContentLength || 0, // not defined yet
         // @ts-ignore
         bodyLength: parseInt(req.headers['content-length'], 10) || 0,
     };
@@ -263,6 +263,8 @@ export default function routes(
     try {
         const validHosts = allEndpoints.concat(websiteEndpoints);
         routesUtils.normalizeRequest(req, validHosts);
+        // @ts-ignore parsedContentLength defined in normalizeRequest
+        log.addDefaultFields({ bytesReceived: req.parsedContentLength || 0 });
     } catch (err: any) {
         log.debug('could not normalize request', { error: err.stack });
         return routesUtils.responseXMLBody(

--- a/lib/s3routes/routes.ts
+++ b/lib/s3routes/routes.ts
@@ -216,8 +216,6 @@ export default function routes(
         // @ts-ignore
         objectKey: req.objectKey,
         // @ts-ignore
-        bytesReceived: req.parsedContentLength || 0, // not defined yet
-        // @ts-ignore
         bodyLength: parseInt(req.headers['content-length'], 10) || 0,
     };
 


### PR DESCRIPTION
Introduced by ARSN-471

Needed in S3C for s3-analytics as logs are ingested by fluent-bit and aggregated into clickhouse. For PUT request we use bytesReceived instead of contentLength for ingress bytes.