### PR TITLE
ARSN-519: Avoid validating key length everywhere

### DIFF
--- a/lib/s3routes/routesUtils.ts
+++ b/lib/s3routes/routesUtils.ts
@@ -1179,10 +1179,17 @@ export function isValidObjectKey(objectKey: string, prefixBlacklist: string[]) {
     if (invalidPrefix) {
         return { isValid: false, invalidPrefix };
     }
-    if (Buffer.byteLength(objectKey, 'utf8') > objectKeyByteLimit) {
-        return { isValid: false };
-    }
     return { isValid: true };
+}
+
+// To be validated only for key creation, such as PutObject, CopyObject, MPU
+export function validateObjectKeyLength(objectKey: string, maxByteLength?: number) {
+    if (maxByteLength !== 0 && Buffer.byteLength(objectKey, 'utf8') > (maxByteLength || objectKeyByteLimit)) {
+        return errorInstances.KeyTooLong.customizeDescription('Object key is too ' +
+            'long. Maximum number of bytes allowed in keys is ' +
+            `${maxByteLength || objectKeyByteLimit}.`);
+    }
+    return null;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=20"
   },
-  "version": "8.2.29",
+  "version": "8.2.30",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/s3routes/routesUtils/isValidObjectKey.spec.js
+++ b/tests/unit/s3routes/routesUtils/isValidObjectKey.spec.js
@@ -22,15 +22,40 @@ describe('routesUtils.isValidObjectKey', () => {
         assert.strictEqual(result.invalidPrefix, bannedStr);
     });
 
-    it('should return isValid false if object key name exceeds length of 915',
-        () => {
-            const key = 'a'.repeat(916);
-            const result = routesUtils.isValidObjectKey(key, prefixBlacklist);
-            assert.strictEqual(result.isValid, false);
-        });
-
-    it('should return isValid true for a utf8 string of byte size 915', () => {
+    it('should return isValid true for a utf8 string', () => {
         const result = routesUtils.isValidObjectKey(keyutf8, prefixBlacklist);
         assert.strictEqual(result.isValid, true);
+    });
+});
+
+describe('routesUtils.validateObjectKeyLength', () => {
+    it('should return null if object key does not exceed length of 915', () => {
+        const key = 'a'.repeat(915);
+        const error = routesUtils.validateObjectKeyLength(key);
+        assert.strictEqual(error, null);
+    });
+
+    it('should return error if object key exceeds length of 915', () => {
+        const key = 'a'.repeat(916);
+        const error = routesUtils.validateObjectKeyLength(key);
+        assert.strictEqual(error?.KeyTooLong, true);
+    });
+
+    it('should return null if object key exceeds length of 915 with byteLength disabled (set to 0)', () => {
+        const key = 'a'.repeat(916);
+        const error = routesUtils.validateObjectKeyLength(key, 0);
+        assert.strictEqual(error, null);
+    });
+
+    it('should return null if object key does not exceed custom byteLength 1024', () => {
+        const key = 'a'.repeat(1024);
+        const error = routesUtils.validateObjectKeyLength(key, 1024);
+        assert.strictEqual(error, null);
+    });
+
+    it('should return error if object key exceeds custom byteLength 1024', () => {
+        const key = 'a'.repeat(1025);
+        const error = routesUtils.validateObjectKeyLength(key, 1024);
+        assert.strictEqual(error?.KeyTooLong, true);
     });
 });


### PR DESCRIPTION
Utility function to be used only for PutObject, CopyObject, MPU

See https://github.com/scality/cloudserver/pull/5942