### PR TITLE
INTEGRATION [PR#2575 > development/8.3] ARSN-539: server access log add missing timestamp

### DIFF
--- a/lib/s3routes/routesUtils.ts
+++ b/lib/s3routes/routesUtils.ts
@@ -645,6 +645,7 @@ export function responseNoBody(
     if (!response.headersSent) {
         return okHeaderResponse(resHeaders, response, httpCode, log);
     }
+    storeServerAccessLogFields(response, process.hrtime.bigint());
     return undefined;
 }
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=20"
   },
-  "version": "8.2.41",
+  "version": "8.2.42",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2575.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.3/bugfix/ARSN-539-server-access-log-add-missing-timestamp`, please follow this
procedure:

```bash
 git fetch
 git checkout w/8.3/bugfix/ARSN-539-server-access-log-add-missing-timestamp
 # <amend or cancel the changeset by _adding_ new commits>
 git push origin w/8.3/bugfix/ARSN-539-server-access-log-add-missing-timestamp
```

Please always comment pull request #2575 instead of this one.