### PR TITLE
ARSN-551: don't require x-amz-content-sha256 header to be signed

### DIFF
--- a/lib/auth/v4/validateInputs.ts
+++ b/lib/auth/v4/validateInputs.ts
@@ -196,6 +196,12 @@ export function areSignedHeadersComplete(signedHeaders: string, allHeaders: Head
     }
     const headers = Object.keys(allHeaders);
     for (let i = 0; i < headers.length; i++) {
+        // We skip x-amz-content-sha256 because in practice AWS does not require that it be present
+        // in the list of signed headers.
+        if (headers[i] === 'x-amz-content-sha256') {
+            continue;
+        }
+
         if ((headers[i].startsWith('x-amz-')
         || headers[i].startsWith('x-scal-'))
         && signedHeadersList.indexOf(headers[i]) === -1) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=20"
   },
-  "version": "8.2.44",
+  "version": "8.2.45",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/auth/v4/headerAuthCheck.spec.js
+++ b/tests/unit/auth/v4/headerAuthCheck.spec.js
@@ -91,6 +91,24 @@ describe('v4 headerAuthCheck', () => {
         done();
     });
 
+    it('should NOT return error if x-amz-content-sha256 is not included ' +
+        'as signed header but is in request', done => {
+        // x-amz-content-sha256 is an exception - AWS does not require it
+        // to be in the signed headers list
+        const clock = fakeTimers.install({ now: 1454962445000 });
+        const alteredRequest = createAlteredRequest({
+            authorization: 'AWS4-HMAC-SHA256 Credential=accessKey1/20160208' +
+                '/us-east-1/s3/aws4_request, SignedHeaders=host;' +
+                'x-amz-date, Signature=abed924c06abf8772c670064d22eacd6ccb85c06' +
+                'befa15f4a789b0bae19307bc',
+            'x-amz-content-sha256': xAMZcontentSha256 },
+            'headers', request, headers);
+        const res = headerAuthCheck(alteredRequest, log);
+        clock.uninstall();
+        assert.strictEqual(res.err, null);
+        done();
+    });
+
     it('should return error if an x-scal header is not included as signed ' +
         'header but is in request', done => {
         const alteredRequest = createAlteredRequest({


### PR DESCRIPTION
In practice AWS does not require `x-amz-content-sha256` to be signed. So we remove the requirement