### PR TITLE
ARSN-574 Update GitHub Actions to Node 24 runtime

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -17,9 +17,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: javascript, typescript
 
       - name: Build and analyze
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4

--- a/.github/workflows/tests-kmip.yaml
+++ b/.github/workflows/tests-kmip.yaml
@@ -28,8 +28,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+      uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
       with:
         node-version: '22'
         cache: 'yarn'
@@ -53,7 +53,7 @@ jobs:
     - name: run kmip ClusterClient functional tests on pykmip
       run: yarn ft_pykmip_test
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: pykmip_logs
         path: /tmp/artifacts/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,8 +25,8 @@ jobs:
           - 6379:6379
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+      uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
       with:
         node-version: '22'
         cache: 'yarn'
@@ -45,7 +45,7 @@ jobs:
       run: yarn --silent coverage
     - name: run functional tests
       run: yarn ft_test
-    - uses: codecov/codecov-action@v4
+    - uses: codecov/codecov-action@v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
     - name: run executables tests
@@ -58,9 +58,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Install NodeJS
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '22'
         cache: yarn


### PR DESCRIPTION
## Summary
Update GitHub Actions workflow files to use action versions that run on Node 24.

Closes ARSN-574

## Context
GitHub is deprecating Node 20 as the JavaScript runtime for GitHub Actions runners:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Timeline:
- June 2, 2026: Runners will default to Node 24 (deprecation warnings)
- Fall 2026: Node 20 completely removed

## Changes
- \`actions/checkout@v4\` → \`@v6\`
- \`actions/setup-node@v4\` → \`@v6\`
- \`actions/upload-artifact@v4\` → \`@v7\`
- \`github/codeql-action@v3\` → \`@v4\`
- \`codecov/codecov-action@v4\` → \`@v6\`