### PR TITLE
ARSN-587: require content md5 in signed headers

### DIFF
--- a/lib/auth/v4/validateInputs.ts
+++ b/lib/auth/v4/validateInputs.ts
@@ -184,15 +184,22 @@ export function extractAuthItems(authHeader: string, log: RequestLogger) {
 }
 
 /**
- * Checks whether the signed headers include the host header
- * and all x-amz- and x-scal- headers in request
+ * Checks whether the signed headers include the host header, the
+ * content-md5 header if present, and all x-amz- and x-scal- headers
+ * in request.
  * @param signedHeaders - signed headers sent with request
  * @param allHeaders - request.headers
- * @return true if all x-amz-headers included and false if not
+ * @return true if all required headers are included and false if not
  */
 export function areSignedHeadersComplete(signedHeaders: string, allHeaders: ArsenalRequestHeaders) {
     const signedHeadersList = signedHeaders.split(';');
     if (signedHeadersList.indexOf('host') === -1) {
+        return false;
+    }
+    // AWS requires the content-md5 header to be signed when present in
+    // the request, for both header-based auth and presigned URLs.
+    if (allHeaders['content-md5'] !== undefined
+        && signedHeadersList.indexOf('content-md5') === -1) {
         return false;
     }
     const headers = Object.keys(allHeaders);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "engines": {
         "node": ">=20"
     },
-    "version": "8.4.4",
+    "version": "8.4.5",
     "description": "Common utilities for the S3 project components",
     "main": "build/index.js",
     "repository": {

--- a/tests/unit/auth/v4/headerAuthCheck.spec.js
+++ b/tests/unit/auth/v4/headerAuthCheck.spec.js
@@ -109,6 +109,44 @@ describe('v4 headerAuthCheck', () => {
         done();
     });
 
+    it('should return error if content-md5 header is not included as ' +
+        'signed header but is in request', done => {
+        const alteredRequest = createAlteredRequest({
+            'content-md5': 'lHP90NiApDwht3eNNIchVw==' }, 'headers',
+        request, headers);
+        const res = headerAuthCheck(alteredRequest, log);
+        assert.deepStrictEqual(res.err, errors.AccessDenied);
+        done();
+    });
+
+    it('should NOT return error if content-md5 header is included as ' +
+        'signed header and is in request', done => {
+        const clock = fakeTimers.install({ now: 1454962445000 });
+        const alteredRequest = createAlteredRequest({
+            'content-md5': 'lHP90NiApDwht3eNNIchVw==',
+            authorization: 'AWS4-HMAC-SHA256 Credential=accessKey1/20160208' +
+                '/us-east-1/s3/aws4_request, SignedHeaders=content-md5;host;' +
+                'x-amz-content-sha256;x-amz-date, Signature=abed924c06abf877' +
+                '2c670064d22eacd6ccb85c06befa15f4a789b0bae19307bc' },
+        'headers', request, headers);
+        const res = headerAuthCheck(alteredRequest, log);
+        clock.uninstall();
+        assert.strictEqual(res.err, null);
+        done();
+    });
+
+    it('should NOT return error if content-type header is not included as ' +
+        'signed header but is in request', done => {
+        // AWS does not require content-type to be signed, unlike content-md5
+        const clock = fakeTimers.install({ now: 1454962445000 });
+        const alteredRequest = createAlteredRequest({
+            'content-type': 'text/plain' }, 'headers', request, headers);
+        const res = headerAuthCheck(alteredRequest, log);
+        clock.uninstall();
+        assert.strictEqual(res.err, null);
+        done();
+    });
+
     it('should return error if an x-scal header is not included as signed ' +
         'header but is in request', done => {
         const alteredRequest = createAlteredRequest({

--- a/tests/unit/auth/v4/queryAuthCheck.spec.js
+++ b/tests/unit/auth/v4/queryAuthCheck.spec.js
@@ -122,6 +122,42 @@ describe('v4 queryAuthCheck', () => {
         done();
     });
 
+    it('should return error if content-md5 header is not included as ' +
+        'signed header but is in request', done => {
+        const alteredRequest = createAlteredRequest({
+            'content-md5': 'lHP90NiApDwht3eNNIchVw==' }, 'headers',
+        request, headers);
+        const res = queryAuthCheck(alteredRequest, log, alteredRequest.query);
+        assert.deepStrictEqual(res.err, errors.AccessDenied);
+        done();
+    });
+
+    it('should NOT return error if content-md5 header is included as ' +
+        'signed header and is in request', done => {
+        const clock = fakeTimers.install({ now: 1454974984001 });
+        const alteredRequest = createAlteredRequest({
+            'content-md5': 'lHP90NiApDwht3eNNIchVw==' }, 'headers',
+        request, headers);
+        alteredRequest.query = Object.assign({}, query,
+            { 'X-Amz-SignedHeaders': 'content-md5;host' });
+        const res = queryAuthCheck(alteredRequest, log, alteredRequest.query);
+        clock.uninstall();
+        assert.deepStrictEqual(res.err, null);
+        done();
+    });
+
+    it('should NOT return error if content-type header is not included as ' +
+        'signed header but is in request', done => {
+        // AWS does not require content-type to be signed, unlike content-md5
+        const clock = fakeTimers.install({ now: 1454974984001 });
+        const alteredRequest = createAlteredRequest({
+            'content-type': 'text/plain' }, 'headers', request, headers);
+        const res = queryAuthCheck(alteredRequest, log, alteredRequest.query);
+        clock.uninstall();
+        assert.deepStrictEqual(res.err, null);
+        done();
+    });
+
     it('should return error if undefined X-Amz-Date param', done => {
         const alteredRequest = createAlteredRequest({ 'X-Amz-Date':
         undefined }, 'query', request, query);


### PR DESCRIPTION
Require the Content-MD5 to be in the signed headers if present in the request like mentioned in the AWS doc [here](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html)