### PR TITLE
feat(ARSN-572): Propagate W3C trace context to MongoDB metadata writes

### DIFF
--- a/lib/models/ObjectMD.ts
+++ b/lib/models/ObjectMD.ts
@@ -2,10 +2,7 @@ import * as crypto from 'crypto';
 import * as constants from '../constants';
 import * as VersionIDUtils from '../versioning/VersionID';
 import { VersioningConstants } from '../versioning/constants';
-import ObjectMDLocation, {
-    ObjectMDLocationData,
-    Location,
-} from './ObjectMDLocation';
+import ObjectMDLocation, { ObjectMDLocationData, Location } from './ObjectMDLocation';
 import ObjectMDAmzRestore from './ObjectMDAmzRestore';
 import ObjectMDArchive from './ObjectMDArchive';
 import { ObjectMDAzureInfoMetadata } from './ObjectMDAzureInfo';
@@ -193,7 +190,7 @@ export default class ObjectMD {
             'cache-control': '',
             'content-disposition': '',
             'content-encoding': '',
-            'expires': '',
+            expires: '',
             'content-length': 0,
             'content-type': '',
             'content-md5': '',
@@ -212,27 +209,27 @@ export default class ObjectMD {
             'x-amz-server-side-encryption-customer-algorithm': '',
             'x-amz-website-redirect-location': '',
             'x-amz-scal-transition-in-progress': undefined,
-            'acl': {
+            acl: {
                 Canned: 'private',
                 FULL_CONTROL: [],
                 WRITE_ACP: [],
                 READ: [],
                 READ_ACP: [],
             },
-            'key': '',
-            'location': null,
-            'azureInfo': undefined,
+            key: '',
+            location: null,
+            azureInfo: undefined,
             // versionId, isNull, nullVersionId and isDeleteMarker
             // should be undefined when not set explicitly
-            'isNull': undefined,
-            'isNull2': undefined,
-            'nullVersionId': undefined,
-            'nullUploadId': undefined,
-            'isDeleteMarker': undefined,
-            'versionId': undefined,
-            'uploadId': undefined,
-            'tags': {},
-            'replicationInfo': {
+            isNull: undefined,
+            isNull2: undefined,
+            nullVersionId: undefined,
+            nullUploadId: undefined,
+            isDeleteMarker: undefined,
+            versionId: undefined,
+            uploadId: undefined,
+            tags: {},
+            replicationInfo: {
                 status: '',
                 backends: [],
                 content: [],
@@ -243,10 +240,10 @@ export default class ObjectMD {
                 dataStoreVersionId: '',
                 isNFS: undefined,
             },
-            'dataStoreName': '',
-            'originOp': '',
-            'deleted': undefined,
-            'isPHD': undefined,
+            dataStoreName: '',
+            originOp: '',
+            deleted: undefined,
+            isPHD: undefined,
         };
     }
 
@@ -489,11 +486,15 @@ export default class ObjectMD {
      * @param checksum - ObjectMDChecksum instance
      * @return itself
      */
-    setChecksum(checksum: ObjectMDChecksum | {
-        checksumAlgorithm: ChecksumAlgorithm;
-        checksumValue: string;
-        checksumType: ChecksumType;
-    }) {
+    setChecksum(
+        checksum:
+            | ObjectMDChecksum
+            | {
+                  checksumAlgorithm: ChecksumAlgorithm;
+                  checksumValue: string;
+                  checksumType: ChecksumType;
+              },
+    ) {
         if (checksum instanceof ObjectMDChecksum) {
             this._data.checksum = checksum;
         } else if (ObjectMDChecksum.isValid(checksum) === null) {
@@ -706,9 +707,9 @@ export default class ObjectMD {
      * @param transitionTime - Date when the transition started
      * @return itself
      */
-    setTransitionInProgress(inProgress: false): this
-    setTransitionInProgress(inProgress: true, transitionTime: Date|string|number): this
-    setTransitionInProgress(inProgress: boolean, transitionTime?: Date|string|number) {
+    setTransitionInProgress(inProgress: false): this;
+    setTransitionInProgress(inProgress: true, transitionTime: Date | string | number): this;
+    setTransitionInProgress(inProgress: boolean, transitionTime?: Date | string | number) {
         this._data['x-amz-scal-transition-in-progress'] = inProgress;
         if (!inProgress || !transitionTime) {
             delete this._data['x-amz-scal-transition-time'];
@@ -1098,17 +1099,8 @@ export default class ObjectMD {
         dataStoreVersionId?: string;
         isNFS?: boolean;
     }) {
-        const {
-            status,
-            backends,
-            content,
-            destination,
-            storageClass,
-            role,
-            storageType,
-            dataStoreVersionId,
-            isNFS,
-        } = replicationInfo;
+        const { status, backends, content, destination, storageClass, role, storageType, dataStoreVersionId, isNFS } =
+            replicationInfo;
         this._data.replicationInfo = {
             status,
             backends,
@@ -1156,9 +1148,7 @@ export default class ObjectMD {
     }
 
     setReplicationSiteStatus(site: string, status: string) {
-        const backend = this._data.replicationInfo.backends.find(
-            o => o.site === site
-        );
+        const backend = this._data.replicationInfo.backends.find(o => o.site === site);
         if (backend) {
             backend.status = status;
         }
@@ -1166,9 +1156,7 @@ export default class ObjectMD {
     }
 
     getReplicationSiteStatus(site: string) {
-        const backend = this._data.replicationInfo.backends.find(
-            o => o.site === site
-        );
+        const backend = this._data.replicationInfo.backends.find(o => o.site === site);
         if (backend) {
             return backend.status;
         }
@@ -1181,9 +1169,7 @@ export default class ObjectMD {
     }
 
     setReplicationSiteDataStoreVersionId(site: string, versionId: string) {
-        const backend = this._data.replicationInfo.backends.find(
-            o => o.site === site
-        );
+        const backend = this._data.replicationInfo.backends.find(o => o.site === site);
         if (backend) {
             backend.dataStoreVersionId = versionId;
         }
@@ -1191,9 +1177,7 @@ export default class ObjectMD {
     }
 
     getReplicationSiteDataStoreVersionId(site: string) {
-        const backend = this._data.replicationInfo.backends.find(
-            o => o.site === site
-        );
+        const backend = this._data.replicationInfo.backends.find(o => o.site === site);
         if (backend) {
             return backend.dataStoreVersionId;
         }
@@ -1510,37 +1494,37 @@ export default class ObjectMD {
     }
 
     /**
-    * Set deleted flag
-    * @param {Boolean} value deleted object
-    * @return {ObjectMD}
-    */
+     * Set deleted flag
+     * @param {Boolean} value deleted object
+     * @return {ObjectMD}
+     */
     setDeleted(value) {
         this._data.deleted = value;
         return this;
     }
 
     /**
-    * Get deleted flag
-    * @return {Boolean}
-    */
+     * Get deleted flag
+     * @return {Boolean}
+     */
     getDeleted() {
         return !!this._data.deleted;
     }
 
     /**
-    * Set isPHD flag
-    * @param {Boolean} value isPHD value
-    * @return {ObjectMD}
-    */
+     * Set isPHD flag
+     * @param {Boolean} value isPHD value
+     * @return {ObjectMD}
+     */
     setIsPHD(value) {
         this._data.isPHD = value;
         return this;
     }
 
     /**
-    * Get isPHD flag
-    * @return {Boolean}
-    */
+     * Get isPHD flag
+     * @return {Boolean}
+     */
     getIsPHD() {
         return !!this._data.isPHD;
     }

--- a/lib/models/ObjectMD.ts
+++ b/lib/models/ObjectMD.ts
@@ -86,6 +86,10 @@ export type ObjectMDData = {
     replicationInfo: ReplicationInfo;
     dataStoreName: string;
     originOp: string;
+    traceContext?: {
+        traceparent: string;
+        tracestate?: string;
+    };
     microVersionId?: string;
     // Deletion flag
     // Used for keeping object metadata in the oplog event

--- a/lib/storage/metadata/captureTraceContext.ts
+++ b/lib/storage/metadata/captureTraceContext.ts
@@ -1,0 +1,51 @@
+import { context, propagation, trace } from '@opentelemetry/api';
+import ObjectMD from '../../models/ObjectMD';
+
+/**
+ * Stamp the currently-active OTEL W3C trace context onto a
+ * metadata-shaped object's `traceContext` field, in place. Always
+ * reflects the current write: if no span is active (OTEL disabled, or
+ * called outside a traced request), clears any previously-set
+ * traceContext so stale context loaded from storage is not carried
+ * forward into a new oplog entry.
+ *
+ * Mongo writes go through `MongoUtils.serialize`, which calls this — so
+ * callers there don't invoke this directly. Use this helper directly
+ * only at write sites that bypass serialize (e.g. paths that hand off
+ * a pre-built `ObjectMDData` to bulkWrite without going through tag
+ * escape).
+ *
+ * Accepts either an `ObjectMD` instance (stamps onto its underlying
+ * `getValue()` object) or a raw metadata object.
+ */
+export function stampActiveTraceContext(objMd: ObjectMD): void;
+export function stampActiveTraceContext(data: Record<string, any>): void;
+export function stampActiveTraceContext(data: ObjectMD | Record<string, any>): void {
+    const target: Record<string, any> = data instanceof ObjectMD ? data.getValue() : data;
+
+    const ctx = context.active();
+    const span = trace.getSpan(ctx);
+    if (!span) {
+        delete target.traceContext;
+        return;
+    }
+
+    const carrier: Record<string, string> = {};
+    propagation.inject(ctx, carrier, {
+        set: (c, k, v) => {
+            c[k] = v;
+        },
+    });
+    if (!carrier.traceparent) {
+        delete target.traceContext;
+        return;
+    }
+
+    const out: { traceparent: string; tracestate?: string } = {
+        traceparent: carrier.traceparent,
+    };
+    if (carrier.tracestate) {
+        out.tracestate = carrier.tracestate;
+    }
+    target.traceContext = out;
+}

--- a/lib/storage/metadata/mongoclient/MongoClientInterface.ts
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.ts
@@ -33,7 +33,7 @@ import {
     UpdateFilter,
     MongoServerError,
     MongoBulkWriteError,
-    WriteError
+    WriteError,
 } from 'mongodb';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -66,47 +66,42 @@ const MONGO_CONNECT_TIMEOUT_MS = process.env.MONGO_CONNECT_TIMEOUT_MS;
 const MONGO_SOCKET_TIMEOUT_MS = process.env.MONGO_SOCKET_TIMEOUT_MS;
 const MONGO_POOL_SIZE = process.env.MONGO_POOL_SIZE;
 // MongoDB default
-const CONNECT_TIMEOUT_MS = MONGO_CONNECT_TIMEOUT_MS ?
-    Number.parseInt(MONGO_CONNECT_TIMEOUT_MS, 10) : 5000;
-const SOCKET_TIMEOUT_MS = MONGO_SOCKET_TIMEOUT_MS ?
-    Number.parseInt(MONGO_SOCKET_TIMEOUT_MS, 10) : 360000;
-const CONCURRENT_CURSORS = process.env.CONCURRENT_CURSORS ?
-    Number.parseInt(process.env.CONCURRENT_CURSORS, 10) : 10;
+const CONNECT_TIMEOUT_MS = MONGO_CONNECT_TIMEOUT_MS ? Number.parseInt(MONGO_CONNECT_TIMEOUT_MS, 10) : 5000;
+const SOCKET_TIMEOUT_MS = MONGO_SOCKET_TIMEOUT_MS ? Number.parseInt(MONGO_SOCKET_TIMEOUT_MS, 10) : 360000;
+const CONCURRENT_CURSORS = process.env.CONCURRENT_CURSORS ? Number.parseInt(process.env.CONCURRENT_CURSORS, 10) : 10;
 
 const initialInstanceID = process.env.INITIAL_INSTANCE_ID;
 
-const BUCKET_VERSIONS = require('../../../versioning/constants')
-    .VersioningConstants.BucketVersioningKeyFormat;
-const DEFAULT_BUCKET_KEY_FORMAT =
-    [<string>BUCKET_VERSIONS.v0, <string>BUCKET_VERSIONS.v1]
-        .includes(process.env.DEFAULT_BUCKET_KEY_FORMAT!) ?
-            <BucketVersioningFormat>process.env.DEFAULT_BUCKET_KEY_FORMAT : BUCKET_VERSIONS.v1;
+const BUCKET_VERSIONS = require('../../../versioning/constants').VersioningConstants.BucketVersioningKeyFormat;
+const DEFAULT_BUCKET_KEY_FORMAT = [<string>BUCKET_VERSIONS.v0, <string>BUCKET_VERSIONS.v1].includes(
+    process.env.DEFAULT_BUCKET_KEY_FORMAT!,
+)
+    ? <BucketVersioningFormat>process.env.DEFAULT_BUCKET_KEY_FORMAT
+    : BUCKET_VERSIONS.v1;
 
-const DB_PREFIXES = require('../../../versioning/constants')
-    .VersioningConstants.DbPrefixes;
+const DB_PREFIXES = require('../../../versioning/constants').VersioningConstants.DbPrefixes;
 
 function inc(str) {
-    return str ? (str.slice(0, str.length - 1) +
-        String.fromCharCode(str.charCodeAt(str.length - 1) + 1)) : str;
+    return str ? str.slice(0, str.length - 1) + String.fromCharCode(str.charCodeAt(str.length - 1) + 1) : str;
 }
 
 export type MongoDBClientInterfaceParameters = {
-    replicaSetHosts: string,
-    writeConcern: string,
-    replicaSet: string,
-    readPreference: ReadPreferenceMode,
-    path: string,
-    database: string,
-    logger: werelogs.Logger,
-    instanceId: string,
-    replicationGroupId: string,
-    authCredentials: MongoUtils.AuthCredentials,
-    isLocationTransient: Function,
-    shardCollections: boolean,
+    replicaSetHosts: string;
+    writeConcern: string;
+    replicaSet: string;
+    readPreference: ReadPreferenceMode;
+    path: string;
+    database: string;
+    logger: werelogs.Logger;
+    instanceId: string;
+    replicationGroupId: string;
+    authCredentials: MongoUtils.AuthCredentials;
+    isLocationTransient: Function;
+    shardCollections: boolean;
 };
 
 export type BucketMetadataMongoDB = Omit<Omit<BucketMetadata, 'quotaMax'>, 'capabilities'> & {
-    // Old buckets might not have a quotaMax 
+    // Old buckets might not have a quotaMax
     quotaMax?: Long;
     capabilities?: NestedOmit<Capabilities, 'VeeamSOSApi.CapacityInfo'> & {
         VeeamSOSApi?: {
@@ -129,17 +124,17 @@ export interface BucketMetastoreDocument extends Document {
 export interface ObjectMetastoreDocument extends Document {
     _id: string;
     value: ObjectMDData;
-};
+}
 
 export type ObjectMDOperationParams = {
-    vFormat: string,
-    versionId: string,
-    repairMaster: boolean,
-    versioning: boolean,
-    needOplogUpdate: boolean,
-    originOp: string,
-    doesNotNeedOpogUpdate?: boolean,
-    conditions: any,
+    vFormat: string;
+    versionId: string;
+    repairMaster: boolean;
+    versioning: boolean;
+    needOplogUpdate: boolean;
+    originOp: string;
+    doesNotNeedOpogUpdate?: boolean;
+    conditions: any;
 };
 
 export type InternalListObjectParams = {
@@ -152,65 +147,65 @@ export type InternalListObjectParams = {
     mongifiedSearch?: object;
     listingType?: string;
     start?: undefined;
-    gt?: undefined
+    gt?: undefined;
 };
 
 export interface InfostoreDocument extends Document {
     _id: string | 'uuid';
-    value?: string | ObjectMDStats,
+    value?: string | ObjectMDStats;
     measuredOn?: string;
     objectCount?: {
-        current: Long | number,
-        _currentCold: Long | number,
-        deleteMarker: Long | number,
-        nonCurrent: Long | number,
-        _nonCurrentCold: Long | number,
-        _currentRestored: Long | number,
-        _currentRestoring: Long | number,
-        _nonCurrentRestored: Long | number,
-        _nonCurrentRestoring: Long | number,
-        _incompleteMPUUploads: Long | number,
-    },
+        current: Long | number;
+        _currentCold: Long | number;
+        deleteMarker: Long | number;
+        nonCurrent: Long | number;
+        _nonCurrentCold: Long | number;
+        _currentRestored: Long | number;
+        _currentRestoring: Long | number;
+        _nonCurrentRestored: Long | number;
+        _nonCurrentRestoring: Long | number;
+        _incompleteMPUUploads: Long | number;
+    };
     usedCapacity?: {
-        current: Long | number,
-        _currentCold: Long | number,
-        nonCurrent: Long | number,
-        _nonCurrentCold: Long | number,
-        _currentRestored: Long | number,
-        _currentRestoring: Long | number,
-        _nonCurrentRestored: Long | number,
-        _nonCurrentRestoring: Long | number,
-        _incompleteMPUParts: Long | number,
-    },
+        current: Long | number;
+        _currentCold: Long | number;
+        nonCurrent: Long | number;
+        _nonCurrentCold: Long | number;
+        _currentRestored: Long | number;
+        _currentRestoring: Long | number;
+        _nonCurrentRestored: Long | number;
+        _nonCurrentRestoring: Long | number;
+        _incompleteMPUParts: Long | number;
+    };
     locations: {
         [key: string]: {
             usedCapacity: {
-                current: Long | number,
-                nonCurrent: Long | number,
-                _currentCold: Long | number,
-                _nonCurrentCold: Long | number,
-                _currentRestored: Long | number,
-                _currentRestoring: Long | number,
-                _nonCurrentRestored: Long | number,
-                _nonCurrentRestoring: Long | number,
-                _inflightsPreScan: Long | number,
-                _incompleteMPUParts: Long | number,
-            },
+                current: Long | number;
+                nonCurrent: Long | number;
+                _currentCold: Long | number;
+                _nonCurrentCold: Long | number;
+                _currentRestored: Long | number;
+                _currentRestoring: Long | number;
+                _nonCurrentRestored: Long | number;
+                _nonCurrentRestoring: Long | number;
+                _inflightsPreScan: Long | number;
+                _incompleteMPUParts: Long | number;
+            };
             objectCount: {
-                current: Long | number,
-                nonCurrent: Long | number,
-                _currentCold: Long | number,
-                _nonCurrentCold: Long | number,
-                _currentRestored: Long | number,
-                _currentRestoring: Long | number,
-                _nonCurrentRestored: Long | number,
-                _nonCurrentRestoring: Long | number,
-                _incompleteMPUUploads: Long | number,
-                deleteMarker: Long | number,
-            },
-        },
-    },
-};
+                current: Long | number;
+                nonCurrent: Long | number;
+                _currentCold: Long | number;
+                _nonCurrentCold: Long | number;
+                _currentRestored: Long | number;
+                _currentRestoring: Long | number;
+                _nonCurrentRestored: Long | number;
+                _nonCurrentRestoring: Long | number;
+                _incompleteMPUUploads: Long | number;
+                deleteMarker: Long | number;
+            };
+        };
+    };
+}
 
 export type ObjectMDStats = {
     versions: number;
@@ -228,7 +223,7 @@ export type ObjectMDStats = {
         isVersioned: boolean;
         ownerCanonicalId: string;
         ingestion: boolean;
-    }[],
+    }[];
     locations?: any;
     buckets?: number;
     bucketWithQuotaCount?: number;
@@ -262,12 +257,22 @@ class MongoClientInterface {
     private isConnected = false;
 
     constructor(params: MongoDBClientInterfaceParameters) {
-        const { replicaSetHosts, writeConcern, replicaSet, readPreference, path,
-            database, logger, instanceId, replicationGroupId, authCredentials,
-            isLocationTransient, shardCollections } = params;
+        const {
+            replicaSetHosts,
+            writeConcern,
+            replicaSet,
+            readPreference,
+            path,
+            database,
+            logger,
+            instanceId,
+            replicationGroupId,
+            authCredentials,
+            isLocationTransient,
+            shardCollections,
+        } = params;
         const cred = MongoUtils.credPrefix(authCredentials);
-        this.mongoUrl = `mongodb://${cred}${replicaSetHosts}/` +
-            `?w=${writeConcern}&readPreference=${readPreference}`;
+        this.mongoUrl = `mongodb://${cred}${replicaSetHosts}/` + `?w=${writeConcern}&readPreference=${readPreference}`;
 
         if (!shardCollections) {
             this.mongoUrl += `&replicaSet=${replicaSet}`;
@@ -298,10 +303,11 @@ class MongoClientInterface {
         // FIXME: constructors shall not have side effect so there
         // should be an async_init(cb) method in the wrapper to
         // initialize this backend
-        if ((MONGO_CONNECT_TIMEOUT_MS && Number.isNaN(MONGO_CONNECT_TIMEOUT_MS)) ||
-            (MONGO_SOCKET_TIMEOUT_MS && Number.isNaN(MONGO_SOCKET_TIMEOUT_MS))) {
-            this.logger.error('MongoDB connect and socket timeouts must be a ' +
-                'number. Using default value(s).');
+        if (
+            (MONGO_CONNECT_TIMEOUT_MS && Number.isNaN(MONGO_CONNECT_TIMEOUT_MS)) ||
+            (MONGO_SOCKET_TIMEOUT_MS && Number.isNaN(MONGO_SOCKET_TIMEOUT_MS))
+        ) {
+            this.logger.error('MongoDB connect and socket timeouts must be a ' + 'number. Using default value(s).');
         }
         const connectTimeoutMS = CONNECT_TIMEOUT_MS;
         const socketTimeoutMS = SOCKET_TIMEOUT_MS;
@@ -315,7 +321,8 @@ class MongoClientInterface {
         }
         const client = new MongoClient(this.mongoUrl, options);
 
-        return client.connect()
+        return client
+            .connect()
             .then(client => {
                 this.logger.info('connected to mongodb');
                 this.client = client;
@@ -326,9 +333,12 @@ class MongoClientInterface {
                 this.adminDb = client.db('admin');
                 // log cache hit/miss every 5min
                 this.cacheHitMissLoggerInterval = setInterval(() => {
-                    const hitRatio = (this.cacheHit / (this.cacheHit + this.cacheMiss)) || 0;
-                    this.logger.debug('MongoClientInterface: Bucket vFormat cache hit/miss (5min)',
-                        { hits: this.cacheHit, misses: this.cacheMiss, hitRatio: hitRatio.toFixed(3) });
+                    const hitRatio = this.cacheHit / (this.cacheHit + this.cacheMiss) || 0;
+                    this.logger.debug('MongoClientInterface: Bucket vFormat cache hit/miss (5min)', {
+                        hits: this.cacheHit,
+                        misses: this.cacheMiss,
+                        hitRatio: hitRatio.toFixed(3),
+                    });
                     this.cacheHit = 0;
                     this.cacheMiss = 0;
                 }, 300000);
@@ -350,22 +360,20 @@ class MongoClientInterface {
            usersBucket to have attributes, we pre-create the
            usersBucket attributes here (see bucketCreation.js line
            36)*/
-        const usersBucketAttr = new BucketInfo(constants.usersBucket,
-            'admin', 'admin', new Date().toJSON(),
-            BucketInfo.currentModelVersion());
-        return this.createBucket(
+        const usersBucketAttr = new BucketInfo(
             constants.usersBucket,
-            usersBucketAttr,
-            this.logger,
-            err => {
-                if (err) {
-                    this.logger.fatal('error writing usersBucket ' +
-                        'attributes to metastore',
-                    { error: err });
-                    throw (errors.InternalError);
-                }
-                return cb();
-            });
+            'admin',
+            'admin',
+            new Date().toJSON(),
+            BucketInfo.currentModelVersion(),
+        );
+        return this.createBucket(constants.usersBucket, usersBucketAttr, this.logger, err => {
+            if (err) {
+                this.logger.fatal('error writing usersBucket ' + 'attributes to metastore', { error: err });
+                throw errors.InternalError;
+            }
+            return cb();
+        });
     }
 
     close(cb) {
@@ -373,7 +381,8 @@ class MongoClientInterface {
             if (this.cacheHitMissLoggerInterval) {
                 clearInterval(this.cacheHitMissLoggerInterval as NodeJS.Timeout);
             }
-            return this.client.close(true)
+            return this.client
+                .close(true)
                 .then(() => cb())
                 .catch(() => cb());
         }
@@ -382,8 +391,7 @@ class MongoClientInterface {
 
     getCollection<T extends Document>(name): Collection<T> {
         /* mongo has a problem with .. in collection names */
-        const newName = (name === constants.usersBucket) ?
-            USERSBUCKET : name;
+        const newName = name === constants.usersBucket ? USERSBUCKET : name;
         return this.db!.collection<T>(newName);
     }
 
@@ -425,9 +433,11 @@ class MongoClientInterface {
                 vFormat: this.defaultBucketKeyFormat,
             },
         };
-        if (bucketName !== constants.usersBucket &&
+        if (
+            bucketName !== constants.usersBucket &&
             bucketName !== PENSIEVE &&
-            !bucketName.startsWith(constants.mpuBucketPrefix)) {
+            !bucketName.startsWith(constants.mpuBucketPrefix)
+        ) {
             payload.$set.vFormat = this.defaultBucketKeyFormat;
         } else {
             payload.$set.vFormat = BUCKET_VERSIONS.v0;
@@ -435,11 +445,15 @@ class MongoClientInterface {
 
         // we don't have to test bucket existence here as it is done
         // on the upper layers
-        m.updateOne({
-            _id: bucketName,
-        }, payload, {
-            upsert: true,
-        })
+        m.updateOne(
+            {
+                _id: bucketName,
+            },
+            payload,
+            {
+                upsert: true,
+            },
+        )
             .then(result => {
                 if (result.matchedCount === 0 && result.modifiedCount === 0 && result.upsertedCount === 0) {
                     log.debug('createBucket: failed to create bucket', { bucketName, result });
@@ -451,22 +465,21 @@ class MongoClientInterface {
                 // "constants.usersBucket" and "PENSIEVE" since it has already
                 // been created
                 if (bucketName !== constants.usersBucket && bucketName !== PENSIEVE) {
-                    return this.db!.createCollection(bucketName)
-                        .then(() => {
-                            if (this.shardCollections) {
-                                const cmd = {
-                                    shardCollection: `${this.database}.${bucketName}`,
-                                    key: { _id: 1 },
-                                };
-                                return this.adminDb!.command(cmd, {}).then(() => cb(null)).catch(err => {
-                                    log.error(
-                                        'createBucket: enabling sharding',
-                                        { error: err });
+                    return this.db!.createCollection(bucketName).then(() => {
+                        if (this.shardCollections) {
+                            const cmd = {
+                                shardCollection: `${this.database}.${bucketName}`,
+                                key: { _id: 1 },
+                            };
+                            return this.adminDb!.command(cmd, {})
+                                .then(() => cb(null))
+                                .catch(err => {
+                                    log.error('createBucket: enabling sharding', { error: err });
                                     return cb(errors.InternalError);
                                 });
-                            }
-                            return cb(null);
-                        });
+                        }
+                        return cb(null);
+                    });
                 }
                 return cb(null);
             })
@@ -500,7 +513,8 @@ class MongoClientInterface {
                         VeeamSOSApi: doc.value.capabilities?.VeeamSOSApi && {
                             ...doc.value.capabilities.VeeamSOSApi,
                             // Long values are automatically serialized to strings
-                            CapacityInfo: doc.value.capabilities.VeeamSOSApi.CapacityInfo &&
+                            CapacityInfo:
+                                doc.value.capabilities.VeeamSOSApi.CapacityInfo &&
                                 VeeamCapacityInfo.serialize(doc.value.capabilities.VeeamSOSApi.CapacityInfo),
                         },
                     },
@@ -508,9 +522,7 @@ class MongoClientInterface {
                 return cb(null, BucketInfo.fromJson(bucketMetadata));
             })
             .catch(err => {
-                log.error(
-                    'getBucketAttributes: error getting bucket attributes',
-                    { error: err.message });
+                log.error('getBucketAttributes: error getting bucket attributes', { error: err.message });
                 return cb(errors.InternalError);
             });
         return undefined;
@@ -544,10 +556,7 @@ class MongoClientInterface {
                 return cb(null, vFormat);
             })
             .catch(err => {
-                log.error(
-                    'getBucketVFormat: error getting bucket vFormat',
-                    { bucket: bucketName, error: err.message },
-                );
+                log.error('getBucketVFormat: error getting bucket vFormat', { bucket: bucketName, error: err.message });
                 return cb(errors.InternalError);
             });
         return undefined;
@@ -558,26 +567,21 @@ class MongoClientInterface {
         objName: string,
         params: ObjectMDOperationParams,
         log: werelogs.Logger,
-        cb: ArsenalCallback<{ bucket: string, obj?: string }>,
+        cb: ArsenalCallback<{ bucket: string; obj?: string }>,
     ) {
         this.getBucketAttributes(bucketName, log, (err, bucket?) => {
             if (err) {
-                log.error(
-                    'getBucketAttributes: error getting bucket attributes',
-                    { error: err.message });
+                log.error('getBucketAttributes: error getting bucket attributes', { error: err.message });
                 return cb(err);
             }
             this.getObject(bucketName, objName, params, log, (err, obj?) => {
                 if (err) {
                     if (err.is.NoSuchKey) {
-                        return cb(null,
-                            {
-                                bucket:
-                                    BucketInfo.fromObj(bucket).serialize(),
-                            });
+                        return cb(null, {
+                            bucket: BucketInfo.fromObj(bucket).serialize(),
+                        });
                     }
-                    log.error('getObject: error getting object',
-                        { error: err.message });
+                    log.error('getObject: error getting object', { error: err.message });
                     return cb(err);
                 }
                 return cb(null, {
@@ -600,16 +604,20 @@ class MongoClientInterface {
 
         newBucketMD.quotaMax = new Long(newBucketMD.quotaMax || 0);
         const m = this.getCollection<BucketMetastoreDocument>(METASTORE);
-        m.updateOne({
-            _id: bucketName,
-        }, {
-            $set: {
+        m.updateOne(
+            {
                 _id: bucketName,
-                value: newBucketMD,
             },
-        }, {
-            upsert: true,
-        })
+            {
+                $set: {
+                    _id: bucketName,
+                    value: newBucketMD,
+                },
+            },
+            {
+                upsert: true,
+            },
+        )
             .then(result => {
                 if (result.matchedCount === 0 && result.modifiedCount === 0 && result.upsertedCount === 0) {
                     log.debug('putBucketAttributes: failed to update bucket', { bucketName });
@@ -618,9 +626,7 @@ class MongoClientInterface {
                 return cb(null);
             })
             .catch(err => {
-                log.error(
-                    'putBucketAttributes: error putting bucket attributes',
-                    { error: err.message });
+                log.error('putBucketAttributes: error putting bucket attributes', { error: err.message });
                 return cb(errors.InternalError);
             });
     }
@@ -644,30 +650,34 @@ class MongoClientInterface {
         cb: ArsenalCallback<void>,
     ) {
         const m = this.getCollection<BucketMetastoreDocument>(METASTORE);
-        const updateString = capabilityField ?
-            `value.capabilities.${capabilityName}.${capabilityField}` :
-            `value.capabilities.${capabilityName}`;
-        m.updateOne({
-            _id: bucketName,
-        }, {
-            $set: {
+        const updateString = capabilityField
+            ? `value.capabilities.${capabilityName}.${capabilityField}`
+            : `value.capabilities.${capabilityName}`;
+        m.updateOne(
+            {
                 _id: bucketName,
-                [updateString]: capability,
             },
-        }, {
-            upsert: true,
-        }).then(result => {
-            if (result.matchedCount === 0 && result.modifiedCount === 0 && result.upsertedCount === 0) {
-                log.error('putBucketAttributesCapabilities: failed to update bucket', { bucketName });
+            {
+                $set: {
+                    _id: bucketName,
+                    [updateString]: capability,
+                },
+            },
+            {
+                upsert: true,
+            },
+        )
+            .then(result => {
+                if (result.matchedCount === 0 && result.modifiedCount === 0 && result.upsertedCount === 0) {
+                    log.error('putBucketAttributesCapabilities: failed to update bucket', { bucketName });
+                    return cb(errors.InternalError);
+                }
+                return cb(null);
+            })
+            .catch(err => {
+                log.error('putBucketAttributesCapabilities: error putting bucket attributes', { error: err.message });
                 return cb(errors.InternalError);
-            }
-            return cb(null);
-        }).catch(err => {
-            log.error(
-                'putBucketAttributesCapabilities: error putting bucket attributes',
-                { error: err.message });
-            return cb(errors.InternalError);
-        });
+            });
     }
 
     /**
@@ -687,31 +697,37 @@ class MongoClientInterface {
         cb: ArsenalCallback<void>,
     ) {
         const m = this.getCollection<BucketMetastoreDocument>(METASTORE);
-        const updateString = capabilityField ?
-            `value.capabilities.${capabilityName}.${capabilityField}` :
-            `value.capabilities.${capabilityName}`;
-        m.updateOne({
-            _id: bucketName,
-        }, {
-            $unset: {
-                [updateString]: '',
+        const updateString = capabilityField
+            ? `value.capabilities.${capabilityName}.${capabilityField}`
+            : `value.capabilities.${capabilityName}`;
+        m.updateOne(
+            {
+                _id: bucketName,
             },
-        }).then(result => {
-            if (result.matchedCount === 0 && result.modifiedCount === 0) {
-                log.debug('deleteBucketAttributesCapability: bucket not found or capability not present',
-                    { bucketName });
-                return cb(errors.NoSuchBucket);
-            }
-            return cb(null);
-        }).catch(err => {
-            if (err) {
-                log.error(
-                    'deleteBucketAttributesCapability: error deleting bucket attributes',
-                    { error: err.message });
-                return cb(errors.InternalError);
-            }
-            return cb(null);
-        });
+            {
+                $unset: {
+                    [updateString]: '',
+                },
+            },
+        )
+            .then(result => {
+                if (result.matchedCount === 0 && result.modifiedCount === 0) {
+                    log.debug('deleteBucketAttributesCapability: bucket not found or capability not present', {
+                        bucketName,
+                    });
+                    return cb(errors.NoSuchBucket);
+                }
+                return cb(null);
+            })
+            .catch(err => {
+                if (err) {
+                    log.error('deleteBucketAttributesCapability: error deleting bucket attributes', {
+                        error: err.message,
+                    });
+                    return cb(errors.InternalError);
+                }
+                return cb(null);
+            });
     }
 
     /*
@@ -719,11 +735,14 @@ class MongoClientInterface {
      */
     deleteBucketStep2(bucketName: string, log: werelogs.Logger, cb: ArsenalCallback<void>) {
         const m = this.getCollection<BucketMetastoreDocument>(METASTORE);
-        m.findOneAndDelete({
-            _id: bucketName,
-        } , {
-            includeResultMetadata: true,
-        })
+        m.findOneAndDelete(
+            {
+                _id: bucketName,
+            },
+            {
+                includeResultMetadata: true,
+            },
+        )
             .then(result => {
                 if (result.ok !== 1) {
                     log.error('deleteBucketStep2: failed deleting bucket');
@@ -734,8 +753,7 @@ class MongoClientInterface {
                 return cb(null);
             })
             .catch(err => {
-                log.error('deleteBucketStep2: error deleting bucket',
-                    { error: err.message });
+                log.error('deleteBucketStep2: error deleting bucket', { error: err.message });
                 return cb(errors.InternalError);
             });
     }
@@ -765,8 +783,7 @@ class MongoClientInterface {
                 if (err.codeName === 'NamespaceNotFound') {
                     return this.deleteBucketStep2(bucketName, log, cb);
                 }
-                log.error('deleteBucket: error deleting bucket',
-                    { error: err.message });
+                log.error('deleteBucket: error deleting bucket', { error: err.message });
                 return cb(errors.InternalError);
             });
     }
@@ -784,8 +801,13 @@ class MongoClientInterface {
      * @param {Boolean} upsert if upserting is needed
      * @return {Object} mongo operation
      */
-    updateDeleteMaster(isDeleteMarker: boolean, vFormat: string, 
-        filter: any, update: any, upsert: boolean): AnyBulkWriteOperation<ObjectMetastoreDocument> {
+    updateDeleteMaster(
+        isDeleteMarker: boolean,
+        vFormat: string,
+        filter: any,
+        update: any,
+        upsert: boolean,
+    ): AnyBulkWriteOperation<ObjectMetastoreDocument> {
         // delete master when we are in v1 and the version is a delete
         // marker
         if (isDeleteMarker && vFormat === BUCKET_VERSIONS.v1) {
@@ -845,21 +867,20 @@ class MongoClientInterface {
         const versionKey = formatVersionKey(objName, versionId, params.vFormat);
         const masterKey = formatMasterKey(objName, params.vFormat);
         // initiating array of operations with version creation
-        const ops: AnyBulkWriteOperation<ObjectMetastoreDocument>[] = [{
-            insertOne: {
-                document: {
-                    _id: versionKey,
-                    value: objVal,
-                } as ObjectMetastoreDocument,
+        const ops: AnyBulkWriteOperation<ObjectMetastoreDocument>[] = [
+            {
+                insertOne: {
+                    document: {
+                        _id: versionKey,
+                        value: objVal,
+                    } as ObjectMetastoreDocument,
+                },
             },
-        }];
+        ];
         // filter to get master
         const filter = {
             _id: masterKey,
-            $or: [
-                { 'value.versionId': { $exists: false } },
-                { 'value.versionId': { $gt: objVal.versionId } },
-            ],
+            $or: [{ 'value.versionId': { $exists: false } }, { 'value.versionId': { $gt: objVal.versionId } }],
         };
         // values to update master
         const update = {
@@ -918,7 +939,8 @@ class MongoClientInterface {
                             error: err.errmsg,
                         });
                         return process.nextTick(() =>
-                            this.putObjectVerCase1(c, bucketName, objName, objVal, params, log, cb, true));
+                            this.putObjectVerCase1(c, bucketName, objName, objVal, params, log, cb, true),
+                        );
                     }
 
                     // Version operation failed twice, reject the operation.
@@ -960,10 +982,7 @@ class MongoClientInterface {
         const versionId = generateVersionId(this.instanceId, this.replicationGroupId);
         objVal.versionId = versionId;
         const masterKey = formatMasterKey(objName, params.vFormat);
-        c.updateOne({ _id: masterKey },
-            { $set: { value: objVal }, $setOnInsert: { _id: masterKey } },
-            { upsert: true },
-        )
+        c.updateOne({ _id: masterKey }, { $set: { value: objVal }, $setOnInsert: { _id: masterKey } }, { upsert: true })
             .then(() => cb(null, `{"versionId": "${objVal.versionId}"}`))
             .catch(err => {
                 log.error('putObjectVerCase2: error putting object version', { error: err.message });
@@ -1022,63 +1041,69 @@ class MongoClientInterface {
                 });
         };
 
-        c.findOne({ _id: masterKey }).then(checkObj => {
-            const objUpsert = !checkObj;
-            // initiating array of operations with version creation/update
-            const ops: AnyBulkWriteOperation<ObjectMetastoreDocument>[] = [{
-                updateOne: {
-                    filter: {
-                        _id: versionKey,
-                    },
-                    update: {
-                        $set: {
-                            _id: versionKey,
-                            value: objVal,
+        c.findOne({ _id: masterKey })
+            .then(checkObj => {
+                const objUpsert = !checkObj;
+                // initiating array of operations with version creation/update
+                const ops: AnyBulkWriteOperation<ObjectMetastoreDocument>[] = [
+                    {
+                        updateOne: {
+                            filter: {
+                                _id: versionKey,
+                            },
+                            update: {
+                                $set: {
+                                    _id: versionKey,
+                                    value: objVal,
+                                },
+                            },
+                            upsert: true,
                         },
                     },
-                    upsert: true,
-                },
-            }];
-            // filter to get master
-            const filter = {
-                '_id': masterKey,
-                'value.versionId': objVal.versionId,
-            };
-            // values to update master
-            const update = {
-                $set: { _id: masterKey, value: objVal },
-            };
+                ];
+                // filter to get master
+                const filter = {
+                    _id: masterKey,
+                    'value.versionId': objVal.versionId,
+                };
+                // values to update master
+                const update = {
+                    $set: { _id: masterKey, value: objVal },
+                };
 
-            c.findOne({ _id: versionKey }).then(verObj => {
-                // existing versioned entry update.
-                // if master entry doesn't exist, skip upsert of master
-                if (verObj && !checkObj) {
-                    putObjectEntry(ops, cb);
-                    return null;
-                }
+                c.findOne({ _id: versionKey })
+                    .then(verObj => {
+                        // existing versioned entry update.
+                        // if master entry doesn't exist, skip upsert of master
+                        if (verObj && !checkObj) {
+                            putObjectEntry(ops, cb);
+                            return null;
+                        }
 
-                // updating or deleting master depending on the last version put
-                // in v0 the master gets updated, in v1 the master gets deleted if version is
-                // a delete marker or updated otherwise.
-                const masterOp = this.updateDeleteMaster(
-                    objVal.isDeleteMarker || false,
-                    params.vFormat,
-                    filter,
-                    update,
-                    objUpsert,
-                );
-                ops.push(masterOp);
-                putObjectEntry(ops, cb);
+                        // updating or deleting master depending on the last version put
+                        // in v0 the master gets updated, in v1 the master gets deleted if version is
+                        // a delete marker or updated otherwise.
+                        const masterOp = this.updateDeleteMaster(
+                            objVal.isDeleteMarker || false,
+                            params.vFormat,
+                            filter,
+                            update,
+                            objUpsert,
+                        );
+                        ops.push(masterOp);
+                        putObjectEntry(ops, cb);
+                        return null;
+                    })
+                    .catch(err => {
+                        log.error('putObjectVerCase3: mongoDB error finding object', { err });
+                        return cb(errors.InternalError);
+                    });
                 return null;
-            }).catch(err => {
+            })
+            .catch(err => {
                 log.error('putObjectVerCase3: mongoDB error finding object', { err });
                 return cb(errors.InternalError);
             });
-            return null;
-        }).catch(err => {
-            log.error('putObjectVerCase3: mongoDB error finding object', { err });
-            return cb(errors.InternalError);
-        });
     }
 
     /**
@@ -1112,75 +1137,88 @@ class MongoClientInterface {
     ) {
         const versionKey = formatVersionKey(objName, params.versionId, params.vFormat);
         const masterKey = formatMasterKey(objName, params.vFormat);
-        c.updateOne({
-            _id: versionKey,
-        }, {
-            $set: {
+        c.updateOne(
+            {
                 _id: versionKey,
-                value: objVal,
             },
-        }, {
-            upsert: true,
-        }).then(() => this.getLatestVersion(c, objName, params.vFormat, log, (err, mstObjVal?) => {
-            if (err?.is.NoSuchKey) {
-                return cb(err);
-            }
+            {
+                $set: {
+                    _id: versionKey,
+                    value: objVal,
+                },
+            },
+            {
+                upsert: true,
+            },
+        )
+            .then(() =>
+                this.getLatestVersion(c, objName, params.vFormat, log, (err, mstObjVal?) => {
+                    if (err?.is.NoSuchKey) {
+                        return cb(err);
+                    }
 
-            if (err) {
-                log.error('getLatestVersion: getting latest version',
-                    { error: err.message });
-                return cb(err);
-            }
+                    if (err) {
+                        log.error('getLatestVersion: getting latest version', { error: err.message });
+                        return cb(err);
+                    }
 
-            MongoUtils.serialize(mstObjVal);
-            const ops: AnyBulkWriteOperation<ObjectMetastoreDocument>[] = [];
-            // filter to get master
-            const filter = {
-                _id: masterKey,
-                $or: [
-                    { 'value.versionId': { $exists: false } },
-                    // We break the semantic correctness here with
-                    // $gte instead of $gt because we do not have
-                    // a microVersionId to capture the micro
-                    // changes (tags, ACLs, etc). If we do not use
-                    // $gte currently the micro changes are not
-                    // propagated. We are now totally dependent of
-                    // the order of changes (which Backbeat
-                    // replication and ingestion can hopefully
-                    // ensure), but this would not work e.g. in
-                    // the case of an active-active replication.
+                    MongoUtils.serialize(mstObjVal);
+                    const ops: AnyBulkWriteOperation<ObjectMetastoreDocument>[] = [];
+                    // filter to get master
+                    const filter = {
+                        _id: masterKey,
+                        $or: [
+                            { 'value.versionId': { $exists: false } },
+                            // We break the semantic correctness here with
+                            // $gte instead of $gt because we do not have
+                            // a microVersionId to capture the micro
+                            // changes (tags, ACLs, etc). If we do not use
+                            // $gte currently the micro changes are not
+                            // propagated. We are now totally dependent of
+                            // the order of changes (which Backbeat
+                            // replication and ingestion can hopefully
+                            // ensure), but this would not work e.g. in
+                            // the case of an active-active replication.
 
-                    { 'value.versionId': { $gte: mstObjVal!.versionId } },
-                ]
-            };
-            // values to update master
-            const update = {
-                $set: { _id: masterKey, value: mstObjVal },
-            };
-            // updating or deleting master depending on the last version put
-            // in v0 the master gets updated, in v1 the master gets deleted if version is
-            // a delete marker or updated otherwise.
-            const masterOp = this.updateDeleteMaster(mstObjVal!.isDeleteMarker || false, params.vFormat, filter, update,
-                true);
-            ops.push(masterOp);
-            return c.bulkWrite(ops, {
-                ordered: true,
-            }).then(() => cb(null, `{"versionId": "${objVal.versionId}"}`)).catch(err => {
-                // we accept that the update fails if
-                // condition is not met, meaning that a more
-                // recent master was already in place
-                if (err.code === 11000) {
-                    return cb(null, `{"versionId": "${objVal.versionId}"}`);
-                }
-                log.error('putObjectVerCase4: error upserting master', { error: err.message });
+                            { 'value.versionId': { $gte: mstObjVal!.versionId } },
+                        ],
+                    };
+                    // values to update master
+                    const update = {
+                        $set: { _id: masterKey, value: mstObjVal },
+                    };
+                    // updating or deleting master depending on the last version put
+                    // in v0 the master gets updated, in v1 the master gets deleted if version is
+                    // a delete marker or updated otherwise.
+                    const masterOp = this.updateDeleteMaster(
+                        mstObjVal!.isDeleteMarker || false,
+                        params.vFormat,
+                        filter,
+                        update,
+                        true,
+                    );
+                    ops.push(masterOp);
+                    return c
+                        .bulkWrite(ops, {
+                            ordered: true,
+                        })
+                        .then(() => cb(null, `{"versionId": "${objVal.versionId}"}`))
+                        .catch(err => {
+                            // we accept that the update fails if
+                            // condition is not met, meaning that a more
+                            // recent master was already in place
+                            if (err.code === 11000) {
+                                return cb(null, `{"versionId": "${objVal.versionId}"}`);
+                            }
+                            log.error('putObjectVerCase4: error upserting master', { error: err.message });
+                            return cb(errors.InternalError);
+                        });
+                }),
+            )
+            .catch(err => {
+                log.error('putObjectVerCase4: error upserting object version', { error: err.message });
                 return cb(errors.InternalError);
             });
-        })).catch(err => {
-            log.error(
-                'putObjectVerCase4: error upserting object version',
-                { error: err.message });
-            return cb(errors.InternalError);
-        });
     }
     /**
      * Puts an object into a MongoDB collection.
@@ -1215,17 +1253,24 @@ class MongoClientInterface {
         }
         const key = formatMasterKey(objName, params.vFormat);
         const putFilter = { _id: key };
-        return collection.updateOne(putFilter, {
-            $set: {
-                _id: key,
-                value,
-            },
-        }, {
-            upsert: true,
-        }).then(() => cb(null)).catch(err => {
-            log.error('putObjectNoVer: error putting obect with no versioning', { error: err.message });
-            return cb(errors.InternalError);
-        });
+        return collection
+            .updateOne(
+                putFilter,
+                {
+                    $set: {
+                        _id: key,
+                        value,
+                    },
+                },
+                {
+                    upsert: true,
+                },
+            )
+            .then(() => cb(null))
+            .catch(err => {
+                log.error('putObjectNoVer: error putting obect with no versioning', { error: err.message });
+                return cb(errors.InternalError);
+            });
     }
 
     /**
@@ -1259,68 +1304,91 @@ class MongoClientInterface {
         // filter used when finding and updating object
         const findFilter = {
             ...putFilter,
-            $or: [
-                { 'value.deleted': { $exists: false } },
-                { 'value.deleted': { $eq: false } },
-            ],
+            $or: [{ 'value.deleted': { $exists: false } }, { 'value.deleted': { $eq: false } }],
         };
         const updateDeleteFilter = {
             ...putFilter,
             'value.deleted': true,
         };
-        return async.waterfall([
-            // Adding delete flag when getting the object
-            // to avoid having race conditions.
-            next => collection.findOneAndUpdate(findFilter, {
-                $set: updateDeleteFilter,
-            }, {
-                upsert: false,
-            }).then(doc => {
-                if (!doc?.value) {
-                    log.error('internalPutObject: unable to find target object to update',
-                        { bucket: bucketName, object: key });
-                    return next(errors.NoSuchKey);
+        return async.waterfall(
+            [
+                // Adding delete flag when getting the object
+                // to avoid having race conditions.
+                next =>
+                    collection
+                        .findOneAndUpdate(
+                            findFilter,
+                            {
+                                $set: updateDeleteFilter,
+                            },
+                            {
+                                upsert: false,
+                            },
+                        )
+                        .then(doc => {
+                            if (!doc?.value) {
+                                log.error('internalPutObject: unable to find target object to update', {
+                                    bucket: bucketName,
+                                    object: key,
+                                });
+                                return next(errors.NoSuchKey);
+                            }
+                            const obj = doc.value;
+                            const objMetadata = new ObjectMD(obj);
+                            objMetadata.setOriginOp(params.originOp);
+                            objMetadata.setDeleted(true);
+                            return next(null, objMetadata.getValue());
+                        })
+                        .catch(err => {
+                            log.error('internalPutObject: error getting object', {
+                                bucket: bucketName,
+                                object: key,
+                                error: err.message,
+                            });
+                            return next(errors.InternalError);
+                        }),
+                // We update the full object to get the whole object metadata
+                // in the oplog update event
+                (objMetadata, next) =>
+                    collection
+                        .bulkWrite(
+                            [
+                                {
+                                    updateOne: {
+                                        filter: updateDeleteFilter,
+                                        update: {
+                                            $set: { _id: key, value: objMetadata },
+                                        },
+                                        upsert: false,
+                                    },
+                                },
+                                {
+                                    updateOne: {
+                                        filter: putFilter,
+                                        update: {
+                                            $set: { _id: key, value },
+                                        },
+                                        upsert: true,
+                                    },
+                                },
+                            ],
+                            { ordered: true },
+                        )
+                        .then(() => next(null))
+                        .catch(next),
+            ],
+            err => {
+                if (err) {
+                    log.error('internalPutObject: error updating object', {
+                        bucket: bucketName,
+                        object: key,
+                        error: err.message,
+                    });
+                    return cb(errors.InternalError);
                 }
-                const obj = doc.value;
-                const objMetadata = new ObjectMD(obj);
-                objMetadata.setOriginOp(params.originOp);
-                objMetadata.setDeleted(true);
-                return next(null, objMetadata.getValue());
-            }).catch(err => {
-                log.error('internalPutObject: error getting object',
-                    { bucket: bucketName, object: key, error: err.message });
-                return next(errors.InternalError);
-            }),
-            // We update the full object to get the whole object metadata
-            // in the oplog update event
-            (objMetadata, next) => collection.bulkWrite([
-                {
-                    updateOne: {
-                        filter: updateDeleteFilter,
-                        update: {
-                            $set: { _id: key, value: objMetadata },
-                        },
-                        upsert: false,
-                    },
-                },
-                {
-                    updateOne: {
-                        filter: putFilter,
-                        update: {
-                            $set: { _id: key, value },
-                        },
-                        upsert: true,
-                    },
-                },
-            ], { ordered: true }).then(() => next(null)).catch(next),
-        ], err => {
-            if (err) {
-                log.error('internalPutObject: error updating object',
-                    { bucket: bucketName, object: key, error: err.message });
-                return cb(errors.InternalError);
-            }
-            return cb(null);
-        });
+                return cb(null);
+            },
+        );
     }
     /**
      * Returns the putObjectVerCase function to use
@@ -1371,8 +1439,7 @@ class MongoClientInterface {
                 _params.vFormat = vFormat;
             }
             if (params) {
-                const putObjectVer = this.getPutObjectVerStrategy(params)
-                    .bind(this);
+                const putObjectVer = this.getPutObjectVerStrategy(params).bind(this);
                 return putObjectVer(c, bucketName, objName, objVal, _params, log, cb);
             }
             return this.putObjectNoVer(c, bucketName, objName, objVal, _params, log, cb);
@@ -1398,59 +1465,70 @@ class MongoClientInterface {
     ) {
         const c = this.getCollection<ObjectMetastoreDocument>(bucketName);
         let key;
-        async.waterfall([
-            next => this.getBucketVFormat(bucketName, log, next),
-            (vFormat, next) => {
-                if (params && params.versionId) {
-                    key = formatVersionKey(objName, params.versionId, vFormat);
-                } else {
-                    key = formatMasterKey(objName, vFormat);
-                }
-                c.findOne({
-                    _id: key,
-                    // filtering out objects flagged for deletion
-                    $or: [
-                        { 'value.deleted': { $exists: false } },
-                        { 'value.deleted': { $eq: false } },
-                    ],
-                }, {}).then(doc => next(null, vFormat, doc)).catch(err => {
-                    log.error('findOne: error getting object',
-                        { bucket: bucketName, object: objName, error: err.message });
-                    return next(errors.InternalError);
-                });
-            },
-            (vFormat, doc, next) => {
-                if (!doc && params && params.versionId) {
-                    return next(errorInstances.NoSuchKey);
-                }
-                // If no master found then object is either non existent
-                // or last version is delete marker
-                if (!doc || doc.value.isPHD) {
-                    this.getLatestVersion(c, objName, vFormat, log, (err, value?) => {
-                        if (err?.is.NoSuchKey) {
-                            return next(err);
-                        }
-
-                        if (err) {
-                            log.error('getLatestVersion: getting latest version',
-                                { bucket: bucketName, object: objName, error: err.message });
-
+        async.waterfall(
+            [
+                next => this.getBucketVFormat(bucketName, log, next),
+                (vFormat, next) => {
+                    if (params && params.versionId) {
+                        key = formatVersionKey(objName, params.versionId, vFormat);
+                    } else {
+                        key = formatMasterKey(objName, vFormat);
+                    }
+                    c.findOne(
+                        {
+                            _id: key,
+                            // filtering out objects flagged for deletion
+                            $or: [{ 'value.deleted': { $exists: false } }, { 'value.deleted': { $eq: false } }],
+                        },
+                        {},
+                    )
+                        .then(doc => next(null, vFormat, doc))
+                        .catch(err => {
+                            log.error('findOne: error getting object', {
+                                bucket: bucketName,
+                                object: objName,
+                                error: err.message,
+                            });
                             return next(errors.InternalError);
-                        }
+                        });
+                },
+                (vFormat, doc, next) => {
+                    if (!doc && params && params.versionId) {
+                        return next(errorInstances.NoSuchKey);
+                    }
+                    // If no master found then object is either non existent
+                    // or last version is delete marker
+                    if (!doc || doc.value.isPHD) {
+                        this.getLatestVersion(c, objName, vFormat, log, (err, value?) => {
+                            if (err?.is.NoSuchKey) {
+                                return next(err);
+                            }
 
-                        return next(null, value);
-                    });
-                    return undefined;
+                            if (err) {
+                                log.error('getLatestVersion: getting latest version', {
+                                    bucket: bucketName,
+                                    object: objName,
+                                    error: err.message,
+                                });
+
+                                return next(errors.InternalError);
+                            }
+
+                            return next(null, value);
+                        });
+                        return undefined;
+                    }
+                    MongoUtils.unserialize(doc.value);
+                    return next(null, doc.value);
+                },
+            ],
+            (err: ArsenalError | null | undefined, result?: ObjectMDData) => {
+                if (err) {
+                    return cb(err);
                 }
-                MongoUtils.unserialize(doc.value);
-                return next(null, doc.value);
+                return cb(null, result!);
             },
-        ], (err: ArsenalError | null | undefined, result?: ObjectMDData) => {
-            if (err) {
-                return cb(err);
-            }
-            return cb(null, result!);
-        });
+        );
     }
 
     /**
@@ -1463,7 +1541,7 @@ class MongoClientInterface {
      */
     getObjects(
         bucketName: string,
-        objects: { key: string, params: ObjectMDOperationParams }[],
+        objects: { key: string; params: ObjectMDOperationParams }[],
         log: werelogs.Logger,
         callback: ArsenalCallback<unknown[]>,
     ) {
@@ -1491,12 +1569,14 @@ class MongoClientInterface {
             // If no master found then object is either non existent or last
             // version is delete marker
             if (!doc || doc.value.isPHD) {
-                return this.getLatestVersion(c!, objName, vFormat, log, (err, _doc?) => cb(null, {
-                    err,
-                    doc: _doc || null,
-                    versionId: versionIdValue,
-                    key,
-                }));
+                return this.getLatestVersion(c!, objName, vFormat, log, (err, _doc?) =>
+                    cb(null, {
+                        err,
+                        doc: _doc || null,
+                        versionId: versionIdValue,
+                        key,
+                    }),
+                );
             }
             MongoUtils.unserialize(doc.value);
             return cb(null, {
@@ -1517,35 +1597,43 @@ class MongoClientInterface {
                 return callback(errors.InternalError);
             }
             vFormat = _vFormat;
-            const keys = objects.map(({ key: objName, params }) => (params && params.versionId
-                ? formatVersionKey(objName, params.versionId, vFormat)
-                : formatMasterKey(objName, vFormat)));
-            return c!.find({
-                _id: { $in: keys },
-                $or: [
-                    { 'value.deleted': { $exists: false } },
-                    { 'value.deleted': { $eq: false } },
-                ],
-            }).toArray().then(docs => {
-                // Create a Map to quickly find docs by their keys
-                const docByKey = new Map(docs.map(doc => [doc._id, doc]));
-                // Process each document using associated context (objName, params)
-                async.mapLimit(objects, constants.maxBatchingConcurrentOperations,
-                    ({ key: objName, params }, cb) => {
-                        const key = params && params.versionId
-                            ? formatVersionKey(objName, params.versionId, vFormat)
-                            : formatMasterKey(objName, vFormat);
-                        const doc = docByKey.get(key);
-                        processDoc(doc, objName, params, key, cb);
-                    }, (err: ArsenalError | null | undefined, result?: unknown[]) => {
-                        if (err) {
-                            return callback(err);
-                        }
-                        return callback(null, result!);
-                    });
-            }).catch(err => {
-                callback(err);
-            });
+            const keys = objects.map(({ key: objName, params }) =>
+                params && params.versionId
+                    ? formatVersionKey(objName, params.versionId, vFormat)
+                    : formatMasterKey(objName, vFormat),
+            );
+            return c!
+                .find({
+                    _id: { $in: keys },
+                    $or: [{ 'value.deleted': { $exists: false } }, { 'value.deleted': { $eq: false } }],
+                })
+                .toArray()
+                .then(docs => {
+                    // Create a Map to quickly find docs by their keys
+                    const docByKey = new Map(docs.map(doc => [doc._id, doc]));
+                    // Process each document using associated context (objName, params)
+                    async.mapLimit(
+                        objects,
+                        constants.maxBatchingConcurrentOperations,
+                        ({ key: objName, params }, cb) => {
+                            const key =
+                                params && params.versionId
+                                    ? formatVersionKey(objName, params.versionId, vFormat)
+                                    : formatMasterKey(objName, vFormat);
+                            const doc = docByKey.get(key);
+                            processDoc(doc, objName, params, key, cb);
+                        },
+                        (err: ArsenalError | null | undefined, result?: unknown[]) => {
+                            if (err) {
+                                return callback(err);
+                            }
+                            return callback(null, result!);
+                        },
+                    );
+                })
+                .catch(err => {
+                    callback(err);
+                });
         });
     }
 
@@ -1573,26 +1661,29 @@ class MongoClientInterface {
         // string gives us the last key in the range
         const versionKey = formatVersionKey(objName, VID_NONE, vFormat);
         const lastVersionKey = inc(versionKey);
-        const filter = vFormat === BUCKET_VERSIONS.v0 ? {
-            $gt: masterKey,
-            $lt: lastVersionKey,
-        } : {
-            $gt: versionKey,
-            $lt: lastVersionKey,
-        };
-        c.find({
-            _id: filter,
-            // filtering out objects flagged for deletion
-            $or: [
-                { 'value.deleted': { $exists: false } },
-                { 'value.deleted': { $eq: false } },
-            ],
-        }, {}).
-            sort({
+        const filter =
+            vFormat === BUCKET_VERSIONS.v0
+                ? {
+                      $gt: masterKey,
+                      $lt: lastVersionKey,
+                  }
+                : {
+                      $gt: versionKey,
+                      $lt: lastVersionKey,
+                  };
+        c.find(
+            {
+                _id: filter,
+                // filtering out objects flagged for deletion
+                $or: [{ 'value.deleted': { $exists: false } }, { 'value.deleted': { $eq: false } }],
+            },
+            {},
+        )
+            .sort({
                 _id: 1,
-            }).
-            limit(1).
-            toArray()
+            })
+            .limit(1)
+            .toArray()
             .then(keys => {
                 if (keys.length === 0) {
                     return cb(errors.NoSuchKey);
@@ -1601,9 +1692,7 @@ class MongoClientInterface {
                 return cb(null, keys[0].value);
             })
             .catch(err => {
-                log.error(
-                    'getLatestVersion: error getting latest version',
-                    { error: err.message });
+                log.error('getLatestVersion: error getting latest version', { error: err.message });
                 return cb(errors.InternalError);
             });
     }
@@ -1635,27 +1724,32 @@ class MongoClientInterface {
         const masterKey = formatMasterKey(objName, vFormat);
         MongoUtils.serialize(objVal);
         objVal.originOp = 's3:ObjectRemoved:Delete';
-        c.findOneAndReplace({
-            '_id': masterKey,
-            'value.isPHD': true,
-            'value.versionId': mst.versionId,
-        }, <WithId<ObjectMetastoreDocument>>{
-            _id: masterKey,
-            value: objVal,
-        }, {
-            includeResultMetadata: true,
-            upsert: true,
-        }).then(result => {
-            if (result.ok !== 1) {
-                log.error('repair: failed trying to repair value');
+        c.findOneAndReplace(
+            {
+                _id: masterKey,
+                'value.isPHD': true,
+                'value.versionId': mst.versionId,
+            },
+            <WithId<ObjectMetastoreDocument>>{
+                _id: masterKey,
+                value: objVal,
+            },
+            {
+                includeResultMetadata: true,
+                upsert: true,
+            },
+        )
+            .then(result => {
+                if (result.ok !== 1) {
+                    log.error('repair: failed trying to repair value');
+                    return cb(errors.InternalError);
+                }
+                return cb(null);
+            })
+            .catch(err => {
+                log.error('repair: error trying to repair value', { error: err.message });
                 return cb(errors.InternalError);
-            }
-            return cb(null);
-        }).catch(err => {
-            log.error('repair: error trying to repair value',
-                { error: err.message });
-            return cb(errors.InternalError);
-        });
+            });
     }
 
     /**
@@ -1676,12 +1770,11 @@ class MongoClientInterface {
         objName: string,
         mst: { versionId: string },
         vFormat: string,
-        log: werelogs.Logger
+        log: werelogs.Logger,
     ) {
         this.getLatestVersion(c, objName, vFormat, log, (err, value?) => {
             if (err) {
-                log.error('async-repair: getting latest version',
-                    { error: err.message });
+                log.error('async-repair: getting latest version', { error: err.message });
                 return undefined;
             }
             this.repair(c, bucketName, objName, value!, mst, vFormat, log, err => {
@@ -1721,11 +1814,14 @@ class MongoClientInterface {
         // Check if there are other versions available
         this.getLatestVersion(c, objName, vFormat, log, (err, version?) => {
             if (err && !err.is.NoSuchKey) {
-                log.error('getLatestVersion: error getting latest version',
-                    { error: err.message, bucket: bucketName, key: objName });
+                log.error('getLatestVersion: error getting latest version', {
+                    error: err.message,
+                    bucket: bucketName,
+                    key: objName,
+                });
                 return cb(err);
             }
-            if ((err?.is.NoSuchKey) || (version!.isDeleteMarker && vFormat === BUCKET_VERSIONS.v1)) {
+            if (err?.is.NoSuchKey || (version!.isDeleteMarker && vFormat === BUCKET_VERSIONS.v1)) {
                 // We try to delete the master. A race condition
                 // is possible here: another process may recreate
                 // a master or re-delete it in between so place an
@@ -1743,9 +1839,11 @@ class MongoClientInterface {
                         if (err.is.NoSuchKey) {
                             return cb(null);
                         }
-                        log.error(
-                            'deleteOrRepairPHD: error deleting object',
-                            { error: err.message, bucket: bucketName, key: objName });
+                        log.error('deleteOrRepairPHD: error deleting object', {
+                            error: err.message,
+                            bucket: bucketName,
+                            key: objName,
+                        });
                         return cb(errors.InternalError);
                     }
                     // do not test result.ok === 1 because
@@ -1791,48 +1889,65 @@ class MongoClientInterface {
         const masterKey = formatMasterKey(objName, params.vFormat);
         const versionKey = formatVersionKey(objName, params.versionId, params.vFormat);
         const _vid = generateVersionId(this.instanceId, this.replicationGroupId);
-        async.series([
-            next => c.updateOne(
-                {
-                    // Can't filter out objects with deletiong flag
-                    // as it will try and recreate an object with the same _id
-                    // instead we reset the flag to false, the data might be
-                    // inconsistent with the current state of the object but
-                    // this is not an issue as the object is in a temporary
-                    // placeholder (PHD) state
-                    _id: masterKey,
-                },
-                {
-                    $set: {
-                        '_id': masterKey,
-                        'value.isPHD': true,
-                        'value.versionId': _vid,
-                        'value.deleted': false,
-                    },
-                },
-                { upsert: true })
-                .then(() => next())
-                .catch(err => next(err)),
-            // delete version
-            next => this.internalDeleteObject(c, bucketName, versionKey, {}, params, log,
-                err => {
-                    // we don't return an error in case we don't find
-                    // a version as we expect this case when dealing with
-                    // a versioning suspended object.
-                    if (err?.is.NoSuchKey) {
-                        return next(null);
-                    }
-                    return next(err);
-                }, originOp),
-        ], err => {
-            if (err) {
-                log.error(
-                    'deleteObjectVerMaster: error deleting the object',
-                    { error: err.message, bucket: bucketName, key: objName });
-                return cb(errors.InternalError);
-            }
-            return this.deleteOrRepairPHD(c, bucketName, objName, { versionId: _vid }, params.vFormat, log, cb);
-        });
+        async.series(
+            [
+                next =>
+                    c
+                        .updateOne(
+                            {
+                                // Can't filter out objects with deletiong flag
+                                // as it will try and recreate an object with the same _id
+                                // instead we reset the flag to false, the data might be
+                                // inconsistent with the current state of the object but
+                                // this is not an issue as the object is in a temporary
+                                // placeholder (PHD) state
+                                _id: masterKey,
+                            },
+                            {
+                                $set: {
+                                    _id: masterKey,
+                                    'value.isPHD': true,
+                                    'value.versionId': _vid,
+                                    'value.deleted': false,
+                                },
+                            },
+                            { upsert: true },
+                        )
+                        .then(() => next())
+                        .catch(err => next(err)),
+                // delete version
+                next =>
+                    this.internalDeleteObject(
+                        c,
+                        bucketName,
+                        versionKey,
+                        {},
+                        params,
+                        log,
+                        err => {
+                            // we don't return an error in case we don't find
+                            // a version as we expect this case when dealing with
+                            // a versioning suspended object.
+                            if (err?.is.NoSuchKey) {
+                                return next(null);
+                            }
+                            return next(err);
+                        },
+                        originOp,
+                    ),
+            ],
+            err => {
+                if (err) {
+                    log.error('deleteObjectVerMaster: error deleting the object', {
+                        error: err.message,
+                        bucket: bucketName,
+                        key: objName,
+                    });
+                    return cb(errors.InternalError);
+                }
+                return this.deleteOrRepairPHD(c, bucketName, objName, { versionId: _vid }, params.vFormat, log, cb);
+            },
+        );
     }
 
     /**
@@ -1859,21 +1974,34 @@ class MongoClientInterface {
         originOp = 's3:ObjectRemoved:Delete',
     ) {
         const versionKey = formatVersionKey(objName, params.versionId, params.vFormat);
-        this.internalDeleteObject(c, bucketName, versionKey, {}, params, log, err => {
-            if (err) {
-                if (err.is.NoSuchKey) {
-                    log.error(
-                        'deleteObjectVerNotMaster: unable to find target object to delete',
-                        { error: err.message, bucket: bucketName, key: objName });
-                    return cb(errors.NoSuchKey);
+        this.internalDeleteObject(
+            c,
+            bucketName,
+            versionKey,
+            {},
+            params,
+            log,
+            err => {
+                if (err) {
+                    if (err.is.NoSuchKey) {
+                        log.error('deleteObjectVerNotMaster: unable to find target object to delete', {
+                            error: err.message,
+                            bucket: bucketName,
+                            key: objName,
+                        });
+                        return cb(errors.NoSuchKey);
+                    }
+                    log.error('deleteObjectVerNotMaster: error deleting object with no version', {
+                        error: err.message,
+                        bucket: bucketName,
+                        key: objName,
+                    });
+                    return cb(errors.InternalError);
                 }
-                log.error(
-                    'deleteObjectVerNotMaster: error deleting object with no version',
-                    { error: err.message, bucket: bucketName, key: objName });
-                return cb(errors.InternalError);
-            }
-            return cb(null);
-        }, originOp);
+                return cb(null);
+            },
+            originOp,
+        );
     }
 
     /**
@@ -1902,51 +2030,54 @@ class MongoClientInterface {
         originOp = 's3:ObjectRemoved:Delete',
     ) {
         const masterKey = formatMasterKey(objName, params.vFormat);
-        async.waterfall([
-            next => {
-                // find the master version
-                c.findOne({
-                    _id: masterKey,
-                    $or: [
-                        { 'value.deleted': { $exists: false } },
-                        { 'value.deleted': { $eq: false } },
-                    ],
-                }, {})
-                    .then(mst => next(null, mst))
-                    .catch(err => {
-                        log.error('deleteObjectVer: error deleting versioned object',
-                            { error: err.message, bucket: bucketName, key: objName });
-                        return cb(errors.InternalError);
-                    });
-            },
-            (mst, next) => {
-                // getting the last version if master not found
-                // (either object non existent or last version is a delete marker)
-                if (!mst) {
-                    return this.getLatestVersion(c, objName, params.vFormat, log, (err, version?) => {
-                        if (err) {
-                            return next(err);
-                        }
-                        return next(null, { value: version });
-                    });
+        async.waterfall(
+            [
+                next => {
+                    // find the master version
+                    c.findOne(
+                        {
+                            _id: masterKey,
+                            $or: [{ 'value.deleted': { $exists: false } }, { 'value.deleted': { $eq: false } }],
+                        },
+                        {},
+                    )
+                        .then(mst => next(null, mst))
+                        .catch(err => {
+                            log.error('deleteObjectVer: error deleting versioned object', {
+                                error: err.message,
+                                bucket: bucketName,
+                                key: objName,
+                            });
+                            return cb(errors.InternalError);
+                        });
+                },
+                (mst, next) => {
+                    // getting the last version if master not found
+                    // (either object non existent or last version is a delete marker)
+                    if (!mst) {
+                        return this.getLatestVersion(c, objName, params.vFormat, log, (err, version?) => {
+                            if (err) {
+                                return next(err);
+                            }
+                            return next(null, { value: version });
+                        });
+                    }
+                    return next(null, mst);
+                },
+                (mst, next) => {
+                    if (mst.value.isPHD || mst.value.versionId === params.versionId) {
+                        return this.deleteObjectVerMaster(c, bucketName, objName, params, log, next, originOp);
+                    }
+                    return this.deleteObjectVerNotMaster(c, bucketName, objName, params, log, next, originOp);
+                },
+            ],
+            (err: ArsenalError | null | undefined) => {
+                if (err) {
+                    return cb(err);
                 }
-                return next(null, mst);
+                return cb(null);
             },
-            (mst, next) => {
-                if (mst.value.isPHD ||
-                    mst.value.versionId === params.versionId) {
-                    return this.deleteObjectVerMaster(c, bucketName, objName,
-                        params, log, next, originOp);
-                }
-                return this.deleteObjectVerNotMaster(c, bucketName, objName,
-                    params, log, next, originOp);
-            },
-        ], (err: ArsenalError | null | undefined) => {
-            if (err) {
-                return cb(err);
-            }
-            return cb(null);
-        });
+        );
     }
 
     /**
@@ -1971,19 +2102,30 @@ class MongoClientInterface {
         originOp = 's3:ObjectRemoved:Delete',
     ) {
         const masterKey = formatMasterKey(objName, params.vFormat);
-        this.internalDeleteObject(c, bucketName, masterKey, {}, params, log, err => {
-            if (err) {
-                if (err.is.NoSuchKey) {
-                    return cb(null);
-                }
+        this.internalDeleteObject(
+            c,
+            bucketName,
+            masterKey,
+            {},
+            params,
+            log,
+            err => {
+                if (err) {
+                    if (err.is.NoSuchKey) {
+                        return cb(null);
+                    }
 
-                log.error(
-                    'deleteObjectNoVer: error deleting object with no version',
-                    { error: err.message, bucket: bucketName, key: objName });
-                return cb(err);
-            }
-            return cb(null);
-        }, originOp);
+                    log.error('deleteObjectNoVer: error deleting object with no version', {
+                        error: err.message,
+                        bucket: bucketName,
+                        key: objName,
+                    });
+                    return cb(err);
+                }
+                return cb(null);
+            },
+            originOp,
+        );
     }
 
     /**
@@ -2012,13 +2154,17 @@ class MongoClientInterface {
         originOp = 's3:ObjectRemoved:Delete',
     ) {
         // filter used when deleting object
-        const deleteFilter = Object.assign({
-            _id: key,
-        }, filter);
+        const deleteFilter = Object.assign(
+            {
+                _id: key,
+            },
+            filter,
+        );
 
         if (params && params.doesNotNeedOpogUpdate) {
             // If flag is true, directly delete object
-            return collection.deleteOne(deleteFilter)
+            return collection
+                .deleteOne(deleteFilter)
                 .then(result => {
                     // In case of race conditions (e.g. two concurrent deletes), or invalid state
                     // (e.g. object is already deleted), the result.deletedCount will be 0
@@ -2026,102 +2172,141 @@ class MongoClientInterface {
                     // delete the actual data, leading to an invalid state, where MongoDB references
                     // and object not in the data layers anymore.
                     if (!result || result?.deletedCount != 1) {
-                        log.debug('internalDeleteObject: object not found or already deleted',
-                            { bucket: bucketName, object: key });
+                        log.debug('internalDeleteObject: object not found or already deleted', {
+                            bucket: bucketName,
+                            object: key,
+                        });
                         return cb(errors.NoSuchKey);
                     }
                     return cb(null, undefined);
                 })
                 .catch(err => {
-                    log.error('internalDeleteObject: error deleting object',
-                        { bucket: bucketName, object: key, error: err.message });
+                    log.error('internalDeleteObject: error deleting object', {
+                        bucket: bucketName,
+                        object: key,
+                        error: err.message,
+                    });
                     // wrong error type in "no found" case
                     return cb(errors.InternalError);
                 });
         }
 
         // filter used when finding and updating object
-        const findFilter = Object.assign({
-            _id: key,
-            $or: [
-                { 'value.deleted': { $exists: false } },
-                { 'value.deleted': { $eq: false } },
-            ],
-        }, filter);
+        const findFilter = Object.assign(
+            {
+                _id: key,
+                $or: [{ 'value.deleted': { $exists: false } }, { 'value.deleted': { $eq: false } }],
+            },
+            filter,
+        );
 
-        const updateDeleteFilter = Object.assign({
-            '_id': key,
-            'value.deleted': true,
-        }, filter);
-        return async.waterfall([
-            // Adding delete flag when getting the object
-            // to avoid having race conditions.
-            next => collection.findOneAndUpdate(findFilter, {
-                $set: {
-                    '_id': key,
-                    'value.deleted': true,
-                },
-            }, {
-                includeResultMetadata : true,
-                upsert: false,
-            }).then(doc => {
-                if (!doc.value) {
-                    log.error('internalDeleteObject: unable to find target object to delete',
-                        { bucket: bucketName, object: key });
-                    return next(errors.NoSuchKey);
+        const updateDeleteFilter = Object.assign(
+            {
+                _id: key,
+                'value.deleted': true,
+            },
+            filter,
+        );
+        return async.waterfall(
+            [
+                // Adding delete flag when getting the object
+                // to avoid having race conditions.
+                next =>
+                    collection
+                        .findOneAndUpdate(
+                            findFilter,
+                            {
+                                $set: {
+                                    _id: key,
+                                    'value.deleted': true,
+                                },
+                            },
+                            {
+                                includeResultMetadata: true,
+                                upsert: false,
+                            },
+                        )
+                        .then(doc => {
+                            if (!doc.value) {
+                                log.error('internalDeleteObject: unable to find target object to delete', {
+                                    bucket: bucketName,
+                                    object: key,
+                                });
+                                return next(errors.NoSuchKey);
+                            }
+                            const obj = doc.value;
+                            const objMetadata = new ObjectMD(obj.value);
+                            objMetadata.setOriginOp(originOp);
+                            objMetadata.setDeleted(true);
+                            return next(null, objMetadata.getValue());
+                        })
+                        .catch(err => {
+                            log.error('internalDeleteObject: error getting object', {
+                                bucket: bucketName,
+                                object: key,
+                                error: err.message,
+                            });
+                            return next(errors.InternalError);
+                        }),
+                // We update the full object to get the whole object metadata
+                // in the oplog update event
+                (objMetadata, next) =>
+                    collection
+                        .bulkWrite(
+                            [
+                                {
+                                    updateOne: {
+                                        filter: updateDeleteFilter,
+                                        update: {
+                                            $set: { _id: key, value: objMetadata },
+                                        },
+                                        upsert: false,
+                                    },
+                                },
+                                {
+                                    deleteOne: {
+                                        filter: updateDeleteFilter,
+                                    },
+                                },
+                            ],
+                            { ordered: true },
+                        )
+                        .then(result => {
+                            // in case of race conditions, the bulk operation might fail
+                            // in this case we return a DeleteConflict error
+                            if (!result || !result.ok) {
+                                log.debug('internalDeleteObject: bulk operation failed', {
+                                    bucket: bucketName,
+                                    object: key,
+                                });
+                                return next(errors.DeleteConflict);
+                            }
+                            if (result.deletedCount === 0) {
+                                log.debug('internalDeleteObject: object not found or already deleted', {
+                                    bucket: bucketName,
+                                    object: key,
+                                });
+                                return next(errors.DeleteConflict);
+                            }
+                            return next(null);
+                        })
+                        .catch(err => next(err)),
+            ],
+            (err, res) => {
+                if (err) {
+                    if (err instanceof ArsenalError) {
+                        return cb(err);
+                    }
+                    log.error('internalDeleteObject: error deleting object', {
+                        bucket: bucketName,
+                        object: key,
+                        error: err.message,
+                    });
+                    return cb(errors.InternalError);
                 }
-                const obj = doc.value;
-                const objMetadata = new ObjectMD(obj.value);
-                objMetadata.setOriginOp(originOp);
-                objMetadata.setDeleted(true);
-                return next(null, objMetadata.getValue());
-            }).catch(err => {
-                log.error('internalDeleteObject: error getting object',
-                    { bucket: bucketName, object: key, error: err.message });
-                return next(errors.InternalError);
-            }),
-            // We update the full object to get the whole object metadata
-            // in the oplog update event
-            (objMetadata, next) => collection.bulkWrite([
-                {
-                    updateOne: {
-                        filter: updateDeleteFilter,
-                        update: {
-                            $set: { _id: key, value: objMetadata },
-                        },
-                        upsert: false,
-                    },
-                }, {
-                    deleteOne: {
-                        filter: updateDeleteFilter,
-                    },
-                },
-            ], { ordered: true }).then(result => {
-                // in case of race conditions, the bulk operation might fail
-                // in this case we return a DeleteConflict error
-                if (!result || !result.ok) {
-                    log.debug('internalDeleteObject: bulk operation failed', 
-                        { bucket: bucketName, object: key });
-                    return next(errors.DeleteConflict);
-                }
-                if (result.deletedCount === 0) {
-                    log.debug('internalDeleteObject: object not found or already deleted', 
-                        { bucket: bucketName, object: key });
-                    return next(errors.DeleteConflict);
-                }
-                return next(null);
-            }).catch(err => next(err)),
-        ], (err, res) => {
-            if (err) {
-                if (err instanceof ArsenalError) {
-                    return cb(err);
-                }
-                log.error('internalDeleteObject: error deleting object',
-                    { bucket: bucketName, object: key, error: err.message });
-                return cb(errors.InternalError);
-            }
-            return cb(null, res);
-        });
+                return cb(null, res);
+            },
+        );
     }
 
     /**
@@ -2151,11 +2336,9 @@ class MongoClientInterface {
             }
             _params.vFormat = vFormat;
             if (_params && _params.versionId) {
-                return this.deleteObjectVer(c, bucketName, objName,
-                    _params, log, cb, originOp);
+                return this.deleteObjectVer(c, bucketName, objName, _params, log, cb, originOp);
             }
-            return this.deleteObjectNoVer(c, bucketName, objName,
-                _params, log, cb, originOp);
+            return this.deleteObjectNoVer(c, bucketName, objName, _params, log, cb, originOp);
         });
     }
 
@@ -2177,7 +2360,7 @@ class MongoClientInterface {
     internalListObject(
         bucketName: string,
         params: InternalListObjectParams,
-        extension: { compareObjects: Function, result: Function },
+        extension: { compareObjects: Function; result: Function },
         vFormat: string,
         log: werelogs.Logger,
         cb: ArsenalCallback<void>,
@@ -2234,9 +2417,9 @@ class MongoClientInterface {
                                     if (err.is.NoSuchKey) {
                                         return callback(null);
                                     }
-                                    log.error(
-                                        'internalListObjectV1: error while getting latest version of PHD key',
-                                        { error: err.message });
+                                    log.error('internalListObjectV1: error while getting latest version of PHD key', {
+                                        error: err.message,
+                                    });
                                     return callback(errors.InternalError);
                                 }
                                 MongoUtils.unserialize(version);
@@ -2264,8 +2447,7 @@ class MongoClientInterface {
                         error: err.message,
                         errorStack: err.stack,
                     };
-                    log.error(
-                        'internalListObjectV1: error listing objects', logObj);
+                    log.error('internalListObjectV1: error listing objects', logObj);
                     return cbOnce(err);
                 });
             }
@@ -2273,11 +2455,11 @@ class MongoClientInterface {
             // listing both master and version keys (delimiterVersion Algo)
             const masterStream = new MongoReadStream(c, params.mainStreamParams, params.mongifiedSearch);
             const versionStream = new MongoReadStream(c, params.secondaryStreamParams, params.mongifiedSearch);
-            stream = new MergeStream(
-                versionStream, masterStream, extension.compareObjects.bind(extension));
+            stream = new MergeStream(versionStream, masterStream, extension.compareObjects.bind(extension));
         }
-        const gteParams = params.secondaryStreamParams ?
-            [params.mainStreamParams.gte, params.secondaryStreamParams.gte] : params.mainStreamParams.gte;
+        const gteParams = params.secondaryStreamParams
+            ? [params.mainStreamParams.gte, params.secondaryStreamParams.gte]
+            : params.mainStreamParams.gte;
         const skip = new Skip({
             extension,
             gte: gteParams,
@@ -2313,8 +2495,7 @@ class MongoClientInterface {
                     error: err.message,
                     errorStack: err.stack,
                 };
-                log.error(
-                    'internalListObjectV1: error listing objects', logObj);
+                log.error('internalListObjectV1: error listing objects', logObj);
                 cbOnce(err);
             })
             .on('end', () => {
@@ -2337,11 +2518,7 @@ class MongoClientInterface {
      * @param {Function} cb callback
      * @return {undefined}
      */
-    listObject(
-        bucketName: string,
-        params: InternalListObjectParams,
-        log: werelogs.Logger,
-        cb: ArsenalCallback<void>) {
+    listObject(bucketName: string, params: InternalListObjectParams, log: werelogs.Logger, cb: ArsenalCallback<void>) {
         return this.getBucketVFormat(bucketName, log, (err, vFormat?) => {
             if (err) {
                 return cb(err);
@@ -2360,8 +2537,7 @@ class MongoClientInterface {
                 secondaryStreamParams: Array.isArray(extensionParams) ? extensionParams[1] : null,
                 mongifiedSearch: params.mongifiedSearch,
             };
-            return this.internalListObject(bucketName, internalParams, extension,
-                vFormat, log, cb);
+            return this.internalListObject(bucketName, internalParams, extension, vFormat, log, cb);
         });
     }
 
@@ -2427,8 +2603,7 @@ class MongoClientInterface {
             mainStreamParams: extensionParams,
             mongifiedSearch: params.mongifiedSearch,
         };
-        return this.internalListObject(bucketName, internalParams, extension,
-            BUCKET_VERSIONS.v0, log, cb);
+        return this.internalListObject(bucketName, internalParams, extension, BUCKET_VERSIONS.v0, log, cb);
     }
 
     checkHealth(implName, log, cb) {
@@ -2451,18 +2626,22 @@ class MongoClientInterface {
             log.error('readUUID: error getting infostore collection');
             return;
         }
-        i.findOne({
-            _id: __UUID,
-        }, {}).then(doc => {
-            if (!doc) {
-                return cb(errors.NoSuchKey);
-            }
-            return cb(null, doc.value!);
-        }).catch(err => {
-            log.error('readUUID: error reading UUID',
-                { error: err.message });
-            return cb(errors.InternalError);
-        });
+        i.findOne(
+            {
+                _id: __UUID,
+            },
+            {},
+        )
+            .then(doc => {
+                if (!doc) {
+                    return cb(errors.NoSuchKey);
+                }
+                return cb(null, doc.value!);
+            })
+            .catch(err => {
+                log.error('readUUID: error reading UUID', { error: err.message });
+                return cb(errors.InternalError);
+            });
     }
 
     writeUUIDIfNotExists(uuid: string, log: werelogs.Logger, cb: ArsenalCallback<void>) {
@@ -2471,23 +2650,27 @@ class MongoClientInterface {
             log.error('writeUUIDIfNotExists: error getting infostore collection');
             return cb(errors.InternalError);
         }
-        return i.insertOne(<InfostoreDocument>{
-            _id: __UUID,
-            value: uuid,
-        }, {}).then(result => {
-            if (!result || !result.acknowledged) {
-                log.debug('writeUUIDIfNotExists: insertion failed');
-                return cb(errors.InternalError);
-            }
-            return cb(null);
-        })
+        return i
+            .insertOne(
+                <InfostoreDocument>{
+                    _id: __UUID,
+                    value: uuid,
+                },
+                {},
+            )
+            .then(result => {
+                if (!result || !result.acknowledged) {
+                    log.debug('writeUUIDIfNotExists: insertion failed');
+                    return cb(errors.InternalError);
+                }
+                return cb(null);
+            })
             .catch(err => {
                 if (err.code === 11000) {
                     // duplicate key error
                     return cb(errors.KeyAlreadyExists);
                 }
-                log.error('writeUUIDIfNotExists: error writing UUID',
-                    { error: err.message });
+                log.error('writeUUIDIfNotExists: error writing UUID', { error: err.message });
                 return cb(errors.InternalError);
             });
     }
@@ -2501,8 +2684,7 @@ class MongoClientInterface {
         this.writeUUIDIfNotExists(_uuid, log, err => {
             if (err) {
                 if (err.is.InternalError) {
-                    log.error('getUUID: error getting UUID',
-                        { error: err.message });
+                    log.error('getUUID: error getting UUID', { error: err.message });
                     return cb(err);
                 }
                 return this.readUUID(log, cb);
@@ -2518,38 +2700,35 @@ class MongoClientInterface {
      */
     getDiskUsage(cb: ArsenalCallback<{ available: number; free: number; total: number }>) {
         if (!this.db || !this.client) {
-            return cb(errors.InternalError.customizeDescription(
-                'Cannot get disk usage: database not connected'));
+            return cb(errors.InternalError.customizeDescription('Cannot get disk usage: database not connected'));
         }
 
-        return this.db.command({ dbStats: 1, scale: 1 })
+        return this.db
+            .command({ dbStats: 1, scale: 1 })
             .then(stats => {
                 if (stats.fsTotalSize === undefined || stats.fsUsedSize === undefined) {
-                    this.logger.error('unexpected dbStats response: missing fsTotalSize or fsUsedSize',
-                        { stats });
+                    this.logger.error('unexpected dbStats response: missing fsTotalSize or fsUsedSize', { stats });
                     return cb(errors.InternalError);
                 }
                 const free = stats.fsTotalSize - stats.fsUsedSize;
                 return cb(null, { available: free, free, total: stats.fsTotalSize });
             })
             .catch(err => {
-                this.logger.error('Error getting MongoDB disk stats',
-                    { error: err.message });
+                this.logger.error('Error getting MongoDB disk stats', { error: err.message });
                 return cb(errors.InternalError);
             });
     }
 
     getCollectionStats(bucketName: string, log: werelogs.Logger, cb: ArsenalCallback<any>) {
         if (!this.db || !this.client) {
-            return cb(errors.InternalError.customizeDescription(
-                'Cannot get collection stats: database not connected'));
+            return cb(errors.InternalError.customizeDescription('Cannot get collection stats: database not connected'));
         }
         const c = this.getCollection(bucketName);
-        return this.db.command({ collStats: c.collectionName })
+        return this.db
+            .command({ collStats: c.collectionName })
             .then(stats => cb(null, stats))
             .catch(err => {
-                log.error('error getting collection stats',
-                    { error: err.message, bucketName });
+                log.error('error getting collection stats', { error: err.message, bucketName });
                 return cb(errors.InternalError);
             });
     }
@@ -2560,31 +2739,37 @@ class MongoClientInterface {
             log.error('readCountItems: error getting infostore collection');
             return cb(errors.InternalError);
         }
-        return i.findOne({
-            _id: __COUNT_ITEMS,
-        }, {}).then(doc => {
-            if (!doc) {
-                // defaults
-                const res = {
-                    objects: 0,
-                    versions: 0,
-                    buckets: 0,
-                    bucketList: [],
-                    dataManaged: {
-                        total: { curr: 0, prev: 0 },
-                        byLocation: {},
-                    },
-                    stalled: 0,
-                };
-                return cb(null, res);
-            }
-            return cb(null, doc.value!);
-        }).catch(err => {
-            log.error('readCountItems: error reading count items', {
-                error: err.message,
+        return i
+            .findOne(
+                {
+                    _id: __COUNT_ITEMS,
+                },
+                {},
+            )
+            .then(doc => {
+                if (!doc) {
+                    // defaults
+                    const res = {
+                        objects: 0,
+                        versions: 0,
+                        buckets: 0,
+                        bucketList: [],
+                        dataManaged: {
+                            total: { curr: 0, prev: 0 },
+                            byLocation: {},
+                        },
+                        stalled: 0,
+                    };
+                    return cb(null, res);
+                }
+                return cb(null, doc.value!);
+            })
+            .catch(err => {
+                log.error('readCountItems: error reading count items', {
+                    error: err.message,
+                });
+                return cb(errors.InternalError);
             });
-            return cb(errors.InternalError);
-        });
     }
 
     /*
@@ -2592,12 +2777,14 @@ class MongoClientInterface {
      * does not need to be collected for infos
      */
     _isSpecialCollection(name: string) {
-        return name === METASTORE ||
+        return (
+            name === METASTORE ||
             name === INFOSTORE ||
             name === USERSBUCKET ||
             name === PENSIEVE ||
             name.startsWith(constants.mpuBucketPrefix) ||
-            name.startsWith('__');
+            name.startsWith('__')
+        );
     }
 
     /*
@@ -2621,63 +2808,70 @@ class MongoClientInterface {
      * @param { function(error, BucketInfos): void } cb - callback
      * @return { undefined }
      */
-    getBucketInfos(log: werelogs.Logger, cb: ArsenalCallback<{ bucketCount: number, bucketInfos: BucketInfo[] }>) {
+    getBucketInfos(log: werelogs.Logger, cb: ArsenalCallback<{ bucketCount: number; bucketInfos: BucketInfo[] }>) {
         let bucketCount = 0;
         const bucketInfos: BucketInfo[] = [];
 
-        this.db!.listCollections({ type: 'collection' }).toArray().then(collInfos =>
-            async.eachLimit(collInfos, 10, (value, next) => {
-                if (this._isSystemCollection(value.name) || this._isSpecialCollection(value.name)) {
-                    // skip
-                    return next();
-                }
-                const bucketName = value.name;
-                // FIXME: there is currently no way of distinguishing
-                // master from versions and searching for VID_SEP
-                // does not work because there cannot be null bytes
-                // in $regex
-                return this.getBucketAttributes(bucketName, log,
-                    (err, bucketInfo?) => {
-                        if (err?.is?.NoSuchBucket) {
-                            // Skip bucket if not found: can happen if bucket has just been removed
+        this.db!.listCollections({ type: 'collection' })
+            .toArray()
+            .then(collInfos =>
+                async.eachLimit(
+                    collInfos,
+                    10,
+                    (value, next) => {
+                        if (this._isSystemCollection(value.name) || this._isSpecialCollection(value.name)) {
+                            // skip
                             return next();
                         }
-                        if (err) {
-                            log.error('failed to get bucket attributes', {
-                                bucketName,
+                        const bucketName = value.name;
+                        // FIXME: there is currently no way of distinguishing
+                        // master from versions and searching for VID_SEP
+                        // does not work because there cannot be null bytes
+                        // in $regex
+                        return this.getBucketAttributes(bucketName, log, (err, bucketInfo?) => {
+                            if (err?.is?.NoSuchBucket) {
+                                // Skip bucket if not found: can happen if bucket has just been removed
+                                return next();
+                            }
+                            if (err) {
+                                log.error('failed to get bucket attributes', {
+                                    bucketName,
+                                    error: err,
+                                });
+                                return next(errors.InternalError);
+                            }
+                            bucketCount++;
+                            bucketInfos!.push(bucketInfo!);
+                            return next();
+                        });
+                    },
+                    err => {
+                        if (err && err instanceof ArsenalError) {
+                            return cb(err);
+                        } else if (err) {
+                            log.error('could not get list of collections', {
+                                method: 'getBucketInfos',
                                 error: err,
                             });
-                            return next(errors.InternalError);
+                            return cb(errors.InternalError);
                         }
-                        bucketCount++;
-                        bucketInfos!.push(bucketInfo!);
-                        return next();
-                    });
-            }, err => {
+                        return cb(null, {
+                            bucketCount,
+                            bucketInfos,
+                        });
+                    },
+                ),
+            )
+            .catch(err => {
+                log.error('could not get list of collections', {
+                    method: 'getBucketInfos',
+                    error: err,
+                });
                 if (err && err instanceof ArsenalError) {
                     return cb(err);
-                } else if (err) {
-                    log.error('could not get list of collections', {
-                        method: 'getBucketInfos',
-                        error: err,
-                    });
-                    return cb(errors.InternalError);
                 }
-                return cb(null, {
-                    bucketCount,
-                    bucketInfos,
-                });
-            })
-        ).catch(err => {
-            log.error('could not get list of collections', {
-                method: 'getBucketInfos',
-                error: err,
+                return cb(errors.InternalError);
             });
-            if (err && err instanceof ArsenalError) {
-                return cb(err);
-            }
-            return cb(errors.InternalError);
-        });
     }
 
     countItems(log: werelogs.Logger, cb: ArsenalCallback<ObjectMDStats>) {
@@ -2751,18 +2945,26 @@ class MongoClientInterface {
     getIngestionBuckets(log: werelogs.Logger, cb: ArsenalCallback<BucketInfo[]>) {
         const m = this.getCollection<BucketMetastoreDocument>(METASTORE);
         m.find({
-            '_id': {
+            _id: {
                 $nin: [PENSIEVE, USERSBUCKET],
             },
             'value.ingestion': {
                 $type: 'object',
             },
-        }).project({
-            'value.name': 1,
-            'value.ingestion': 1,
-            'value.locationConstraint': 1,
-        }).toArray()
-            .then(doc => cb(null, doc.map(i => i.value))).catch(err => {
+        })
+            .project({
+                'value.name': 1,
+                'value.ingestion': 1,
+                'value.locationConstraint': 1,
+            })
+            .toArray()
+            .then(doc =>
+                cb(
+                    null,
+                    doc.map(i => i.value),
+                ),
+            )
+            .catch(err => {
                 log.error('error getting ingestion buckets', {
                     error: err.message,
                     method: 'MongoClientInterface.getIngestionBuckets',
@@ -2776,8 +2978,13 @@ class MongoClientInterface {
      * @warning this method only work on master keys, and will thus break
      * when the object is versionned
      */
-    deleteObjectWithCond(bucketName: string, objName: string, params: ObjectMDOperationParams,
-        log: werelogs.Logger, cb: ArsenalCallback<void>) {
+    deleteObjectWithCond(
+        bucketName: string,
+        objName: string,
+        params: ObjectMDOperationParams,
+        log: werelogs.Logger,
+        cb: ArsenalCallback<void>,
+    ) {
         const c = this.getCollection<ObjectMetastoreDocument>(bucketName);
         const method = 'deleteObjectWithCond';
         this.getBucketVFormat(bucketName, log, (err, vFormat?) => {
@@ -2787,33 +2994,31 @@ class MongoClientInterface {
             const masterKey = formatMasterKey(objName, vFormat);
             const filter = {};
             try {
-                MongoUtils.translateConditions(0, 'value', filter,
-                    params.conditions);
+                MongoUtils.translateConditions(0, 'value', filter, params.conditions);
             } catch (err) {
                 log.error('error creating mongodb filter', {
                     error: reshapeExceptionError(err as ErrorLike),
                 });
                 return cb(errors.InternalError);
             }
-            return this.internalDeleteObject(c, bucketName, masterKey, filter, null, log,
-                err => {
-                    if (err) {
-                        // unable to find an object that matches the conditions
-                        if (err.is.NoSuchKey) {
-                            log.error('unable to find target object to delete', {
-                                method,
-                                filter,
-                            });
-                            return cb(errors.NoSuchKey);
-                        }
-                        log.error('error occurred when attempting to delete object', {
+            return this.internalDeleteObject(c, bucketName, masterKey, filter, null, log, err => {
+                if (err) {
+                    // unable to find an object that matches the conditions
+                    if (err.is.NoSuchKey) {
+                        log.error('unable to find target object to delete', {
                             method,
-                            error: err.message,
+                            filter,
                         });
-                        return cb(errors.InternalError);
+                        return cb(errors.NoSuchKey);
                     }
-                    return cb(null);
-                });
+                    log.error('error occurred when attempting to delete object', {
+                        method,
+                        error: err.message,
+                    });
+                    return cb(errors.InternalError);
+                }
+                return cb(null);
+            });
         });
     }
 
@@ -2831,42 +3036,47 @@ class MongoClientInterface {
             const masterKey = formatMasterKey(objName, vFormat);
             const filter = { _id: masterKey };
             try {
-                MongoUtils.translateConditions(0, 'value', filter,
-                    params.conditions);
+                MongoUtils.translateConditions(0, 'value', filter, params.conditions);
             } catch (err) {
                 log.error('error creating mongodb filter', {
                     error: reshapeExceptionError(err as ErrorLike),
                 });
                 return cb(errors.InternalError);
             }
-            return c.findOneAndUpdate(filter, {
-                $set: {
-                    _id: masterKey,
-                    value: objVal,
-                },
-            }, {
-                includeResultMetadata: true,
-                upsert: true,
-            }).then(res => {
-                if (res.ok !== 1) {
-                    log.error('failed to update object', {
-                        method,
-                    });
-                    return cb(errors.InternalError);
-                }
-                if (!res.value) {
-                    log.debug('object not found...upserted object', {
+            return c
+                .findOneAndUpdate(
+                    filter,
+                    {
+                        $set: {
+                            _id: masterKey,
+                            value: objVal,
+                        },
+                    },
+                    {
+                        includeResultMetadata: true,
+                        upsert: true,
+                    },
+                )
+                .then(res => {
+                    if (res.ok !== 1) {
+                        log.error('failed to update object', {
+                            method,
+                        });
+                        return cb(errors.InternalError);
+                    }
+                    if (!res.value) {
+                        log.debug('object not found...upserted object', {
+                            method,
+                            filter,
+                        });
+                        return cb();
+                    }
+                    log.debug('Object found...updated object', {
                         method,
                         filter,
                     });
                     return cb();
-                }
-                log.debug('Object found...updated object', {
-                    method,
-                    filter,
-                });
-                return cb();
-            })
+                })
                 .catch(err => {
                     log.error('error occurred when attempting to update object', {
                         method,
@@ -2888,16 +3098,16 @@ class MongoClientInterface {
     putBucketIndexes(bucketName: string, indexSpecs, log: werelogs.Logger, cb: ArsenalCallback<void>) {
         const c = this.getCollection<ObjectMetastoreDocument>(bucketName);
         const indexes = MongoUtils.indexFormatObjectToMongoArray(indexSpecs);
-        c.createIndexes(indexes).then(() => cb(null)).catch(err => {
-            if (err.codeName === 'NamespaceNotFound') {
-                return cb(errors.NoSuchBucket);
-            }
+        c.createIndexes(indexes)
+            .then(() => cb(null))
+            .catch(err => {
+                if (err.codeName === 'NamespaceNotFound') {
+                    return cb(errors.NoSuchBucket);
+                }
 
-            log.error(
-                'putBucketIndexes: error creating bucket indexes',
-                { error: err });
-            return cb(errors.InternalError);
-        });
+                log.error('putBucketIndexes: error creating bucket indexes', { error: err });
+                return cb(errors.InternalError);
+            });
     }
 
     /**
@@ -2908,30 +3118,38 @@ class MongoClientInterface {
      * @param {Function} cb callback
      * @return {undefined}
      */
-    deleteBucketIndexes(bucketName: string, indexSpecs: { name: string }[],
-        log: werelogs.Logger, cb: ArsenalCallback<void>) {
+    deleteBucketIndexes(
+        bucketName: string,
+        indexSpecs: { name: string }[],
+        log: werelogs.Logger,
+        cb: ArsenalCallback<void>,
+    ) {
         const c = this.getCollection<ObjectMetastoreDocument>(bucketName);
-        async.each(indexSpecs,
-            (spec, next) => c.dropIndex(spec.name).then(result => {
-                if (!result || !result.ok) {
-                    log.debug('deleteBucketIndexes: failed to drop index', { indexName: spec.name });
-                    return next(errors.DeleteConflict);
-                }
-                return next();
-            }).catch(err => next(err)),
+        async.each(
+            indexSpecs,
+            (spec, next) =>
+                c
+                    .dropIndex(spec.name)
+                    .then(result => {
+                        if (!result || !result.ok) {
+                            log.debug('deleteBucketIndexes: failed to drop index', { indexName: spec.name });
+                            return next(errors.DeleteConflict);
+                        }
+                        return next();
+                    })
+                    .catch(err => next(err)),
             err => {
                 if (err) {
                     if (err instanceof MongoServerError && err.codeName === 'NamespaceNotFound') {
                         return cb(errors.NoSuchBucket);
                     }
 
-                    log.error(
-                        'deleteBucketIndexes: error deleting bucket indexes',
-                        { error: err });
+                    log.error('deleteBucketIndexes: error deleting bucket indexes', { error: err });
                     return cb(errors.InternalError);
                 }
                 return cb(null);
-            });
+            },
+        );
     }
 
     /**
@@ -2941,13 +3159,19 @@ class MongoClientInterface {
      * @param {Function} cb callback
      * @return {undefined}
      */
-    getBucketIndexes(bucketName: string, log: werelogs.Logger, cb: ArsenalCallback<{
-        name: string;
-        keys: {
-            key: string;
-            order: number;
-        }[];
-    }[]>) {
+    getBucketIndexes(
+        bucketName: string,
+        log: werelogs.Logger,
+        cb: ArsenalCallback<
+            {
+                name: string;
+                keys: {
+                    key: string;
+                    order: number;
+                }[];
+            }[]
+        >,
+    ) {
         const c = this.getCollection<ObjectMetastoreDocument>(bucketName);
         c.listIndexes()
             .toArray()
@@ -2969,29 +3193,31 @@ class MongoClientInterface {
         this.adminDb!.command({
             currentOp: true,
             $or: [
-                { 'op': 'command', 'command.createIndexes': { $exists: true } },
+                { op: 'command', 'command.createIndexes': { $exists: true } },
                 { op: 'none', msg: /^Index Build/ },
             ],
-        }).then(res => {
-            const jobs: {
-                bucket: string, indexes: {
-                    name: any;
-                    keys: {
-                        key: any;
-                        order: any;
-                    }[];
-                }[]
-            }[] = [];
-
-            for (const j of res.inprog) {
-                jobs.push({
-                    bucket: j.command.createIndexes,
-                    indexes: MongoUtils.indexFormatMongoArrayToObject(j.command.indexes),
-                });
-            }
-
-            return cb(null, jobs);
         })
+            .then(res => {
+                const jobs: {
+                    bucket: string;
+                    indexes: {
+                        name: any;
+                        keys: {
+                            key: any;
+                            order: any;
+                        }[];
+                    }[];
+                }[] = [];
+
+                for (const j of res.inprog) {
+                    jobs.push({
+                        bucket: j.command.createIndexes,
+                        indexes: MongoUtils.indexFormatMongoArrayToObject(j.command.indexes),
+                    });
+                }
+
+                return cb(null, jobs);
+            })
             .catch(err => {
                 log.error('getIndexingJobs: error retrieving current index jobs', {
                     error: err,

--- a/lib/storage/metadata/mongoclient/MongoClientInterface.ts
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.ts
@@ -18,6 +18,7 @@ import { ErrorLike, reshapeExceptionError } from '../../../errorUtils';
 import errors, { ArsenalError, errorInstances } from '../../../errors';
 import BucketInfo, { BucketMetadata, Capabilities } from '../../../models/BucketInfo';
 import ObjectMD, { ObjectMDData } from '../../../models/ObjectMD';
+import { stampActiveTraceContext } from '../captureTraceContext';
 import * as jsutil from '../../../jsutil';
 import { ArsenalCallback, NestedOmit } from '../../../types';
 
@@ -1337,6 +1338,7 @@ class MongoClientInterface {
                             const objMetadata = new ObjectMD(obj);
                             objMetadata.setOriginOp(params.originOp);
                             objMetadata.setDeleted(true);
+                            stampActiveTraceContext(objMetadata);
                             return next(null, objMetadata.getValue());
                         })
                         .catch(err => {
@@ -2238,6 +2240,7 @@ class MongoClientInterface {
                             const objMetadata = new ObjectMD(obj.value);
                             objMetadata.setOriginOp(originOp);
                             objMetadata.setDeleted(true);
+                            stampActiveTraceContext(objMetadata);
                             return next(null, objMetadata.getValue());
                         })
                         .catch(err => {

--- a/lib/storage/metadata/mongoclient/utils.ts
+++ b/lib/storage/metadata/mongoclient/utils.ts
@@ -1,7 +1,4 @@
-import {
-    supportedOperators,
-    validateConditionsObject,
-} from '../conditions';
+import { supportedOperators, validateConditionsObject } from '../conditions';
 import { VersioningConstants } from '../../../versioning/constants';
 import errors from '../../../errors';
 
@@ -30,9 +27,7 @@ type Condition = string | number | boolean | Record<string, any>;
 function escape(obj: Record<string, string>): Record<string, string> {
     const _obj: Record<string, string> = {};
     Object.keys(obj).forEach(prop => {
-        const _prop = prop
-            .replace(/\$/g, '\uFF04')
-            .replace(/\./g, '\uFF0E');
+        const _prop = prop.replace(/\$/g, '\uFF04').replace(/\./g, '\uFF0E');
         _obj[_prop] = obj[prop];
     });
     return _obj;
@@ -41,9 +36,7 @@ function escape(obj: Record<string, string>): Record<string, string> {
 function unescape(obj: Record<string, string>): Record<string, string> {
     const _obj: Record<string, string> = {};
     Object.keys(obj).forEach(prop => {
-        const _prop = prop
-            .replace(/\uFF04/g, '$')
-            .replace(/\uFF0E/g, '.');
+        const _prop = prop.replace(/\uFF04/g, '$').replace(/\uFF0E/g, '.');
         _obj[_prop] = obj[prop];
     });
     return _obj;
@@ -95,12 +88,7 @@ function _assignCondition(prefix: string, object: Record<string, any>, cond: Con
  *      }
  *  }                              }
  */
-function translateConditions(
-    depth: number,
-    prefix: string,
-    object: Record<string, any>,
-    cond: Condition
-): void {
+function translateConditions(depth: number, prefix: string, object: Record<string, any>, cond: Condition): void {
     if (depth < 0 || depth > 10) {
         throw errors.InternalError;
     }
@@ -116,12 +104,12 @@ function translateConditions(
 
     const fields = Object.keys(cond as Record<string, any>);
     const opFields = fields.filter(f => supportedOperators[f]);
-    
+
     if (fields.length === opFields.length) {
         _assignCondition(prefix, object, cond);
         return;
     }
-    
+
     if (opFields.length === 0) {
         for (const f of fields) {
             if (f.startsWith('$')) {
@@ -132,7 +120,7 @@ function translateConditions(
         }
         return;
     }
-    
+
     // mix of operators and nested fields
     throw errors.InternalError;
 }
@@ -208,13 +196,11 @@ interface MongoIndex {
 
 function indexFormatMongoArrayToObject(mongoIndexArray: MongoIndex[]): Index[] {
     return mongoIndexArray.map(idx => {
-        const entries = idx.key instanceof Map
-            ? Array.from(idx.key.entries())
-            : Object.entries(idx.key);
+        const entries = idx.key instanceof Map ? Array.from(idx.key.entries()) : Object.entries(idx.key);
 
         return {
             name: idx.name,
-            keys: entries.map(([key, order]) => ({ key, order }))
+            keys: entries.map(([key, order]) => ({ key, order })),
         };
     });
 }
@@ -223,7 +209,7 @@ function indexFormatObjectToMongoArray(indexObj: Index[]): MongoIndex[] {
     if (!indexObj || !Array.isArray(indexObj)) {
         return [];
     }
-    
+
     return indexObj.map(idx => {
         const key = new Map();
         idx.keys.forEach(k => key.set(k.key, k.order));

--- a/lib/storage/metadata/mongoclient/utils.ts
+++ b/lib/storage/metadata/mongoclient/utils.ts
@@ -1,6 +1,7 @@
 import { supportedOperators, validateConditionsObject } from '../conditions';
 import { VersioningConstants } from '../../../versioning/constants';
 import errors from '../../../errors';
+import { stampActiveTraceContext } from '../captureTraceContext';
 
 interface AuthCredentials {
     username?: string;
@@ -47,6 +48,9 @@ function serialize(objMD: ObjectMetadata): void {
     if (objMD.tags) {
         objMD.tags = escape(objMD.tags);
     }
+    // Stamp the active OTEL trace context onto every metadata write
+    // so the oplog carries traceparent forward to backbeat consumers.
+    stampActiveTraceContext(objMD);
 }
 
 function unserialize(objMD: ObjectMetadata): void {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "@azure/identity": "^4.13.0",
         "@azure/storage-blob": "^12.31.0",
         "@js-sdsl/ordered-set": "^4.4.2",
+        "@opentelemetry/api": "^1.9.0",
         "@scality/hdclient": "^1.3.2",
         "@smithy/node-http-handler": "^4.3.0",
         "@smithy/protocol-http": "^5.3.5",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "engines": {
         "node": ">=20"
     },
-    "version": "8.4.2",
+    "version": "8.4.3",
     "description": "Common utilities for the S3 project components",
     "main": "build/index.js",
     "repository": {

--- a/tests/unit/storage/metadata/captureTraceContext.noOtel.spec.js
+++ b/tests/unit/storage/metadata/captureTraceContext.noOtel.spec.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const assert = require('assert');
+
+// No jest.mock here: this spec deliberately drives the REAL
+// @opentelemetry/api with no SDK / propagator registered — the
+// "arsenal bumped into a consumer that never initialized OTEL" case.
+// With no SDK, trace.getSpan(context.active()) returns undefined, so
+// stampActiveTraceContext must be a safe no-op: clear any stale
+// traceContext and never throw.
+const { stampActiveTraceContext } = require('../../../../lib/storage/metadata/captureTraceContext');
+
+describe('stampActiveTraceContext (no OTEL SDK registered)', () => {
+    it('is a safe no-op and clears a stale traceContext', () => {
+        const data = { foo: 'bar', traceContext: { traceparent: 'stale' } };
+        assert.doesNotThrow(() => stampActiveTraceContext(data));
+        assert.strictEqual('traceContext' in data, false);
+    });
+
+    it('adds no traceContext field when none existed', () => {
+        const data = { foo: 'bar' };
+        assert.doesNotThrow(() => stampActiveTraceContext(data));
+        assert.strictEqual('traceContext' in data, false);
+    });
+});

--- a/tests/unit/storage/metadata/captureTraceContext.spec.js
+++ b/tests/unit/storage/metadata/captureTraceContext.spec.js
@@ -1,0 +1,121 @@
+'use strict';
+
+const assert = require('assert');
+
+// Mock @opentelemetry/api so we can drive stampActiveTraceContext
+// without needing a registered SDK or propagator. The api package is a
+// runtime dep of arsenal but we can stub the small surface it consumes.
+const mockActive = jest.fn();
+const mockGetSpan = jest.fn();
+const mockInject = jest.fn();
+
+jest.mock('@opentelemetry/api', () => ({
+    context: { active: mockActive },
+    trace: { getSpan: mockGetSpan },
+    propagation: { inject: mockInject },
+}));
+
+const { stampActiveTraceContext } = require('../../../../lib/storage/metadata/captureTraceContext');
+
+describe('stampActiveTraceContext', () => {
+    beforeEach(() => {
+        mockActive.mockReset();
+        mockGetSpan.mockReset();
+        mockInject.mockReset();
+        mockActive.mockReturnValue({ tag: 'mock-active-context' });
+    });
+
+    it('clears traceContext when no span is active', () => {
+        mockGetSpan.mockReturnValue(undefined);
+        const data = { traceContext: { traceparent: 'stale-prior-trace' } };
+        stampActiveTraceContext(data);
+        assert.strictEqual(data.traceContext, undefined);
+        // No injection should be attempted when there is no active span.
+        assert.strictEqual(mockInject.mock.calls.length, 0);
+    });
+
+    it('is a no-op (no traceContext field added) when no span is active and data had none', () => {
+        mockGetSpan.mockReturnValue(undefined);
+        const data = { foo: 'bar' };
+        stampActiveTraceContext(data);
+        assert.strictEqual('traceContext' in data, false);
+    });
+
+    it('writes { traceparent } when active span yields a traceparent', () => {
+        mockGetSpan.mockReturnValue({
+            /* opaque span object */
+        });
+        mockInject.mockImplementation((ctx, carrier, setter) => {
+            setter.set(carrier, 'traceparent', '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01');
+        });
+
+        const data = {};
+        stampActiveTraceContext(data);
+        assert.deepStrictEqual(data.traceContext, {
+            traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+        });
+
+        // Verify inject was given the active context so propagation
+        // sees the right state, not a freshly-constructed empty one.
+        assert.strictEqual(mockInject.mock.calls.length, 1);
+        const [ctxArg, carrierArg] = mockInject.mock.calls[0];
+        assert.deepStrictEqual(ctxArg, { tag: 'mock-active-context' });
+        assert.strictEqual(typeof carrierArg, 'object');
+    });
+
+    it('writes both traceparent and tracestate when both are present', () => {
+        mockGetSpan.mockReturnValue({});
+        mockInject.mockImplementation((ctx, carrier, setter) => {
+            setter.set(carrier, 'traceparent', '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01');
+            setter.set(carrier, 'tracestate', 'rojo=00f067aa0ba902b7');
+        });
+
+        const data = {};
+        stampActiveTraceContext(data);
+        assert.deepStrictEqual(data.traceContext, {
+            traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+            tracestate: 'rojo=00f067aa0ba902b7',
+        });
+    });
+
+    it('clears traceContext when propagation injects no traceparent', () => {
+        // Defensive case: a misbehaving propagator that exposes only
+        // unrelated headers. We must not write a partial / invalid
+        // trace context, and we must clear any stale value.
+        mockGetSpan.mockReturnValue({});
+        mockInject.mockImplementation((ctx, carrier, setter) => {
+            setter.set(carrier, 'baggage', 'unrelated=true');
+        });
+
+        const data = { traceContext: { traceparent: 'stale' } };
+        stampActiveTraceContext(data);
+        assert.strictEqual(data.traceContext, undefined);
+    });
+
+    it('overwrites a stale traceContext with the active one', () => {
+        mockGetSpan.mockReturnValue({});
+        mockInject.mockImplementation((ctx, carrier, setter) => {
+            setter.set(carrier, 'traceparent', 'fresh-tp');
+        });
+
+        const data = { traceContext: { traceparent: 'stale-tp' } };
+        stampActiveTraceContext(data);
+        assert.deepStrictEqual(data.traceContext, { traceparent: 'fresh-tp' });
+    });
+
+    it('accepts an ObjectMD instance and stamps onto its underlying value', () => {
+        mockGetSpan.mockReturnValue({});
+        mockInject.mockImplementation((ctx, carrier, setter) => {
+            setter.set(carrier, 'traceparent', 'tp-from-objmd');
+        });
+
+        // ObjectMD is not mocked (only @opentelemetry/api is), so this is
+        // the real class and the `instanceof ObjectMD` branch is exercised.
+        const ObjectMD = require('../../../../lib/models/ObjectMD').default;
+        const objMd = new ObjectMD();
+        stampActiveTraceContext(objMd);
+        assert.deepStrictEqual(objMd.getValue().traceContext, {
+            traceparent: 'tp-from-objmd',
+        });
+    });
+});

--- a/tests/unit/storage/metadata/mongoclient/delObject.spec.js
+++ b/tests/unit/storage/metadata/mongoclient/delObject.spec.js
@@ -3,8 +3,7 @@ const werelogs = require('werelogs');
 const logger = new werelogs.Logger('MongoClientInterface', 'debug', 'debug');
 const errors = require('../../../../../lib/errors').default;
 const sinon = require('sinon');
-const MongoClientInterface =
-    require('../../../../../lib/storage/metadata/mongoclient/MongoClientInterface');
+const MongoClientInterface = require('../../../../../lib/storage/metadata/mongoclient/MongoClientInterface');
 const utils = require('../../../../../lib/storage/metadata/mongoclient/utils');
 
 const objMD = {
@@ -69,7 +68,8 @@ describe('MongoClientInterface:delObject', () => {
     });
 
     it('deleteObjectNoVer:: should fail when internalDeleteObject fails', done => {
-        const internalDeleteObjectStub = sinon.stub(client, 'internalDeleteObject')
+        const internalDeleteObjectStub = sinon
+            .stub(client, 'internalDeleteObject')
             .callsArgWith(6, errors.InternalError);
         client.deleteObjectNoVer(null, 'example-bucket', 'example-object', {}, logger, err => {
             assert(internalDeleteObjectStub.calledOnce);
@@ -126,7 +126,6 @@ describe('MongoClientInterface:delObject', () => {
             return done();
         });
     });
-
 
     it('deleteObjectVer:: should call deleteObjectVerMaster when version is last', done => {
         const mst = {
@@ -229,11 +228,19 @@ describe('MongoClientInterface:delObject', () => {
             findOneAndUpdate: sinon.stub().resolves({ value: { value: objMD } }),
         };
         const originOp = 's3:TestOriginOp:Created';
-        client.internalDeleteObject(collection, 'example-bucket', 'example-object', {}, null, logger, () => {
-            assert.deepEqual(collection.bulkWrite.args[0][0][0].updateOne.update.$set.value.originOp,
-                originOp);
-            return done();
-        }, originOp);
+        client.internalDeleteObject(
+            collection,
+            'example-bucket',
+            'example-object',
+            {},
+            null,
+            logger,
+            () => {
+                assert.deepEqual(collection.bulkWrite.args[0][0][0].updateOne.update.$set.value.originOp, originOp);
+                return done();
+            },
+            originOp,
+        );
     });
 
     it('internalDeleteObject:: should directly delete object if params.doesNotNeedOpogUpdate is true', done => {
@@ -243,11 +250,20 @@ describe('MongoClientInterface:delObject', () => {
         const params = {
             doesNotNeedOpogUpdate: true,
         };
-        client.internalDeleteObject(collection, 'example-bucket', 'example-object', null, params, logger, err => {
-            assert.deepEqual(err, null);
-            assert(collection.deleteOne.calledOnce);
-            return done();
-        }, 's3:ObjectRemoved:Delete');
+        client.internalDeleteObject(
+            collection,
+            'example-bucket',
+            'example-object',
+            null,
+            params,
+            logger,
+            err => {
+                assert.deepEqual(err, null);
+                assert(collection.deleteOne.calledOnce);
+                return done();
+            },
+            's3:ObjectRemoved:Delete',
+        );
     });
 
     it('internalDeleteObject:: should go through the normal flow if params is null', done => {

--- a/tests/unit/storage/metadata/mongoclient/delObject.spec.js
+++ b/tests/unit/storage/metadata/mongoclient/delObject.spec.js
@@ -1,3 +1,16 @@
+// Mock @opentelemetry/api so the trace-context tests below can drive
+// the active-span state without bringing up an OTEL SDK. Existing
+// delObject tests don't touch OTEL; with these defaults the mocks
+// behave like "no active span" and stampActiveTraceContext is a no-op.
+const mockOtelActive = jest.fn();
+const mockOtelGetSpan = jest.fn();
+const mockOtelInject = jest.fn();
+jest.mock('@opentelemetry/api', () => ({
+    context: { active: mockOtelActive },
+    trace: { getSpan: mockOtelGetSpan },
+    propagation: { inject: mockOtelInject },
+}));
+
 const assert = require('assert');
 const werelogs = require('werelogs');
 const logger = new werelogs.Logger('MongoClientInterface', 'debug', 'debug');
@@ -5,6 +18,13 @@ const errors = require('../../../../../lib/errors').default;
 const sinon = require('sinon');
 const MongoClientInterface = require('../../../../../lib/storage/metadata/mongoclient/MongoClientInterface');
 const utils = require('../../../../../lib/storage/metadata/mongoclient/utils');
+const { makeOtelHelpers } = require('../otelMockHelpers');
+
+const otel = makeOtelHelpers({
+    active: mockOtelActive,
+    getSpan: mockOtelGetSpan,
+    inject: mockOtelInject,
+});
 
 const objMD = {
     _id: 'example-object',
@@ -296,6 +316,75 @@ describe('MongoClientInterface:delObject', () => {
             assert(findOneAndUpdate.args[0][0]['value.isPHD']);
             assert.strictEqual(findOneAndUpdate.args[0][0]['value.versionId'], '1234');
             return done();
+        });
+    });
+});
+
+describe('MongoClientInterface:internalDeleteObject trace-context plumbing', () => {
+    let client;
+    let collection;
+    let bulkWriteArg;
+
+    beforeAll(() => {
+        client = new MongoClientInterface({});
+    });
+
+    beforeEach(() => {
+        otel.resetMocks();
+        bulkWriteArg = null;
+        collection = {
+            findOneAndUpdate: sinon.stub().callsFake(() =>
+                Promise.resolve({
+                    value: {
+                        _id: 'example',
+                        value: {
+                            // Loaded from storage with a stale trace context —
+                            // exercises the carry-forward guard inside
+                            // stampActiveTraceContext.
+                            key: 'example',
+                            traceContext: { traceparent: 'stale-prior-trace' },
+                        },
+                    },
+                }),
+            ),
+            bulkWrite: sinon.stub().callsFake(ops => {
+                bulkWriteArg = ops;
+                return Promise.resolve({ ok: 1, deletedCount: 1 });
+            }),
+        };
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('stamps the active traceContext on the delete tombstone', done => {
+        otel.activateSpan();
+        client.internalDeleteObject(collection, 'bucket', 'example', {}, null, logger, err => {
+            assert.ifError(err);
+            assert.ok(bulkWriteArg, 'bulkWrite was called');
+            const written = bulkWriteArg[0].updateOne.update.$set.value;
+            assert.deepStrictEqual(written.traceContext, { traceparent: otel.TRACEPARENT });
+            done();
+        });
+    });
+
+    it("clears the loaded objVal's stale traceContext when no span is active", done => {
+        otel.deactivateSpan();
+        client.internalDeleteObject(collection, 'bucket', 'example', {}, null, logger, err => {
+            assert.ifError(err);
+            const written = bulkWriteArg[0].updateOne.update.$set.value;
+            assert.strictEqual(written.traceContext, undefined);
+            done();
+        });
+    });
+
+    it('returns NoSuchKey when target object is not found', done => {
+        collection.findOneAndUpdate = sinon.stub().callsFake(() => Promise.resolve({ value: null }));
+        client.internalDeleteObject(collection, 'bucket', 'missing', {}, null, logger, err => {
+            assert.ok(err);
+            assert(err.is.NoSuchKey);
+            done();
         });
     });
 });

--- a/tests/unit/storage/metadata/mongoclient/putObject.spec.js
+++ b/tests/unit/storage/metadata/mongoclient/putObject.spec.js
@@ -3,8 +3,7 @@ const werelogs = require('werelogs');
 const logger = new werelogs.Logger('MongoClientInterface', 'debug', 'debug');
 const errors = require('../../../../../lib/errors').default;
 const sinon = require('sinon');
-const MongoClientInterface =
-    require('../../../../../lib/storage/metadata/mongoclient/MongoClientInterface');
+const MongoClientInterface = require('../../../../../lib/storage/metadata/mongoclient/MongoClientInterface');
 const utils = require('../../../../../lib/storage/metadata/mongoclient/utils');
 const { createClient, createBucket } = require('./MongoClientInterface.spec');
 const { BucketVersioningKeyFormat } = require('../../../../../lib/versioning/constants').VersioningConstants;
@@ -241,11 +240,13 @@ describe('MongoClientInterface:putObjectVerCase1 race condition error handling',
         const versionError = new Error('Duplicate key error');
         versionError.code = 11000;
         // Simulate MongoDB's error structure with writeErrors
-        versionError.writeErrors = [{
-            index: 0, // First operation (version creation)
-            code: 11000,
-            errmsg: 'E11000 duplicate key error',
-        }];
+        versionError.writeErrors = [
+            {
+                index: 0, // First operation (version creation)
+                code: 11000,
+                errmsg: 'E11000 duplicate key error',
+            },
+        ];
 
         // Create a spy to track if putObjectVerCase1 is called with isRetry=true
         // This is a more reliable way to check the retry mechanism
@@ -265,24 +266,16 @@ describe('MongoClientInterface:putObjectVerCase1 race condition error handling',
         };
 
         // Call the method directly to avoid race conditions with the stub
-        client.putObjectVerCase1(
-            collection,
-            bucketName,
-            objName,
-            objMD.getValue(),
-            params,
-            logger,
-            () => {
-                // Check that bulkWrite was called twice (original + retry)
-                assert.strictEqual(bulkWriteStub.callCount, 2, 'Expected bulkWrite to be called twice');
+        client.putObjectVerCase1(collection, bucketName, objName, objMD.getValue(), params, logger, () => {
+            // Check that bulkWrite was called twice (original + retry)
+            assert.strictEqual(bulkWriteStub.callCount, 2, 'Expected bulkWrite to be called twice');
 
-                // Verify putObjectVerCase1 was called with isRetry=true for the retry
-                assert(putObjectVerCase1Spy.calledTwice, 'Expected putObjectVerCase1 to be called twice');
-                assert(putObjectVerCase1Spy.secondCall.args[7], 'Expected second call to have isRetry=true');
+            // Verify putObjectVerCase1 was called with isRetry=true for the retry
+            assert(putObjectVerCase1Spy.calledTwice, 'Expected putObjectVerCase1 to be called twice');
+            assert(putObjectVerCase1Spy.secondCall.args[7], 'Expected second call to have isRetry=true');
 
-                done();
-            },
-        );
+            done();
+        });
     });
 
     it('should handle MongoDB error on master operation (second operation)', done => {
@@ -297,11 +290,13 @@ describe('MongoClientInterface:putObjectVerCase1 race condition error handling',
         const masterError = new Error('Duplicate key error');
         masterError.code = 11000;
         // Simulate MongoDB's error structure with writeErrors
-        masterError.writeErrors = [{
-            index: 1, // Second operation (master update)
-            code: 11000,
-            errmsg: 'E11000 duplicate key error',
-        }];
+        masterError.writeErrors = [
+            {
+                index: 1, // Second operation (master update)
+                code: 11000,
+                errmsg: 'E11000 duplicate key error',
+            },
+        ];
 
         // Add result info showing one operation succeeded
         masterError.result = {
@@ -320,21 +315,13 @@ describe('MongoClientInterface:putObjectVerCase1 race condition error handling',
             conditions: {},
         };
 
-        client.putObjectVerCase1(
-            collection,
-            bucketName,
-            objName,
-            objMD.getValue(),
-            params,
-            logger,
-            (err, result) => {
-                assert.ifError(err, 'Expected no error when master operation fails but version succeeds');
-                assert(result, 'Expected a result to be returned');
-                assert(result.includes('versionId'), 'Expected versionId in result');
-                assert(bulkWriteStub.calledOnce, 'Expected bulkWrite to be called once');
-                done();
-            },
-        );
+        client.putObjectVerCase1(collection, bucketName, objName, objMD.getValue(), params, logger, (err, result) => {
+            assert.ifError(err, 'Expected no error when master operation fails but version succeeds');
+            assert(result, 'Expected a result to be returned');
+            assert(result.includes('versionId'), 'Expected versionId in result');
+            assert(bulkWriteStub.calledOnce, 'Expected bulkWrite to be called once');
+            done();
+        });
     });
 
     it('should handle retry failure when version operation fails twice', done => {
@@ -347,11 +334,13 @@ describe('MongoClientInterface:putObjectVerCase1 race condition error handling',
 
         const versionError = new Error('Duplicate key error');
         versionError.code = 11000;
-        versionError.writeErrors = [{
-            index: 0,
-            code: 11000,
-            errmsg: 'E11000 duplicate key error',
-        }];
+        versionError.writeErrors = [
+            {
+                index: 0,
+                code: 11000,
+                errmsg: 'E11000 duplicate key error',
+            },
+        ];
 
         const putObjectVerCase1Spy = sandbox.spy(client, 'putObjectVerCase1');
 
@@ -367,23 +356,15 @@ describe('MongoClientInterface:putObjectVerCase1 race condition error handling',
             conditions: {},
         };
 
-        client.putObjectVerCase1(
-            collection,
-            bucketName,
-            objName,
-            objMD.getValue(),
-            params,
-            logger,
-            (err, result) => {
-                assert(err, 'Expected an error to be returned after retry failure');
-                assert.strictEqual(err.is.InternalError, true, 'Expected InternalError after retry failure');
-                assert(!result, 'Expected no result on error');
-                assert.strictEqual(bulkWriteStub.callCount, 2, 'Expected bulkWrite to be called twice');
-                assert(putObjectVerCase1Spy.calledTwice, 'Expected putObjectVerCase1 to be called twice');
-                assert(putObjectVerCase1Spy.secondCall.args[7], 'Expected second call to have isRetry=true');
-                done();
-            },
-        );
+        client.putObjectVerCase1(collection, bucketName, objName, objMD.getValue(), params, logger, (err, result) => {
+            assert(err, 'Expected an error to be returned after retry failure');
+            assert.strictEqual(err.is.InternalError, true, 'Expected InternalError after retry failure');
+            assert(!result, 'Expected no result on error');
+            assert.strictEqual(bulkWriteStub.callCount, 2, 'Expected bulkWrite to be called twice');
+            assert(putObjectVerCase1Spy.calledTwice, 'Expected putObjectVerCase1 to be called twice');
+            assert(putObjectVerCase1Spy.secondCall.args[7], 'Expected second call to have isRetry=true');
+            done();
+        });
     });
 
     it('should return version id when no error', done => {
@@ -404,21 +385,13 @@ describe('MongoClientInterface:putObjectVerCase1 race condition error handling',
             conditions: {},
         };
 
-        client.putObjectVerCase1(
-            collection,
-            bucketName,
-            objName,
-            objMD.getValue(),
-            params,
-            logger,
-            (err, result) => {
-                assert.ifError(err, 'Expected no error on successful operation');
-                assert(result, 'Expected a result to be returned');
-                assert(result.includes('versionId'), 'Expected versionId in result');
-                assert(bulkWriteStub.calledOnce, 'Expected bulkWrite to be called once');
-                done();
-            },
-        );
+        client.putObjectVerCase1(collection, bucketName, objName, objMD.getValue(), params, logger, (err, result) => {
+            assert.ifError(err, 'Expected no error on successful operation');
+            assert(result, 'Expected a result to be returned');
+            assert(result.includes('versionId'), 'Expected versionId in result');
+            assert(bulkWriteStub.calledOnce, 'Expected bulkWrite to be called once');
+            done();
+        });
     });
 });
 
@@ -618,9 +591,18 @@ describe('MongoClientInterface:putObjectNoVer', () => {
         const collection = {
             updateOne: () => Promise.reject(errors.InternalError),
         };
-        client.putObjectNoVer(collection, 'example-bucket', 'example-object', {}, {}, logger, err => {
-            assert.deepStrictEqual(err, errors.InternalError);
-            return done();
-        }, false);
+        client.putObjectNoVer(
+            collection,
+            'example-bucket',
+            'example-object',
+            {},
+            {},
+            logger,
+            err => {
+                assert.deepStrictEqual(err, errors.InternalError);
+                return done();
+            },
+            false,
+        );
     });
 });

--- a/tests/unit/storage/metadata/mongoclient/putObject.spec.js
+++ b/tests/unit/storage/metadata/mongoclient/putObject.spec.js
@@ -1,3 +1,16 @@
+// Mock @opentelemetry/api so the trace-context tests below can drive
+// the active-span state without bringing up an OTEL SDK. Existing
+// putObject tests don't touch OTEL; with these defaults the mocks
+// behave like "no active span" and stampActiveTraceContext is a no-op.
+const mockOtelActive = jest.fn();
+const mockOtelGetSpan = jest.fn();
+const mockOtelInject = jest.fn();
+jest.mock('@opentelemetry/api', () => ({
+    context: { active: mockOtelActive },
+    trace: { getSpan: mockOtelGetSpan },
+    propagation: { inject: mockOtelInject },
+}));
+
 const assert = require('assert');
 const werelogs = require('werelogs');
 const logger = new werelogs.Logger('MongoClientInterface', 'debug', 'debug');
@@ -9,8 +22,14 @@ const { createClient, createBucket } = require('./MongoClientInterface.spec');
 const { BucketVersioningKeyFormat } = require('../../../../../lib/versioning/constants').VersioningConstants;
 const { default: ObjectMD } = require('../../../../../lib/models/ObjectMD');
 const DummyRequestLogger = require('../../../helpers').DummyRequestLogger;
+const { makeOtelHelpers } = require('../otelMockHelpers');
 
 const log = new DummyRequestLogger();
+const otel = makeOtelHelpers({
+    active: mockOtelActive,
+    getSpan: mockOtelGetSpan,
+    inject: mockOtelInject,
+});
 
 describe('MongoClientInterface:putObject', () => {
     let client;
@@ -603,6 +622,155 @@ describe('MongoClientInterface:putObjectNoVer', () => {
                 return done();
             },
             false,
+        );
+    });
+});
+
+describe('MongoClientInterface:putObject trace-context plumbing', () => {
+    let client;
+
+    beforeAll(() => {
+        client = new MongoClientInterface({});
+    });
+
+    beforeEach(() => {
+        otel.resetMocks();
+        sinon.stub(utils, 'formatMasterKey').callsFake(() => 'master-key');
+        sinon.stub(utils, 'formatVersionKey').callsFake(() => 'version-key');
+        sinon.stub(client, 'getCollection').callsFake(() => ({}));
+        sinon.stub(client, 'getBucketVFormat').callsFake((b, l, cb) => cb(null, 'v0'));
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('stamps traceContext on the write when a span is active', done => {
+        otel.activateSpan();
+        const seen = {};
+        sinon.stub(client, 'putObjectNoVer').callsFake((_c, _b, _o, objVal, _p, _l, cb) => {
+            Object.assign(seen, objVal);
+            cb();
+        });
+
+        client.putObject('bucket', 'example', { key: 'example' }, {}, log, err => {
+            assert.ifError(err);
+            assert.deepStrictEqual(seen.traceContext, { traceparent: otel.TRACEPARENT });
+            done();
+        });
+    });
+
+    it('omits traceContext when no span is active', done => {
+        otel.deactivateSpan();
+        const seen = {};
+        sinon.stub(client, 'putObjectNoVer').callsFake((_c, _b, _o, objVal, _p, _l, cb) => {
+            Object.assign(seen, objVal);
+            cb();
+        });
+
+        client.putObject('bucket', 'example', { key: 'x' }, {}, log, err => {
+            assert.ifError(err);
+            assert.strictEqual(seen.traceContext, undefined);
+            done();
+        });
+    });
+
+    it('clears stale traceContext from a loaded objVal when no span is active', done => {
+        // Regression: an objVal loaded from storage may already carry a
+        // previous write's trace context. Without explicit clearing the
+        // next write would inherit the stale value.
+        otel.deactivateSpan();
+        const seen = {};
+        sinon.stub(client, 'putObjectNoVer').callsFake((_c, _b, _o, objVal, _p, _l, cb) => {
+            Object.assign(seen, objVal);
+            cb();
+        });
+
+        const objVal = {
+            key: 'example',
+            traceContext: { traceparent: 'stale-from-prior-write' },
+        };
+        client.putObject('bucket', 'example', objVal, {}, log, err => {
+            assert.ifError(err);
+            assert.strictEqual(seen.traceContext, undefined);
+            done();
+        });
+    });
+});
+
+// putObjectNoVerWithOplogUpdate is reached on the archived-object replace
+// path (cloudserver sets params.needOplogUpdate with originOp
+// 's3:ReplaceArchivedObject'). It bulkWrites two oplog entries: a
+// tombstone of the loaded existing object (consumed by downstream
+// cleanup workers) and the new value. Both need traceContext so
+// consumers reading either oplog event can correlate to the originating
+// S3 request.
+describe('MongoClientInterface:putObjectNoVerWithOplogUpdate trace-context plumbing', () => {
+    let client;
+    let collection;
+    let bulkWriteArg;
+
+    beforeAll(() => {
+        client = new MongoClientInterface({});
+    });
+
+    beforeEach(() => {
+        otel.resetMocks();
+        bulkWriteArg = null;
+        collection = {
+            findOneAndUpdate: sinon.stub().callsFake(() =>
+                Promise.resolve({
+                    value: {
+                        key: 'existing',
+                        traceContext: { traceparent: 'stale-prior-trace' },
+                    },
+                }),
+            ),
+            bulkWrite: sinon.stub().callsFake(ops => {
+                bulkWriteArg = ops;
+                return Promise.resolve({ ok: 1 });
+            }),
+        };
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('stamps traceContext on the loaded-object tombstone when a span is active', done => {
+        otel.activateSpan();
+        client.putObjectNoVerWithOplogUpdate(
+            collection,
+            'bucket',
+            'example',
+            { key: 'replacement' },
+            { vFormat: 'v0', originOp: 's3:ReplaceArchivedObject' },
+            log,
+            err => {
+                assert.ifError(err);
+                assert.ok(bulkWriteArg, 'bulkWrite was called');
+                const tombstone = bulkWriteArg[0].updateOne.update.$set.value;
+                assert.deepStrictEqual(tombstone.traceContext, { traceparent: otel.TRACEPARENT });
+                done();
+            },
+        );
+    });
+
+    it('clears stale traceContext on the tombstone when no span is active', done => {
+        otel.deactivateSpan();
+        client.putObjectNoVerWithOplogUpdate(
+            collection,
+            'bucket',
+            'example',
+            { key: 'replacement' },
+            { vFormat: 'v0', originOp: 's3:ReplaceArchivedObject' },
+            log,
+            err => {
+                assert.ifError(err);
+                const tombstone = bulkWriteArg[0].updateOne.update.$set.value;
+                assert.strictEqual(tombstone.traceContext, undefined);
+                done();
+            },
         );
     });
 });

--- a/tests/unit/storage/metadata/mongoclient/repair.spec.js
+++ b/tests/unit/storage/metadata/mongoclient/repair.spec.js
@@ -1,0 +1,70 @@
+// Mock @opentelemetry/api so the trace-context tests can drive the
+// active-span state without bringing up an OTEL SDK.
+const mockOtelActive = jest.fn();
+const mockOtelGetSpan = jest.fn();
+const mockOtelInject = jest.fn();
+jest.mock('@opentelemetry/api', () => ({
+    context: { active: mockOtelActive },
+    trace: { getSpan: mockOtelGetSpan },
+    propagation: { inject: mockOtelInject },
+}));
+
+const assert = require('assert');
+const werelogs = require('werelogs');
+const logger = new werelogs.Logger('MongoClientInterface', 'debug', 'debug');
+const sinon = require('sinon');
+const MongoClientInterface = require('../../../../../lib/storage/metadata/mongoclient/MongoClientInterface');
+const { makeOtelHelpers } = require('../otelMockHelpers');
+
+const otel = makeOtelHelpers({
+    active: mockOtelActive,
+    getSpan: mockOtelGetSpan,
+    inject: mockOtelInject,
+});
+
+describe('MongoClientInterface:repair trace-context plumbing', () => {
+    let client;
+    let collection;
+    let captured;
+
+    beforeAll(() => {
+        client = new MongoClientInterface({});
+    });
+
+    beforeEach(() => {
+        otel.resetMocks();
+        captured = null;
+        collection = {
+            findOneAndReplace: sinon.stub().callsFake((_filter, doc) => {
+                captured = doc;
+                return Promise.resolve({ ok: 1, value: doc });
+            }),
+        };
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('stamps traceContext on the repair write when a span is active', done => {
+        otel.activateSpan();
+        client.repair(collection, 'bucket', 'example', { key: 'example' }, { versionId: 'v1' }, 'v0', logger, err => {
+            assert.ifError(err);
+            assert.deepStrictEqual(captured.value.traceContext, { traceparent: otel.TRACEPARENT });
+            done();
+        });
+    });
+
+    it('clears stale traceContext when no span is active', done => {
+        otel.deactivateSpan();
+        const objVal = {
+            key: 'example',
+            traceContext: { traceparent: 'stale-prior-trace' },
+        };
+        client.repair(collection, 'bucket', 'example', objVal, { versionId: 'v1' }, 'v0', logger, err => {
+            assert.ifError(err);
+            assert.strictEqual(captured.value.traceContext, undefined);
+            done();
+        });
+    });
+});

--- a/tests/unit/storage/metadata/otelMockHelpers.js
+++ b/tests/unit/storage/metadata/otelMockHelpers.js
@@ -1,0 +1,36 @@
+'use strict';
+
+// Shared OTEL mock plumbing for the trace-context tests scattered across
+// the per-method MongoClientInterface specs. Each spec file declares its
+// own `mockOtel*` jest.fn()s at the top and passes them into
+// makeOtelHelpers() — jest hoists `jest.mock(...)` factories above local
+// requires, so the mocks themselves can't live here.
+
+const TRACEPARENT = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01';
+
+function makeOtelHelpers(mocks) {
+    return {
+        TRACEPARENT,
+        activateSpan(traceparent = TRACEPARENT) {
+            mocks.active.mockReturnValue({ tag: 'mock-active-context' });
+            mocks.getSpan.mockReturnValue({
+                /* opaque span */
+            });
+            mocks.inject.mockImplementation((ctx, carrier, setter) => {
+                setter.set(carrier, 'traceparent', traceparent);
+            });
+        },
+        deactivateSpan() {
+            mocks.active.mockReturnValue({});
+            mocks.getSpan.mockReturnValue(undefined);
+            mocks.inject.mockImplementation(() => {});
+        },
+        resetMocks() {
+            mocks.active.mockReset();
+            mocks.getSpan.mockReset();
+            mocks.inject.mockReset();
+        },
+    };
+}
+
+module.exports = { TRACEPARENT, makeOtelHelpers };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2466,6 +2466,11 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.0.tgz#d03eba68273dc0f7509e2a3d5cba21eae10379fe"
   integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
 
+"@opentelemetry/api@^1.9.0":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.1.tgz#c1b0346de336ba55af2d5a7970882037baedec05"
+  integrity sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==
+
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"


### PR DESCRIPTION
## Context

Cloudserver recently gained OpenTelemetry tracing ([CLDSRV-884], cloudserver PR scality/cloudserver#6140). That gives us a single end-to-end trace per S3 request spanning cloudserver → vault → hdproxy → hyperiod.

But many state mutations in the S3 stack are written to MongoDB and **consumed asynchronously** by worker services via the oplog:
- **Backbeat** — replication, lifecycle expiration/transition, garbage collection
- **Sorbet** — cold-storage restore completion
- Other oplog consumers

Today the oplog entry carries no trace context, so async work performed hours or days after the S3 request cannot be tied back to the request that caused it. A user's `POST …?restore` produces a trace that ends at the metadata write; the actual cold-tier retrieval by Sorbet is invisible from the original trace.

## Solution

Stamp a W3C trace context (`traceparent`/`tracestate`) on every mutating metadata write, auto-derived from the currently-active OTEL context.

The field lives on `ObjectMDData` next to `originOp`:

```ts
traceContext?: {
    traceparent?: string;
    tracestate?: string;
};
```

A new helper `stampActiveTraceContext` in `lib/storage/metadata/captureTraceContext.ts`:
- reads the active OTEL context via `@opentelemetry/api`
- serializes it via `propagation.inject()`
- writes the result to `data.traceContext`, or clears the field if no span is active (so a stale value loaded from storage cannot leak forward into a new oplog entry)

It is exposed with TS **overloads** so callers pass whichever shape they have — an `ObjectMD` instance or a raw metadata object:

```ts
export function stampActiveTraceContext(objMd: ObjectMD): void;
export function stampActiveTraceContext(data: Record<string, any>): void;
export function stampActiveTraceContext(data: ObjectMD | Record<string, any>): void {
    const target = data instanceof ObjectMD ? data.getValue() : data;
    // ...
}
```

It is called from inside `MongoUtils.serialize()`, so **every metadata write that goes through serialize automatically gets the stamp** (the `putObject` / `putObjectVerCase4` / `repair` paths in `MongoClientInterface`). For the 2 paths that bypass `serialize` because they rewrite a doc previously read from the DB with already-escaped tags (`internalPutObject`, `internalDeleteObject`), `stampActiveTraceContext()` is called explicitly on the `ObjectMD` instance (the overload resolves `.getValue()` internally).

Consumers (backbeat, sorbet — **out of scope for this PR**) will later:
1. Read `value.traceContext.traceparent` from the oplog entry
2. `propagation.extract()` it to reconstruct a parent context
3. Wrap per-entry processing in `context.with(extractedCtx, ...)`

This closes the loop on end-to-end tracing across the async boundary.

## Design decisions

**1. Auto-inject at the arsenal write boundary (vs. param plumbing).**
The alternative was to thread a new `traceContext` parameter through the ~15 cloudserver call sites that already set `originOp`. Rejected because:
- `@opentelemetry/context-async-hooks` (loaded by the OTEL SDK at cloudserver startup) already propagates the request context through arsenal's async call chain for free. Re-reading it at the mongo write is idiomatic OTEL.
- Zero cloudserver surface change — we can iterate on arsenal independently.
- Parallels existing behavior where arsenal reads `originOp` out of params and attaches it to the `ObjectMD`.
- Avoids replicating the maintenance cost that makes `originOp` easy to forget on new API endpoints today.

**2. Only `@opentelemetry/api` as a runtime dep (~10 KB, no SDK).**
The api package is specifically designed to be safe for libraries to depend on. When no SDK is registered (today's state for anyone not opting into cloudserver OTEL), `context.active()` returns a no-op context, `trace.getSpan()` returns undefined, and `stampActiveTraceContext()` clears the field and returns. **Zero runtime cost when OTEL is off** — covered by a dedicated unit test (see Verification).

**3. Optional field, no schema migration.**
`traceContext` is absent by default — consistent with other optional ObjectMD fields like `legalHold`, `retentionDate`. No default-value change in the ObjectMDData construction. Existing consumers that don't understand the field simply ignore it; fully backward compatible.

**4. Always reflects the current write — never carries a stale context forward.**
If no span is active when `stampActiveTraceContext()` runs, it clears `traceContext` (rather than leaving whatever was loaded from storage). Same when `propagation.inject()` produces no `traceparent`. This prevents both edge-case OTEL output and the more practical hazard where a doc read for a delete/repair carries a `traceContext` from its original write that does not belong on the new oplog entry.

**5. Single helper, single contract.**
The trace-stamping API on arsenal is one function — `stampActiveTraceContext`, with overloads for the `ObjectMD` and raw-data call shapes but a single implementation. There is intentionally no public setter on `ObjectMD`: the contract is "trace context is stamped by the metadata backend at write time," and a model-level setter would invite callers in cloudserver/backbeat to bypass that contract (issue raised in review). Internally this also keeps the stamp/clear semantics in exactly one place. The overload pattern matches existing arsenal usage (`convertToEpochTime`, `uuidv4`).

## Interaction with async flows (cold restore as example)

Cold storage restore exercises both a sync and an async metadata write:

1. `ObjectRestore:Post` (sync, user-initiated via `POST /bucket/key?restore`) — cloudserver sets `originOp`; arsenal now also stamps `traceContext` pointing to the user's request trace. ✅
2. `ObjectRestore:Completed` (async, Sorbet-triggered via cloudserver's `/_/backbeat/*` route) — behavior depends on Sorbet:
   - If Sorbet forwards `traceparent` on its HTTP call (ideally extracted from step 1's stored `traceContext`): arsenal picks it up via `context.with(remoteContext, ...)` in cloudserver's `server.js`, and the Completed write ties back to the original user restore. ✅
   - If Sorbet calls without `traceparent` (today's state): safely no-ops — Completed write has no `traceContext`, no regression. ✅

Same pattern applies to lifecycle expiration/transition, CRR replication, and GC.

## Verification

### Unit tests

- `tests/unit/storage/metadata/captureTraceContext.spec.js` — `stampActiveTraceContext` against a mocked `@opentelemetry/api`: no-active-span clears (and is a no-op when there was nothing to clear), traceparent-only write, traceparent + tracestate write, defensive handling of a propagator that injects no `traceparent`, overwrite of a stale value, and the `ObjectMD`-instance overload stamping onto `getValue()`.
- `tests/unit/storage/metadata/captureTraceContext.noOtel.spec.js` — drives the **real** `@opentelemetry/api` with no SDK registered (the "arsenal bumped into a consumer that never initialized OTEL" case): confirms a safe no-op that clears stale context and never throws.
- `tests/unit/storage/metadata/mongoclient/{putObject,delObject,repair}.spec.js` — sinon-stubbed tests verify the field lands on the document handed to `findOneAndReplace` / `bulkWrite` for each write path the cloudserver hot path exercises, and that it is cleared rather than carried forward when no span is active.

All unit tests in `tests/unit/models/` and `tests/unit/storage/metadata/` pass; `yarn build` is clean.

### End-to-end (follow-up on a test cluster)

1. Bump cloudserver's arsenal pin to a build of this branch; roll the cloudserver deployment on an Artesca cluster with `ENABLE_OTEL=true`
2. Make a PutObject; note the trace ID in Jaeger
3. Inspect the MongoDB oplog: `o.value.traceContext.traceparent` should be present, with characters 3-35 matching the Jaeger trace ID
4. Negative test with `ENABLE_OTEL=false` → field should be absent

Issue: ARSN-572


[CLDSRV-884]: https://scality.atlassian.net/browse/CLDSRV-884