### PR TITLE
Fix ETag fallback to dataStoreETag for ring-s3-rdma-http objects

### DIFF
--- a/lib/storage/metadata/MetadataWrapper.js
+++ b/lib/storage/metadata/MetadataWrapper.js
@@ -41,11 +41,27 @@ function _parseListEntries(entries) {
             };
         }
 
+        // Fall back to dataStoreETag when content-md5 is absent (e.g. parts
+        // written by ring-s3-rdma-http which stores ETag only as "1:<hex>").
+        let etag = tmp['content-md5'];
+        if (!etag) {
+            const loc = Array.isArray(tmp.partLocations)
+                ? tmp.partLocations[0]
+                : tmp.partLocations;
+            const dst = loc && loc.dataStoreETag;
+            if (dst) {
+                const colon = dst.indexOf(':');
+                if (colon !== -1) {
+                    etag = dst.slice(colon + 1);
+                }
+            }
+        }
+
         return {
             key: entry.key,
             value: {
                 Size: tmp['content-length'],
-                ETag: tmp['content-md5'],
+                ETag: etag,
                 VersionId: tmp.versionId,
                 IsNull: tmp.isNull,
                 IsDeleteMarker: tmp.isDeleteMarker,


### PR DESCRIPTION
When content-md5 is absent (e.g. parts written by ring-s3-rdma-http which stores ETag only as "1:<hex>" in dataStoreETag), fall back to extracting the hex portion from dataStoreETag for use as the ETag in list entries.

Issue: ARSN-579