### PR TITLE
Probe with HeadBucketCommand in AwsClient healthcheck

### DIFF
--- a/lib/storage/data/external/AwsClient.js
+++ b/lib/storage/data/external/AwsClient.js
@@ -1,6 +1,7 @@
 const { S3Client,
     PutObjectCommand,
     HeadObjectCommand,
+    HeadBucketCommand,
     GetObjectCommand,
     DeleteObjectCommand,
     CreateMultipartUploadCommand,
@@ -324,7 +325,7 @@ class AwsClient {
 
     healthcheck(location, callback) {
         const awsResp = {};
-        this._client.send(new HeadObjectCommand({ Bucket: this._awsBucketName }))
+        this._client.send(new HeadBucketCommand({ Bucket: this._awsBucketName }))
             .then(() => {
                 if (!this._supportsVersioning) {
                     awsResp[location] = {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=20"
   },
-  "version": "8.3.11",
+  "version": "8.3.12",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/tests/unit/storage/data/DummyService.js
+++ b/tests/unit/storage/data/DummyService.js
@@ -6,13 +6,15 @@ const assert = require('assert');
 const DummyObjectStream = require('./DummyObjectStream');
 const { parseRange } = require('../../../../lib/network/http/utils');
 const errors = require('../../../../lib/errors').default;
-const { 
-    PutObjectCommand, 
-    CopyObjectCommand, 
+const {
+    PutObjectCommand,
+    CopyObjectCommand,
     HeadObjectCommand,
-    PutObjectTaggingCommand, 
+    HeadBucketCommand,
+    GetBucketVersioningCommand,
+    PutObjectTaggingCommand,
     DeleteObjectTaggingCommand,
-    CompleteMultipartUploadCommand, 
+    CompleteMultipartUploadCommand,
     GetObjectCommand,
     DeleteObjectCommand,
     CreateMultipartUploadCommand,
@@ -102,6 +104,8 @@ class DummyService {
         this.putObjectAsync = promisify(this.putObject.bind(this));
         this.copyObjectAsync = promisify(this.copyObject.bind(this));
         this.headObjectAsync = promisify(this.headObject.bind(this));
+        this.headBucketAsync = promisify(this.headBucket.bind(this));
+        this.getBucketVersioningAsync = promisify(this.getBucketVersioning.bind(this));
         this.putObjectTaggingAsync = promisify(this.putObjectTagging.bind(this));
         this.deleteObjectTaggingAsync = promisify(this.deleteObjectTagging.bind(this));
         this.completeMultipartUploadAsync = promisify(this.completeMultipartUpload.bind(this));
@@ -110,11 +114,13 @@ class DummyService {
         this.uploadPartAsync = promisify(this.uploadPart.bind(this));
         this.listPartsAsync = promisify(this.listParts.bind(this));
         this.abortMultipartUploadAsync = promisify(this.abortMultipartUpload.bind(this));
-        
+
         this.commandHandlers = new Map([
             [PutObjectCommand, cmd => this.putObjectAsync(cmd.input)],
             [CopyObjectCommand, cmd => this.copyObjectAsync(cmd.input)],
             [HeadObjectCommand, cmd => this.headObjectAsync(cmd.input)],
+            [HeadBucketCommand, cmd => this.headBucketAsync(cmd.input)],
+            [GetBucketVersioningCommand, cmd => this.getBucketVersioningAsync(cmd.input)],
             [PutObjectTaggingCommand, cmd => this.putObjectTaggingAsync(cmd.input)],
             [DeleteObjectTaggingCommand, cmd => this.deleteObjectTaggingAsync(cmd.input)],
             [CompleteMultipartUploadCommand, cmd => this.completeMultipartUploadAsync(cmd.input)],

--- a/tests/unit/storage/data/external/ExternalClients.spec.js
+++ b/tests/unit/storage/data/external/ExternalClients.spec.js
@@ -10,6 +10,7 @@ const AzureClient =
 const DummyService = require('../DummyService');
 const { DummyRequestLogger } = require('../../../helpers');
 const BucketInfo = require('../../../../../lib/models/BucketInfo').default;
+const { HeadBucketCommand } = require('@aws-sdk/client-s3');
 
 const backendClients = [
     {
@@ -149,6 +150,28 @@ describe('external backend clients', () => {
                 assert(err);
                 assert(err.is.LocationNotFound);
             }
+        });
+
+        const itIfAws = backend.config.type === 'aws' ? it : it.skip;
+
+        itIfAws(`${backend.name} healthcheck should respond ok when the bucket is reachable`, async () => {
+            const sendStub = sandbox.stub(testClient._client, 'send').resolves({});
+            const healthcheckAsync = promisify(testClient.healthcheck.bind(testClient));
+            await healthcheckAsync(backend.config.dataStoreName);
+
+            const cmd = sendStub.firstCall.args[0];
+            assert.strictEqual(cmd.constructor.name, HeadBucketCommand.name);
+            assert.strictEqual(cmd.input.Bucket, backend.config.bucketName);
+        });
+
+        itIfAws(`${backend.name} healthcheck should mark response external on bucket failure`, async () => {
+            sandbox.stub(testClient._client, 'send').rejects(new Error('bucket unreachable'));
+            const healthcheckAsync = promisify(testClient.healthcheck.bind(testClient));
+            const resp = await healthcheckAsync(backend.config.dataStoreName);
+
+            const entry = resp[backend.config.dataStoreName];
+            assert.ok(entry.error);
+            assert.strictEqual(entry.external, true);
         });
 
         it(`${backend.name} get() should stream a range of data`, async () => {


### PR DESCRIPTION
HeadObjectCommand requires both Bucket and Key. Sending it with only Bucket is rejected by the v3 SDK validator, making every aws_s3-typed location (real AWS, RING-S3) report an error on every healthcheck. HeadBucketCommand only needs Bucket and is the correct probe.

Issue: ARSN-585