### PR TITLE
Extract shared timestamp-id primitives into TimestampId module

### DIFF
--- a/lib/models/ObjectMD.ts
+++ b/lib/models/ObjectMD.ts
@@ -2,10 +2,7 @@ import * as constants from '../constants';
 import * as VersionIDUtils from '../versioning/VersionID';
 import * as MicroVersionIdUtils from '../versioning/MicroVersionId';
 import { VersioningConstants } from '../versioning/constants';
-import ObjectMDLocation, {
-    ObjectMDLocationData,
-    Location,
-} from './ObjectMDLocation';
+import ObjectMDLocation, { ObjectMDLocationData, Location } from './ObjectMDLocation';
 import ObjectMDAmzRestore from './ObjectMDAmzRestore';
 import ObjectMDArchive from './ObjectMDArchive';
 import { ObjectMDAzureInfoMetadata } from './ObjectMDAzureInfo';
@@ -194,7 +191,7 @@ export default class ObjectMD {
             'cache-control': '',
             'content-disposition': '',
             'content-encoding': '',
-            'expires': '',
+            expires: '',
             'content-length': 0,
             'content-type': '',
             'content-md5': '',
@@ -213,27 +210,27 @@ export default class ObjectMD {
             'x-amz-server-side-encryption-customer-algorithm': '',
             'x-amz-website-redirect-location': '',
             'x-amz-scal-transition-in-progress': undefined,
-            'acl': {
+            acl: {
                 Canned: 'private',
                 FULL_CONTROL: [],
                 WRITE_ACP: [],
                 READ: [],
                 READ_ACP: [],
             },
-            'key': '',
-            'location': null,
-            'azureInfo': undefined,
+            key: '',
+            location: null,
+            azureInfo: undefined,
             // versionId, isNull, nullVersionId and isDeleteMarker
             // should be undefined when not set explicitly
-            'isNull': undefined,
-            'isNull2': undefined,
-            'nullVersionId': undefined,
-            'nullUploadId': undefined,
-            'isDeleteMarker': undefined,
-            'versionId': undefined,
-            'uploadId': undefined,
-            'tags': {},
-            'replicationInfo': {
+            isNull: undefined,
+            isNull2: undefined,
+            nullVersionId: undefined,
+            nullUploadId: undefined,
+            isDeleteMarker: undefined,
+            versionId: undefined,
+            uploadId: undefined,
+            tags: {},
+            replicationInfo: {
                 status: '',
                 backends: [],
                 content: [],
@@ -245,10 +242,10 @@ export default class ObjectMD {
                 isNFS: undefined,
                 isReplica: undefined,
             },
-            'dataStoreName': '',
-            'originOp': '',
-            'deleted': undefined,
-            'isPHD': undefined,
+            dataStoreName: '',
+            originOp: '',
+            deleted: undefined,
+            isPHD: undefined,
         };
     }
 
@@ -491,11 +488,15 @@ export default class ObjectMD {
      * @param checksum - ObjectMDChecksum instance
      * @return itself
      */
-    setChecksum(checksum: ObjectMDChecksum | {
-        checksumAlgorithm: ChecksumAlgorithm;
-        checksumValue: string;
-        checksumType: ChecksumType;
-    }) {
+    setChecksum(
+        checksum:
+            | ObjectMDChecksum
+            | {
+                  checksumAlgorithm: ChecksumAlgorithm;
+                  checksumValue: string;
+                  checksumType: ChecksumType;
+              },
+    ) {
         if (checksum instanceof ObjectMDChecksum) {
             this._data.checksum = checksum;
         } else if (ObjectMDChecksum.isValid(checksum) === null) {
@@ -708,9 +709,9 @@ export default class ObjectMD {
      * @param transitionTime - Date when the transition started
      * @return itself
      */
-    setTransitionInProgress(inProgress: false): this
-    setTransitionInProgress(inProgress: true, transitionTime: Date|string|number): this
-    setTransitionInProgress(inProgress: boolean, transitionTime?: Date|string|number) {
+    setTransitionInProgress(inProgress: false): this;
+    setTransitionInProgress(inProgress: true, transitionTime: Date | string | number): this;
+    setTransitionInProgress(inProgress: boolean, transitionTime?: Date | string | number) {
         this._data['x-amz-scal-transition-in-progress'] = inProgress;
         if (!inProgress || !transitionTime) {
             delete this._data['x-amz-scal-transition-time'];
@@ -1181,9 +1182,7 @@ export default class ObjectMD {
     }
 
     setReplicationSiteStatus(site: string, status: string) {
-        const backend = this._data.replicationInfo.backends.find(
-            o => o.site === site
-        );
+        const backend = this._data.replicationInfo.backends.find(o => o.site === site);
         if (backend) {
             backend.status = status;
         }
@@ -1191,9 +1190,7 @@ export default class ObjectMD {
     }
 
     getReplicationSiteStatus(site: string) {
-        const backend = this._data.replicationInfo.backends.find(
-            o => o.site === site
-        );
+        const backend = this._data.replicationInfo.backends.find(o => o.site === site);
         if (backend) {
             return backend.status;
         }
@@ -1206,9 +1203,7 @@ export default class ObjectMD {
     }
 
     setReplicationSiteDataStoreVersionId(site: string, versionId: string) {
-        const backend = this._data.replicationInfo.backends.find(
-            o => o.site === site
-        );
+        const backend = this._data.replicationInfo.backends.find(o => o.site === site);
         if (backend) {
             backend.dataStoreVersionId = versionId;
         }
@@ -1216,9 +1211,7 @@ export default class ObjectMD {
     }
 
     getReplicationSiteDataStoreVersionId(site: string) {
-        const backend = this._data.replicationInfo.backends.find(
-            o => o.site === site
-        );
+        const backend = this._data.replicationInfo.backends.find(o => o.site === site);
         if (backend) {
             return backend.dataStoreVersionId;
         }
@@ -1541,37 +1534,37 @@ export default class ObjectMD {
     }
 
     /**
-    * Set deleted flag
-    * @param {Boolean} value deleted object
-    * @return {ObjectMD}
-    */
+     * Set deleted flag
+     * @param {Boolean} value deleted object
+     * @return {ObjectMD}
+     */
     setDeleted(value) {
         this._data.deleted = value;
         return this;
     }
 
     /**
-    * Get deleted flag
-    * @return {Boolean}
-    */
+     * Get deleted flag
+     * @return {Boolean}
+     */
     getDeleted() {
         return !!this._data.deleted;
     }
 
     /**
-    * Set isPHD flag
-    * @param {Boolean} value isPHD value
-    * @return {ObjectMD}
-    */
+     * Set isPHD flag
+     * @param {Boolean} value isPHD value
+     * @return {ObjectMD}
+     */
     setIsPHD(value) {
         this._data.isPHD = value;
         return this;
     }
 
     /**
-    * Get isPHD flag
-    * @return {Boolean}
-    */
+     * Get isPHD flag
+     * @return {Boolean}
+     */
     getIsPHD() {
         return !!this._data.isPHD;
     }

--- a/lib/models/ObjectMD.ts
+++ b/lib/models/ObjectMD.ts
@@ -1,6 +1,6 @@
-import * as crypto from 'crypto';
 import * as constants from '../constants';
 import * as VersionIDUtils from '../versioning/VersionID';
+import * as MicroVersionIdUtils from '../versioning/MicroVersionId';
 import { VersioningConstants } from '../versioning/constants';
 import ObjectMDLocation, {
     ObjectMDLocationData,
@@ -35,6 +35,7 @@ export type ReplicationInfo = {
     storageType: string;
     dataStoreVersionId: string;
     isNFS?: boolean;
+    isReplica?: boolean;
 };
 
 export type ObjectMDTag = {
@@ -242,6 +243,7 @@ export default class ObjectMD {
                 storageType: '',
                 dataStoreVersionId: '',
                 isNFS: undefined,
+                isReplica: undefined,
             },
             'dataStoreName': '',
             'originOp': '',
@@ -1097,6 +1099,7 @@ export default class ObjectMD {
         storageType?: string;
         dataStoreVersionId?: string;
         isNFS?: boolean;
+        isReplica?: boolean;
     }) {
         const {
             status,
@@ -1108,6 +1111,7 @@ export default class ObjectMD {
             storageType,
             dataStoreVersionId,
             isNFS,
+            isReplica,
         } = replicationInfo;
         this._data.replicationInfo = {
             status,
@@ -1119,6 +1123,7 @@ export default class ObjectMD {
             storageType: storageType || '',
             dataStoreVersionId: dataStoreVersionId || '',
             isNFS,
+            isReplica,
         };
         return this;
     }
@@ -1153,6 +1158,26 @@ export default class ObjectMD {
      */
     getReplicationIsNFS() {
         return !!this._data.replicationInfo.isNFS;
+    }
+
+    /**
+     * Mark this object as the result of a replication write (replica),
+     * as opposed to a write originating from a user request.
+     *
+     * @param isReplica - true if this object was written by replication
+     * @return itself
+     */
+    setReplicationIsReplica(isReplica: boolean) {
+        this._data.replicationInfo.isReplica = isReplica;
+        return this;
+    }
+
+    /**
+     * Get whether this object was written by replication (replica).
+     * @return true if this object is a replica
+     */
+    getReplicationIsReplica() {
+        return !!this._data.replicationInfo.isReplica;
     }
 
     setReplicationSiteStatus(site: string, status: string) {
@@ -1353,12 +1378,18 @@ export default class ObjectMD {
      * - to manage conflicts during concurrent updates, using
      *   conditions on the microVersionId field.
      *
-     * It's a field of 16 hexadecimal characters randomly generated
+     * The value is a timestamp-ordered identifier matching the
+     * versionId scheme, so two microVersionIds can be compared with
+     * {@link MicroVersionIdUtils.compare} to determine which one is
+     * more recent.
+     *
+     * @param replicationGroupId - replication group id, used to keep
+     *   microVersionIds unique across concurrent writers
      *
      * @return itself
      */
-    updateMicroVersionId() {
-        this._data.microVersionId = crypto.randomBytes(8).toString('hex');
+    updateMicroVersionId(replicationGroupId: string) {
+        this._data.microVersionId = MicroVersionIdUtils.generate(replicationGroupId);
     }
 
     /**

--- a/lib/versioning/MicroVersionId.ts
+++ b/lib/versioning/MicroVersionId.ts
@@ -24,11 +24,10 @@ import {
     hexEncode,
     hexDecode,
     createTimestampSequenceGenerator,
-    compare as tsIdCompare,
+    parse,
 } from './TimestampId';
 
-const MICRO_VERSION_ID_LENGTH = TS_SEQ_RG_LENGTH;
-const ENCODED_LENGTH = MICRO_VERSION_ID_LENGTH * 2;
+const ENCODED_LENGTH = TS_SEQ_RG_LENGTH * 2;
 
 /**
  * Generate a timestamp-ordered microVersionId.
@@ -84,27 +83,19 @@ export function decode(str: string): string | Error {
     if (str.length !== ENCODED_LENGTH || !/^[0-9a-f]+$/.test(str)) {
         return new Error('microVersionId is not in the current format');
     }
-
     const decoded = hexDecode(str);
     if (decoded instanceof Error) {
         return decoded;
     }
-
-    if (decoded.length !== MICRO_VERSION_ID_LENGTH) {
-        return new Error(`decoded microVersionId has invalid length ${decoded.length}`);
+    const parsed = parse(decoded);
+    if (parsed instanceof Error) {
+        return parsed;
     }
-
     return decoded;
 }
 
 /**
- * Compare two microVersionIds chronologically. Thin wrapper over
- * {@link tsIdCompare} preserved for callers importing from this module.
- *
- * @param a - first microVersionId (raw, non-encoded form)
- * @param b - second microVersionId (raw, non-encoded form)
- * @return - positive if a is newer than b, negative if older, 0 if equal
+ * Compare two microVersionIds chronologically. Positive if {@code a}
+ * is newer than {@code b}, negative if older, 0 if equal.
  */
-export function compare(a: string, b: string): number {
-    return tsIdCompare(a, b);
-}
+export { compare } from './TimestampId';

--- a/lib/versioning/MicroVersionId.ts
+++ b/lib/versioning/MicroVersionId.ts
@@ -30,11 +30,6 @@ import {
 const MICRO_VERSION_ID_LENGTH = TS_SEQ_RG_LENGTH;
 const ENCODED_LENGTH = MICRO_VERSION_ID_LENGTH * 2;
 
-// Stateful ts+seq+rg generator owning the lastTimestamp/lastSeq counters
-// for microVersionId generation. Kept separate from versionId state so
-// microVersionId generation does not perturb versionId sequencing.
-const generateTsSeqRg = createTimestampSequenceGenerator();
-
 /**
  * Generate a timestamp-ordered microVersionId.
  *
@@ -59,9 +54,7 @@ const generateTsSeqRg = createTimestampSequenceGenerator();
  *   // => '98283606399999999999RG001  '
  *   //     └── MAX_TS-now ──┘└MAX_SEQ┘└pad┘
  */
-export function generate(replicationGroupId: string): string {
-    return generateTsSeqRg(replicationGroupId);
-}
+export const generate = createTimestampSequenceGenerator();
 
 /**
  * Encode a microVersionId to obscure its internal structure.

--- a/lib/versioning/MicroVersionId.ts
+++ b/lib/versioning/MicroVersionId.ts
@@ -73,11 +73,7 @@ export function generate(replicationGroupId: string): string {
     const ts = Date.now();
     lastSeq = lastTimestamp === ts ? lastSeq + 1 : 0;
     lastTimestamp = ts;
-    return (
-        padLeft(MAX_TS - lastTimestamp, TEMPLATE_TS) +
-        padLeft(MAX_SEQ - lastSeq, TEMPLATE_SEQ) +
-        repGroupId
-    );
+    return padLeft(MAX_TS - lastTimestamp, TEMPLATE_TS) + padLeft(MAX_SEQ - lastSeq, TEMPLATE_SEQ) + repGroupId;
 }
 
 /**
@@ -113,8 +109,7 @@ export function decode(str: string): string | Error {
         return decoded;
     }
     if (decoded.length !== MICRO_VERSION_ID_LENGTH) {
-        return new Error(
-            `decoded microVersionId has invalid length ${decoded.length}`);
+        return new Error(`decoded microVersionId has invalid length ${decoded.length}`);
     }
     return decoded;
 }

--- a/lib/versioning/MicroVersionId.ts
+++ b/lib/versioning/MicroVersionId.ts
@@ -1,0 +1,140 @@
+// MicroVersionId format (27 chars, same ts+seq+rg layout as VersionId):
+//         timestamp  sequential_position  rep_group_id
+// where:
+// - timestamp              14 bytes        MAX_TS - epoch_ms (reversed for newest-first ordering)
+// - sequential_position    06 bytes        MAX_SEQ - position in the ms slot (reversed)
+// - rep_group_id           07 bytes        replication group id (space-padded right, truncated if longer)
+//
+// Lexicographic order matches reverse-chronological order (newer < older),
+// matching the VersionId scheme. The encoded form is the 54-char hex
+// representation of the raw 27-char string.
+//
+// Example (raw):     "98283606399999999999RG001  "
+//                     └──── ts ────┘└─seq─┘└─rg──┘
+// Example (encoded): "3938323833363036333939...5247303031 2020" (54 hex chars)
+//
+// The rep_group_id segment makes microVersionIds unique across writers
+// that can generate ids at the same millisecond (e.g. concurrent writers
+// bypassing CloudServer, like the CRR resync tool). State is local to
+// this module so that microVersionId generation does not perturb
+// versionId sequencing.
+
+import {
+    hexEncode,
+    hexDecode,
+    LENGTH_TS,
+    LENGTH_SEQ,
+    LENGTH_RG,
+    TEMPLATE_TS,
+    TEMPLATE_SEQ,
+    TEMPLATE_RG,
+    MAX_TS,
+    MAX_SEQ,
+    padLeft,
+    padRight,
+    wait,
+} from './VersionID';
+
+const MICRO_VERSION_ID_LENGTH = LENGTH_TS + LENGTH_SEQ + LENGTH_RG;
+const ENCODED_LENGTH = MICRO_VERSION_ID_LENGTH * 2;
+
+let lastTimestamp = 0;
+let lastSeq = 0;
+
+/**
+ * Generate a timestamp-ordered microVersionId.
+ *
+ * The returned value is a 27-character string where the timestamp and
+ * sequence are stored in reversed form (MAX - value), followed by the
+ * replication group id normalized to {@link LENGTH_RG} characters
+ * (space-padded if shorter, truncated if longer). String comparison
+ * orders microVersionIds from newest to oldest, matching the
+ * versionId scheme.
+ *
+ * @param replicationGroupId - replication group id. Normally a
+ *   configured, stable value identifying the writer's cluster (same
+ *   one passed to {@link generateVersionId}). Callers bypassing
+ *   CloudServer that have no such stable identity (e.g. the CRR
+ *   resync tool) should supply a random token to avoid colliding with
+ *   concurrent writers.
+ *
+ * @return - the generated microVersionId
+ *
+ * @example
+ *   generate('RG001')
+ *   // => '98283606399999999999RG001  '
+ *   //     └── MAX_TS-now ──┘└MAX_SEQ┘└pad┘
+ */
+export function generate(replicationGroupId: string): string {
+    const repGroupId = padRight(replicationGroupId, TEMPLATE_RG);
+    if (lastTimestamp === 0) {
+        wait(1000000);
+    }
+    const ts = Date.now();
+    lastSeq = lastTimestamp === ts ? lastSeq + 1 : 0;
+    lastTimestamp = ts;
+    return (
+        padLeft(MAX_TS - lastTimestamp, TEMPLATE_TS) +
+        padLeft(MAX_SEQ - lastSeq, TEMPLATE_SEQ) +
+        repGroupId
+    );
+}
+
+/**
+ * Encode a microVersionId to obscure its internal structure.
+ *
+ * @param str - the microVersionId to encode
+ * @return - the encoded microVersionId
+ *
+ * @example
+ *   encode('98283606399999999999RG001  ')
+ *   // => '3938323833363036333939...5247303031 2020' (54 hex chars)
+ */
+export function encode(str: string): string {
+    return hexEncode(str);
+}
+
+/**
+ * Decode an encoded microVersionId back to its raw form.
+ *
+ * @param str - the encoded microVersionId to decode
+ * @return - the decoded microVersionId or an Error
+ *
+ * @example
+ *   decode('3938323833363036333939...5247303031 2020')
+ *   // => '98283606399999999999RG001  '
+ */
+export function decode(str: string): string | Error {
+    if (str.length !== ENCODED_LENGTH || !/^[0-9a-f]+$/.test(str)) {
+        return new Error('microVersionId is not in the current format');
+    }
+    const decoded = hexDecode(str);
+    if (decoded instanceof Error) {
+        return decoded;
+    }
+    if (decoded.length !== MICRO_VERSION_ID_LENGTH) {
+        return new Error(
+            `decoded microVersionId has invalid length ${decoded.length}`);
+    }
+    return decoded;
+}
+
+/**
+ * Compare two microVersionIds chronologically.
+ *
+ * Because microVersionIds use the reversed-time encoding, the
+ * lexicographically smaller value is the more recent one. This
+ * function returns a positive number if {@code a} is more recent
+ * than {@code b}, a negative number if {@code a} is older, and 0
+ * if both refer to the same instant.
+ *
+ * @param a - first microVersionId (raw, non-encoded form)
+ * @param b - second microVersionId (raw, non-encoded form)
+ * @return - positive if a is newer than b, negative if older, 0 if equal
+ */
+export function compare(a: string, b: string): number {
+    if (a === b) {
+        return 0;
+    }
+    return a < b ? 1 : -1;
+}

--- a/lib/versioning/MicroVersionId.ts
+++ b/lib/versioning/MicroVersionId.ts
@@ -20,26 +20,20 @@
 // versionId sequencing.
 
 import {
+    TS_SEQ_RG_LENGTH,
     hexEncode,
     hexDecode,
-    LENGTH_TS,
-    LENGTH_SEQ,
-    LENGTH_RG,
-    TEMPLATE_TS,
-    TEMPLATE_SEQ,
-    TEMPLATE_RG,
-    MAX_TS,
-    MAX_SEQ,
-    padLeft,
-    padRight,
-    wait,
-} from './VersionID';
+    createTimestampSequenceGenerator,
+    compare as tsIdCompare,
+} from './TimestampId';
 
-const MICRO_VERSION_ID_LENGTH = LENGTH_TS + LENGTH_SEQ + LENGTH_RG;
+const MICRO_VERSION_ID_LENGTH = TS_SEQ_RG_LENGTH;
 const ENCODED_LENGTH = MICRO_VERSION_ID_LENGTH * 2;
 
-let lastTimestamp = 0;
-let lastSeq = 0;
+// Stateful ts+seq+rg generator owning the lastTimestamp/lastSeq counters
+// for microVersionId generation. Kept separate from versionId state so
+// microVersionId generation does not perturb versionId sequencing.
+const generateTsSeqRg = createTimestampSequenceGenerator();
 
 /**
  * Generate a timestamp-ordered microVersionId.
@@ -66,14 +60,7 @@ let lastSeq = 0;
  *   //     └── MAX_TS-now ──┘└MAX_SEQ┘└pad┘
  */
 export function generate(replicationGroupId: string): string {
-    const repGroupId = padRight(replicationGroupId, TEMPLATE_RG);
-    if (lastTimestamp === 0) {
-        wait(1000000);
-    }
-    const ts = Date.now();
-    lastSeq = lastTimestamp === ts ? lastSeq + 1 : 0;
-    lastTimestamp = ts;
-    return padLeft(MAX_TS - lastTimestamp, TEMPLATE_TS) + padLeft(MAX_SEQ - lastSeq, TEMPLATE_SEQ) + repGroupId;
+    return generateTsSeqRg(replicationGroupId);
 }
 
 /**
@@ -104,32 +91,27 @@ export function decode(str: string): string | Error {
     if (str.length !== ENCODED_LENGTH || !/^[0-9a-f]+$/.test(str)) {
         return new Error('microVersionId is not in the current format');
     }
+
     const decoded = hexDecode(str);
     if (decoded instanceof Error) {
         return decoded;
     }
+
     if (decoded.length !== MICRO_VERSION_ID_LENGTH) {
         return new Error(`decoded microVersionId has invalid length ${decoded.length}`);
     }
+
     return decoded;
 }
 
 /**
- * Compare two microVersionIds chronologically.
- *
- * Because microVersionIds use the reversed-time encoding, the
- * lexicographically smaller value is the more recent one. This
- * function returns a positive number if {@code a} is more recent
- * than {@code b}, a negative number if {@code a} is older, and 0
- * if both refer to the same instant.
+ * Compare two microVersionIds chronologically. Thin wrapper over
+ * {@link tsIdCompare} preserved for callers importing from this module.
  *
  * @param a - first microVersionId (raw, non-encoded form)
  * @param b - second microVersionId (raw, non-encoded form)
  * @return - positive if a is newer than b, negative if older, 0 if equal
  */
 export function compare(a: string, b: string): number {
-    if (a === b) {
-        return 0;
-    }
-    return a < b ? 1 : -1;
+    return tsIdCompare(a, b);
 }

--- a/lib/versioning/TimestampId.ts
+++ b/lib/versioning/TimestampId.ts
@@ -20,37 +20,42 @@ export const LENGTH_RG = 7; // replication group id
 // length of the canonical ts+seq+rg backbone (27 characters)
 export const TS_SEQ_RG_LENGTH = LENGTH_TS + LENGTH_SEQ + LENGTH_RG;
 
-// empty string templates for the variables in a versionId
-export const TEMPLATE_TS = new Array(LENGTH_TS + 1).join('0');
-export const TEMPLATE_SEQ = new Array(LENGTH_SEQ + 1).join('0');
-export const TEMPLATE_RG = new Array(LENGTH_RG + 1).join(' ');
+// empty string templates kept for backwards compatibility with callers
+// that import them directly. New code should use padStart/padEnd.
+export const TEMPLATE_TS = '0'.repeat(LENGTH_TS);
+export const TEMPLATE_SEQ = '0'.repeat(LENGTH_SEQ);
+export const TEMPLATE_RG = ' '.repeat(LENGTH_RG);
 
 // constants for max epoch and max sequential number in the same epoch
-export const MAX_TS = Math.pow(10, LENGTH_TS) - 1; // good until 16 Nov 5138
-export const MAX_SEQ = Math.pow(10, LENGTH_SEQ) - 1; // good for 1 billion ops
+export const MAX_TS = 10 ** LENGTH_TS - 1; // good until 16 Nov 5138
+export const MAX_SEQ = 10 ** LENGTH_SEQ - 1; // good for 1 billion ops
 
 /**
- * Left-pad a string representation of a value with a given template.
- * For example: pad('foo', '00000') gives '00foo'.
+ * Left-pad a value to the template's length using its first character
+ * as the fill. Thin wrapper over {@link String.prototype.padStart}
+ * preserved for callers that still pass a template string.
  *
  * @param value - value to pad
- * @param template - padding template
+ * @param template - padding template; its first character is used as
+ *   the fill, and its length as the target width
  * @return - padded string
  */
-export function padLeft(value: any, template: string) {
-    return `${template}${value}`.slice(-template.length);
+export function padLeft(value: any, template: string): string {
+    return String(value).padStart(template.length, template[0]).slice(-template.length);
 }
 
 /**
- * Right-pad a string representation of a value with a given template.
- * For example: pad('foo', '00000') gives 'foo00'.
+ * Right-pad a value to the template's length using its first character
+ * as the fill, truncating from the right if the value is longer than
+ * the template.
  *
  * @param value - value to pad
- * @param template - padding template
- * @return - padded string
+ * @param template - padding template; its first character is used as
+ *   the fill, and its length as the target width
+ * @return - padded (or truncated) string
  */
-export function padRight(value: any, template: string) {
-    return `${value}${template}`.slice(0, template.length);
+export function padRight(value: any, template: string): string {
+    return String(value).padEnd(template.length, template[0]).slice(0, template.length);
 }
 
 /**
@@ -98,8 +103,16 @@ export function hexDecode(str: string): string | Error {
     } catch (err) {
         // Buffer.from() may throw TypeError if invalid input, e.g. non-string
         // or string with inappropriate charlength
-        return err as any;
+        return err as Error;
     }
+}
+
+/**
+ * Normalize a replication group id to exactly {@link LENGTH_RG}
+ * characters: space-padded if shorter, truncated if longer.
+ */
+function normalizeRg(replicationGroupId: string): string {
+    return replicationGroupId.padEnd(LENGTH_RG, ' ').slice(0, LENGTH_RG);
 }
 
 /**
@@ -123,7 +136,7 @@ export function createTimestampSequenceGenerator(): (replicationGroupId: string)
     let lastSeq = 0;
 
     return function generate(replicationGroupId: string): string {
-        const repGroupId = padRight(replicationGroupId, TEMPLATE_RG);
+        const rg = normalizeRg(replicationGroupId);
 
         // Wait for the millisecond slot to "flush" on first call after
         // module load, to guarantee uniqueness across restarts.
@@ -138,7 +151,9 @@ export function createTimestampSequenceGenerator(): (replicationGroupId: string)
         lastSeq = lastTimestamp === ts ? lastSeq + 1 : 0;
         lastTimestamp = ts;
 
-        return padLeft(MAX_TS - lastTimestamp, TEMPLATE_TS) + padLeft(MAX_SEQ - lastSeq, TEMPLATE_SEQ) + repGroupId;
+        const tsPart = String(MAX_TS - lastTimestamp).padStart(LENGTH_TS, '0');
+        const seqPart = String(MAX_SEQ - lastSeq).padStart(LENGTH_SEQ, '0');
+        return tsPart + seqPart + rg;
     };
 }
 
@@ -153,8 +168,8 @@ export function createTimestampSequenceGenerator(): (replicationGroupId: string)
  * @return - the 27-character sentinel id
  */
 export function getInfId(replicationGroupId: string): string {
-    const repGroupId = padRight(replicationGroupId, TEMPLATE_RG);
-    return padLeft(MAX_TS, TEMPLATE_TS) + padLeft(MAX_SEQ, TEMPLATE_SEQ) + repGroupId;
+    // MAX_TS and MAX_SEQ are already at their full digit width.
+    return String(MAX_TS) + String(MAX_SEQ) + normalizeRg(replicationGroupId);
 }
 
 /**

--- a/lib/versioning/TimestampId.ts
+++ b/lib/versioning/TimestampId.ts
@@ -1,0 +1,200 @@
+// Shared building blocks for versionId-like identifiers.
+//
+// The canonical layout produced by {@link createTimestampSequenceGenerator}
+// is a 27-character string:
+//         timestamp  sequential_position  rep_group_id
+// where:
+// - timestamp              14 bytes        MAX_TS - epoch_ms (reversed)
+// - sequential_position    06 bytes        MAX_SEQ - position in the ms slot (reversed)
+// - rep_group_id           07 bytes        replication group id (space-padded, truncated if longer)
+//
+// Reversing timestamp and sequence makes lexicographic order match
+// reverse-chronological order (newest first), which is what callers
+// listing keys in leveldb-style stores rely on.
+
+// the lengths of the components in bytes
+export const LENGTH_TS = 14; // timestamp: epoch in ms
+export const LENGTH_SEQ = 6; // position in ms slot
+export const LENGTH_RG = 7; // replication group id
+
+// length of the canonical ts+seq+rg backbone (27 characters)
+export const TS_SEQ_RG_LENGTH = LENGTH_TS + LENGTH_SEQ + LENGTH_RG;
+
+// empty string templates for the variables in a versionId
+export const TEMPLATE_TS = new Array(LENGTH_TS + 1).join('0');
+export const TEMPLATE_SEQ = new Array(LENGTH_SEQ + 1).join('0');
+export const TEMPLATE_RG = new Array(LENGTH_RG + 1).join(' ');
+
+// constants for max epoch and max sequential number in the same epoch
+export const MAX_TS = Math.pow(10, LENGTH_TS) - 1; // good until 16 Nov 5138
+export const MAX_SEQ = Math.pow(10, LENGTH_SEQ) - 1; // good for 1 billion ops
+
+/**
+ * Left-pad a string representation of a value with a given template.
+ * For example: pad('foo', '00000') gives '00foo'.
+ *
+ * @param value - value to pad
+ * @param template - padding template
+ * @return - padded string
+ */
+export function padLeft(value: any, template: string) {
+    return `${template}${value}`.slice(-template.length);
+}
+
+/**
+ * Right-pad a string representation of a value with a given template.
+ * For example: pad('foo', '00000') gives 'foo00'.
+ *
+ * @param value - value to pad
+ * @param template - padding template
+ * @return - padded string
+ */
+export function padRight(value: any, template: string) {
+    return `${value}${template}`.slice(0, template.length);
+}
+
+/**
+ * This function ACTIVELY (wastes CPU cycles and) waits for an amount of time
+ * before returning to the caller. This should not be used frequently.
+ *
+ * @param span - time to wait in nanoseconds (1/1000000 millisecond)
+ * @return - nothing
+ */
+export function wait(span: number) {
+    function getspan(diff: [number, number]) {
+        return diff[0] * 1e9 + diff[1];
+    }
+    const start = process.hrtime();
+    while (getspan(process.hrtime(start)) < span) {
+        // do nothing
+    }
+}
+
+/**
+ * Encode a string to its hex representation. Used to obscure the
+ * internal structure of a versionId-like identifier.
+ *
+ * @param str - the string to encode
+ * @return - the hex-encoded string
+ */
+export function hexEncode(str: string): string {
+    return Buffer.from(str, 'utf8').toString('hex');
+}
+
+/**
+ * Decode a hex-encoded string. Returns an Error if the input is not
+ * valid hex or decodes to an empty string.
+ *
+ * @param str - the hex-encoded string to decode
+ * @return - the decoded string or an Error
+ */
+export function hexDecode(str: string): string | Error {
+    try {
+        const result = Buffer.from(str, 'hex').toString('utf8');
+        if (result === '') {
+            return new Error('invalid decoded value');
+        }
+        return result;
+    } catch (err) {
+        // Buffer.from() may throw TypeError if invalid input, e.g. non-string
+        // or string with inappropriate charlength
+        return err as any;
+    }
+}
+
+/**
+ * Build a stateful generator producing the 27-character
+ * `timestamp + sequential_position + rep_group_id` backbone shared by
+ * {@link generateVersionId} and microVersionId generation.
+ *
+ * The returned function keeps its own `lastTimestamp` / `lastSeq`
+ * state, so each caller (versionId vs microVersionId) maintains an
+ * independent counter and one stream cannot perturb the other.
+ *
+ * Timestamps and sequence numbers are stored in reversed form
+ * (MAX - value) so that lexicographic ordering yields newest-first
+ * results.
+ *
+ * @return - a function that, given a replicationGroupId, returns the
+ *   27-character ts+seq+rg prefix for the current instant
+ */
+export function createTimestampSequenceGenerator(): (replicationGroupId: string) => string {
+    let lastTimestamp = 0;
+    let lastSeq = 0;
+
+    return function generate(replicationGroupId: string): string {
+        const repGroupId = padRight(replicationGroupId, TEMPLATE_RG);
+
+        // Wait for the millisecond slot to "flush" on first call after
+        // module load, to guarantee uniqueness across restarts.
+        if (lastTimestamp === 0) {
+            wait(1000000);
+        }
+
+        // A sequence number is used (rather than nanosecond clocks) because
+        // concurrent requests within the same millisecond must still get
+        // unique, monotonically-ordered ids based on their queue position.
+        const ts = Date.now();
+        lastSeq = lastTimestamp === ts ? lastSeq + 1 : 0;
+        lastTimestamp = ts;
+
+        return padLeft(MAX_TS - lastTimestamp, TEMPLATE_TS) + padLeft(MAX_SEQ - lastSeq, TEMPLATE_SEQ) + repGroupId;
+    };
+}
+
+/**
+ * Build a sentinel id representing the earliest possible position in
+ * the reverse-chronological ordering. Produced by combining MAX_TS
+ * and MAX_SEQ with the given replication group id; useful as a lower
+ * bound for "versions before versioning" markers.
+ *
+ * @param replicationGroupId - replication group id (space-padded /
+ *   truncated to {@link LENGTH_RG})
+ * @return - the 27-character sentinel id
+ */
+export function getInfId(replicationGroupId: string): string {
+    const repGroupId = padRight(replicationGroupId, TEMPLATE_RG);
+    return padLeft(MAX_TS, TEMPLATE_TS) + padLeft(MAX_SEQ, TEMPLATE_SEQ) + repGroupId;
+}
+
+/**
+ * Decompose a 27-character ts+seq+rg id into its components,
+ * un-reversing the timestamp and sequence so they read as wall-clock
+ * values. The replication group id is returned trimmed of trailing
+ * spaces.
+ *
+ * @param id - the raw, non-encoded ts+seq+rg id (typically the
+ *   {@link TS_SEQ_RG_LENGTH}-character prefix of a longer identifier)
+ * @return - parsed components, or an Error if the input is too short
+ *   or contains a non-numeric timestamp/sequence
+ */
+export function parse(id: string): { ts: number; seq: number; rg: string } | Error {
+    if (id.length < TS_SEQ_RG_LENGTH) {
+        return new Error(`id too short: expected at least ${TS_SEQ_RG_LENGTH} chars, got ${id.length}`);
+    }
+    const reversedTs = Number(id.substring(0, LENGTH_TS));
+    const reversedSeq = Number(id.substring(LENGTH_TS, LENGTH_TS + LENGTH_SEQ));
+    if (!Number.isFinite(reversedTs) || !Number.isFinite(reversedSeq)) {
+        return new Error('id has non-numeric timestamp or sequence');
+    }
+    const rg = id.substring(LENGTH_TS + LENGTH_SEQ, TS_SEQ_RG_LENGTH).trimEnd();
+    return { ts: MAX_TS - reversedTs, seq: MAX_SEQ - reversedSeq, rg };
+}
+
+/**
+ * Compare two ts+seq+rg ids chronologically. Because the encoding
+ * reverses time, the lexicographically smaller value is the more
+ * recent one. Returns a positive number if {@code a} is newer than
+ * {@code b}, a negative number if {@code a} is older, and 0 if both
+ * refer to the same id.
+ *
+ * @param a - first id (raw, non-encoded form)
+ * @param b - second id (raw, non-encoded form)
+ * @return - positive if a is newer than b, negative if older, 0 if equal
+ */
+export function compare(a: string, b: string): number {
+    if (a === b) {
+        return 0;
+    }
+    return a < b ? 1 : -1;
+}

--- a/lib/versioning/TimestampId.ts
+++ b/lib/versioning/TimestampId.ts
@@ -115,6 +115,14 @@ function normalizeRg(replicationGroupId: string): string {
     return replicationGroupId.padEnd(LENGTH_RG, ' ').slice(0, LENGTH_RG);
 }
 
+// Process-wide guard for the post-boot millisecond flush. The wait
+// exists to push Date.now() past any millisecond a pre-crash process
+// might have used; once any code path in the process has waited, the
+// clock has moved on and additional waits are redundant. Hoisted out
+// of the generator closure so generators created later in the process
+// don't pay the cost again.
+let hasWaitedAtBoot = false;
+
 /**
  * Build a stateful generator producing the 27-character
  * `timestamp + sequential_position + rep_group_id` backbone shared by
@@ -122,7 +130,9 @@ function normalizeRg(replicationGroupId: string): string {
  *
  * The returned function keeps its own `lastTimestamp` / `lastSeq`
  * state, so each caller (versionId vs microVersionId) maintains an
- * independent counter and one stream cannot perturb the other.
+ * independent counter and one stream cannot perturb the other. The
+ * post-boot ms-flush wait is shared across all generators (see
+ * {@link hasWaitedAtBoot}).
  *
  * Timestamps and sequence numbers are stored in reversed form
  * (MAX - value) so that lexicographic ordering yields newest-first
@@ -138,10 +148,9 @@ export function createTimestampSequenceGenerator(): (replicationGroupId: string)
     return function generate(replicationGroupId: string): string {
         const rg = normalizeRg(replicationGroupId);
 
-        // Wait for the millisecond slot to "flush" on first call after
-        // module load, to guarantee uniqueness across restarts.
-        if (lastTimestamp === 0) {
+        if (!hasWaitedAtBoot) {
             wait(1000000);
+            hasWaitedAtBoot = true;
         }
 
         // A sequence number is used (rather than nanosecond clocks) because

--- a/lib/versioning/VersionID.ts
+++ b/lib/versioning/VersionID.ts
@@ -30,12 +30,6 @@ import {
     LENGTH_TS,
     LENGTH_SEQ,
     LENGTH_RG,
-    TEMPLATE_TS,
-    TEMPLATE_SEQ,
-    TEMPLATE_RG,
-    MAX_TS,
-    MAX_SEQ,
-    padLeft,
     padRight,
     hexEncode,
     hexDecode,
@@ -46,15 +40,10 @@ import {
 const BASE62 = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 const base62String = baseX(BASE62);
 
-// Re-exports for backwards compatibility with existing importers.
-export { LENGTH_TS, LENGTH_SEQ, LENGTH_RG, TEMPLATE_TS, TEMPLATE_SEQ, TEMPLATE_RG, MAX_TS, MAX_SEQ };
-export { padLeft, padRight, hexEncode, hexDecode };
-export { wait } from './TimestampId';
-
 const LENGTH_ID = 6; // instance id
 const LENGTH_FT = 2; // version ID format, 1 byte + separator
 
-const TEMPLATE_ID = new Array(LENGTH_ID + 1).join('0');
+const TEMPLATE_ID = '0'.repeat(LENGTH_ID);
 
 export const S3_VERSION_ID_ENCODING_TYPE = process.env.S3_VERSION_ID_ENCODING_TYPE;
 

--- a/lib/versioning/VersionID.ts
+++ b/lib/versioning/VersionID.ts
@@ -30,16 +30,16 @@ const BASE62 = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 const base62String = baseX(BASE62);
 
 // the lengths of the components in bytes
-const LENGTH_TS = 14; // timestamp: epoch in ms
-const LENGTH_SEQ = 6; // position in ms slot
-const LENGTH_RG = 7; // replication group id
+export const LENGTH_TS = 14; // timestamp: epoch in ms
+export const LENGTH_SEQ = 6; // position in ms slot
+export const LENGTH_RG = 7; // replication group id
 const LENGTH_ID = 6; // instance id
 const LENGTH_FT = 2; // version ID format, 1 byte + separator
 
 // empty string template for the variables in a versionId
-const TEMPLATE_TS = new Array(LENGTH_TS + 1).join('0');
-const TEMPLATE_SEQ = new Array(LENGTH_SEQ + 1).join('0');
-const TEMPLATE_RG = new Array(LENGTH_RG + 1).join(' ');
+export const TEMPLATE_TS = new Array(LENGTH_TS + 1).join('0');
+export const TEMPLATE_SEQ = new Array(LENGTH_SEQ + 1).join('0');
+export const TEMPLATE_RG = new Array(LENGTH_RG + 1).join(' ');
 const TEMPLATE_ID = new Array(LENGTH_ID + 1).join('0');
 
 export const S3_VERSION_ID_ENCODING_TYPE = process.env.S3_VERSION_ID_ENCODING_TYPE;
@@ -73,7 +73,7 @@ const BASE62_ENCODED_LENGTH = 32;
  * @param template - padding template
  * @return - padded string
  */
-function padLeft(value: any, template: string) {
+export function padLeft(value: any, template: string) {
     return `${template}${value}`.slice(-template.length);
 }
 
@@ -85,13 +85,13 @@ function padLeft(value: any, template: string) {
  * @param template - padding template
  * @return - padded string
  */
-function padRight(value: any, template: string) {
+export function padRight(value: any, template: string) {
     return `${value}${template}`.slice(0, template.length);
 }
 
 // constants for max epoch and max sequential number in the same epoch
-const MAX_TS = Math.pow(10, LENGTH_TS) - 1; // good until 16 Nov 5138
-const MAX_SEQ = Math.pow(10, LENGTH_SEQ) - 1; // good for 1 billion ops
+export const MAX_TS = Math.pow(10, LENGTH_TS) - 1; // good until 16 Nov 5138
+export const MAX_SEQ = Math.pow(10, LENGTH_SEQ) - 1; // good for 1 billion ops
 
 /**
  * Generates the earliest versionId, used for versions before versioning
@@ -119,7 +119,7 @@ let lastSeq = 0; // sequential number of the last versionId
  * @param span - time to wait in nanoseconds (1/1000000 millisecond)
  * @return - nothing
  */
-function wait(span: number) {
+export function wait(span: number) {
     function getspan(diff: [number, number]) {
         return diff[0] * 1e9 + diff[1];
     }

--- a/lib/versioning/VersionID.ts
+++ b/lib/versioning/VersionID.ts
@@ -53,8 +53,7 @@ export const S3_VERSION_ID_ENCODING_TYPE = process.env.S3_VERSION_ID_ENCODING_TY
 //   - Uses old format: timestamp + sequential_position + rep_group_id (legacy 27-char format)
 // Falls back to hex encoding if S3_VERSION_ID_ENCODING_TYPE is 'hex' or unset
 export const ENABLE_FORMATTED_VERSION_ID =
-    process.env.ENABLE_FORMATTED_VERSION_ID === 'true' ||
-    process.env.ENABLE_FORMATTED_VERSION_ID === '1';
+    process.env.ENABLE_FORMATTED_VERSION_ID === 'true' || process.env.ENABLE_FORMATTED_VERSION_ID === '1';
 
 // version ID format added to the end of the version ID
 const VERSION_ID_FORMAT_VERSION = '1';
@@ -101,11 +100,7 @@ export const MAX_SEQ = Math.pow(10, LENGTH_SEQ) - 1; // good for 1 billion ops
  */
 export function getInfVid(replicationGroupId: string) {
     const repGroupId = padRight(replicationGroupId, TEMPLATE_RG);
-    return (
-        padLeft(MAX_TS, TEMPLATE_TS) +
-        padLeft(MAX_SEQ, TEMPLATE_SEQ) +
-        repGroupId
-    );
+    return padLeft(MAX_TS, TEMPLATE_TS) + padLeft(MAX_SEQ, TEMPLATE_SEQ) + repGroupId;
 }
 
 // internal state of the module
@@ -232,9 +227,7 @@ export function hexDecode(str: string): string | Error {
  */
 const B62V_TOTAL = LENGTH_TS + LENGTH_SEQ;
 const B62V_HALF = B62V_TOTAL / 2;
-const B62V_EPAD = '0'.repeat(
-    Math.ceil(B62V_HALF * (Math.log(10) / Math.log(62)))
-);
+const B62V_EPAD = '0'.repeat(Math.ceil(B62V_HALF * (Math.log(10) / Math.log(62))));
 const B62V_DPAD = '0'.repeat(B62V_HALF);
 const B62V_STRING_EPAD = '0'.repeat(32 - 2 * B62V_EPAD.length);
 
@@ -355,11 +348,14 @@ export function decode(str: string): string | Error {
         const decoded: string | Error = base62Decode(str);
         // Legacy base62 version IDs (without 'info' field) are always 27 characters long.
         // The new base62 format is always 35 characters long.
-        if (typeof decoded === 'string' &&
+        if (
+            typeof decoded === 'string' &&
             decoded.length !== LEGACY_BASE62_DECODED_LENGTH &&
-            decoded.length !== BASE62_DECODED_LENGTH) {
-            return new Error(`decoded ${str} is not length ` +
-                `${LEGACY_BASE62_DECODED_LENGTH} or ${BASE62_DECODED_LENGTH}`);
+            decoded.length !== BASE62_DECODED_LENGTH
+        ) {
+            return new Error(
+                `decoded ${str} is not length ` + `${LEGACY_BASE62_DECODED_LENGTH} or ${BASE62_DECODED_LENGTH}`,
+            );
         }
         return decoded;
     }

--- a/lib/versioning/VersionID.ts
+++ b/lib/versioning/VersionID.ts
@@ -78,9 +78,6 @@ export function getInfVid(replicationGroupId: string): string {
     return getInfId(replicationGroupId);
 }
 
-// Stateful ts+seq+rg generator owning the lastTimestamp/lastSeq counters
-// for versionId generation. Kept separate from microVersionId state so
-// the two streams don't interfere.
 const generateTsSeqRg = createTimestampSequenceGenerator();
 
 /**

--- a/lib/versioning/VersionID.ts
+++ b/lib/versioning/VersionID.ts
@@ -160,17 +160,8 @@ export function base62Decode(str: string): string | Error {
         const enc2 = str.substring(start, start + B62V_EPAD.length);
         const orig2 = base62Integer.decode(enc2);
         start += B62V_EPAD.length;
-        let enc3 = str.substring(start);
-        // take off prefix 0s which represent null bytes
-        let idx = 0;
-        while (idx < enc3.length) {
-            if (enc3[idx] === '0') {
-                idx++;
-            } else {
-                break;
-            }
-        }
-        enc3 = enc3.slice(idx);
+        // strip prefix 0s which represent null bytes
+        const enc3 = str.substring(start).replace(/^0+/, '');
         const orig3 = base62String.decode(enc3);
 
         return (

--- a/lib/versioning/VersionID.ts
+++ b/lib/versioning/VersionID.ts
@@ -188,27 +188,21 @@ export const ENC_TYPE_HEX = 0; // legacy (large) encoding
 export const ENC_TYPE_BASE62 = 1; // new (tiny) encoding
 
 /**
- * Checks if the given versionId string contains the specified format version.
+ * Checks whether the given versionId carries the current format
+ * marker + version suffix at its end.
  *
- * @param versionId - The versionId string to check.
- * @param version - The expected format version.
- * @returns true if the versionId contains the format marker and version, false otherwise.
+ * @param versionId - the versionId string to check
+ * @returns true if the versionId ends with the current format suffix
  */
-function hasVersionIDFormat(versionId: string, version: string): boolean {
+function hasCurrentFormatSuffix(versionId: string): boolean {
     // Format marker can only exist after the required versionId sections.
     // This check removes the risk of looking for the format marker in the
     // replication group ID, which can technically contain any character as
     // it's set by the end user.
     if (versionId.length < LENGTH_TS + LENGTH_SEQ + LENGTH_RG + LENGTH_FT) {
-        return false; // Not enough characters for format marker
+        return false;
     }
-    // For constant time lookup, we always assume that the format marker is
-    // at the end of the versionId.
-    const formatMarkerIdx = versionId.length - LENGTH_FT;
-    if (versionId.charAt(formatMarkerIdx) !== VersioningConstants.VersionId.FormatMarker) {
-        return false; // no format marker
-    }
-    return versionId.substring(formatMarkerIdx + 1) === version; // check if the version matches
+    return versionId.endsWith(VERSION_ID_FORMAT_SUFFIX);
 }
 
 /**
@@ -223,7 +217,7 @@ function hasVersionIDFormat(versionId: string, version: string): boolean {
 export function encode(str: string): string {
     // Legacy base62 version IDs (without 'info' field) are always 27 characters long.
     // The new base62 format is 35 characters and includes the format marker at the end.
-    if (str.length === LEGACY_BASE62_DECODED_LENGTH || hasVersionIDFormat(str, VERSION_ID_FORMAT_VERSION)) {
+    if (str.length === LEGACY_BASE62_DECODED_LENGTH || hasCurrentFormatSuffix(str)) {
         return base62Encode(str);
     } // legacy format
     return hexEncode(str);

--- a/lib/versioning/VersionID.ts
+++ b/lib/versioning/VersionID.ts
@@ -26,20 +26,34 @@ import base62Integer from 'base62';
 import baseX from 'base-x';
 import assert from 'assert';
 import { VersioningConstants } from './constants';
+import {
+    LENGTH_TS,
+    LENGTH_SEQ,
+    LENGTH_RG,
+    TEMPLATE_TS,
+    TEMPLATE_SEQ,
+    TEMPLATE_RG,
+    MAX_TS,
+    MAX_SEQ,
+    padLeft,
+    padRight,
+    hexEncode,
+    hexDecode,
+    createTimestampSequenceGenerator,
+    getInfId,
+} from './TimestampId';
+
 const BASE62 = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 const base62String = baseX(BASE62);
 
-// the lengths of the components in bytes
-export const LENGTH_TS = 14; // timestamp: epoch in ms
-export const LENGTH_SEQ = 6; // position in ms slot
-export const LENGTH_RG = 7; // replication group id
+// Re-exports for backwards compatibility with existing importers.
+export { LENGTH_TS, LENGTH_SEQ, LENGTH_RG, TEMPLATE_TS, TEMPLATE_SEQ, TEMPLATE_RG, MAX_TS, MAX_SEQ };
+export { padLeft, padRight, hexEncode, hexDecode };
+export { wait } from './TimestampId';
+
 const LENGTH_ID = 6; // instance id
 const LENGTH_FT = 2; // version ID format, 1 byte + separator
 
-// empty string template for the variables in a versionId
-export const TEMPLATE_TS = new Array(LENGTH_TS + 1).join('0');
-export const TEMPLATE_SEQ = new Array(LENGTH_SEQ + 1).join('0');
-export const TEMPLATE_RG = new Array(LENGTH_RG + 1).join(' ');
 const TEMPLATE_ID = new Array(LENGTH_ID + 1).join('0');
 
 export const S3_VERSION_ID_ENCODING_TYPE = process.env.S3_VERSION_ID_ENCODING_TYPE;
@@ -65,64 +79,20 @@ const BASE62_DECODED_LENGTH = 35;
 const BASE62_ENCODED_LENGTH = 32;
 
 /**
- * Left-pad a string representation of a value with a given template.
- * For example: pad('foo', '00000') gives '00foo'.
- *
- * @param value - value to pad
- * @param template - padding template
- * @return - padded string
- */
-export function padLeft(value: any, template: string) {
-    return `${template}${value}`.slice(-template.length);
-}
-
-/**
- * Right-pad a string representation of a value with a given template.
- * For example: pad('foo', '00000') gives 'foo00'.
- *
- * @param value - value to pad
- * @param template - padding template
- * @return - padded string
- */
-export function padRight(value: any, template: string) {
-    return `${value}${template}`.slice(0, template.length);
-}
-
-// constants for max epoch and max sequential number in the same epoch
-export const MAX_TS = Math.pow(10, LENGTH_TS) - 1; // good until 16 Nov 5138
-export const MAX_SEQ = Math.pow(10, LENGTH_SEQ) - 1; // good for 1 billion ops
-
-/**
- * Generates the earliest versionId, used for versions before versioning
+ * Generates the earliest versionId, used for versions before versioning.
+ * Thin wrapper over {@link getInfId} preserved for backwards compatibility.
  *
  * @param replicationGroupId - replication group id
- * @return version ID for versions before versionig
+ * @return version ID for versions before versioning
  */
-export function getInfVid(replicationGroupId: string) {
-    const repGroupId = padRight(replicationGroupId, TEMPLATE_RG);
-    return padLeft(MAX_TS, TEMPLATE_TS) + padLeft(MAX_SEQ, TEMPLATE_SEQ) + repGroupId;
+export function getInfVid(replicationGroupId: string): string {
+    return getInfId(replicationGroupId);
 }
 
-// internal state of the module
-let lastTimestamp = 0; // epoch of the last versionId
-let lastSeq = 0; // sequential number of the last versionId
-
-/**
- * This function ACTIVELY (wastes CPU cycles and) waits for an amount of time
- * before returning to the caller. This should not be used frequently.
- *
- * @param span - time to wait in nanoseconds (1/1000000 millisecond)
- * @return - nothing
- */
-export function wait(span: number) {
-    function getspan(diff: [number, number]) {
-        return diff[0] * 1e9 + diff[1];
-    }
-    const start = process.hrtime();
-    while (getspan(process.hrtime(start)) < span) {
-        // do nothing
-    }
-}
+// Stateful ts+seq+rg generator owning the lastTimestamp/lastSeq counters
+// for versionId generation. Kept separate from microVersionId state so
+// the two streams don't interfere.
+const generateTsSeqRg = createTimestampSequenceGenerator();
 
 /**
  * This function returns a "versionId" string indicating the current time as a
@@ -137,9 +107,6 @@ export function wait(span: number) {
  * @return - the formated versionId string
  */
 export function generateVersionId(info: string, replicationGroupId: string): string {
-    // replication group ID, like PARIS; will be trimmed if exceed LENGTH_RG
-    const repGroupId = padRight(replicationGroupId, TEMPLATE_RG);
-
     let otherInfo = '';
     let instanceIdPadded = '';
     let formatSuffix = '';
@@ -154,69 +121,7 @@ export function generateVersionId(info: string, replicationGroupId: string): str
         formatSuffix = VERSION_ID_FORMAT_SUFFIX;
     }
 
-    // Need to wait for the millisecond slot got "flushed". We wait for
-    // only a single millisecond when the module is restarted, which is
-    // necessary for the correctness of the system. This is therefore cheap.
-    if (lastTimestamp === 0) {
-        wait(1000000);
-    }
-    // get the present epoch (in millisecond)
-    const ts = Date.now();
-    // A bit more rationale: why do we use a sequence number instead of using
-    // process.hrtime which gives us time in nanoseconds? The idea is that at
-    // any time resolution, some concurrent requests may have the same time due
-    // to the way the OS is queueing requests or getting clock cycles. Our
-    // approach however will give the time based on the position of a request
-    // in the queue for the same millisecond which is supposed to be unique.
-
-    // increase the position if this request is in the same epoch
-    lastSeq = lastTimestamp === ts ? lastSeq + 1 : 0;
-    lastTimestamp = ts;
-
-    // In the default cases, we reverse the chronological order of the
-    // timestamps so that all versions of an object can be retrieved in the
-    // reversed chronological order---newest versions first. This is because of
-    // the limitation of leveldb for listing keys in the reverse order.
-    return (
-        padLeft(MAX_TS - lastTimestamp, TEMPLATE_TS) +
-        padLeft(MAX_SEQ - lastSeq, TEMPLATE_SEQ) +
-        repGroupId +
-        otherInfo +
-        instanceIdPadded +
-        formatSuffix
-    );
-}
-
-/**
- * Encode a versionId to obscure internal information contained
- * in a version ID.
- *
- * @param str - the versionId to encode
- * @return - the encoded versionId
- */
-export function hexEncode(str: string): string {
-    return Buffer.from(str, 'utf8').toString('hex');
-}
-
-/**
- * Decode a versionId. May return an error if the input string is
- * invalid hex string or results in an invalid value.
- *
- * @param str - the encoded versionId to decode
- * @return - the decoded versionId or an error
- */
-export function hexDecode(str: string): string | Error {
-    try {
-        const result = Buffer.from(str, 'hex').toString('utf8');
-        if (result === '') {
-            return new Error('invalid decoded value');
-        }
-        return result;
-    } catch (err) {
-        // Buffer.from() may throw TypeError if invalid input, e.g. non-string
-        // or string with inappropriate charlength
-        return err as any;
-    }
+    return generateTsSeqRg(replicationGroupId) + otherInfo + instanceIdPadded + formatSuffix;
 }
 
 /* base62 version Ids constants:
@@ -237,6 +142,8 @@ const B62V_STRING_EPAD = '0'.repeat(32 - 2 * B62V_EPAD.length);
  *
  * @param str - the versionId to encode
  * @return - the encoded base62VersionId
+ * @throws - if the timestamp/sequence segments cannot be parsed as numbers,
+ *   or if the underlying base62 libraries reject the input
  */
 export function base62Encode(str: string): string {
     const part1 = Number(str.substring(0, B62V_HALF));
@@ -324,6 +231,8 @@ function hasVersionIDFormat(versionId: string, version: string): boolean {
  *
  * @param str - the versionId to encode
  * @return - the encoded versionId
+ * @throws - via {@link base62Encode} when the input has a base62 shape
+ *   (27 chars or carries the format marker) but malformed segments
  */
 export function encode(str: string): string {
     // Legacy base62 version IDs (without 'info' field) are always 27 characters long.

--- a/lib/versioning/index.ts
+++ b/lib/versioning/index.ts
@@ -1,6 +1,7 @@
 export { VersioningConstants } from './constants';
 export { Version, isMasterKey } from './Version';
 export * as VersionID from './VersionID';
+export * as MicroVersionId from './MicroVersionId';
 export { default as WriteGatheringManager } from './WriteGatheringManager';
 export { default as WriteCache } from './WriteCache';
 export { default as VersioningRequestProcessor } from './VersioningRequestProcessor';

--- a/tests/unit/models/ObjectMD.spec.js
+++ b/tests/unit/models/ObjectMD.spec.js
@@ -100,6 +100,7 @@ describe('ObjectMD class setters/getters', () => {
             storageType: '',
             dataStoreVersionId: '',
             isNFS: undefined,
+            isReplica: undefined,
         }],
         ['ReplicationInfo', {
             status: 'PENDING',
@@ -116,10 +117,13 @@ describe('ObjectMD class setters/getters', () => {
             storageType: 'aws_s3',
             dataStoreVersionId: '',
             isNFS: undefined,
+            isReplica: undefined,
         }],
         ['DataStoreName', null, ''],
         ['ReplicationIsNFS', null, false],
         ['ReplicationIsNFS', true],
+        ['ReplicationIsReplica', null, false],
+        ['ReplicationIsReplica', true],
         ['AzureInfo', {
             containerPublicAccess: 'container',
             containerStoredAccessPolicies: [],
@@ -299,18 +303,26 @@ describe('ObjectMD class setters/getters', () => {
     });
 
     it('ObjectMD::microVersionId set', () => {
-        const generatedIds = new Set();
+        const repGroupId = crypto.randomBytes(7).toString('hex').slice(0, 7);
+
+        const generatedIds = [];
         for (let i = 0; i < 100; ++i) {
-            md.updateMicroVersionId();
-            generatedIds.add(md.getMicroVersionId());
+            md.updateMicroVersionId(repGroupId);
+            generatedIds.push(md.getMicroVersionId());
         }
         // all generated IDs should be different
-        assert.strictEqual(generatedIds.size, 100);
+        assert.strictEqual(new Set(generatedIds).size, 100);
         generatedIds.forEach(key => {
-            // length is always 16 in hex because leading 0s are
-            // also encoded in the 8-byte random buffer.
-            assert.strictEqual(key.length, 16);
+            // timestamp (14) + sequence (6) + rep_group_id (7) = 27 chars,
+            // matching the versionId layout.
+            assert.strictEqual(key.length, 27);
         });
+        // microVersionIds are timestamp-ordered with the same reversed
+        // scheme as versionIds: newer values sort before older ones
+        // lexicographically, so the sequence is strictly decreasing.
+        for (let i = 1; i < generatedIds.length; ++i) {
+            assert(generatedIds[i] < generatedIds[i - 1]);
+        }
     });
 
     it('ObjectMD::set/getRetentionMode', () => {

--- a/tests/unit/models/ObjectMD.spec.js
+++ b/tests/unit/models/ObjectMD.spec.js
@@ -1,9 +1,9 @@
 const assert = require('assert');
+const crypto = require('crypto');
 const ObjectMD = require('../../../lib/models/ObjectMD').default;
 const ObjectMDChecksum = require('../../../lib/models/ObjectMDChecksum').default;
 const constants = require('../../../lib/constants');
-const ExternalNullVersionId = require('../../../lib/versioning/constants')
-    .VersioningConstants.ExternalNullVersionId;
+const ExternalNullVersionId = require('../../../lib/versioning/constants').VersioningConstants.ExternalNullVersionId;
 
 const retainDate = new Date();
 retainDate.setDate(retainDate.getDate() + 1);
@@ -53,20 +53,27 @@ describe('ObjectMD class setters/getters', () => {
         ['AmzEncryptionKeyId', 'encryption-key-id'],
         ['AmzEncryptionCustomerAlgorithm', null, ''],
         ['AmzEncryptionCustomerAlgorithm', 'customer-algorithm'],
-        ['Acl', null, {
-            Canned: 'private',
-            FULL_CONTROL: [],
-            WRITE_ACP: [],
-            READ: [],
-            READ_ACP: [],
-        }],
-        ['Acl', {
-            Canned: 'public',
-            FULL_CONTROL: ['id'],
-            WRITE_ACP: ['id'],
-            READ: ['id'],
-            READ_ACP: ['id'],
-        }],
+        [
+            'Acl',
+            null,
+            {
+                Canned: 'private',
+                FULL_CONTROL: [],
+                WRITE_ACP: [],
+                READ: [],
+                READ_ACP: [],
+            },
+        ],
+        [
+            'Acl',
+            {
+                Canned: 'public',
+                FULL_CONTROL: ['id'],
+                WRITE_ACP: ['id'],
+                READ: ['id'],
+                READ_ACP: ['id'],
+            },
+        ],
         ['Key', null, ''],
         ['Key', 'key'],
         ['Location', null, []],
@@ -84,59 +91,73 @@ describe('ObjectMD class setters/getters', () => {
         ['VersionId', null, undefined],
         ['VersionId', '111111'],
         ['Tags', null, {}],
-        ['Tags', {
-            key: 'value',
-        }],
+        [
+            'Tags',
+            {
+                key: 'value',
+            },
+        ],
         ['Tags', null, {}],
         ['UploadId', null, undefined],
         ['UploadId', 'abcdefghi'],
-        ['ReplicationInfo', null, {
-            status: '',
-            backends: [],
-            content: [],
-            destination: '',
-            storageClass: '',
-            role: '',
-            storageType: '',
-            dataStoreVersionId: '',
-            isNFS: undefined,
-            isReplica: undefined,
-        }],
-        ['ReplicationInfo', {
-            status: 'PENDING',
-            backends: [{
-                site: 'zenko',
+        [
+            'ReplicationInfo',
+            null,
+            {
+                status: '',
+                backends: [],
+                content: [],
+                destination: '',
+                storageClass: '',
+                role: '',
+                storageType: '',
+                dataStoreVersionId: '',
+                isNFS: undefined,
+                isReplica: undefined,
+            },
+        ],
+        [
+            'ReplicationInfo',
+            {
                 status: 'PENDING',
-                dataStoreVersionId: 'a',
-            }],
-            content: ['DATA', 'METADATA'],
-            destination: 'destination-bucket',
-            storageClass: 'STANDARD',
-            role: 'arn:aws:iam::account-id:role/src-resource,' +
-                'arn:aws:iam::account-id:role/dest-resource',
-            storageType: 'aws_s3',
-            dataStoreVersionId: '',
-            isNFS: undefined,
-            isReplica: undefined,
-        }],
+                backends: [
+                    {
+                        site: 'zenko',
+                        status: 'PENDING',
+                        dataStoreVersionId: 'a',
+                    },
+                ],
+                content: ['DATA', 'METADATA'],
+                destination: 'destination-bucket',
+                storageClass: 'STANDARD',
+                role: 'arn:aws:iam::account-id:role/src-resource,' + 'arn:aws:iam::account-id:role/dest-resource',
+                storageType: 'aws_s3',
+                dataStoreVersionId: '',
+                isNFS: undefined,
+                isReplica: undefined,
+            },
+        ],
         ['DataStoreName', null, ''],
         ['ReplicationIsNFS', null, false],
         ['ReplicationIsNFS', true],
         ['ReplicationIsReplica', null, false],
         ['ReplicationIsReplica', true],
-        ['AzureInfo', {
-            containerPublicAccess: 'container',
-            containerStoredAccessPolicies: [],
-            containerImmutabilityPolicy: {},
-            containerLegalHoldStatus: false,
-            containerDeletionInProgress: false,
-            blobType: 'BlockBlob',
-            blobContentMD5: 'ABCDEF==',
-            blobCopyInfo: {},
-            blobSequenceNumber: 42,
-            blobAccessTierChangeTime: 'abcdef',
-            blobUncommitted: false,
-        }],
+        [
+            'AzureInfo',
+            {
+                containerPublicAccess: 'container',
+                containerStoredAccessPolicies: [],
+                containerImmutabilityPolicy: {},
+                containerLegalHoldStatus: false,
+                containerDeletionInProgress: false,
+                blobType: 'BlockBlob',
+                blobContentMD5: 'ABCDEF==',
+                blobCopyInfo: {},
+                blobSequenceNumber: 42,
+                blobAccessTierChangeTime: 'abcdef',
+                blobUncommitted: false,
+            },
+        ],
         ['LegalHold', null, false],
         ['LegalHold', true],
         ['RetentionMode', 'GOVERNANCE'],
@@ -157,8 +178,7 @@ describe('ObjectMD class setters/getters', () => {
                 md[`set${property}`](testValue);
             }
             const value = md[`get${property}`]();
-            if ((testValue !== null && typeof testValue === 'object') ||
-                typeof defaultValue === 'object') {
+            if ((testValue !== null && typeof testValue === 'object') || typeof defaultValue === 'object') {
                 assert.deepStrictEqual(value, testValue || defaultValue);
             } else if (testValue !== null) {
                 assert.strictEqual(value, testValue);
@@ -170,31 +190,39 @@ describe('ObjectMD class setters/getters', () => {
 
     it('ObjectMD::setReplicationSiteStatus', () => {
         md.setReplicationInfo({
-            backends: [{
-                site: 'zenko',
-                status: 'PENDING',
-                dataStoreVersionId: 'a',
-            }],
+            backends: [
+                {
+                    site: 'zenko',
+                    status: 'PENDING',
+                    dataStoreVersionId: 'a',
+                },
+            ],
         });
         md.setReplicationSiteStatus('zenko', 'COMPLETED');
-        assert.deepStrictEqual(md.getReplicationInfo().backends, [{
-            site: 'zenko',
-            status: 'COMPLETED',
-            dataStoreVersionId: 'a',
-        }]);
+        assert.deepStrictEqual(md.getReplicationInfo().backends, [
+            {
+                site: 'zenko',
+                status: 'COMPLETED',
+                dataStoreVersionId: 'a',
+            },
+        ]);
     });
 
     it('ObjectMD::setReplicationBackends', () => {
-        md.setReplicationBackends([{
-            site: 'a',
-            status: 'b',
-            dataStoreVersionId: 'c',
-        }]);
-        assert.deepStrictEqual(md.getReplicationBackends(), [{
-            site: 'a',
-            status: 'b',
-            dataStoreVersionId: 'c',
-        }]);
+        md.setReplicationBackends([
+            {
+                site: 'a',
+                status: 'b',
+                dataStoreVersionId: 'c',
+            },
+        ]);
+        assert.deepStrictEqual(md.getReplicationBackends(), [
+            {
+                site: 'a',
+                status: 'b',
+                dataStoreVersionId: 'c',
+            },
+        ]);
     });
 
     it('ObjectMD::setReplicationStorageType', () => {
@@ -221,41 +249,48 @@ describe('ObjectMD class setters/getters', () => {
 
     it('ObjectMD::getReplicationSiteStatus', () => {
         md.setReplicationInfo({
-            backends: [{
-                site: 'zenko',
-                status: 'PENDING',
-                dataStoreVersionId: 'a',
-            }],
+            backends: [
+                {
+                    site: 'zenko',
+                    status: 'PENDING',
+                    dataStoreVersionId: 'a',
+                },
+            ],
         });
         assert.strictEqual(md.getReplicationSiteStatus('zenko'), 'PENDING');
     });
 
     it('ObjectMD::setReplicationSiteDataStoreVersionId', () => {
         md.setReplicationInfo({
-            backends: [{
-                site: 'zenko',
-                status: 'PENDING',
-                dataStoreVersionId: 'a',
-            }],
+            backends: [
+                {
+                    site: 'zenko',
+                    status: 'PENDING',
+                    dataStoreVersionId: 'a',
+                },
+            ],
         });
         md.setReplicationSiteDataStoreVersionId('zenko', 'b');
-        assert.deepStrictEqual(md.getReplicationInfo().backends, [{
-            site: 'zenko',
-            status: 'PENDING',
-            dataStoreVersionId: 'b',
-        }]);
+        assert.deepStrictEqual(md.getReplicationInfo().backends, [
+            {
+                site: 'zenko',
+                status: 'PENDING',
+                dataStoreVersionId: 'b',
+            },
+        ]);
     });
 
     it('ObjectMD::getReplicationSiteDataStoreVersionId', () => {
         md.setReplicationInfo({
-            backends: [{
-                site: 'zenko',
-                status: 'PENDING',
-                dataStoreVersionId: 'a',
-            }],
+            backends: [
+                {
+                    site: 'zenko',
+                    status: 'PENDING',
+                    dataStoreVersionId: 'a',
+                },
+            ],
         });
-        assert.strictEqual(
-            md.getReplicationSiteDataStoreVersionId('zenko'), 'a');
+        assert.strictEqual(md.getReplicationSiteDataStoreVersionId('zenko'), 'a');
     });
 
     it('ObjectMd::isMultipartUpload', () => {
@@ -276,7 +311,7 @@ describe('ObjectMD class setters/getters', () => {
             // This one should be changed to 'x-amz-meta-foobar'
             'x-ms-meta-foobar': 'bar',
             // ACLs are updated
-            'acl': {
+            acl: {
                 FULL_CONTROL: ['john'],
             },
         });
@@ -432,10 +467,8 @@ describe('ObjectMD import from stored blob', () => {
         assert.strictEqual(importedRes.error, undefined);
         const importedMd = importedRes.result;
         const valueImported = importedMd.getValue();
-        assert.strictEqual(valueImported['md-model-version'],
-            constants.mdModelVersion);
-        assert.deepStrictEqual(valueImported.location,
-            [{ key: 'stringLocation' }]);
+        assert.strictEqual(valueImported['md-model-version'], constants.mdModelVersion);
+        assert.deepStrictEqual(valueImported.location, [{ key: 'stringLocation' }]);
     });
 
     it('should keep null location as is', () => {
@@ -462,21 +495,19 @@ describe('ObjectMD import from stored blob', () => {
         assert.strictEqual(importedRes.error, undefined);
         const importedMd = importedRes.result;
         const valueImported = importedMd.getValue();
-        assert.strictEqual(valueImported['md-model-version'],
-            constants.mdModelVersion);
+        assert.strictEqual(valueImported['md-model-version'], constants.mdModelVersion);
         assert.notStrictEqual(valueImported.dataStoreName, undefined);
     });
 
-    it('should return undefined for dataStoreVersionId if no object location',
-        () => {
-            const md = new ObjectMD();
-            const value = md.getValue();
-            const jsonMd = JSON.stringify(value);
-            const importedRes = ObjectMD.createFromBlob(jsonMd);
-            assert.strictEqual(importedRes.error, undefined);
-            const importedMd = importedRes.result;
-            assert.strictEqual(importedMd.getDataStoreVersionId(), undefined);
-        });
+    it('should return undefined for dataStoreVersionId if no object location', () => {
+        const md = new ObjectMD();
+        const value = md.getValue();
+        const jsonMd = JSON.stringify(value);
+        const importedRes = ObjectMD.createFromBlob(jsonMd);
+        assert.strictEqual(importedRes.error, undefined);
+        const importedMd = importedRes.result;
+        assert.strictEqual(importedMd.getDataStoreVersionId(), undefined);
+    });
 
     it('should get dataStoreVersionId if saved in object location', () => {
         const md = new ObjectMD();
@@ -489,8 +520,7 @@ describe('ObjectMD import from stored blob', () => {
         const importedRes = ObjectMD.createFromBlob(jsonMd);
         assert.strictEqual(importedRes.error, undefined);
         const importedMd = importedRes.result;
-        assert.strictEqual(importedMd.getDataStoreVersionId(),
-            dummyLocation.dataStoreVersionId);
+        assert.strictEqual(importedMd.getDataStoreVersionId(), dummyLocation.dataStoreVersionId);
     });
 
     it('should return an error if blob is malformed JSON', () => {
@@ -509,7 +539,7 @@ describe('getAttributes static method', () => {
             'cache-control': true,
             'content-disposition': true,
             'content-encoding': true,
-            'expires': true,
+            expires: true,
             'content-length': true,
             'content-type': true,
             'content-md5': true,
@@ -523,25 +553,25 @@ describe('getAttributes static method', () => {
             'x-amz-server-side-encryption-customer-algorithm': true,
             'x-amz-website-redirect-location': true,
             'x-amz-scal-transition-in-progress': true,
-            'acl': true,
-            'key': true,
-            'location': true,
-            'azureInfo': true,
-            'isNull': true,
-            'isNull2': true,
-            'nullVersionId': true,
-            'nullUploadId': true,
-            'isDeleteMarker': true,
-            'versionId': true,
-            'tags': true,
-            'uploadId': true,
-            'replicationInfo': true,
-            'dataStoreName': true,
+            acl: true,
+            key: true,
+            location: true,
+            azureInfo: true,
+            isNull: true,
+            isNull2: true,
+            nullVersionId: true,
+            nullUploadId: true,
+            isDeleteMarker: true,
+            versionId: true,
+            tags: true,
+            uploadId: true,
+            replicationInfo: true,
+            dataStoreName: true,
             'last-modified': true,
             'md-model-version': true,
-            'originOp': true,
-            'deleted': true,
-            'isPHD': true,
+            originOp: true,
+            deleted: true,
+            isPHD: true,
         };
         assert.deepStrictEqual(attributes, expectedResult);
     });
@@ -939,5 +969,4 @@ describe('ObjectMD checksum', () => {
         assert.strictEqual(c.checksumValue, `${sha256Digest}-3`);
         assert.strictEqual(c.checksumType, 'COMPOSITE');
     });
-
 });

--- a/tests/unit/versioning/MicroVersionId.spec.js
+++ b/tests/unit/versioning/MicroVersionId.spec.js
@@ -1,0 +1,73 @@
+const crypto = require('crypto');
+const MVID = require('../../../lib/versioning/MicroVersionId');
+const assert = require('assert');
+
+function randomRepGroupId() {
+    return crypto.randomBytes(7).toString('hex').slice(0, 7);
+}
+
+describe('microVersionId', () => {
+    it('should generate unique, length-27 timestamp-ordered ids', () => {
+        const repGroupId = randomRepGroupId();
+        const ids = Array(1000).fill(null).map(() => MVID.generate(repGroupId));
+
+        assert.strictEqual(new Set(ids).size, ids.length);
+        ids.forEach(id => assert.strictEqual(id.length, 27));
+
+        // reversed-time scheme: newer values sort before older ones
+        const isDecreasing = ids.slice(1).every((id, i) => id < ids[i]);
+        assert(isDecreasing);
+    });
+
+    it('should embed the replication group id', () => {
+        const repGroupId = randomRepGroupId();
+        const id = MVID.generate(repGroupId);
+        assert.strictEqual(id.slice(20), repGroupId);
+    });
+
+    it('should space-pad a short replication group id', () => {
+        const id = MVID.generate('abc');
+        assert.strictEqual(id.length, 27);
+        assert.strictEqual(id.slice(20), 'abc    ');
+    });
+
+    it('should truncate a long replication group id', () => {
+        const id = MVID.generate('abcdefghij');
+        assert.strictEqual(id.length, 27);
+        assert.strictEqual(id.slice(20), 'abcdefg');
+    });
+
+    it('should round-trip through encode/decode', () => {
+        const repGroupId = randomRepGroupId();
+        const id = MVID.generate(repGroupId);
+
+        const encoded = MVID.encode(id);
+        assert.notStrictEqual(encoded, id);
+
+        const decoded = MVID.decode(encoded);
+        assert.strictEqual(decoded, id);
+    });
+
+    it('should return an Error for legacy 16-char hex microVersionIds', () => {
+        const legacy = '0123456789abcdef';
+        assert(MVID.decode(legacy) instanceof Error);
+    });
+
+    it('should return an Error for anything not matching the current format', () => {
+        assert(MVID.decode('not-valid-hex!') instanceof Error);
+
+        // valid hex but wrong length
+        const wrongLength = Buffer.from('short').toString('hex');
+        assert(MVID.decode(wrongLength) instanceof Error);
+    });
+
+    it('should compare microVersionIds chronologically', () => {
+        const repGroupId = randomRepGroupId();
+        const older = MVID.generate(repGroupId);
+        const newer = MVID.generate(repGroupId);
+
+        assert(MVID.compare(newer, older) > 0);
+        assert(MVID.compare(older, newer) < 0);
+        assert.strictEqual(MVID.compare(newer, newer), 0);
+    });
+});

--- a/tests/unit/versioning/MicroVersionId.spec.js
+++ b/tests/unit/versioning/MicroVersionId.spec.js
@@ -9,7 +9,9 @@ function randomRepGroupId() {
 describe('microVersionId', () => {
     it('should generate unique, length-27 timestamp-ordered ids', () => {
         const repGroupId = randomRepGroupId();
-        const ids = Array(1000).fill(null).map(() => MVID.generate(repGroupId));
+        const ids = Array(1000)
+            .fill(null)
+            .map(() => MVID.generate(repGroupId));
 
         assert.strictEqual(new Set(ids).size, ids.length);
         ids.forEach(id => assert.strictEqual(id.length, 27));

--- a/tests/unit/versioning/TimestampId.spec.js
+++ b/tests/unit/versioning/TimestampId.spec.js
@@ -1,0 +1,377 @@
+const assert = require('assert');
+const crypto = require('crypto');
+const timestampId = require('../../../lib/versioning/TimestampId');
+
+describe('timestampId', () => {
+    describe('constants', () => {
+        it('should expose the documented byte lengths', () => {
+            assert.strictEqual(timestampId.LENGTH_TS, 14);
+            assert.strictEqual(timestampId.LENGTH_SEQ, 6);
+            assert.strictEqual(timestampId.LENGTH_RG, 7);
+        });
+
+        it('should expose templates matching the byte lengths', () => {
+            assert.strictEqual(timestampId.TEMPLATE_TS.length, timestampId.LENGTH_TS);
+            assert.strictEqual(timestampId.TEMPLATE_SEQ.length, timestampId.LENGTH_SEQ);
+            assert.strictEqual(timestampId.TEMPLATE_RG.length, timestampId.LENGTH_RG);
+            assert.strictEqual(timestampId.TEMPLATE_TS, '0'.repeat(timestampId.LENGTH_TS));
+            assert.strictEqual(timestampId.TEMPLATE_SEQ, '0'.repeat(timestampId.LENGTH_SEQ));
+            assert.strictEqual(timestampId.TEMPLATE_RG, ' '.repeat(timestampId.LENGTH_RG));
+        });
+
+        it('should expose MAX_TS and MAX_SEQ at the digit boundary', () => {
+            assert.strictEqual(timestampId.MAX_TS, Math.pow(10, timestampId.LENGTH_TS) - 1);
+            assert.strictEqual(timestampId.MAX_SEQ, Math.pow(10, timestampId.LENGTH_SEQ) - 1);
+            assert.strictEqual(String(timestampId.MAX_TS).length, timestampId.LENGTH_TS);
+            assert.strictEqual(String(timestampId.MAX_SEQ).length, timestampId.LENGTH_SEQ);
+        });
+
+        it('should keep MAX_TS large enough for current timestamps', () => {
+            assert(timestampId.MAX_TS > Date.now());
+        });
+    });
+
+    describe('padLeft', () => {
+        it('should left-pad shorter values', () => {
+            assert.strictEqual(timestampId.padLeft('foo', '00000'), '00foo');
+            assert.strictEqual(timestampId.padLeft(42, '0000'), '0042');
+        });
+
+        it('should return only the rightmost template-length characters when value is longer', () => {
+            assert.strictEqual(timestampId.padLeft('abcdef', '000'), 'def');
+            assert.strictEqual(timestampId.padLeft('123456', '00'), '56');
+        });
+
+        it('should return the value unchanged when it already matches the template length', () => {
+            assert.strictEqual(timestampId.padLeft('abc', '000'), 'abc');
+        });
+
+        it('should return the full template when value is empty', () => {
+            assert.strictEqual(timestampId.padLeft('', '00000'), '00000');
+        });
+
+        it('should coerce non-string values via template substitution', () => {
+            assert.strictEqual(timestampId.padLeft(0, '00000'), '00000');
+            assert.strictEqual(timestampId.padLeft(null, '0000'), 'null');
+        });
+    });
+
+    describe('padRight', () => {
+        it('should right-pad shorter values', () => {
+            assert.strictEqual(timestampId.padRight('foo', '00000'), 'foo00');
+            assert.strictEqual(timestampId.padRight('abc', '       '), 'abc    ');
+        });
+
+        it('should truncate when value is longer than the template', () => {
+            assert.strictEqual(timestampId.padRight('abcdef', '000'), 'abc');
+            assert.strictEqual(timestampId.padRight('abcdefghij', '0000000'), 'abcdefg');
+        });
+
+        it('should return the value unchanged when it already matches the template length', () => {
+            assert.strictEqual(timestampId.padRight('abc', '000'), 'abc');
+        });
+
+        it('should return the full template when value is empty', () => {
+            assert.strictEqual(timestampId.padRight('', '00000'), '00000');
+        });
+    });
+
+    describe('wait', () => {
+        it('should block for at least the requested time span', () => {
+            const start = process.hrtime();
+            timestampId.wait(2_000_000); // 2 ms in ns
+            const diff = process.hrtime(start);
+            const elapsedNs = diff[0] * 1e9 + diff[1];
+            assert(elapsedNs >= 2_000_000, `expected >= 2ms, got ${elapsedNs}ns`);
+        });
+
+        it('should return immediately for a zero or negative span', () => {
+            const start = process.hrtime();
+            timestampId.wait(0);
+            timestampId.wait(-1);
+            const diff = process.hrtime(start);
+            const elapsedMs = (diff[0] * 1e9 + diff[1]) / 1e6;
+            assert(elapsedMs < 50, `expected near-instant return, got ${elapsedMs}ms`);
+        });
+    });
+
+    describe('hexEncode / hexDecode', () => {
+        it('should round-trip an ASCII string', () => {
+            const str = 'hello world';
+            const encoded = timestampId.hexEncode(str);
+            assert.strictEqual(encoded, '68656c6c6f20776f726c64');
+            assert.strictEqual(timestampId.hexDecode(encoded), str);
+        });
+
+        it('should round-trip a string containing spaces and digits', () => {
+            const str = '98283606399999999999RG001  ';
+            assert.strictEqual(timestampId.hexDecode(timestampId.hexEncode(str)), str);
+        });
+
+        it('should produce a hex string of double the input length', () => {
+            for (let len = 1; len <= 32; len++) {
+                const str = 'a'.repeat(len);
+                assert.strictEqual(timestampId.hexEncode(str).length, len * 2);
+            }
+        });
+
+        it('should round-trip arbitrary binary-safe content', () => {
+            const str = crypto.randomBytes(27).toString('binary');
+            const encoded = timestampId.hexEncode(str);
+            assert(/^[0-9a-f]+$/.test(encoded));
+            // utf-8 round-tripping of arbitrary bytes is not lossless, but
+            // the produced encoded form must always be valid lowercase hex
+        });
+
+        it('should return an Error when decoding an empty string', () => {
+            const result = timestampId.hexDecode('');
+            assert(result instanceof Error);
+        });
+
+        it('should return an Error or an empty/garbage value gracefully for non-hex input', () => {
+            // Buffer.from(str, 'hex') silently drops invalid characters
+            // rather than throwing, so the contract here is: never crash.
+            const result = timestampId.hexDecode('not-hex-zz');
+            assert(typeof result === 'string' || result instanceof Error);
+        });
+    });
+
+    describe('createTimestampSequenceGenerator', () => {
+        it('should produce ids of length LENGTH_TS + LENGTH_SEQ + LENGTH_RG', () => {
+            const gen = timestampId.createTimestampSequenceGenerator();
+            const id = gen('RG001');
+            assert.strictEqual(id.length, timestampId.LENGTH_TS + timestampId.LENGTH_SEQ + timestampId.LENGTH_RG);
+        });
+
+        it('should produce unique ids across many calls', () => {
+            const gen = timestampId.createTimestampSequenceGenerator();
+            const ids = Array(5000)
+                .fill(null)
+                .map(() => gen('RG001'));
+            assert.strictEqual(new Set(ids).size, ids.length);
+        });
+
+        it('should produce strictly decreasing ids (newest first)', () => {
+            const gen = timestampId.createTimestampSequenceGenerator();
+            const ids = Array(2000)
+                .fill(null)
+                .map(() => gen('RG001'));
+            for (let i = 1; i < ids.length; i++) {
+                assert(ids[i] < ids[i - 1], `expected ${ids[i]} < ${ids[i - 1]}`);
+            }
+        });
+
+        it('should embed the replication group id at bytes 20-27', () => {
+            const gen = timestampId.createTimestampSequenceGenerator();
+            const id = gen('RG001');
+            assert.strictEqual(id.slice(timestampId.LENGTH_TS + timestampId.LENGTH_SEQ), 'RG001  ');
+        });
+
+        it('should right-pad a short replication group id with spaces', () => {
+            const gen = timestampId.createTimestampSequenceGenerator();
+            const id = gen('a');
+            assert.strictEqual(id.slice(timestampId.LENGTH_TS + timestampId.LENGTH_SEQ), 'a      ');
+        });
+
+        it('should truncate a long replication group id', () => {
+            const gen = timestampId.createTimestampSequenceGenerator();
+            const id = gen('abcdefghij');
+            assert.strictEqual(id.slice(timestampId.LENGTH_TS + timestampId.LENGTH_SEQ), 'abcdefg');
+        });
+
+        it('should accept an empty replication group id and pad with spaces', () => {
+            const gen = timestampId.createTimestampSequenceGenerator();
+            const id = gen('');
+            assert.strictEqual(id.length, timestampId.LENGTH_TS + timestampId.LENGTH_SEQ + timestampId.LENGTH_RG);
+            assert.strictEqual(id.slice(timestampId.LENGTH_TS + timestampId.LENGTH_SEQ), '       ');
+        });
+
+        it('should encode a reversed timestamp (MAX_TS - now)', () => {
+            const gen = timestampId.createTimestampSequenceGenerator();
+            const before = Date.now();
+            const id = gen('RG001');
+            const after = Date.now();
+
+            const reversedTs = Number(id.slice(0, timestampId.LENGTH_TS));
+            const ts = timestampId.MAX_TS - reversedTs;
+            assert(ts >= before && ts <= after, `expected ${before} <= ${ts} <= ${after}`);
+        });
+
+        it('should reset the sequence counter when the millisecond changes', async () => {
+            const gen = timestampId.createTimestampSequenceGenerator();
+            const idA = gen('RG001');
+            // sleep long enough to guarantee a new millisecond
+            await new Promise(resolve => setTimeout(resolve, 5));
+            const idB = gen('RG001');
+
+            const seqB = Number(idB.slice(timestampId.LENGTH_TS, timestampId.LENGTH_TS + timestampId.LENGTH_SEQ));
+            // reversed sequence: MAX_SEQ on the first call of a new ms
+            assert.strictEqual(seqB, timestampId.MAX_SEQ);
+            // distinct timestamps, so the full ids must differ too
+            assert.notStrictEqual(idA, idB);
+        });
+
+        it('should increment the sequence within the same millisecond', () => {
+            const gen = timestampId.createTimestampSequenceGenerator();
+            // generate many ids in a tight loop; most will share a ms
+            const ids = Array(200)
+                .fill(null)
+                .map(() => gen('RG001'));
+
+            // find a window of consecutive ids that share a timestamp
+            for (let i = 1; i < ids.length; i++) {
+                const tsPrev = ids[i - 1].slice(0, timestampId.LENGTH_TS);
+                const tsCurr = ids[i].slice(0, timestampId.LENGTH_TS);
+                if (tsPrev === tsCurr) {
+                    const seqPrev = Number(ids[i - 1].slice(timestampId.LENGTH_TS, timestampId.LENGTH_TS + timestampId.LENGTH_SEQ));
+                    const seqCurr = Number(ids[i].slice(timestampId.LENGTH_TS, timestampId.LENGTH_TS + timestampId.LENGTH_SEQ));
+                    // reversed: each subsequent id has a smaller seq number
+                    assert.strictEqual(seqCurr, seqPrev - 1);
+                    return;
+                }
+            }
+            assert.fail('expected at least two ids in the same millisecond');
+        });
+
+        it('should produce independent state across separate generators', () => {
+            const genA = timestampId.createTimestampSequenceGenerator();
+            const genB = timestampId.createTimestampSequenceGenerator();
+
+            // interleave calls; each generator should produce a strictly
+            // decreasing sequence considered on its own
+            const aIds = [];
+            const bIds = [];
+            for (let i = 0; i < 200; i++) {
+                aIds.push(genA('RGA001 '));
+                bIds.push(genB('RGB001 '));
+            }
+
+            for (let i = 1; i < aIds.length; i++) {
+                assert(aIds[i] < aIds[i - 1]);
+                assert(bIds[i] < bIds[i - 1]);
+            }
+            assert.strictEqual(new Set(aIds).size, aIds.length);
+            assert.strictEqual(new Set(bIds).size, bIds.length);
+        });
+
+        it('should produce a different timestamp portion on the first call of a fresh generator', () => {
+            // First-call wait() guarantees the millisecond slot is flushed.
+            const gen = timestampId.createTimestampSequenceGenerator();
+            const id = gen('RG001');
+            const reversedTs = Number(id.slice(0, timestampId.LENGTH_TS));
+            const ts = timestampId.MAX_TS - reversedTs;
+            // sanity: timestamp must look like a recent epoch in ms
+            assert(ts > 1_700_000_000_000);
+            assert(ts <= Date.now());
+        });
+    });
+
+    describe('TS_SEQ_RG_LENGTH', () => {
+        it('should equal LENGTH_TS + LENGTH_SEQ + LENGTH_RG', () => {
+            assert.strictEqual(
+                timestampId.TS_SEQ_RG_LENGTH,
+                timestampId.LENGTH_TS + timestampId.LENGTH_SEQ + timestampId.LENGTH_RG,
+            );
+            assert.strictEqual(timestampId.TS_SEQ_RG_LENGTH, 27);
+        });
+    });
+
+    describe('getInfId', () => {
+        it('should produce a 27-character sentinel with MAX_TS / MAX_SEQ', () => {
+            const id = timestampId.getInfId('RG001');
+            assert.strictEqual(id.length, timestampId.TS_SEQ_RG_LENGTH);
+            assert.strictEqual(id.slice(0, timestampId.LENGTH_TS), String(timestampId.MAX_TS));
+            assert.strictEqual(
+                id.slice(timestampId.LENGTH_TS, timestampId.LENGTH_TS + timestampId.LENGTH_SEQ),
+                String(timestampId.MAX_SEQ),
+            );
+            assert.strictEqual(id.slice(-timestampId.LENGTH_RG), 'RG001  ');
+        });
+
+        it('should sort strictly after any generated id', () => {
+            const gen = timestampId.createTimestampSequenceGenerator();
+            const generated = gen('RG001');
+            const sentinel = timestampId.getInfId('RG001');
+            // reversed-time encoding: "infinitely old" is lex-greater than anything recent
+            assert(sentinel > generated, `${sentinel} should sort after ${generated}`);
+        });
+
+        it('should pad and truncate the replication group id', () => {
+            assert.strictEqual(timestampId.getInfId('a').slice(-timestampId.LENGTH_RG), 'a      ');
+            assert.strictEqual(timestampId.getInfId('abcdefghij').slice(-timestampId.LENGTH_RG), 'abcdefg');
+        });
+    });
+
+    describe('parse', () => {
+        it('should round-trip a generated id', () => {
+            const gen = timestampId.createTimestampSequenceGenerator();
+            const before = Date.now();
+            const id = gen('RG001');
+            const after = Date.now();
+
+            const parsed = timestampId.parse(id);
+            assert(!(parsed instanceof Error), `unexpected error: ${parsed}`);
+            assert(parsed.ts >= before && parsed.ts <= after);
+            assert.strictEqual(typeof parsed.seq, 'number');
+            assert(parsed.seq >= 0 && parsed.seq <= timestampId.MAX_SEQ);
+            assert.strictEqual(parsed.rg, 'RG001');
+        });
+
+        it('should accept a longer id and parse only the prefix', () => {
+            const gen = timestampId.createTimestampSequenceGenerator();
+            const id = gen('RG001') + 'extra-suffix-bytes';
+            const parsed = timestampId.parse(id);
+            assert(!(parsed instanceof Error));
+            assert.strictEqual(parsed.rg, 'RG001');
+        });
+
+        it('should trim trailing spaces from the rg id', () => {
+            const gen = timestampId.createTimestampSequenceGenerator();
+            const id = gen('a');
+            const parsed = timestampId.parse(id);
+            assert(!(parsed instanceof Error));
+            assert.strictEqual(parsed.rg, 'a');
+        });
+
+        it('should reflect the seq=0 first-call invariant after a fresh generator', () => {
+            const gen = timestampId.createTimestampSequenceGenerator();
+            const parsed = timestampId.parse(gen('RG001'));
+            assert(!(parsed instanceof Error));
+            assert.strictEqual(parsed.seq, 0);
+        });
+
+        it('should return an Error for too-short input', () => {
+            assert(timestampId.parse('') instanceof Error);
+            assert(timestampId.parse('abc') instanceof Error);
+            assert(timestampId.parse('0'.repeat(timestampId.TS_SEQ_RG_LENGTH - 1)) instanceof Error);
+        });
+
+        it('should return an Error for non-numeric timestamp or sequence', () => {
+            const bad = 'x'.repeat(timestampId.LENGTH_TS) + '0'.repeat(timestampId.LENGTH_SEQ) + 'RG001  ';
+            assert(timestampId.parse(bad) instanceof Error);
+        });
+    });
+
+    describe('compare', () => {
+        it('should return 0 for equal ids', () => {
+            assert.strictEqual(timestampId.compare('abc', 'abc'), 0);
+        });
+
+        it('should return positive when a is more recent (lex-smaller)', () => {
+            // reversed-time encoding: smaller string == newer
+            assert(timestampId.compare('aaa', 'bbb') > 0);
+        });
+
+        it('should return negative when a is older (lex-greater)', () => {
+            assert(timestampId.compare('bbb', 'aaa') < 0);
+        });
+
+        it('should agree with the ordering of a generated stream', () => {
+            const gen = timestampId.createTimestampSequenceGenerator();
+            const older = gen('RG001');
+            const newer = gen('RG001');
+            assert(timestampId.compare(newer, older) > 0);
+            assert(timestampId.compare(older, newer) < 0);
+        });
+    });
+});

--- a/tests/unit/versioning/VersionID.spec.js
+++ b/tests/unit/versioning/VersionID.spec.js
@@ -1,4 +1,5 @@
 const VID = require('../../../lib/versioning/VersionID');
+const TimestampId = require('../../../lib/versioning/TimestampId');
 const VersioningConstants = require('../../../lib/versioning/constants').VersioningConstants;
 const assert = require('assert');
 
@@ -53,14 +54,14 @@ describe('test generating versionIds', () => {
 
         // nodejs 10 no longer returns error for non-hex string versionIds
         it.skip('should return error decoding non-hex string versionIds', () => {
-            const encoded = vids.map(vid => VID.hexEncode(vid));
-            const decoded = encoded.map(vid => VID.hexDecode(`${vid}foo`));
+            const encoded = vids.map(vid => TimestampId.hexEncode(vid));
+            const decoded = encoded.map(vid => TimestampId.hexDecode(`${vid}foo`));
             decoded.forEach(result => assert(result instanceof Error));
         });
 
         it('should encode and decode versionIds', () => {
-            const encoded = vids.map(vid => VID.hexEncode(vid));
-            const decoded = encoded.map(vid => VID.hexDecode(vid));
+            const encoded = vids.map(vid => TimestampId.hexEncode(vid));
+            const decoded = encoded.map(vid => TimestampId.hexDecode(vid));
             assert.deepStrictEqual(vids, decoded);
         });
 


### PR DESCRIPTION
Move the constants, padding/hex helpers, and the stateful ts+seq+rg
generator out of VersionID into a new TimestampId module that both
VersionID and MicroVersionId consume. Add
a dedicated test suite covering constants, helpers, and generator
behaviour.

Issue: ARSN-583