### PR TITLE
ARSN-512: Fix Deprecation DEP0066 _headers

### DIFF
--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -234,7 +234,7 @@ function generateV4Headers(
     }
     const payloadChecksum = crypto.createHash('sha256')
         .update(payload, 'binary').digest('hex');
-    request.setHeader('host', request._headers.host);
+    request.setHeader('host', request.getHeader('host'));
     request.setHeader('x-amz-date', amzDate);
     request.setHeader('x-amz-content-sha256', payloadChecksum);
     request.setHeader('content-md5', generateContentMD5Header(request.path, payload));
@@ -243,8 +243,9 @@ function generateV4Headers(
         request.setHeader('x-amz-security-token', sessionToken);
     }
 
-    Object.assign(request.headers, request._headers);
-    const signedHeaders = Object.keys(request._headers)
+    const currentHeaders = request.getHeaders();
+    Object.assign(request.headers, currentHeaders);
+    const signedHeaders = Object.keys(currentHeaders)
         .filter(headerName =>
             headerName.startsWith('x-amz-')
             || headerName.startsWith('x-scal-')

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=20"
   },
-  "version": "8.2.27",
+  "version": "8.2.28",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {


### PR DESCRIPTION
```
OutgoingMessage.prototype._headers is deprecated
    at Object.generateV4Headers (/home/scality/identisee/api/node_modules/vaultclient/node_modules/arsenal/lib/auth/auth.js:221:39)
```

cf [S3C-10071](https://scality.atlassian.net/browse/S3C-10071)

[S3C-10071]: https://scality.atlassian.net/browse/S3C-10071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ