### PR TITLE
ARSN-519: Document bucket model collision

### DIFF
--- a/documentation/BucketInfoModelVersion.md
+++ b/documentation/BucketInfoModelVersion.md
@@ -1,5 +1,28 @@
 # BucketInfo Model Version History
 
+## Version collision between S3C (dev/7.X) and Zenko (dev/8.X)
+
+- v7 to v11 can mean different features between S3C & Zenko.
+- Avoid using model version to check features
+  - used by model < v2 (for splitter)
+  - used in some tests (v5 and v10)
+
+| Version | S3C (dev/7.X)           | Zenko (dev/8.X)          | Status      |
+|---------|-------------------------|--------------------------|-------------|
+| v2 - v6 | ✅                      | ✅                       | ✅ Common   |
+| v7      | ObjectLock              | UID                      | ❌ Collision|
+| v8      | BucketNotification      | ReadLocationConstraints  | ❌ Collision|
+| v9      | SSEConfiguredMasterKey  | isNFS                    | ❌ Collision|
+| v10     | UID                     | Ingestion                | ❌ Collision|
+| v11     | Tags                    | AzureInfo                | ❌ Collision|
+| v12     | -                       | ObjectLock               | ↪️ Forward  |
+| v13     | -                       | BucketNotification       | ↪️ Forward  |
+| v14     | -                       | SSEConfiguredMasterKey   | ↪️ Forward  |
+| v15     | -                       | Tags                     | ↪️ Forward  |
+| v16     | -                       | Capabilities(VeeamSOSApi)| ✅ New      |
+| v17     | -                       | QuotaMax                 | ✅ New      |
+| **Unified at v17**                                                         |
+
 ## Model Version 0/1
 
 ### Properties

--- a/lib/models/BucketInfo.ts
+++ b/lib/models/BucketInfo.ts
@@ -15,7 +15,7 @@ import { AzureInfoMetadata } from './BucketAzureInfo';
 // WHEN UPDATING THIS NUMBER, UPDATE BucketInfoModelVersion.md CHANGELOG
 // BucketInfoModelVersion.md can be found in documentation/ at the root
 // of this repository
-const modelVersion = 16;
+const modelVersion = 17;
 
 export type CORS = {
     id: string;


### PR DESCRIPTION
Object metadata diff with unification:

```diff
<     "key": "",
>     "key": "myobj",
>       "isNFS": false // replicationInfo
```

- key is not empty anymore
- replicationInfo.isNFS

---

Bucket metadata diff with unification:

```diff
<     "objectLockEnabled": false,
<     "objectLockConfiguration": null,
<     "notificationConfiguration": null,
>     "readLocationConstraint": null,
>       "preferredReadLocation": null // replicationConfiguration
>     "isNFS": false,
>     "ingestion": null,
>     "azureInfo": null,
>     "quotaMax": "0"
<     "tags": null,
>     "tags": [],
```

- Some field are not present if not configured: `objectLock`,`notificationConfiguration`
- `tags` type changed by default to empty list
- new field present