### PR TITLE
feat: add reusable OpenTelemetry tracing module

### DIFF
--- a/lib/tracing/README.md
+++ b/lib/tracing/README.md
@@ -1,0 +1,133 @@
+# OpenTelemetry tracing
+
+Shared OTEL tracing bootstrap and helpers for the S3 platform services
+(backbeat, cloudserver, vault). Arsenal owns the parts that are hard to get
+right and identical across services — SDK lifecycle, the outbound trust
+boundary, span conventions — while each consumer supplies its own
+instrumentation packages.
+
+## Import
+
+Deep-require the built module; do **not** use `require('arsenal').tracing`:
+
+```js
+const tracing = require('arsenal/build/lib/tracing');
+```
+
+The arsenal barrel (`require('arsenal')`) eagerly loads `ioredis` (via
+`lib/metrics`) and `mongodb` (via `lib/storage`); reaching `init()` through it
+would load those before OpenTelemetry can patch them, silently disabling the
+instrumentation. The deep-require pulls only the tracing module, which loads
+nothing instrumentable at import time.
+
+## Enabling
+
+Tracing is **off** unless `ENABLE_OTEL=true`. When enabled, `init()` requires
+`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` and fails fast if it is unset.
+
+- `ENABLE_OTEL` — master switch (`isEnabled()`); must be exactly `true`.
+  Default: off.
+- `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` — OTLP/HTTP traces collector URL;
+  required when enabled.
+- `OTEL_SAMPLING_RATIO` — root sampling ratio in `[0, 1]`. Default `0.01`.
+- `OTEL_SERVICE_NAME` — overrides the `serviceName` option.
+- `OTEL_SERVICE_VERSION` — overrides the `serviceVersion` option.
+- `OTEL_SERVICE_NAMESPACE` — resource `service.namespace`. Default `scality`.
+- `OTEL_TRUSTED_HOSTS` — comma-separated hostnames trusted for outbound trace
+  propagation; a `.suffix` entry matches any subdomain. Default: loopback only.
+
+## Lifecycle
+
+```js
+const tracing = require('arsenal/build/lib/tracing');
+
+tracing.init({
+    serviceName: 'cloudserver',
+    serviceVersion: require('./package.json').version,
+    // Lazy thunk — invoked once inside init(), only when OTEL is enabled, so
+    // the instrumentation packages (and their patch hooks) never load when
+    // OTEL is off. The consumer owns these packages and their options.
+    instrumentations: () => {
+        const { HttpInstrumentation } = require('@opentelemetry/instrumentation-http');
+        const { IORedisInstrumentation } = require('@opentelemetry/instrumentation-ioredis');
+        const { MongoDBInstrumentation } = require('@opentelemetry/instrumentation-mongodb');
+        return [
+            // makeHttpInstrumentationConfig wires the trust boundary + health
+            // filter. Outbound-only services (backbeat) spread it and add
+            // disableIncomingRequestInstrumentation: true.
+            new HttpInstrumentation(
+                tracing.makeHttpInstrumentationConfig({
+                    healthPaths: ['/live', '/_/healthcheck', '/metrics'],
+                }),
+            ),
+            new IORedisInstrumentation({ requireParentSpan: true }),
+            new MongoDBInstrumentation({ enhancedDatabaseReporting: false }),
+        ];
+    },
+});
+
+// On shutdown — bounded flush (~5s), safe to call concurrently / when never inited:
+await tracing.close();
+```
+
+`init()` is idempotent and a no-op when disabled. Build the instrumentation
+array entirely inside the thunk so packages resolve from the consumer's
+`node_modules` and load lazily.
+
+## API
+
+- `init(options)` — boot the SDK. Options: `serviceName` (required),
+  `serviceVersion?`, `instrumentations?: () => Instrumentation[]`.
+- `close()` — bounded-flush shutdown; idempotent.
+- `isEnabled()` — `process.env.ENABLE_OTEL === 'true'`.
+- `makeHttpInstrumentationConfig({ healthPaths? })` → params for the consumer's
+  `HttpInstrumentation`: the outbound trust-boundary `requestHook` plus an
+  `ignoreIncomingRequestHook` that drops OPTIONS and the given health/probe
+  paths (none by default). arsenal never disables inbound spans — an
+  outbound-only service spreads the result and adds
+  `disableIncomingRequestInstrumentation: true`.
+- `instrumentApiMethod(handler, methodName)` — wrap a callback/async/sync
+  handler in an `api.<methodName>` span (scope `arsenal.api`, `err.code` →
+  `error.type`); returns the handler unchanged when OTEL is off.
+- `kafka.*` — trace-context propagation over node-rdkafka headers (scope
+  `arsenal.kafka`): `traceHeadersFromEntry`, `traceHeadersFromCurrentContext`,
+  `contextFromKafkaHeaders`, `startLinkedSpanFromKafkaEntry`.
+
+## Examples
+
+Instrument API handlers (cloudserver / vault) — wrap each handler so calls
+produce `api.<name>` spans:
+
+```js
+const { instrumentApiMethod } = require('arsenal/build/lib/tracing');
+for (const [name, handler] of Object.entries(api)) {
+    api[name] = instrumentApiMethod(handler, name);
+}
+```
+
+Kafka propagation (backbeat) — producer stamps headers from the active span or
+an oplog entry; consumer starts a new trace linked to the upstream span:
+
+```js
+const { kafka } = require('arsenal/build/lib/tracing');
+
+// producer side
+producer.send(payload, kafka.traceHeadersFromCurrentContext());
+producer.send(payload, kafka.traceHeadersFromEntry(objectMd));
+
+// consumer side
+const { ctx, span } = kafka.startLinkedSpanFromKafkaEntry(entry, 'replicate');
+try {
+    /* ...work within ctx... */
+} finally {
+    span.end();
+}
+```
+
+## Dependencies
+
+`@opentelemetry/api` is a hard dependency (inert until an SDK is registered).
+The SDK-core packages (`sdk-node`, `sdk-trace-base`, `resources`,
+`exporter-trace-otlp-http`) are **optional** dependencies, required lazily in
+`init()`. The `instrumentation-*` packages are **not** arsenal dependencies —
+consumers bring their own and pass them via the `instrumentations` thunk.

--- a/lib/tracing/bootstrap.ts
+++ b/lib/tracing/bootstrap.ts
@@ -1,0 +1,125 @@
+import assert from 'assert';
+
+import { DEFAULT_SAMPLING_RATIO, SPAN_LIMITS, SHUTDOWN_DEADLINE_MS } from './constants';
+
+export interface InitOptions {
+    // service.name (OTEL_SERVICE_NAME env overrides).
+    serviceName: string;
+    // service.version (OTEL_SERVICE_VERSION env overrides).
+    serviceVersion?: string;
+    // Lazy invoked once inside init() only when OTEL is enabled, so the
+    // consumer's require()s and instrumentation patch hooks never load when off.
+    instrumentations?: () => any[];
+}
+
+let sdk: any = null;
+
+let diagLog: any = null;
+function getDiagLog(): any {
+    if (!diagLog) {
+        const werelogs = require('werelogs');
+        diagLog = new werelogs.Logger('tracing');
+    }
+    return diagLog;
+}
+
+function makeDiagLogger(): any {
+    const log = getDiagLog();
+    const fwd =
+        (level: string) =>
+        (m: string, ...a: unknown[]) =>
+            log[level](m, a.length ? { args: a } : undefined);
+    return {
+        error: fwd('error'),
+        warn: fwd('warn'),
+        info: fwd('info'),
+        debug: fwd('debug'),
+        verbose: fwd('trace'),
+    };
+}
+
+export function isEnabled(): boolean {
+    return process.env.ENABLE_OTEL === 'true';
+}
+
+export function init(options: InitOptions): void {
+    if (!isEnabled() || sdk) {
+        return;
+    }
+
+    const endpoint = process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+    assert(endpoint, 'ENABLE_OTEL=true but OTEL_EXPORTER_OTLP_TRACES_ENDPOINT is unset');
+    assert(options.serviceName, 'tracing.init: options.serviceName is required');
+
+    let samplingRatio = DEFAULT_SAMPLING_RATIO;
+    if (process.env.OTEL_SAMPLING_RATIO !== undefined) {
+        const parsed = Number(process.env.OTEL_SAMPLING_RATIO);
+        assert(
+            Number.isFinite(parsed) && parsed >= 0 && parsed <= 1,
+            `OTEL_SAMPLING_RATIO must be a finite number in [0, 1], got: ${process.env.OTEL_SAMPLING_RATIO}`,
+        );
+        samplingRatio = parsed;
+    }
+
+    // diag + NodeSDK are required lazily here (never at module top) so OTEL-off
+    // processes load nothing beyond @opentelemetry/api.
+    const { diag, DiagLogLevel } = require('@opentelemetry/api');
+    const { NodeSDK } = require('@opentelemetry/sdk-node');
+    diag.setLogger(makeDiagLogger(), DiagLogLevel.WARN);
+
+    sdk = new NodeSDK(_buildSdkConfig(options, endpoint, samplingRatio));
+    sdk.start();
+}
+
+export function _buildSdkConfig(options: InitOptions, endpoint: string, samplingRatio: number): any {
+    const { resourceFromAttributes } = require('@opentelemetry/resources');
+    const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-http');
+    const { ParentBasedSampler, TraceIdRatioBasedSampler } = require('@opentelemetry/sdk-trace-base');
+
+    return {
+        resource: resourceFromAttributes({
+            'service.name': process.env.OTEL_SERVICE_NAME || options.serviceName,
+            'service.version': process.env.OTEL_SERVICE_VERSION || options.serviceVersion,
+            // Operators set OTEL_SERVICE_NAME per-pod but not the namespace,
+            // so the 'scality' default marks Scality-owned traces.
+            'service.namespace': process.env.OTEL_SERVICE_NAMESPACE || 'scality',
+        }),
+        traceExporter: new OTLPTraceExporter({ url: endpoint }),
+        // Disable OTLP log + metric exporters with empties
+        logRecordProcessors: [],
+        metricReaders: [],
+        spanLimits: SPAN_LIMITS,
+        // ParentBased so a service honors the upstream sampled flag; without
+        // it, it re-samples at `ratio` and the pipeline rate collapses to
+        // ratio × ratio.
+        sampler: new ParentBasedSampler({
+            root: new TraceIdRatioBasedSampler(samplingRatio),
+        }),
+        instrumentations: options.instrumentations ? options.instrumentations() : [],
+    };
+}
+
+export async function close(): Promise<void> {
+    if (!sdk) {
+        return;
+    }
+    // Capture the sdk via the IIFE param and null the module ref synchronously
+    // (before any await) so concurrent callers don't both shutdown() — the SDK
+    // isn't idempotent. The IIFE owns the rejection so a late failure after the
+    // timeout wins the race can't crash the process.
+    const shutdown = (async (running: any) => {
+        try {
+            await running.shutdown();
+        } catch (err) {
+            getDiagLog().error('tracing close failed', { err });
+        }
+    })(sdk);
+    sdk = null;
+    await Promise.race([
+        shutdown,
+        // .unref() so the timer doesn't keep the event loop alive.
+        new Promise<void>(resolve => {
+            setTimeout(resolve, SHUTDOWN_DEADLINE_MS).unref();
+        }),
+    ]);
+}

--- a/lib/tracing/constants.ts
+++ b/lib/tracing/constants.ts
@@ -1,0 +1,19 @@
+export const DEFAULT_SAMPLING_RATIO = 0.01;
+
+export const SPAN_LIMITS = {
+    attributeValueLengthLimit: 4096,
+    attributeCountLimit: 128,
+    eventCountLimit: 128,
+    linkCountLimit: 128,
+};
+
+// Bound the shutdown flush so an unreachable collector can't block past
+// Kubernetes' 30s grace (BatchSpanProcessor's own export timeout is also 30s).
+export const SHUTDOWN_DEADLINE_MS = 5000;
+
+// Instrumentation scopes + API span naming. Service identity comes from
+// service.name on the resource, not these.
+export const API_TRACER_NAME = 'arsenal.api';
+export const KAFKA_TRACER_NAME = 'arsenal.kafka';
+export const SPAN_PREFIX = 'api.';
+export const ERROR_TYPE_ATTR = 'error.type';

--- a/lib/tracing/httpHooks.ts
+++ b/lib/tracing/httpHooks.ts
@@ -1,0 +1,92 @@
+import type { ClientRequest } from 'http';
+import type { Span } from '@opentelemetry/api';
+
+// makeHttpInstrumentationConfig builds the params a consumer passes to its
+// HttpInstrumentation: the outbound trust boundary and the inbound health-path
+// span filter.
+
+const LOOPBACK_HOSTS = ['localhost', '127.0.0.1', '::1'];
+
+const HOST_BRACKET_RE = /^\[([^\]]+)\](?::\d+)?$/;
+const HOST_PORT_RE = /:\d+$/;
+const TRAILING_DOT_RE = /\.$/;
+
+// Operator-supplied bare hostnames (+ always-trusted loopback). A '.'-prefixed
+// entry is a NO_PROXY-style suffix (see makeTrustedHostsHook). Unset → only
+// loopback, so every other outbound call gets traceparent stripped.
+export function loadTrustedHosts(): Set<string> {
+    const hosts = new Set(LOOPBACK_HOSTS);
+    const raw = process.env.OTEL_TRUSTED_HOSTS;
+    if (typeof raw === 'string' && raw.length > 0) {
+        raw.split(',').forEach(entry => {
+            if (entry) {
+                hosts.add(entry.toLowerCase());
+            }
+        });
+    }
+    return hosts;
+}
+
+// Bare hostname for matching. IPv6 is bracket-handled separately so the :port
+// strip can't eat into the address (naive strip of `[::1]` → `:`). A trailing
+// dot (FQDN form) is stripped so it matches the same patterns.
+function normalizeHostHeader(s: string): string {
+    const bracket = HOST_BRACKET_RE.exec(s);
+    if (bracket) {
+        return bracket[1].toLowerCase();
+    }
+    return s.replace(HOST_PORT_RE, '').replace(TRAILING_DOT_RE, '').toLowerCase();
+}
+
+// HTTP requestHook that strips traceparent/tracestate (and tags the span
+// suppressed) on outbound calls to untrusted hosts, so trace IDs don't leak off-platform.
+export function makeTrustedHostsHook(trustedHosts: Set<string>) {
+    // '.'-prefixed entries are suffix patterns, partitioned once (not per request).
+    const suffixes = [...trustedHosts].filter(h => h.startsWith('.'));
+    const isTrusted = (host: string): boolean =>
+        trustedHosts.has(host) ||
+        // endsWith keeps the dot boundary (`xsvc.cluster.local` not matched);
+        // the slice(1) check also trusts the bare apex.
+        suffixes.some(sfx => host.endsWith(sfx) || host === sfx.slice(1));
+
+    return function requestHook(span: Span, request: ClientRequest): void {
+        // Only ClientRequest exposes getHeader/removeHeader, not inbound IncomingMessage.
+        if (!request || typeof request.getHeader !== 'function') {
+            return;
+        }
+        const host = normalizeHostHeader((request.getHeader('host') || '').toString());
+        if (isTrusted(host)) {
+            return;
+        }
+        if (typeof request.removeHeader === 'function') {
+            request.removeHeader('traceparent');
+            request.removeHeader('tracestate');
+        }
+        if (span && typeof span.setAttribute === 'function') {
+            span.setAttribute('scality.trace.suppressed', true);
+        }
+    };
+}
+
+// True when url's path (query string stripped) exactly matches an entry in
+// pathSet — used to skip spans for health/probe endpoints. The set differs per
+// service, so the caller passes it in.
+export function isHealthPath(url: string | undefined, pathSet: Set<string>): boolean {
+    if (typeof url !== 'string' || url.length === 0) {
+        return false;
+    }
+    const qIdx = url.indexOf('?');
+    const path = qIdx === -1 ? url : url.slice(0, qIdx);
+    return pathSet.has(path);
+}
+
+// HttpInstrumentation params (the consumer constructs it): trust-boundary
+// requestHook + an ignore hook for OPTIONS and the given health paths.
+export function makeHttpInstrumentationConfig(options: { healthPaths?: string[] } = {}): Record<string, any> {
+    const healthPaths = new Set(options.healthPaths ?? []);
+    return {
+        ignoreIncomingRequestHook: (req: { method?: string; url?: string }) =>
+            req.method === 'OPTIONS' || isHealthPath(req.url, healthPaths),
+        requestHook: makeTrustedHostsHook(loadTrustedHosts()),
+    };
+}

--- a/lib/tracing/index.ts
+++ b/lib/tracing/index.ts
@@ -1,0 +1,10 @@
+import * as bootstrap from './bootstrap';
+
+export { makeHttpInstrumentationConfig } from './httpHooks';
+export { instrumentApiMethod, endSpan } from './instrumentation';
+export type { InitOptions } from './bootstrap';
+export * as kafka from './kafkaTraceContext';
+
+export const isEnabled = bootstrap.isEnabled;
+export const init = bootstrap.init;
+export const close = bootstrap.close;

--- a/lib/tracing/instrumentation.ts
+++ b/lib/tracing/instrumentation.ts
@@ -1,0 +1,121 @@
+import type { Tracer, Span } from '@opentelemetry/api';
+import { isEnabled } from './bootstrap';
+import { API_TRACER_NAME, SPAN_PREFIX, ERROR_TYPE_ATTR } from './constants';
+
+// Lazy-loaded so OTEL-off processes don't pull in @opentelemetry/api at all
+// (consumers expect "no @opentelemetry/* loaded when ENABLE_OTEL is unset").
+// instrumentApiMethod gates on isEnabled() before any code path here that
+// calls getApi(), so it's safe to assume the require succeeds when reached.
+let api: typeof import('@opentelemetry/api') | null = null;
+function getApi(): typeof import('@opentelemetry/api') {
+    if (api) {
+        return api;
+    }
+    api = require('@opentelemetry/api');
+    return api!;
+}
+
+let tracer: Tracer | null = null;
+function getTracer(): Tracer {
+    if (tracer) {
+        return tracer;
+    }
+    tracer = getApi().trace.getTracer(API_TRACER_NAME);
+    return tracer;
+}
+
+// Test-only: drop the cached tracer so a freshly-installed provider is picked up.
+export function resetTracer(): void {
+    tracer = null;
+}
+
+// Mark a span errored or OK, then end it. Exported for callers owning their spans.
+export function endSpan(span: Span, err?: any): void {
+    const { SpanStatusCode } = getApi();
+    if (err) {
+        span.recordException(err);
+        span.setStatus({ code: SpanStatusCode.ERROR });
+        if (err.code) {
+            span.setAttribute(ERROR_TYPE_ATTR, err.code);
+        }
+    } else {
+        span.setStatus({ code: SpanStatusCode.OK });
+    }
+    span.end();
+}
+
+type ApiMethod = (...args: any[]) => any;
+
+function instrumentCallbackHandler(
+    self: unknown,
+    apiMethod: ApiMethod,
+    spanName: string,
+    args: any[],
+    callbackIndex: number,
+): any {
+    const { trace, context, SpanKind } = getApi();
+    const span = getTracer().startSpan(spanName, { kind: SpanKind.INTERNAL });
+
+    const wrappedArgs = [...args];
+    const originalCallback = args[callbackIndex];
+    wrappedArgs[callbackIndex] = function wrappedCallback(this: unknown, err: any, ...results: any[]) {
+        endSpan(span, err);
+        return originalCallback.call(this, err, ...results);
+    };
+
+    const ctx = trace.setSpan(context.active(), span);
+    try {
+        return context.with(ctx, () => apiMethod.apply(self, wrappedArgs));
+    } catch (err) {
+        endSpan(span, err);
+        throw err;
+    }
+}
+
+function instrumentAsyncHandler(self: unknown, apiMethod: ApiMethod, spanName: string, args: any[]): any {
+    const { trace, context, SpanKind } = getApi();
+    const span = getTracer().startSpan(spanName, { kind: SpanKind.INTERNAL });
+    const ctx = trace.setSpan(context.active(), span);
+
+    let result;
+    try {
+        result = context.with(ctx, () => apiMethod.apply(self, args));
+    } catch (err) {
+        endSpan(span, err);
+        throw err;
+    }
+
+    // Only chain endSpan if the handler returned a Promise; otherwise end now
+    // and return the raw value (preserve sync vs async return shape).
+    if (result && typeof result.then === 'function') {
+        return (async () => {
+            let value;
+            try {
+                value = await result;
+            } catch (err) {
+                endSpan(span, err);
+                throw err;
+            }
+            endSpan(span);
+            return value;
+        })();
+    }
+    endSpan(span);
+    return result;
+}
+
+// Wrap an API handler so each call produces an `api.<methodName>` span; returns
+// the handler unchanged when OTEL is off.
+export function instrumentApiMethod<T extends (...args: any[]) => any>(apiMethod: T, methodName: string): T {
+    if (!isEnabled()) {
+        return apiMethod;
+    }
+    const spanName = `${SPAN_PREFIX}${methodName}`;
+    return function instrumented(this: unknown, ...args: any[]) {
+        const callbackIndex = (args as any).findLastIndex((a: any) => typeof a === 'function');
+        if (callbackIndex !== -1) {
+            return instrumentCallbackHandler(this, apiMethod, spanName, args, callbackIndex);
+        }
+        return instrumentAsyncHandler(this, apiMethod, spanName, args);
+    } as T;
+}

--- a/lib/tracing/kafkaTraceContext.ts
+++ b/lib/tracing/kafkaTraceContext.ts
@@ -1,0 +1,106 @@
+import type { Context, Span, Link } from '@opentelemetry/api';
+import { KAFKA_TRACER_NAME } from './constants';
+
+type KafkaHeader = Record<string, Buffer | string>;
+
+// Lazy-loaded so OTEL-off processes (and arsenal consumers that don't use the
+// kafka helpers at all, e.g. cloudserver) never pull in @opentelemetry/api.
+let api: typeof import('@opentelemetry/api') | null = null;
+function getApi(): typeof import('@opentelemetry/api') {
+    if (api) {
+        return api;
+    }
+    api = require('@opentelemetry/api');
+    return api!;
+}
+
+// Extract traceparent from a parsed oplog entry value into node-rdkafka headers.
+export function traceHeadersFromEntry(entryValue: any): KafkaHeader[] | undefined {
+    const tc = entryValue && entryValue.traceContext;
+    if (!tc || !tc.traceparent) {
+        return undefined;
+    }
+    const headers: KafkaHeader[] = [{ traceparent: tc.traceparent }];
+    if (tc.tracestate) {
+        headers.push({ tracestate: tc.tracestate });
+    }
+    return headers;
+}
+
+// Build an OTEL context carrying the remote span from Kafka message headers.
+export function contextFromKafkaHeaders(kafkaHeaders?: KafkaHeader[] | null): Context {
+    const { propagation, ROOT_CONTEXT } = getApi();
+    // Base on ROOT_CONTEXT, not context.active(): with no traceparent we want
+    // no link (not a spurious one to whatever span happens to be active).
+    if (!kafkaHeaders) {
+        return ROOT_CONTEXT;
+    }
+    const carrier: Record<string, string> = {};
+    for (const h of kafkaHeaders) {
+        if (h.traceparent) {
+            carrier.traceparent = h.traceparent.toString();
+        }
+        if (h.tracestate) {
+            carrier.tracestate = h.tracestate.toString();
+        }
+    }
+    if (!carrier.traceparent) {
+        return ROOT_CONTEXT;
+    }
+    return propagation.extract(ROOT_CONTEXT, carrier);
+}
+
+// Start a new root span that LINKS to (not a child of) the upstream span in the
+// Kafka entry. Kafka hops can fire hours after the original request, so links —
+// not parent/child — keep traces small. Caller must span.end(). New trace each read.
+export function startLinkedSpanFromKafkaEntry(
+    kafkaEntry: { headers?: KafkaHeader[] },
+    operationName: string,
+): { ctx: Context; span: Span } {
+    const { trace, SpanKind, ROOT_CONTEXT } = getApi();
+    const tracer = trace.getTracer(KAFKA_TRACER_NAME);
+    const links: Link[] = [];
+
+    const parentCtx = contextFromKafkaHeaders(kafkaEntry.headers);
+    const remoteSpan = trace.getSpan(parentCtx);
+    const remoteSpanCtx = remoteSpan && remoteSpan.spanContext();
+    if (remoteSpanCtx && trace.isSpanContextValid(remoteSpanCtx)) {
+        links.push({ context: remoteSpanCtx });
+    }
+
+    // ROOT_CONTEXT forces a new trace even if a span is somehow active here.
+    const span = tracer.startSpan(
+        operationName,
+        {
+            kind: SpanKind.CONSUMER,
+            links,
+        },
+        ROOT_CONTEXT,
+    );
+
+    return { ctx: trace.setSpan(ROOT_CONTEXT, span), span };
+}
+
+// Serialize the active OTEL context into node-rdkafka traceparent/tracestate headers.
+export function traceHeadersFromCurrentContext(): KafkaHeader[] | undefined {
+    const { trace, context, propagation } = getApi();
+    const span = trace.getSpan(context.active());
+    if (!span) {
+        return undefined;
+    }
+    const spanCtx = span.spanContext();
+    if (!spanCtx || !trace.isSpanContextValid(spanCtx)) {
+        return undefined;
+    }
+
+    const carrier: Record<string, string> = {};
+    propagation.inject(context.active(), carrier);
+    const headers: KafkaHeader[] = [];
+    if (carrier.traceparent) {
+        headers.push({ traceparent: carrier.traceparent });
+    }
+    if (carrier.tracestate) {
+        headers.push({ tracestate: carrier.tracestate });
+    }
+    return headers.length > 0 ? headers : undefined;
+}

--- a/package.json
+++ b/package.json
@@ -57,6 +57,10 @@
         "xml2js": "^0.6.2"
     },
     "optionalDependencies": {
+        "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
+        "@opentelemetry/resources": "^2.7.1",
+        "@opentelemetry/sdk-node": "^0.218.0",
+        "@opentelemetry/sdk-trace-base": "^2.7.1",
         "ioctl": "^2.0.2"
     },
     "devDependencies": {
@@ -64,6 +68,8 @@
         "@babel/preset-typescript": "^7.27.1",
         "@eslint/compat": "^1.4.0",
         "@eslint/plugin-kit": "^0.4.0",
+        "@opentelemetry/context-async-hooks": "^2.7.1",
+        "@opentelemetry/core": "^2.7.1",
         "@scality/eslint-config-scality": "scality/Guidelines#8.3.2",
         "@sinonjs/fake-timers": "^15.0.0",
         "@types/async": "^3.2.24",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "engines": {
         "node": ">=20"
     },
-    "version": "8.4.4",
+    "version": "8.4.5",
     "description": "Common utilities for the S3 project components",
     "main": "build/index.js",
     "repository": {

--- a/tests/unit/tracing/bootstrap.spec.js
+++ b/tests/unit/tracing/bootstrap.spec.js
@@ -1,0 +1,244 @@
+'use strict';
+
+const assert = require('assert');
+const sinon = require('sinon');
+const { NodeSDK } = require('@opentelemetry/sdk-node');
+const { diag } = require('@opentelemetry/api');
+const werelogs = require('werelogs');
+
+const BOOTSTRAP_PATH = '../../../lib/tracing/bootstrap';
+const ENDPOINT = 'http://otel-collector.test:4318/v1/traces';
+
+// Under jest, require.cache busting is a no-op, so the bootstrap module is a
+// singleton across tests; afterEach close()s it to reset module-level sdk.
+function freshTracing() {
+    // eslint-disable-next-line global-require
+    return require(BOOTSTRAP_PATH);
+}
+
+describe('tracing/bootstrap', () => {
+    let startStub;
+    let shutdownStub;
+    const savedEnv = {};
+
+    beforeEach(() => {
+        ['ENABLE_OTEL', 'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', 'OTEL_SAMPLING_RATIO'].forEach(k => {
+            savedEnv[k] = process.env[k];
+            delete process.env[k];
+        });
+        startStub = sinon.stub(NodeSDK.prototype, 'start');
+        shutdownStub = sinon.stub(NodeSDK.prototype, 'shutdown').resolves();
+        // Suppress diag's "logger overwritten" warnings across reloads.
+        sinon.stub(diag, 'setLogger');
+    });
+
+    afterEach(async () => {
+        // Null out any sdk a test left set (shutdown still stubbed) for a clean next test.
+        try {
+            await require(BOOTSTRAP_PATH).close();
+        } catch (e) {
+            void e;
+        }
+        sinon.restore();
+        Object.keys(savedEnv).forEach(k => {
+            if (savedEnv[k] === undefined) {
+                delete process.env[k];
+            } else {
+                process.env[k] = savedEnv[k];
+            }
+        });
+    });
+
+    describe('isEnabled', () => {
+        it('is false unless ENABLE_OTEL === "true"', () => {
+            const tracing = freshTracing();
+            assert.strictEqual(tracing.isEnabled(), false);
+            process.env.ENABLE_OTEL = 'false';
+            assert.strictEqual(tracing.isEnabled(), false);
+            process.env.ENABLE_OTEL = '1';
+            assert.strictEqual(tracing.isEnabled(), false);
+            process.env.ENABLE_OTEL = 'true';
+            assert.strictEqual(tracing.isEnabled(), true);
+        });
+    });
+
+    describe('init', () => {
+        it('is a no-op when OTEL is disabled — and never calls the instrumentations thunk', () => {
+            let thunkCalls = 0;
+            const tracing = freshTracing();
+            tracing.init({
+                serviceName: 'svc',
+                instrumentations: () => {
+                    thunkCalls += 1;
+                    return [];
+                },
+            });
+            assert.strictEqual(startStub.callCount, 0);
+            assert.strictEqual(thunkCalls, 0);
+        });
+
+        it('throws when enabled without an exporter endpoint (before the thunk runs)', () => {
+            process.env.ENABLE_OTEL = 'true';
+            let thunkCalls = 0;
+            const tracing = freshTracing();
+            assert.throws(
+                () =>
+                    tracing.init({
+                        serviceName: 'svc',
+                        instrumentations: () => {
+                            thunkCalls += 1;
+                            return [];
+                        },
+                    }),
+                /OTEL_EXPORTER_OTLP_TRACES_ENDPOINT is unset/,
+            );
+            assert.strictEqual(startStub.callCount, 0);
+            assert.strictEqual(thunkCalls, 0);
+        });
+
+        it('throws when enabled without a serviceName', () => {
+            process.env.ENABLE_OTEL = 'true';
+            process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = ENDPOINT;
+            const tracing = freshTracing();
+            assert.throws(() => tracing.init({}), /serviceName is required/);
+            assert.strictEqual(startStub.callCount, 0);
+        });
+
+        it('throws on a non-finite sampling ratio', () => {
+            process.env.ENABLE_OTEL = 'true';
+            process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = ENDPOINT;
+            process.env.OTEL_SAMPLING_RATIO = 'abc';
+            const tracing = freshTracing();
+            assert.throws(() => tracing.init({ serviceName: 'svc' }), /OTEL_SAMPLING_RATIO/);
+        });
+
+        it('throws on a sampling ratio outside [0, 1]', () => {
+            process.env.ENABLE_OTEL = 'true';
+            process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = ENDPOINT;
+            process.env.OTEL_SAMPLING_RATIO = '1.5';
+            const tracing = freshTracing();
+            assert.throws(() => tracing.init({ serviceName: 'svc' }), /OTEL_SAMPLING_RATIO/);
+        });
+
+        it('boots the SDK once, invokes the thunk once, and is idempotent', () => {
+            process.env.ENABLE_OTEL = 'true';
+            process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = ENDPOINT;
+            let thunkCalls = 0;
+            const tracing = freshTracing();
+            const opts = {
+                serviceName: 'svc',
+                instrumentations: () => {
+                    thunkCalls += 1;
+                    return [];
+                },
+            };
+            tracing.init(opts);
+            tracing.init(opts);
+            assert.strictEqual(startStub.callCount, 1);
+            assert.strictEqual(thunkCalls, 1);
+        });
+
+        it('works without an instrumentations thunk (empty instrumentation set)', () => {
+            process.env.ENABLE_OTEL = 'true';
+            process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = ENDPOINT;
+            const tracing = freshTracing();
+            assert.doesNotThrow(() => tracing.init({ serviceName: 'svc' }));
+            assert.strictEqual(startStub.callCount, 1);
+        });
+    });
+
+    describe('close', () => {
+        it('is a no-op when never initialized', async () => {
+            const tracing = freshTracing();
+            await tracing.close();
+            assert.strictEqual(shutdownStub.callCount, 0);
+        });
+
+        it('shuts the SDK down exactly once across concurrent close() callers', async () => {
+            process.env.ENABLE_OTEL = 'true';
+            process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = ENDPOINT;
+            const tracing = freshTracing();
+            tracing.init({ serviceName: 'svc' });
+            await Promise.all([tracing.close(), tracing.close()]);
+            assert.strictEqual(shutdownStub.callCount, 1);
+        });
+
+        it('resolves (does not throw) when sdk.shutdown rejects', async () => {
+            process.env.ENABLE_OTEL = 'true';
+            process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = ENDPOINT;
+            shutdownStub.rejects(new Error('collector unreachable'));
+            // werelogs level methods live on the instance prototype, not Logger.prototype.
+            const errStub = sinon.stub(Object.getPrototypeOf(new werelogs.Logger('stub')), 'error');
+            const tracing = freshTracing();
+            tracing.init({ serviceName: 'svc' });
+            await tracing.close();
+            assert.strictEqual(shutdownStub.callCount, 1);
+            assert(errStub.called);
+        });
+    });
+});
+
+const { _buildSdkConfig } = require('../../../lib/tracing/bootstrap');
+
+// _buildSdkConfig is pure assembly — asserted directly to lock the resource/
+// sampler/instrumentation contract handed to NodeSDK.
+describe('tracing/bootstrap _buildSdkConfig', () => {
+    const SERVICE_ENV = ['OTEL_SERVICE_NAME', 'OTEL_SERVICE_VERSION', 'OTEL_SERVICE_NAMESPACE'];
+    const saved = {};
+    beforeEach(() =>
+        SERVICE_ENV.forEach(k => {
+            saved[k] = process.env[k];
+            delete process.env[k];
+        }),
+    );
+    afterEach(() =>
+        SERVICE_ENV.forEach(k => {
+            if (saved[k] === undefined) {
+                delete process.env[k];
+            } else {
+                process.env[k] = saved[k];
+            }
+        }),
+    );
+
+    it('puts service.name/version/namespace on the resource from options + defaults', () => {
+        const cfg = _buildSdkConfig({ serviceName: 'cloudserver', serviceVersion: '1.2.3' }, ENDPOINT, 0.5);
+        assert.strictEqual(cfg.resource.attributes['service.name'], 'cloudserver');
+        assert.strictEqual(cfg.resource.attributes['service.version'], '1.2.3');
+        assert.strictEqual(cfg.resource.attributes['service.namespace'], 'scality');
+    });
+
+    it('lets OTEL_SERVICE_* env override the options', () => {
+        process.env.OTEL_SERVICE_NAME = 'from-env';
+        process.env.OTEL_SERVICE_NAMESPACE = 'tenant-x';
+        const cfg = _buildSdkConfig({ serviceName: 'cloudserver' }, ENDPOINT, 0.5);
+        assert.strictEqual(cfg.resource.attributes['service.name'], 'from-env');
+        assert.strictEqual(cfg.resource.attributes['service.namespace'], 'tenant-x');
+    });
+
+    it('leaves service.version unset when no serviceVersion/env is given', () => {
+        const cfg = _buildSdkConfig({ serviceName: 'svc' }, ENDPOINT, 0.5);
+        assert.strictEqual(cfg.resource.attributes['service.version'], undefined);
+    });
+
+    it('forwards the consumer instrumentations thunk result', () => {
+        const sentinel = [{ id: 'http' }, { id: 'ioredis' }];
+        const cfg = _buildSdkConfig({ serviceName: 'svc', instrumentations: () => sentinel }, ENDPOINT, 0.5);
+        assert.strictEqual(cfg.instrumentations, sentinel);
+    });
+
+    it('defaults to no instrumentations when no thunk is given', () => {
+        const cfg = _buildSdkConfig({ serviceName: 'svc' }, ENDPOINT, 0.5);
+        assert.deepStrictEqual(cfg.instrumentations, []);
+    });
+
+    it('is traces-only with the documented span limits and a ParentBased(TraceIdRatio) sampler', () => {
+        const cfg = _buildSdkConfig({ serviceName: 'svc' }, ENDPOINT, 0.5);
+        assert.deepStrictEqual(cfg.logRecordProcessors, []);
+        assert.deepStrictEqual(cfg.metricReaders, []);
+        assert.strictEqual(cfg.spanLimits.attributeValueLengthLimit, 4096);
+        assert.match(cfg.sampler.toString(), /ParentBased/);
+        assert.match(cfg.sampler.toString(), /TraceIdRatioBased\{0\.5/);
+        assert(cfg.traceExporter, 'a trace exporter is configured');
+    });
+});

--- a/tests/unit/tracing/httpHooks.spec.js
+++ b/tests/unit/tracing/httpHooks.spec.js
@@ -1,0 +1,231 @@
+'use strict';
+
+const assert = require('assert');
+const {
+    loadTrustedHosts,
+    makeTrustedHostsHook,
+    isHealthPath,
+    makeHttpInstrumentationConfig,
+} = require('../../../lib/tracing/httpHooks');
+
+describe('tracing/httpHooks', () => {
+    const savedEnv = process.env.OTEL_TRUSTED_HOSTS;
+
+    afterEach(() => {
+        if (savedEnv === undefined) {
+            delete process.env.OTEL_TRUSTED_HOSTS;
+        } else {
+            process.env.OTEL_TRUSTED_HOSTS = savedEnv;
+        }
+    });
+
+    describe('loadTrustedHosts', () => {
+        it('trusts only loopback when OTEL_TRUSTED_HOSTS is unset', () => {
+            delete process.env.OTEL_TRUSTED_HOSTS;
+            const hosts = loadTrustedHosts();
+            assert(hosts.has('localhost'));
+            assert(hosts.has('127.0.0.1'));
+            assert(hosts.has('::1'));
+            assert.strictEqual(hosts.size, 3);
+        });
+
+        it('adds each comma-separated host, lowercased, plus loopback', () => {
+            process.env.OTEL_TRUSTED_HOSTS = 'cloudserver.backend,Kafka-0,mongo-primary';
+            const hosts = loadTrustedHosts();
+            assert(hosts.has('cloudserver.backend'));
+            assert(hosts.has('kafka-0'));
+            assert(hosts.has('mongo-primary'));
+            assert(hosts.has('localhost'));
+        });
+
+        it('ignores empty entries from trailing/double commas', () => {
+            process.env.OTEL_TRUSTED_HOSTS = 'a,,b,';
+            const hosts = loadTrustedHosts();
+            assert(hosts.has('a'));
+            assert(hosts.has('b'));
+            assert.strictEqual(hosts.has(''), false);
+        });
+
+        it('does no port/url normalization (operator supplies bare hosts)', () => {
+            process.env.OTEL_TRUSTED_HOSTS = 'host-with-port:9092';
+            const hosts = loadTrustedHosts();
+            assert(hosts.has('host-with-port:9092'));
+            assert.strictEqual(hosts.has('host-with-port'), false);
+        });
+    });
+
+    describe('makeTrustedHostsHook', () => {
+        const trusted = new Set(['localhost', 'trusted.internal']);
+
+        function fakeClientRequest(hostHeader) {
+            const removed = [];
+            return {
+                _removed: removed,
+                getHeader: name => (name === 'host' ? hostHeader : undefined),
+                removeHeader: name => removed.push(name),
+            };
+        }
+
+        function fakeSpan() {
+            const attrs = {};
+            return {
+                _attrs: attrs,
+                setAttribute: (k, v) => {
+                    attrs[k] = v;
+                },
+            };
+        }
+
+        it('leaves traceparent intact on trusted hosts', () => {
+            const hook = makeTrustedHostsHook(trusted);
+            const req = fakeClientRequest('trusted.internal');
+            const span = fakeSpan();
+            hook(span, req);
+            assert.deepStrictEqual(req._removed, []);
+            assert.strictEqual(span._attrs['scality.trace.suppressed'], undefined);
+        });
+
+        it('strips traceparent/tracestate + tags span on untrusted hosts', () => {
+            const hook = makeTrustedHostsHook(trusted);
+            const req = fakeClientRequest('s3.amazonaws.com');
+            const span = fakeSpan();
+            hook(span, req);
+            assert.deepStrictEqual(req._removed, ['traceparent', 'tracestate']);
+            assert.strictEqual(span._attrs['scality.trace.suppressed'], true);
+        });
+
+        it('strips the port from the Host header before matching', () => {
+            const hook = makeTrustedHostsHook(trusted);
+            const req = fakeClientRequest('trusted.internal:8000');
+            const span = fakeSpan();
+            hook(span, req);
+            assert.deepStrictEqual(req._removed, []);
+        });
+
+        it('normalizes a bracketed IPv6 Host header', () => {
+            const hook = makeTrustedHostsHook(new Set(['::1']));
+            const req = fakeClientRequest('[::1]:4318');
+            const span = fakeSpan();
+            hook(span, req);
+            assert.deepStrictEqual(req._removed, []);
+        });
+
+        describe('NO_PROXY-style leading-dot suffix entries', () => {
+            const clusterTrusted = new Set(['.svc.cluster.local']);
+
+            it('trusts a multi-label subdomain', () => {
+                const req = fakeClientRequest('foo.bar.svc.cluster.local');
+                makeTrustedHostsHook(clusterTrusted)(fakeSpan(), req);
+                assert.deepStrictEqual(req._removed, []);
+            });
+
+            it('trusts a single-label subdomain', () => {
+                const req = fakeClientRequest('bar.svc.cluster.local');
+                makeTrustedHostsHook(clusterTrusted)(fakeSpan(), req);
+                assert.deepStrictEqual(req._removed, []);
+            });
+
+            it('trusts the bare apex', () => {
+                const req = fakeClientRequest('svc.cluster.local');
+                makeTrustedHostsHook(clusterTrusted)(fakeSpan(), req);
+                assert.deepStrictEqual(req._removed, []);
+            });
+
+            it('normalizes a trailing dot (FQDN form) before matching', () => {
+                const req = fakeClientRequest('foo.svc.cluster.local.:4318');
+                makeTrustedHostsHook(clusterTrusted)(fakeSpan(), req);
+                assert.deepStrictEqual(req._removed, []);
+            });
+
+            it('does not match without the dot boundary', () => {
+                const req = fakeClientRequest('notsvc.cluster.local');
+                makeTrustedHostsHook(clusterTrusted)(fakeSpan(), req);
+                assert.deepStrictEqual(req._removed, ['traceparent', 'tracestate']);
+            });
+
+            it('does not match when the suffix is not at the end', () => {
+                const req = fakeClientRequest('svc.cluster.local.attacker.com');
+                makeTrustedHostsHook(clusterTrusted)(fakeSpan(), req);
+                assert.deepStrictEqual(req._removed, ['traceparent', 'tracestate']);
+            });
+
+            it('keeps non-dotted entries exact (no suffix behavior)', () => {
+                const hook = makeTrustedHostsHook(new Set(['kafka-0']));
+                const exact = fakeClientRequest('kafka-0');
+                hook(fakeSpan(), exact);
+                assert.deepStrictEqual(exact._removed, []);
+                const sub = fakeClientRequest('x.kafka-0');
+                hook(fakeSpan(), sub);
+                assert.deepStrictEqual(sub._removed, ['traceparent', 'tracestate']);
+            });
+        });
+
+        it('treats a missing Host header as untrusted', () => {
+            const hook = makeTrustedHostsHook(trusted);
+            const req = fakeClientRequest(undefined);
+            const span = fakeSpan();
+            hook(span, req);
+            assert.deepStrictEqual(req._removed, ['traceparent', 'tracestate']);
+        });
+
+        it('skips inbound server requests (no getHeader)', () => {
+            const hook = makeTrustedHostsHook(trusted);
+            const span = fakeSpan();
+            assert.doesNotThrow(() => hook(span, { url: '/foo' }));
+            assert.strictEqual(span._attrs['scality.trace.suppressed'], undefined);
+        });
+    });
+
+    describe('isHealthPath', () => {
+        const PATHS = new Set(['/probe', '/ready', '/metrics']);
+
+        it('matches paths in the set', () => {
+            ['/probe', '/ready', '/metrics'].forEach(p => assert.strictEqual(isHealthPath(p, PATHS), true, p));
+        });
+
+        it('ignores a query string when matching', () => {
+            assert.strictEqual(isHealthPath('/probe?token=x', PATHS), true);
+            assert.strictEqual(isHealthPath('/metrics?format=prom', PATHS), true);
+        });
+
+        it('does not match paths outside the set', () => {
+            ['/bucket/key', '/probez', '/metrics/custom', '/ready/deep'].forEach(p =>
+                assert.strictEqual(isHealthPath(p, PATHS), false, p),
+            );
+        });
+
+        it('respects the caller-provided set', () => {
+            const single = new Set(['/healthcheck']);
+            assert.strictEqual(isHealthPath('/healthcheck', single), true);
+            assert.strictEqual(isHealthPath('/probe', single), false);
+        });
+
+        it('returns false for non-string / empty input', () => {
+            assert.strictEqual(isHealthPath(undefined, PATHS), false);
+            assert.strictEqual(isHealthPath('', PATHS), false);
+            assert.strictEqual(isHealthPath(42, PATHS), false);
+        });
+    });
+
+    describe('makeHttpInstrumentationConfig', () => {
+        it('always wires requestHook + an ignore hook; never disables inbound', () => {
+            const cfg = makeHttpInstrumentationConfig({ healthPaths: ['/live', '/metrics'] });
+            assert.strictEqual(typeof cfg.requestHook, 'function');
+            assert.strictEqual(cfg.disableIncomingRequestInstrumentation, undefined);
+            const ignore = cfg.ignoreIncomingRequestHook;
+            assert.strictEqual(ignore({ method: 'OPTIONS', url: '/anything' }), true);
+            assert.strictEqual(ignore({ method: 'GET', url: '/metrics?x=1' }), true);
+            assert.strictEqual(ignore({ method: 'GET', url: '/live' }), true);
+            assert.strictEqual(ignore({ method: 'GET', url: '/bucket/key' }), false);
+        });
+
+        it('omitted/empty healthPaths: still inbound-enabled, drops only OPTIONS', () => {
+            for (const cfg of [makeHttpInstrumentationConfig(), makeHttpInstrumentationConfig({ healthPaths: [] })]) {
+                assert.strictEqual(cfg.disableIncomingRequestInstrumentation, undefined);
+                assert.strictEqual(typeof cfg.requestHook, 'function');
+                assert.strictEqual(cfg.ignoreIncomingRequestHook({ method: 'OPTIONS', url: '/x' }), true);
+                assert.strictEqual(cfg.ignoreIncomingRequestHook({ method: 'GET', url: '/anything' }), false);
+            }
+        });
+    });
+});

--- a/tests/unit/tracing/instrumentation.spec.js
+++ b/tests/unit/tracing/instrumentation.spec.js
@@ -1,0 +1,157 @@
+'use strict';
+
+const assert = require('assert');
+const { trace, SpanStatusCode } = require('@opentelemetry/api');
+const {
+    BasicTracerProvider,
+    InMemorySpanExporter,
+    SimpleSpanProcessor,
+    AlwaysOnSampler,
+} = require('@opentelemetry/sdk-trace-base');
+
+const { instrumentApiMethod, resetTracer } = require('../../../lib/tracing/instrumentation');
+
+describe('instrumentApiMethod', () => {
+    let exporter;
+    let provider;
+
+    beforeAll(() => {
+        process.env.ENABLE_OTEL = 'true';
+        exporter = new InMemorySpanExporter();
+        provider = new BasicTracerProvider({
+            sampler: new AlwaysOnSampler(),
+            spanProcessors: [new SimpleSpanProcessor(exporter)],
+        });
+        trace.setGlobalTracerProvider(provider);
+        // Drop any tracer cached before the provider above was installed.
+        resetTracer();
+    });
+
+    afterAll(async () => {
+        delete process.env.ENABLE_OTEL;
+        resetTracer();
+        await provider.shutdown();
+        trace.disable();
+    });
+
+    describe('OTEL on', () => {
+        afterEach(() => exporter.reset());
+
+        it('should wrap a callback handler and end span on success', done => {
+            const handler = (a, b, cb) => cb(null, 'ok');
+            const wrapped = instrumentApiMethod(handler, 'objectGet');
+
+            wrapped('foo', 'bar', (err, value) => {
+                assert.strictEqual(err, null);
+                assert.strictEqual(value, 'ok');
+
+                const spans = exporter.getFinishedSpans();
+                assert.strictEqual(spans.length, 1);
+                assert.strictEqual(spans[0].name, 'api.objectGet');
+                assert.strictEqual(spans[0].status.code, SpanStatusCode.OK);
+                done();
+            });
+        });
+
+        it("should end span with ERROR when handler's callback fires with err", done => {
+            const handler = (a, cb) => cb(Object.assign(new Error('nope'), { code: 'NoSuchBucket' }));
+            const wrapped = instrumentApiMethod(handler, 'bucketHead');
+
+            wrapped('foo', err => {
+                assert.strictEqual(err.message, 'nope');
+
+                const spans = exporter.getFinishedSpans();
+                assert.strictEqual(spans.length, 1);
+                assert.strictEqual(spans[0].status.code, SpanStatusCode.ERROR);
+                assert.strictEqual(spans[0].attributes['error.type'], 'NoSuchBucket');
+                done();
+            });
+        });
+
+        it('should end span and re-throw on synchronous throw before callback fires', () => {
+            const handler = () => {
+                throw new Error('sync-boom');
+            };
+            const wrapped = instrumentApiMethod(handler, 'objectDelete');
+
+            assert.throws(() => wrapped(() => {}), /sync-boom/);
+
+            const spans = exporter.getFinishedSpans();
+            assert.strictEqual(spans.length, 1);
+            assert.strictEqual(spans[0].status.code, SpanStatusCode.ERROR);
+        });
+
+        it('should wrap an async handler and end span on resolution', async () => {
+            const handler = async a => `async-${a}`;
+            const wrapped = instrumentApiMethod(handler, 'objectGetAsync');
+
+            const value = await wrapped('x');
+            assert.strictEqual(value, 'async-x');
+
+            const spans = exporter.getFinishedSpans();
+            assert.strictEqual(spans.length, 1);
+            assert.strictEqual(spans[0].name, 'api.objectGetAsync');
+            assert.strictEqual(spans[0].status.code, SpanStatusCode.OK);
+        });
+
+        it('should wrap an async handler and end span with ERROR on rejection', async () => {
+            const handler = async () => {
+                const err = new Error('async-nope');
+                err.code = 'NoSuchKey';
+                throw err;
+            };
+            const wrapped = instrumentApiMethod(handler, 'objectGetAsync');
+
+            await assert.rejects(wrapped(), /async-nope/);
+
+            const spans = exporter.getFinishedSpans();
+            assert.strictEqual(spans.length, 1);
+            assert.strictEqual(spans[0].status.code, SpanStatusCode.ERROR);
+            assert.strictEqual(spans[0].attributes['error.type'], 'NoSuchKey');
+        });
+
+        it('should end span on sync return when handler has no callback arg', () => {
+            const handler = (a, b) => `${a}-${b}`;
+            const wrapped = instrumentApiMethod(handler, 'objectRestore');
+
+            assert.strictEqual(wrapped('x', 'y'), 'x-y');
+
+            const spans = exporter.getFinishedSpans();
+            assert.strictEqual(spans.length, 1);
+            assert.strictEqual(spans[0].status.code, SpanStatusCode.OK);
+        });
+
+        it('should preserve `this` across async cross-calls (static-method shape)', done => {
+            // Guards apiMethod.apply(self, args): consumers (e.g. vault's
+            // Router.js call to RoleHandler.assumeRole) pass `Class.method.bind(Class)`
+            // because the static method invokes other statics via `this` from
+            // an async waterfall callback. If apply forgets to thread the
+            // receiver, the inner `this.rejectAccessDenied(cb)` crashes.
+            class Handler {
+                static rejectAccessDenied(cb) {
+                    cb(null, 'denied');
+                }
+                static assumeRole(req, cb) {
+                    setImmediate(() => this.rejectAccessDenied(cb));
+                }
+            }
+            const wrapped = instrumentApiMethod(Handler.assumeRole.bind(Handler), 'AssumeRole');
+            wrapped({}, (err, value) => {
+                assert.strictEqual(err, null);
+                assert.strictEqual(value, 'denied');
+                done();
+            });
+        });
+    });
+
+    describe('OTEL off', () => {
+        afterEach(() => {
+            process.env.ENABLE_OTEL = 'true';
+        });
+        it('should return the original function unchanged', () => {
+            process.env.ENABLE_OTEL = 'false';
+            const handler = () => 'identity';
+            assert.strictEqual(instrumentApiMethod(handler, 'foo'), handler);
+        });
+    });
+});

--- a/tests/unit/tracing/kafkaTraceContext.spec.js
+++ b/tests/unit/tracing/kafkaTraceContext.spec.js
@@ -1,0 +1,147 @@
+'use strict';
+
+const assert = require('assert');
+const { ROOT_CONTEXT, trace, propagation, context } = require('@opentelemetry/api');
+const { W3CTraceContextPropagator } = require('@opentelemetry/core');
+const { AsyncLocalStorageContextManager } = require('@opentelemetry/context-async-hooks');
+
+const {
+    traceHeadersFromEntry,
+    traceHeadersFromCurrentContext,
+    contextFromKafkaHeaders,
+    startLinkedSpanFromKafkaEntry,
+} = require('../../../lib/tracing/kafkaTraceContext');
+
+describe('kafkaTraceContext', () => {
+    describe('traceHeadersFromEntry', () => {
+        it('should return undefined when entryValue is null', () => {
+            assert.strictEqual(traceHeadersFromEntry(null), undefined);
+        });
+
+        it('should return undefined when entryValue is undefined', () => {
+            assert.strictEqual(traceHeadersFromEntry(undefined), undefined);
+        });
+
+        it('should return undefined when traceContext is missing', () => {
+            assert.strictEqual(traceHeadersFromEntry({ foo: 'bar' }), undefined);
+        });
+
+        it('should return undefined when traceparent is missing', () => {
+            assert.strictEqual(traceHeadersFromEntry({ traceContext: {} }), undefined);
+        });
+
+        it('should return headers array with traceparent only', () => {
+            const tp = '00-abcdef1234567890abcdef1234567890-1234567890abcdef-01';
+            const result = traceHeadersFromEntry({
+                traceContext: { traceparent: tp },
+            });
+            assert.deepStrictEqual(result, [{ traceparent: tp }]);
+        });
+
+        it('should return headers array with traceparent and tracestate', () => {
+            const tp = '00-abcdef1234567890abcdef1234567890-1234567890abcdef-01';
+            const ts = 'congo=t61rcWkgMzE';
+            const result = traceHeadersFromEntry({
+                traceContext: { traceparent: tp, tracestate: ts },
+            });
+            assert.deepStrictEqual(result, [{ traceparent: tp }, { tracestate: ts }]);
+        });
+    });
+
+    describe('contextFromKafkaHeaders', () => {
+        it('should return root context when headers are undefined', () => {
+            const result = contextFromKafkaHeaders(undefined);
+            assert.strictEqual(result, ROOT_CONTEXT);
+        });
+
+        it('should return root context when headers are null', () => {
+            const result = contextFromKafkaHeaders(null);
+            assert.strictEqual(result, ROOT_CONTEXT);
+        });
+
+        it('should return root context when no traceparent header', () => {
+            const headers = [{ unrelated: Buffer.from('value') }];
+            const result = contextFromKafkaHeaders(headers);
+            assert.strictEqual(result, ROOT_CONTEXT);
+        });
+
+        it('should call propagation.extract with correct carrier', () => {
+            const tp = '00-abcdef1234567890abcdef1234567890-1234567890abcdef-01';
+            const headers = [{ traceparent: Buffer.from(tp) }, { tracestate: Buffer.from('congo=t61rcWkgMzE') }];
+            const result = contextFromKafkaHeaders(headers);
+            assert(result, 'should return a context object');
+        });
+    });
+
+    describe('startLinkedSpanFromKafkaEntry', () => {
+        it('returns a span with no headers (no link)', () => {
+            const entry = { topic: 'test-topic', partition: 0 };
+            const { ctx, span } = startLinkedSpanFromKafkaEntry(entry, 'test-op');
+            assert(ctx);
+            assert(span);
+            assert.strictEqual(typeof span.end, 'function');
+            span.end();
+        });
+
+        it('returns a span with traceparent header (creates link)', () => {
+            const tp = '00-abcdef1234567890abcdef1234567890-1234567890abcdef-01';
+            const entry = {
+                topic: 'test-topic',
+                partition: 0,
+                headers: [{ traceparent: Buffer.from(tp) }],
+            };
+            const { ctx, span } = startLinkedSpanFromKafkaEntry(entry, 'test-op');
+            assert(ctx);
+            assert(span);
+            assert.strictEqual(typeof span.setAttribute, 'function');
+            assert.strictEqual(typeof span.recordException, 'function');
+            span.end();
+        });
+    });
+
+    describe('traceHeadersFromCurrentContext', () => {
+        it('returns undefined when no active span', () => {
+            assert.strictEqual(traceHeadersFromCurrentContext(), undefined);
+        });
+    });
+
+    describe('with a registered W3C propagator', () => {
+        const traceId = '0af7651916cd43dd8448eb211c80319c';
+        const spanId = 'b7ad6b7169203331';
+
+        beforeAll(() => {
+            context.setGlobalContextManager(new AsyncLocalStorageContextManager().enable());
+            propagation.setGlobalPropagator(new W3CTraceContextPropagator());
+        });
+        afterAll(() => {
+            context.disable();
+            propagation.disable();
+        });
+
+        it('startLinkedSpanFromKafkaEntry adds a link for a valid upstream traceparent', () => {
+            const entry = {
+                headers: [{ traceparent: Buffer.from(`00-${traceId}-${spanId}-01`) }],
+            };
+            const { ctx, span } = startLinkedSpanFromKafkaEntry(entry, 'test.process');
+            assert(ctx);
+            assert(span);
+            span.end();
+        });
+
+        it('traceHeadersFromCurrentContext serializes the active span to a traceparent header', () => {
+            const span = trace.wrapSpanContext({ traceId, spanId, traceFlags: 1 });
+            const headers = context.with(trace.setSpan(context.active(), span), () => traceHeadersFromCurrentContext());
+            assert(Array.isArray(headers));
+            const tp = headers.find(h => h.traceparent);
+            assert(tp && tp.traceparent.startsWith(`00-${traceId}-`));
+        });
+
+        it('traceHeadersFromCurrentContext returns undefined for an invalid (all-zero) span context', () => {
+            const invalid = trace.wrapSpanContext({ traceId: '0'.repeat(32), spanId: '0'.repeat(16), traceFlags: 0 });
+            const headers = context.with(trace.setSpan(context.active(), invalid), () =>
+                traceHeadersFromCurrentContext(),
+            );
+            assert.strictEqual(headers, undefined);
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2079,6 +2079,24 @@
     "@eslint/core" "^0.16.0"
     levn "^0.4.1"
 
+"@grpc/grpc-js@^1.14.3":
+  version "1.14.4"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.14.4.tgz#e73ff57d97802f063999545f43ebb2b1eca65d9d"
+  integrity sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==
+  dependencies:
+    "@grpc/proto-loader" "^0.8.0"
+    "@js-sdsl/ordered-map" "^4.4.2"
+
+"@grpc/proto-loader@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.8.1.tgz#5a6b290ccbfb1ae2f6775afb74e9898bd8c5d4e8"
+  integrity sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==
+  dependencies:
+    lodash.camelcase "^4.3.0"
+    long "^5.0.0"
+    protobufjs "^7.5.5"
+    yargs "^17.7.2"
+
 "@hapi/address@^5.1.1":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-5.1.1.tgz#e9925fc1b65f5cc3fbea821f2b980e4652e84cb6"
@@ -2410,6 +2428,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@js-sdsl/ordered-map@^4.4.2":
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz#9299f82874bab9e4c7f9c48d865becbfe8d6907c"
+  integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
+
 "@js-sdsl/ordered-set@^4.4.2":
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-set/-/ordered-set-4.4.2.tgz#ab857eb63cf358b5a0f74fdd458b4601423779b7"
@@ -2461,20 +2484,360 @@
   dependencies:
     semver "^7.3.5"
 
+"@opentelemetry/api-logs@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz#7b9818e8dfdf1d3dcab88bfe4d6724f2f831f7ec"
+  integrity sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==
+  dependencies:
+    "@opentelemetry/api" "^1.3.0"
+
+"@opentelemetry/api@^1.3.0", "@opentelemetry/api@^1.9.0":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.1.tgz#c1b0346de336ba55af2d5a7970882037baedec05"
+  integrity sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==
+
 "@opentelemetry/api@^1.4.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.0.tgz#d03eba68273dc0f7509e2a3d5cba21eae10379fe"
   integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
 
-"@opentelemetry/api@^1.9.0":
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.1.tgz#c1b0346de336ba55af2d5a7970882037baedec05"
-  integrity sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==
+"@opentelemetry/configuration@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/configuration/-/configuration-0.218.0.tgz#a5fdd50ec9cfa0adb3bb41202cb39f79c5f4e7d9"
+  integrity sha512-W8wIz7H2R1pufR5jfjb3gU2XkMpm2x/7b1RJcsuzvd70Il/rWWE+g5/Od7hQKrxRTSrTrOWlru101PWXz5I1EQ==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    yaml "^2.0.0"
+
+"@opentelemetry/context-async-hooks@2.7.1", "@opentelemetry/context-async-hooks@^2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/context-async-hooks/-/context-async-hooks-2.7.1.tgz#1555a6fb269596416d8c626fd020c3f2c38e071f"
+  integrity sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==
+
+"@opentelemetry/core@2.7.1", "@opentelemetry/core@^2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-2.7.1.tgz#162bfab46d6ff4da1bef240ea52e23a926b0fdbc"
+  integrity sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==
+  dependencies:
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/exporter-logs-otlp-grpc@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.218.0.tgz#7e5a7e624074d6449590c851d58efe60096314b3"
+  integrity sha512-hoxrNH1l/Xy6F9WTJ5IK+6j1r9nQFlPOmrnTlhYHTySdunfXLmUCPv3bQtKYntxag9h3wLYBZQ2HI6FOx+BT2g==
+  dependencies:
+    "@grpc/grpc-js" "^1.14.3"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-grpc-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/sdk-logs" "0.218.0"
+
+"@opentelemetry/exporter-logs-otlp-http@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.218.0.tgz#0996cb45e0ebc6c7465445430a018edcac9871b4"
+  integrity sha512-Qx+4rpVHzgg89dawcWRHyt+XRXeLnhFz/qBtvggmjkcgPUdr+NAB0/u/eIPA8yAeJV0J80Vz43JZCh/XFvZFGw==
+  dependencies:
+    "@opentelemetry/api-logs" "0.218.0"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/sdk-logs" "0.218.0"
+
+"@opentelemetry/exporter-logs-otlp-proto@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.218.0.tgz#e539720b2e145e85a7a4901a1eabb0b2e77990f8"
+  integrity sha512-1/noQNsp9gXD75HPzgjBrcF1+XTtry7pFAUfxVEJgg7mPv2AawKQuYkhMmJ8qjxz4Ubc3Y8bwvfxevXsKTq4cg==
+  dependencies:
+    "@opentelemetry/api-logs" "0.218.0"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-logs" "0.218.0"
+    "@opentelemetry/sdk-trace-base" "2.7.1"
+
+"@opentelemetry/exporter-metrics-otlp-grpc@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.218.0.tgz#6d66c2638702489d063b8857741eee9cea1d21d6"
+  integrity sha512-YapQ9vNMX0NSZF6LK5pWAFfjpJleV2O9uYWfYGeb/5F1Kb9rPGK8tZDMJFa/sOksgdFuflDvYuA0B4qjDB4fjQ==
+  dependencies:
+    "@grpc/grpc-js" "^1.14.3"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/exporter-metrics-otlp-http" "0.218.0"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-grpc-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-metrics" "2.7.1"
+
+"@opentelemetry/exporter-metrics-otlp-http@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.218.0.tgz#c205581585d04c5106d1ca766e23632006e46a2c"
+  integrity sha512-bV7d2OuMpZu2+gAaxUAhzfZ0h3WVZk8ETQUEE3DNSntbTaMpuITjtm8I0rNyHFdm7Ax57K6ty7SgFXlBmOLIvQ==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-metrics" "2.7.1"
+
+"@opentelemetry/exporter-metrics-otlp-proto@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.218.0.tgz#66642b8bb5e654ca7a5944a4f0b490814fc875fd"
+  integrity sha512-ubLddKjWULhla9YZRCj/rTBeppjJYE4e9w0icx5mTu3eFhWjQzbV75NYjXuIlEG+NJsBl6d+sTFw5Qu+oej4oQ==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/exporter-metrics-otlp-http" "0.218.0"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-metrics" "2.7.1"
+
+"@opentelemetry/exporter-prometheus@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.218.0.tgz#41bddc97d34cd9d9993382b9c10fed19a8de63f4"
+  integrity sha512-RT5oEyu1kddZJ1vt7/BUo5wV+P7hpNAESsR3dUd3+8deHuX7gWNoCOZn+SfDT+hJHlIJ5h/AxiCLXIrutswDJg==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-metrics" "2.7.1"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/exporter-trace-otlp-grpc@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.218.0.tgz#5d5532ab94d5514bec8aedc19ce3170b6381eed1"
+  integrity sha512-3fXxVQEj9TNAFaCi79JeFKfeLd0sDtInaR3gaZDVlzNSPHtz8PZuCV34JKWjD4XXzT20IdMe8IpX6mRVNDA4Tw==
+  dependencies:
+    "@grpc/grpc-js" "^1.14.3"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-grpc-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-trace-base" "2.7.1"
+
+"@opentelemetry/exporter-trace-otlp-http@0.218.0", "@opentelemetry/exporter-trace-otlp-http@^0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.218.0.tgz#36d6abf6d639b9ea861603c61f434751c0b1a0ea"
+  integrity sha512-8dqezsmPhtKitIK/eTipZhYl9EX2/gNQ5zUMhaz3uxEURwfkNf8IPvo6yNfrzbxdtpAOybS/+h7wmIWYqFSpiw==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-trace-base" "2.7.1"
+
+"@opentelemetry/exporter-trace-otlp-proto@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.218.0.tgz#de0b2b3545149dafedd2b948fb891f9bf962940c"
+  integrity sha512-r1Msf8SNLRmwh9J6XQ5uh82D7CdDWMNHnPB7LAVHjzut0TkSeKc5KcIvr4SvHvfk/xwN5gxC+VLKQ1k0o8PSPw==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-trace-base" "2.7.1"
+
+"@opentelemetry/exporter-zipkin@2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.7.1.tgz#3b79d223adc8c097ba3323e4de4ed8abb83c789e"
+  integrity sha512-mfsD9bKAxcKrh5+y08TPodvClBO0CznBE3p79YAGnO81WI4LrdsGA65T53e4iTSbCalW4WaUpkbeJcbpyIUHfg==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-trace-base" "2.7.1"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/instrumentation@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.218.0.tgz#fcceb4ffb45f99c0d292600769150fc5944dc3e9"
+  integrity sha512-mIZil8Es+sYDK5m+DQiwAwF57F14TF2YlEqvIjZ/RQWcxDBwRGsKfdK2Tv65OU9meQKCMzSIFS9mxAcnAb6Bkg==
+  dependencies:
+    "@opentelemetry/api-logs" "0.218.0"
+    import-in-the-middle "^3.0.0"
+    require-in-the-middle "^8.0.0"
+
+"@opentelemetry/otlp-exporter-base@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz#f33e3217ce568756baa132fabe30f0c9345db086"
+  integrity sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+
+"@opentelemetry/otlp-grpc-exporter-base@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.218.0.tgz#dc5a1fec716245d84dc4167de9b1c607e07fb6a7"
+  integrity sha512-H/lCGJ536N98VpYJOaWTQOkv4Dx6TnmStK6Rqfu1W7KkFbPAx04hjdYEMZF/YbnHzPUSIK4kM6OE2GKGBTpV9A==
+  dependencies:
+    "@grpc/grpc-js" "^1.14.3"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+
+"@opentelemetry/otlp-transformer@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz#6784d0ddd13803c63a1b24072606c02fc21b9071"
+  integrity sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==
+  dependencies:
+    "@opentelemetry/api-logs" "0.218.0"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-logs" "0.218.0"
+    "@opentelemetry/sdk-metrics" "2.7.1"
+    "@opentelemetry/sdk-trace-base" "2.7.1"
+
+"@opentelemetry/propagator-b3@2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/propagator-b3/-/propagator-b3-2.7.1.tgz#107fe3e16d0728c489edbad221c402ee197514a4"
+  integrity sha512-RJid6E2CKyeGfKBzXKF21ejabGMHypFkPAh3qZ+NvI+SGjuIye79t3PmiqcDgtRzdKH6ynXzbfslQ8DfpRUg2A==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+
+"@opentelemetry/propagator-jaeger@2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.7.1.tgz#e8ebf3f6c0e9aa525cf041893425889cf3e69125"
+  integrity sha512-KMjVBHzP4N60bOzxja76M1F1hZZ43lGPga5ix+mkv9+kk1nx9SbkxSvJsMbuVUxdPQmsPTqGShmhN8ulrMOg6Q==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+
+"@opentelemetry/resources@2.7.1", "@opentelemetry/resources@^2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-2.7.1.tgz#3b2a9179f6119bb1f2cddefe41ba9b2855504a5d"
+  integrity sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/sdk-logs@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz#78886fe300b82802cee9963208b2af326b928af5"
+  integrity sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==
+  dependencies:
+    "@opentelemetry/api-logs" "0.218.0"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/sdk-metrics@2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz#b713f69dd67933ecc9c61357f1d452cdc9f4e281"
+  integrity sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/resources" "2.7.1"
+
+"@opentelemetry/sdk-node@^0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-node/-/sdk-node-0.218.0.tgz#cf8bdc0c993387189c7c474612e0f801505feb97"
+  integrity sha512-tPMjHrLV5gsfNdYqoRHjeGbCAZBXXD9c1Qo/2ut7VwnUABDNh76xNxrT0SEhkIIJuCN45bbN1vZnYL1gY0IkOg==
+  dependencies:
+    "@opentelemetry/api-logs" "0.218.0"
+    "@opentelemetry/configuration" "0.218.0"
+    "@opentelemetry/context-async-hooks" "2.7.1"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/exporter-logs-otlp-grpc" "0.218.0"
+    "@opentelemetry/exporter-logs-otlp-http" "0.218.0"
+    "@opentelemetry/exporter-logs-otlp-proto" "0.218.0"
+    "@opentelemetry/exporter-metrics-otlp-grpc" "0.218.0"
+    "@opentelemetry/exporter-metrics-otlp-http" "0.218.0"
+    "@opentelemetry/exporter-metrics-otlp-proto" "0.218.0"
+    "@opentelemetry/exporter-prometheus" "0.218.0"
+    "@opentelemetry/exporter-trace-otlp-grpc" "0.218.0"
+    "@opentelemetry/exporter-trace-otlp-http" "0.218.0"
+    "@opentelemetry/exporter-trace-otlp-proto" "0.218.0"
+    "@opentelemetry/exporter-zipkin" "2.7.1"
+    "@opentelemetry/instrumentation" "0.218.0"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/propagator-b3" "2.7.1"
+    "@opentelemetry/propagator-jaeger" "2.7.1"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-logs" "0.218.0"
+    "@opentelemetry/sdk-metrics" "2.7.1"
+    "@opentelemetry/sdk-trace-base" "2.7.1"
+    "@opentelemetry/sdk-trace-node" "2.7.1"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/sdk-trace-base@2.7.1", "@opentelemetry/sdk-trace-base@^2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz#9160c3af9ef2219c26563abd136e22fb7d19b34f"
+  integrity sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/sdk-trace-node@2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.7.1.tgz#54dedb8e77fa51a6d02fc2192097739266c82168"
+  integrity sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg==
+  dependencies:
+    "@opentelemetry/context-async-hooks" "2.7.1"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/sdk-trace-base" "2.7.1"
+
+"@opentelemetry/semantic-conventions@^1.29.0":
+  version "1.41.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz#b04e7151c5913a7a006d4f465479da75efb98a7a"
+  integrity sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
+
+"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+  integrity sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==
+
+"@protobufjs/base64@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+  integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
+
+"@protobufjs/codegen@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.5.tgz#d9315ad7cf3f30aac70bda3c068443dc6f143659"
+  integrity sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==
+
+"@protobufjs/eventemitter@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz#d512cb26c0ae026091ee2c1167f1be6faf5c842a"
+  integrity sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==
+
+"@protobufjs/fetch@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.1.tgz#4d6fc00c8fb64016a5c81b469d549046350f1065"
+  integrity sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
+
+"@protobufjs/float@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+  integrity sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==
+
+"@protobufjs/inquire@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.2.tgz#ae64fbc014ff44c8bfad03dd4c93cd2d6a4c82db"
+  integrity sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==
+
+"@protobufjs/path@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+  integrity sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==
+
+"@protobufjs/pool@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+  integrity sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==
+
+"@protobufjs/utf8@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.1.tgz#eaee5900122c110a3dbcb728c0597014a2621774"
+  integrity sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==
 
 "@scality/eslint-config-scality@scality/Guidelines#8.3.2":
   version "8.3.2"
@@ -3223,6 +3586,13 @@
   dependencies:
     undici-types "~7.14.0"
 
+"@types/node@>=13.7.0":
+  version "25.9.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.9.1.tgz#3bda556db500ae4319c08e7fc9ab94f19013ba0b"
+  integrity sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==
+  dependencies:
+    undici-types ">=7.24.0 <7.24.7"
+
 "@types/node@^22.7.6":
   version "22.18.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.18.8.tgz#738d9dafa38f6e0c467687c158f8e1ca2d7d8eaa"
@@ -3435,6 +3805,11 @@ accepts@~1.3.4:
   dependencies:
     mime-types "~2.1.34"
     negotiator "0.6.3"
+
+acorn-import-attributes@^1.9.5:
+  version "1.9.5"
+  resolved "https://registry.yarnpkg.com/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz#7eb1557b1ba05ef18b5ed0ec67591bfab04688ef"
+  integrity sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==
 
 acorn-jsx@^5.3.2:
   version "5.3.2"
@@ -4058,6 +4433,11 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz#0f79731eb8cfe1ec72acd4066efac9d61991b00d"
   integrity sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==
 
+cjs-module-lexer@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz#b3ca5101843389259ade7d88c77bd06ce55849ca"
+  integrity sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==
+
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
@@ -4212,7 +4592,7 @@ data-view-byte-offset@^1.0.1:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
-debug@4, debug@^4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.1, debug@^4.4.3:
+debug@4, debug@^4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@^4.4.1, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -5264,6 +5644,16 @@ import-fresh@^3.2.1:
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
+
+import-in-the-middle@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz#8a0a1230c9b865c0e12698171646ae1e3fff691d"
+  integrity sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==
+  dependencies:
+    acorn "^8.15.0"
+    acorn-import-attributes "^1.9.5"
+    cjs-module-lexer "^2.2.0"
+    module-details-from-path "^1.0.4"
 
 import-local@^3.0.2:
   version "3.2.0"
@@ -6328,6 +6718,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -6412,6 +6807,11 @@ lodash@^4.17.14:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+long@^5.0.0, long@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.3.2.tgz#1d84463095999262d7d7b7f8bfd4a8cc55167f83"
+  integrity sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==
 
 looper@^2.0.0:
   version "2.0.0"
@@ -6652,6 +7052,11 @@ mkdirp@^0.5.1:
   integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
   dependencies:
     minimist "^1.2.6"
+
+module-details-from-path@^1.0.3, module-details-from-path@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.4.tgz#b662fdcd93f6c83d3f25289da0ce81c8d9685b94"
+  integrity sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==
 
 mongodb-connection-string-url@^3.0.2:
   version "3.0.2"
@@ -7167,6 +7572,24 @@ prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
+protobufjs@^7.5.5:
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.6.2.tgz#2659f77bd8d54778814c274dc0df808f54c88918"
+  integrity sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.5"
+    "@protobufjs/eventemitter" "^1.1.1"
+    "@protobufjs/fetch" "^1.1.1"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.2"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.1"
+    "@types/node" ">=13.7.0"
+    long "^5.3.2"
+
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
@@ -7366,6 +7789,14 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
+require-in-the-middle@^8.0.0:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz#dbde2587f669398626d56b20c868ab87bf01cce4"
+  integrity sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==
+  dependencies:
+    debug "^4.3.5"
+    module-details-from-path "^1.0.3"
 
 require-main-filename@^2.0.0:
   version "2.0.0"
@@ -8251,6 +8682,11 @@ undefsafe@^2.0.5:
   resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-2.0.5.tgz#38733b9327bdcd226db889fb723a6efd162e6e2c"
   integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
 
+"undici-types@>=7.24.0 <7.24.7":
+  version "7.24.6"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
+  integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
+
 undici-types@~6.21.0:
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
@@ -8592,6 +9028,11 @@ yallist@^5.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
   integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
 
+yaml@^2.0.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.9.0.tgz#78274afd93598a1dfdd6130df6a566defcbf9aa4"
+  integrity sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==
+
 yargs-parser@^18.1.2:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
@@ -8622,7 +9063,7 @@ yargs@^15.0.2:
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
 
-yargs@^17.3.1:
+yargs@^17.3.1, yargs@^17.7.2:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==


### PR DESCRIPTION
## What

Extracts the OpenTelemetry tracing code duplicated across backbeat, cloudserver and vault into a single shared module, `lib/tracing/`, consumed via `require('arsenal/build/lib/tracing')`.

It provides:

- `init(options)` / `close()` / `isEnabled()` — SDK bootstrap (ParentBased(TraceIdRatio) sampler, span limits, traces-only, fail-fast asserts, bounded-flush shutdown race). Config assembly is split into a testable `buildSdkConfig()`.
- `loadTrustedHosts()` / `makeTrustedHostsHook()` — outbound trust boundary that strips `traceparent`/`tracestate` on calls to untrusted hosts. `OTEL_TRUSTED_HOSTS` supports NO_PROXY-style `.suffix` entries (e.g. `.svc.cluster.local` trusts every in-cluster service, subdomains and apex). We do not bother doing a trim() on each host, the value is expected to be well-formed, avoiding swallowing formatting mistakes.
- `isHealthPath(url, pathSet)` — probe/scrape span filter.
- `instrumentApiMethod(handler, name)` — per-API-method span wrapper (scope `scality.api`, span `api.<method>`, `error.type` attribute; service disambiguated by `service.name` on the resource).
- `kafka.*` — W3C trace-context propagation over node-rdkafka headers.

## Design notes

- **Consumers own their instrumentations.** `init()` takes a lazy `instrumentations: () => Instrumentation[]` thunk, invoked only when OTEL is enabled. So arsenal carries no `instrumentation-*` packages — only the OTEL SDK core, as `optionalDependencies`; `@opentelemetry/api` stays a hard (inert) dependency.
- **Deep-require, not `require('arsenal').tracing`.** The arsenal barrel eagerly loads ioredis/mongodb; reaching `init()` through it would load them before OTEL can patch them. The `lib/tracing` subpath loads nothing instrumentable at import time.
- Off by default (`ENABLE_OTEL=true` to enable); see `lib/tracing/README.md` for env vars and usage.

Consumer adoption (backbeat, cloudserver, vault) lands in separate PRs once this ships.

Issue: ARSN-586