### PR TITLE
ARSN-540: export rate limit API action map and bump `package.json` to 8.2.41

### DIFF
--- a/lib/policyEvaluator/utils/actionMaps.ts
+++ b/lib/policyEvaluator/utils/actionMaps.ts
@@ -260,4 +260,5 @@ export {
     actionMapSTS,
     actionMapMetadata,
     actionMapSUR,
+    actionMapBucketRateLimit,
 };

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=20"
   },
-  "version": "8.2.40",
+  "version": "8.2.41",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {


### PR DESCRIPTION
Per requirements we should be able to call the  bucket rate limit APIs without
assuming role (like SUR admin APIs) using the normal credentials of a service user. For the same, we
need access to the rate limit action map in the cloudserver using this export.