### PR TITLE
Bound MongoDB sort memory in lifecycle current listing

### DIFF
--- a/lib/algos/list/delimiterCurrent.ts
+++ b/lib/algos/list/delimiterCurrent.ts
@@ -48,6 +48,19 @@ class DelimiterCurrent extends DelimiterMaster {
             };
         }
 
+        // Limit the number of documents MongoDB returns to bound the
+        // in-memory sort when lifecycle indexes are used (these indexes
+        // order by value.last-modified, forcing a re-sort on _id). Without
+        // a limit, MongoDB must sort all matching documents — which can
+        // exceed the 100MB memory cap and spill to disk.
+        // We use maxScannedLifecycleListingEntries (default 10,000) as the
+        // bound because it counts documents scanned, which maps directly
+        // to cursor documents regardless of bucket format (v0 or v1).
+        // The +1 allows the listing algorithm to detect truncation.
+        if (this.maxScannedLifecycleListingEntries) {
+            params.limit = this.maxScannedLifecycleListingEntries + 1;
+        }
+
         return params;
     }
 

--- a/tests/unit/algos/list/delimiterCurrent.spec.js
+++ b/tests/unit/algos/list/delimiterCurrent.spec.js
@@ -56,6 +56,7 @@ function getListingKey(key, vFormat) {
                 },
                 gt: getListingKey('premark', v),
                 lt: getListingKey('prf', v),
+                limit: maxScannedLifecycleListingEntries + 1,
             };
             assert.deepStrictEqual(delimiter.genMDParams(), expectedParams);
             assert.strictEqual(delimiter.maxScannedLifecycleListingEntries, 2);


### PR DESCRIPTION
## Summary

When lifecycle v2 indexes are used for current listings, MongoDB must
re-sort results by `_id` in memory because the indexes are ordered by
`value.last-modified`. Without a cursor `.limit()`, this SORT stage
collects **all** matching documents before returning any — which can
exceed the 100MB `memLimit` and spill to disk.

On systems with low disk space (the scenario described in BB-753),
this disk spill fails, breaking lifecycle processing entirely. The
problem is not index *creation* failing, but index *usage* triggering
an unbounded sort that spills to a full disk.

## Fix

Add a cursor limit based on `maxScannedLifecycleListingEntries`
(default 10,000) in `DelimiterCurrent.genMDParamsV0()`. This flows
through to `MongoReadStream` which already supports `options.limit`
on the cursor.

With the limit, MongoDB uses a bounded top-k heap sort — keeping only
~10,000 documents in memory regardless of total matches. We use
`maxScannedLifecycleListingEntries` rather than `maxKeys` because it
counts documents scanned (not results), which maps directly to cursor
documents regardless of bucket key format (v0 or v1).

## Impact

Tested on a 100k-object bucket with `explain("executionStats")`:

| | Without `.limit()` | With `.limit(1001)` |
|---|---|---|
| **nReturned** | 448,497 | 1,001 |
| **totalDataSizeSorted** | **478 MB** | **1 MB** |
| **usedDisk** | **true** (spilled!) | false |

Issue: ARSN-565