### PR TITLE
Fix extracting unique reference of oplog documents on Mongo >=7.1.0

### DIFF
--- a/lib/storage/metadata/mongoclient/ListRecordStream.js
+++ b/lib/storage/metadata/mongoclient/ListRecordStream.js
@@ -63,7 +63,7 @@ class ListRecordStream extends stream.Readable {
 
     _processItem(itemObj) {
         // always update to most recent uniqID
-        this._lastConsumedID = itemObj.h.toString();
+        this._lastConsumedID = (itemObj.h || itemObj.ts).toString();
 
         // only push to stream unpublished objects
         if (!this._lastSavedID) {

--- a/lib/storage/metadata/mongoclient/LogConsumer.js
+++ b/lib/storage/metadata/mongoclient/LogConsumer.js
@@ -117,7 +117,7 @@ class LogConsumer {
                 if (!data || data.length === 0) {
                     return cb(new Error('no oplog entry found'));
                 }
-                const latestOplogID = data[0].h.toString();
+                const latestOplogID = (data[0].h || data[0].ts).toString();
                 this._logger.debug('latest oplog ID read', { latestOplogID });
                 return cb(null, latestOplogID);
             })


### PR DESCRIPTION
The h field was removed, replaced with ts.

See:
- https://jira.mongodb.org/browse/SERVER-36334
- https://jira.mongodb.org/browse/SERVER-69062
- https://github.com/mongodb/mongo/commit/a0866639120c8bdce3eff8c446ea70e982ce1839

Issue: ARSN-545