### PR TITLE
ARSN-568: make Server response header configurable

### DIFF
--- a/lib/s3routes/routesUtils.ts
+++ b/lib/s3routes/routesUtils.ts
@@ -14,6 +14,12 @@ const jsutil = require('../jsutil');
 
 const ALLOW_INVALID_META_HEADERS = !!process.env.ALLOW_INVALID_META_HEADERS;
 
+let serverHeaderValue = 'S3 Server';
+
+export function setServerHeader(value: string) {
+    serverHeaderValue = value;
+}
+
 function storeServerAccessLogFields(
     res: http.ServerResponse,
     endTurnAroundTime: bigint,
@@ -91,7 +97,7 @@ export function setCommonResponseHeaders(
             }
         });
     }
-    response.setHeader('server', 'S3 Server');
+    response.setHeader('server', serverHeaderValue);
     // to be expanded in further implementation of logging of requests
     response.setHeader('x-amz-id-2', log.getSerializedUids());
     response.setHeader('x-amz-request-id', log.getSerializedUids());

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=20"
   },
-  "version": "8.2.49",
+  "version": "8.2.50",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/s3routes/routesUtils/setServerHeader.spec.js
+++ b/tests/unit/s3routes/routesUtils/setServerHeader.spec.js
@@ -1,0 +1,52 @@
+const sinon = require('sinon');
+const assert = require('assert');
+const werelogs = require('werelogs');
+const {
+    setServerHeader,
+    okHeaderResponse,
+} = require('../../../../lib/s3routes/routesUtils');
+
+const logger = new werelogs.Logger('test:setServerHeader', 'debug', 'debug');
+const log = logger.newRequestLogger();
+
+describe('setServerHeader', () => {
+    let mockResponse;
+    let sandbox;
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+
+        mockResponse = {
+            headersSent: false,
+            setHeader: sandbox.stub(),
+            writeHead: sandbox.stub(),
+            end: sandbox.stub().callsFake(callback => callback && callback()),
+            statusCode: 200,
+        };
+
+        sandbox.stub(log, 'debug');
+        sandbox.stub(log, 'end').returns({
+            info: sandbox.stub(),
+        });
+    });
+
+    afterEach(() => {
+        // Reset to default after each test
+        setServerHeader('S3 Server');
+        sandbox.restore();
+    });
+
+    it('should use the default value "S3 Server" when not configured', () => {
+        okHeaderResponse({}, mockResponse, 200, log);
+
+        assert(mockResponse.setHeader.calledWith('server', 'S3 Server'));
+    });
+
+    it('should use a custom value when configured via setServerHeader', () => {
+        setServerHeader('ScalityS3');
+
+        okHeaderResponse({}, mockResponse, 200, log);
+
+        assert(mockResponse.setHeader.calledWith('server', 'ScalityS3'));
+    });
+});


### PR DESCRIPTION
Export `setServerHeader()` so callers can configure the HTTP Server response header value at startup. Default remains `'S3 Server'`.