### PR TITLE
feat: add stampTraceHeaders kafka helper

### DIFF
--- a/lib/tracing/README.md
+++ b/lib/tracing/README.md
@@ -90,7 +90,7 @@ array entirely inside the thunk so packages resolve from the consumer's
   handler in an `api.<methodName>` span (scope `arsenal.api`, `err.code` →
   `error.type`); returns the handler unchanged when OTEL is off.
 - `kafka.*` — trace-context propagation over node-rdkafka headers (scope
-  `arsenal.kafka`): `traceHeadersFromEntry`, `traceHeadersFromCurrentContext`,
+  `arsenal.kafka`): `traceHeadersFromEntry`, `stampTraceHeaders`,
   `contextFromKafkaHeaders`, `startLinkedSpanFromKafkaEntry`.
 
 ## Examples
@@ -111,8 +111,9 @@ an oplog entry; consumer starts a new trace linked to the upstream span:
 ```js
 const { kafka } = require('arsenal/build/lib/tracing');
 
-// producer side
-producer.send(payload, kafka.traceHeadersFromCurrentContext());
+// producer side: stamp the active span onto the entry (no-op when OTEL is off)
+producer.send(kafka.stampTraceHeaders({ key, message }));
+// or propagate from a stored oplog entry's trace context:
 producer.send(payload, kafka.traceHeadersFromEntry(objectMd));
 
 // consumer side

--- a/lib/tracing/kafkaTraceContext.ts
+++ b/lib/tracing/kafkaTraceContext.ts
@@ -82,7 +82,7 @@ export function startLinkedSpanFromKafkaEntry(
 }
 
 // Serialize the active OTEL context into node-rdkafka traceparent/tracestate headers.
-export function traceHeadersFromCurrentContext(): KafkaHeader[] | undefined {
+function traceHeadersFromCurrentContext(): KafkaHeader[] | undefined {
     const { trace, context, propagation } = getApi();
     const span = trace.getSpan(context.active());
     if (!span) {
@@ -103,4 +103,13 @@ export function traceHeadersFromCurrentContext(): KafkaHeader[] | undefined {
         headers.push({ tracestate: carrier.tracestate });
     }
     return headers.length > 0 ? headers : undefined;
+}
+
+// Attach the active span's trace headers to a kafka entry, returning a copy with
+// `headers` set. Returns the entry unchanged when tracing is off / no span is
+// active, so the OTEL-off path keeps its original message shape (no
+// `headers: undefined`).
+export function stampTraceHeaders<T extends object>(entry: T): T {
+    const headers = traceHeadersFromCurrentContext();
+    return headers ? { ...entry, headers } : entry;
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "engines": {
         "node": ">=20"
     },
-    "version": "8.4.5",
+    "version": "8.4.6",
     "description": "Common utilities for the S3 project components",
     "main": "build/index.js",
     "repository": {

--- a/tests/unit/tracing/kafkaTraceContext.spec.js
+++ b/tests/unit/tracing/kafkaTraceContext.spec.js
@@ -7,7 +7,7 @@ const { AsyncLocalStorageContextManager } = require('@opentelemetry/context-asyn
 
 const {
     traceHeadersFromEntry,
-    traceHeadersFromCurrentContext,
+    stampTraceHeaders,
     contextFromKafkaHeaders,
     startLinkedSpanFromKafkaEntry,
 } = require('../../../lib/tracing/kafkaTraceContext');
@@ -99,9 +99,10 @@ describe('kafkaTraceContext', () => {
         });
     });
 
-    describe('traceHeadersFromCurrentContext', () => {
-        it('returns undefined when no active span', () => {
-            assert.strictEqual(traceHeadersFromCurrentContext(), undefined);
+    describe('stampTraceHeaders', () => {
+        it('returns the entry unchanged when no active span', () => {
+            const entry = { message: 'm' };
+            assert.strictEqual(stampTraceHeaders(entry), entry);
         });
     });
 
@@ -128,20 +129,23 @@ describe('kafkaTraceContext', () => {
             span.end();
         });
 
-        it('traceHeadersFromCurrentContext serializes the active span to a traceparent header', () => {
+        it('stampTraceHeaders attaches the active span traceparent to the entry', () => {
             const span = trace.wrapSpanContext({ traceId, spanId, traceFlags: 1 });
-            const headers = context.with(trace.setSpan(context.active(), span), () => traceHeadersFromCurrentContext());
-            assert(Array.isArray(headers));
-            const tp = headers.find(h => h.traceparent);
+            const entry = { message: 'm' };
+            const stamped = context.with(trace.setSpan(context.active(), span), () => stampTraceHeaders(entry));
+            assert(Array.isArray(stamped.headers));
+            const tp = stamped.headers.find(h => h.traceparent);
             assert(tp && tp.traceparent.startsWith(`00-${traceId}-`));
+            assert.strictEqual(stamped.message, 'm');
+            // original entry is not mutated
+            assert.strictEqual(entry.headers, undefined);
         });
 
-        it('traceHeadersFromCurrentContext returns undefined for an invalid (all-zero) span context', () => {
+        it('stampTraceHeaders returns the entry unchanged for an invalid (all-zero) span context', () => {
             const invalid = trace.wrapSpanContext({ traceId: '0'.repeat(32), spanId: '0'.repeat(16), traceFlags: 0 });
-            const headers = context.with(trace.setSpan(context.active(), invalid), () =>
-                traceHeadersFromCurrentContext(),
-            );
-            assert.strictEqual(headers, undefined);
+            const entry = { message: 'm' };
+            const stamped = context.with(trace.setSpan(context.active(), invalid), () => stampTraceHeaders(entry));
+            assert.strictEqual(stamped, entry);
         });
     });
 });


### PR DESCRIPTION
## Summary

Add `kafka.stampTraceHeaders(entry)` to the tracing module: it returns a copy of a node-rdkafka entry with the active span's trace headers attached, or the entry unchanged when tracing is off / no span is active (so the OTEL-off path keeps its original message shape — no `headers: undefined`).

This replaces the lower-level `traceHeadersFromCurrentContext` in the public API: that function is now an internal helper, since every consumer was using it only to stamp headers onto an entry. Folding the `if (headers) entry.headers = headers` boilerplate into one helper removes that repetition at the call sites (backbeat has ~4).

`traceHeadersFromEntry`, `contextFromKafkaHeaders`, and `startLinkedSpanFromKafkaEntry` are unchanged.

Issue: ARSN-586