### PR TITLE
test: functional test for putBucketIndexes error handling + bump test mongo to 8.0.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
         "node": ">=20"
     },
     "version": "8.4.7",
+    "config": {
+        "mongodbMemoryServer": {
+            "version": "8.0.23"
+        }
+    },
     "description": "Common utilities for the S3 project components",
     "main": "build/index.js",
     "repository": {

--- a/tests/functional/metadata/mongodb/putBucketIndexes.spec.js
+++ b/tests/functional/metadata/mongodb/putBucketIndexes.spec.js
@@ -1,0 +1,147 @@
+const assert = require('assert');
+const util = require('util');
+const werelogs = require('werelogs');
+const { MongoMemoryReplSet } = require('mongodb-memory-server');
+
+const logger = new werelogs.Logger('MongoClientInterface', 'debug', 'debug');
+const BucketInfo = require('../../../../lib/models/BucketInfo').default;
+const MetadataWrapper = require('../../../../lib/storage/metadata/MetadataWrapper');
+
+const IMPL_NAME = 'mongodb';
+const DB_NAME = 'metadata';
+const BUCKET_NAME = 'test-put-bucket-indexes';
+
+const BUCKET_MD = {
+    _owner: 'testowner',
+    _ownerDisplayName: 'testdisplayname',
+    _creationDate: new Date().toJSON(),
+    _acl: {
+        Canned: 'private',
+        FULL_CONTROL: [],
+        WRITE: [],
+        WRITE_ACP: [],
+        READ: [],
+        READ_ACP: [],
+    },
+    _mdBucketModelVersion: 10,
+    _transient: false,
+    _deleted: false,
+    _serverSideEncryption: null,
+    _versioningConfiguration: null,
+    _locationConstraint: 'us-east-1',
+    _readLocationConstraint: null,
+    _cors: null,
+    _replicationConfiguration: null,
+    _lifecycleConfiguration: null,
+    _uid: '',
+    _isNFS: null,
+    ingestion: null,
+};
+
+const mongoserver = new MongoMemoryReplSet({
+    debug: false,
+    instanceOpts: [{ port: 27024 }],
+    replSet: {
+        name: 'rs0',
+        count: 1,
+        DB_NAME,
+        storageEngine: 'wiredTiger',
+    },
+});
+
+describe('MongoClientInterface:putBucketIndexes error handling', () => {
+    let metadata;
+    let putBucketIndexes;
+
+    beforeAll(async () => {
+        await mongoserver.start();
+        await mongoserver.waitUntilRunning();
+
+        const opts = {
+            mongodb: {
+                replicaSetHosts: 'localhost:27024',
+                writeConcern: 'majority',
+                replicaSet: 'rs0',
+                readPreference: 'primary',
+                database: DB_NAME,
+            },
+        };
+        metadata = new MetadataWrapper(IMPL_NAME, opts, null, logger);
+        metadata.setup = util.promisify(metadata.setup.bind(metadata));
+        metadata.createBucket = util.promisify(metadata.createBucket.bind(metadata));
+        metadata.close = util.promisify(metadata.close.bind(metadata));
+
+        await metadata.setup();
+        putBucketIndexes = util.promisify(metadata.client.putBucketIndexes.bind(metadata.client));
+
+        const bucketMD = BucketInfo.fromObj({
+            _name: BUCKET_NAME,
+            ...BUCKET_MD,
+        });
+        await metadata.createBucket(BUCKET_NAME, bucketMD, logger);
+    });
+
+    afterAll(async () => {
+        await metadata.close();
+        await mongoserver.stop();
+    });
+
+    const okSpec = [
+        {
+            keys: [{ key: 'value.last-modified', order: 1 }],
+            name: 'lastModified',
+        },
+    ];
+
+    it('should succeed on a valid index spec', async () => {
+        await putBucketIndexes(BUCKET_NAME, okSpec, logger);
+    });
+
+    it('should return InternalError when indexBuildMinAvailableDiskSpaceMB exceeds available disk', async () => {
+        const adminDb = metadata.client.client.db('admin');
+        const getRes = await adminDb.command({
+            getParameter: 1,
+            indexBuildMinAvailableDiskSpaceMB: 1,
+        });
+        const prevValue = getRes.indexBuildMinAvailableDiskSpaceMB;
+        // 100 TiB in MB — larger than any plausible test machine disk
+        await adminDb.command({
+            setParameter: 1,
+            indexBuildMinAvailableDiskSpaceMB: 100 * 1024 * 1024,
+        });
+        const spec = [
+            {
+                keys: [{ key: 'value.creation-date', order: 1 }],
+                name: 'disk-kill-test-idx',
+            },
+        ];
+        try {
+            await putBucketIndexes(BUCKET_NAME, spec, logger);
+        } catch (err) {
+            assert(err.is.InternalError, `expected InternalError, got ${err.name} (${err.message})`);
+            return;
+        } finally {
+            await adminDb.command({
+                setParameter: 1,
+                indexBuildMinAvailableDiskSpaceMB: prevValue,
+            });
+        }
+        assert.fail('expected an error from putBucketIndexes');
+    });
+
+    it('should return InternalError on a spec conflict (same name, different keys)', async () => {
+        const conflictingSpec = [
+            {
+                keys: [{ key: 'value.dataStoreName', order: 1 }],
+                name: 'lastModified',
+            },
+        ];
+        try {
+            await putBucketIndexes(BUCKET_NAME, conflictingSpec, logger);
+        } catch (err) {
+            assert(err.is.InternalError, `expected InternalError, got ${err.name} (${err.message})`);
+            return;
+        }
+        assert.fail('expected an error from putBucketIndexes');
+    });
+});


### PR DESCRIPTION
## Summary

Adds a functional test for `MongoClientInterface.putBucketIndexes` error handling — including the case where MongoDB 7.1+ refuses an index build because available disk falls below `indexBuildMinAvailableDiskSpaceMB`.

Companion to [BB-783](https://scality.atlassian.net/browse/BB-783) (Backbeat conductor metric for index-creation failures, scality/backbeat#2751) and [BB-784](https://scality.atlassian.net/browse/BB-784) (Prometheus alert on the metric, scality/backbeat#2753), under the [ARTESCA-16740](https://scality.atlassian.net/browse/ARTESCA-16740) "Empty bucket feature" epic.

## Commits

1. **`test: pin mongodb-memory-server to MongoDB 8.0.23`** — version pin via `package.json` `config.mongodbMemoryServer.version`. The library default (7.0.14) doesn't enforce `indexBuildMinAvailableDiskSpaceMB`; the test needs 7.1+ behavior. 8.0.23 also aligns with what Artesca 4.1+ runs in production.

2. **`test: add functional test for putBucketIndexes error handling`** — new spec covering three cases:
   - **Happy path**: valid spec → success.
   - **`indexBuildMinAvailableDiskSpaceMB` refusal**: set the parameter to 100 TiB at runtime, attempt an index build, restore the previous value in `finally`. MongoDB returns `OutOfDiskSpace` (code 14031) → Arsenal maps to `errors.InternalError`.
   - **Spec conflict**: existing index name + different keys → `IndexKeySpecsConflict` → `errors.InternalError`.

## Empirical observation

The disk-kill test confirms MongoDB returns:

```
{"errmsg":"available disk space of N bytes is less than required minimum of M","code":14031,"codeName":"OutOfDiskSpace"}
```

Arsenal's existing catch handler at `MongoClientInterface.putBucketIndexes` correctly maps this to `errors.InternalError` — same path used by all non-`NamespaceNotFound` MongoDB errors. Backbeat's `putBucketIndexesFailed` metric on BB-783 is cause-agnostic (fires on any `putBucketIndexes` error), so this gives us the signal regardless of the specific MongoDB error code.

## Notes

- The disk-kill test reads the current `indexBuildMinAvailableDiskSpaceMB` value via `getParameter`, sets it to 100 TiB during the test, and restores the original in `finally` — does not leak state to other tests.
- Async style follows @francoisferrand's review: `util.promisify` on `putBucketIndexes` in `beforeAll`, then `try { await ... } catch { assert; return } assert.fail(...)` for the two negative-path tests.

Issue: ARSN-588

[BB-783]: https://scality.atlassian.net/browse/BB-783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BB-784]: https://scality.atlassian.net/browse/BB-784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ARTESCA-16740]: https://scality.atlassian.net/browse/ARTESCA-16740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ