### PR TITLE
ARSN-519: Include mpu uploadId in listing result

### DIFF
--- a/lib/storage/metadata/MetadataWrapper.js
+++ b/lib/storage/metadata/MetadataWrapper.js
@@ -46,6 +46,7 @@ function _parseListEntries(entries) {
                 partLocations: tmp.partLocations,
                 creationDate: tmp.creationDate,
                 ingestion: tmp.ingestion,
+                uploadId: tmp.uploadId, // used by AbortMPU findObjectVersionByUploadId (bucketGet ignores it)
             },
         };
     });

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "8.1.163",
+  "version": "8.1.164",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {


### PR DESCRIPTION
Relates to CLDSRV-669

The AbortMPU services.findObjectVersionByUploadId filters
versions by uploadId

___

Needed for https://github.com/scality/cloudserver/pull/5948 to fix orphan deletion on abort