### PR TITLE
impr: ARSN-563 change error code of RaftSessionLeaderNotConnected to 500

### DIFF
--- a/lib/errors/arsenalErrors.ts
+++ b/lib/errors/arsenalErrors.ts
@@ -1019,8 +1019,8 @@ export const RaftSessionNotLeader: ErrorFormat = {
 };
 
 export const RaftSessionLeaderNotConnected: ErrorFormat = {
-    description: 'RaftSessionLeaderNotConnected',
-    code: 400,
+    description: 'not connected to the RAFT session leader',
+    code: 500,
 };
 
 export const NoLeaderForDB: ErrorFormat = {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=20"
   },
-  "version": "8.2.48",
+  "version": "8.2.49",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {


### PR DESCRIPTION
The RaftSessionLeaderNotConnected Arsenal error was mapped to HTTP 400 (client error), but "not connected to the leader" is a server-side condition that the client cannot influence. Change it to 500 (server error) so callers can correctly distinguish it from bad-request errors.
    
Also update the description to the more human-readable 'not connected to the RAFT session leader'.
