### PR TITLE
ARSN-556: add MalformedTrailerError

### DIFF
--- a/lib/errors/arsenalErrors.ts
+++ b/lib/errors/arsenalErrors.ts
@@ -285,6 +285,12 @@ export const MalformedXML: ErrorFormat = {
         'The XML you provided was not well-formed or did not validate against our published schema.',
 };
 
+export const MalformedTrailerError: ErrorFormat = {
+    code: 400,
+    description: 
+        'The request contained trailing data that was not well-formed or did not conform to our published schema.',
+};
+
 export const MaxMessageLengthExceeded: ErrorFormat = {
     code: 400,
     description: 'Your request was too big.',

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=20"
   },
-  "version": "8.3.5",
+  "version": "8.3.6",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {


### PR DESCRIPTION
AWS returns the following error when 

The trailer is malformed

The body trailer does not match the x-amz-trailer header

The x-amz-trailer is not set but the body contains a trailer 
```
<Error>
  <Code>MalformedTrailerError</Code>
  <Message>The request contained trailing data that was not well-formed or did not conform to our published schema.</Message>
  <RequestId>6CT2C9JNZ4HJR8NX</RequestId>
  <HostId>7XlEgaoezG665Gmp1ncaPgnLo8QsktiCCO6EZpbNh5JbhLVz9FMRr32Cos9HXWhpdw3SfI++tsg=</HostId>
</Error>
```


`MalformedTrailerError` is not present in arsenal, this ticket adds it 