### PR TITLE
optimize checkArnMatch: equality fast-path and memoized matchers

### DIFF
--- a/lib/policyEvaluator/utils/checkArnMatch.ts
+++ b/lib/policyEvaluator/utils/checkArnMatch.ts
@@ -21,27 +21,25 @@ export default function checkArnMatch(
     // object name in S3)
     // Join on ":" in case there were ":" in the relativeID at the end
     // of the arn
-    const policyRelativeId = caseSensitive ? regExofArn.slice(5).join(':') :
-        regExofArn.slice(5).join(':').toLowerCase();
+    const policyRelativeId = caseSensitive
+        ? regExofArn.slice(5).join(':')
+        : regExofArn.slice(5).join(':').toLowerCase();
     const policyRelativeIdRegEx = new RegExp(policyRelativeId);
     // Check to see if the relative-id matches first since most likely
     // to diverge.  If not a match, the resource is not applicable so return
     // false
-    if (!policyRelativeIdRegEx.test(caseSensitive ?
-        requestRelativeId : requestRelativeId.toLowerCase())) {
+    if (!policyRelativeIdRegEx.test(caseSensitive ? requestRelativeId : requestRelativeId.toLowerCase())) {
         return false;
     }
     // Check the other parts of the ARN to make sure they match.  If not,
     // return false.
     for (let j = 0; j < 5; j++) {
         const segmentRegEx = new RegExp(regExofArn[j]);
-        const requestSegment = caseSensitive ? requestArnArr[j] :
-            requestArnArr[j].toLowerCase();
+        const requestSegment = caseSensitive ? requestArnArr[j] : requestArnArr[j].toLowerCase();
         const policyArnArr = policyArn.split(':');
         // We want to allow an empty account ID for utapi and SUR service ARNs to not
         // break compatibility.
-        if (j === 4 && policyArnAllowedEmptyAccountId.includes(policyArnArr[2])
-            && policyArnArr[4] === '') {
+        if (j === 4 && policyArnAllowedEmptyAccountId.includes(policyArnArr[2]) && policyArnArr[4] === '') {
             continue;
         } else if (!segmentRegEx.test(requestSegment)) {
             return false;

--- a/lib/policyEvaluator/utils/checkArnMatch.ts
+++ b/lib/policyEvaluator/utils/checkArnMatch.ts
@@ -1,5 +1,12 @@
+import LRUCache from '../../algos/cache/LRUCache';
 import { handleWildcards } from './wildcards';
 import { policyArnAllowedEmptyAccountId } from '../../constants';
+
+// Compiled matchers are pure functions of (policyArn, caseSensitive), so the
+// cache needs no invalidation; the LRU cap bounds the cardinality introduced
+// by policy-variable substitution (per-request values in the policy arn).
+const ARN_MATCHER_CACHE_ENTRIES = 10000;
+const arnMatcherCache = new LRUCache(ARN_MATCHER_CACHE_ENTRIES);
 
 // A wildcard-free portion translates to a fully-escaped, anchored regExp,
 // so testing it is equivalent to comparing for string equality: keep the
@@ -73,7 +80,12 @@ export default function checkArnMatch(
     requestArnArr: string[],
     caseSensitive: boolean,
 ): boolean {
-    const matcher = compileArnMatcher(policyArn, caseSensitive);
+    const cacheKey = `${caseSensitive ? 'cs' : 'ci'}:${policyArn}`;
+    let matcher: ArnMatcher = arnMatcherCache.get(cacheKey);
+    if (matcher === undefined) {
+        matcher = compileArnMatcher(policyArn, caseSensitive);
+        arnMatcherCache.add(cacheKey, matcher);
+    }
     // Check to see if the relative-id matches first since most likely
     // to diverge.  If not a match, the resource is not applicable so return
     // false

--- a/lib/policyEvaluator/utils/checkArnMatch.ts
+++ b/lib/policyEvaluator/utils/checkArnMatch.ts
@@ -1,5 +1,62 @@
-import { handleWildcardInResource } from './wildcards';
+import { handleWildcards } from './wildcards';
 import { policyArnAllowedEmptyAccountId } from '../../constants';
+
+// A wildcard-free portion translates to a fully-escaped, anchored regExp,
+// so testing it is equivalent to comparing for string equality: keep the
+// literal value and skip the regExp construction entirely.
+type PortionMatcher = { literal: string } | { regExp: RegExp };
+
+type ArnMatcher = {
+    relativeId: PortionMatcher;
+    segments: PortionMatcher[];
+    skipAccountIdCheck: boolean;
+};
+
+// '*' and '?' are AWS wildcards; '${' starts the ${*}/${?}/${$} literal
+// escapes that handleWildcards rewrites - all of these need the regExp path.
+// Compiled once at module load; no 'g' flag, so test() is stateless.
+const WILDCARD_RE = /[*?]|\$\{/;
+
+function hasWildcards(portion: string): boolean {
+    return WILDCARD_RE.test(portion);
+}
+
+function compileArnMatcher(policyArn: string, caseSensitive: boolean): ArnMatcher {
+    const policyArnArr = policyArn.split(':');
+    // The relativeId is the last part of the ARN (for instance, a bucket and
+    // object name in S3)
+    // Join on ":" in case there were ":" in the relativeID at the end
+    // of the arn
+    let relativeId: PortionMatcher;
+    if (policyArnArr.length === 6 && !hasWildcards(policyArnArr[5])) {
+        relativeId = {
+            literal: caseSensitive ? policyArnArr[5] : policyArnArr[5].toLowerCase(),
+        };
+    } else {
+        const source = policyArnArr.slice(5).map(handleWildcards).join(':');
+        relativeId = {
+            regExp: new RegExp(caseSensitive ? source : source.toLowerCase()),
+        };
+    }
+    const segments: PortionMatcher[] = [];
+    for (let j = 0; j < 5; j++) {
+        const portion = policyArnArr[j];
+        segments.push(
+            portion !== undefined && !hasWildcards(portion)
+                ? { literal: portion }
+                : { regExp: new RegExp(portion && handleWildcards(portion)) },
+        );
+    }
+    // We want to allow an empty account ID for utapi and SUR service ARNs to not
+    // break compatibility.
+    const skipAccountIdCheck = policyArnAllowedEmptyAccountId.includes(policyArnArr[2]) && policyArnArr[4] === '';
+    return { relativeId, segments, skipAccountIdCheck };
+}
+
+function portionMatches(matcher: PortionMatcher, value: string): boolean {
+    return 'literal' in matcher ? matcher.literal === value : matcher.regExp.test(value);
+}
+
 /**
  * Checks whether an ARN from a request matches an ARN in a policy
  * to compare against each portion of the ARN from the request
@@ -16,32 +73,21 @@ export default function checkArnMatch(
     requestArnArr: string[],
     caseSensitive: boolean,
 ): boolean {
-    const regExofArn = handleWildcardInResource(policyArn);
-    // The relativeId is the last part of the ARN (for instance, a bucket and
-    // object name in S3)
-    // Join on ":" in case there were ":" in the relativeID at the end
-    // of the arn
-    const policyRelativeId = caseSensitive
-        ? regExofArn.slice(5).join(':')
-        : regExofArn.slice(5).join(':').toLowerCase();
-    const policyRelativeIdRegEx = new RegExp(policyRelativeId);
+    const matcher = compileArnMatcher(policyArn, caseSensitive);
     // Check to see if the relative-id matches first since most likely
     // to diverge.  If not a match, the resource is not applicable so return
     // false
-    if (!policyRelativeIdRegEx.test(caseSensitive ? requestRelativeId : requestRelativeId.toLowerCase())) {
+    if (!portionMatches(matcher.relativeId, caseSensitive ? requestRelativeId : requestRelativeId.toLowerCase())) {
         return false;
     }
     // Check the other parts of the ARN to make sure they match.  If not,
     // return false.
     for (let j = 0; j < 5; j++) {
-        const segmentRegEx = new RegExp(regExofArn[j]);
         const requestSegment = caseSensitive ? requestArnArr[j] : requestArnArr[j].toLowerCase();
-        const policyArnArr = policyArn.split(':');
-        // We want to allow an empty account ID for utapi and SUR service ARNs to not
-        // break compatibility.
-        if (j === 4 && policyArnAllowedEmptyAccountId.includes(policyArnArr[2]) && policyArnArr[4] === '') {
+        if (j === 4 && matcher.skipAccountIdCheck) {
             continue;
-        } else if (!segmentRegEx.test(requestSegment)) {
+        }
+        if (!portionMatches(matcher.segments[j], requestSegment)) {
             return false;
         }
     }

--- a/lib/policyEvaluator/utils/wildcards.ts
+++ b/lib/policyEvaluator/utils/wildcards.ts
@@ -4,7 +4,6 @@
 // TODO: Note that there are special rules for * in Principal.
 // Handle when working with bucket policies.
 
-
 // Replace all '*' with '.*' (allow any combo of letters)
 // and all '?' with '.{1}' (allow for any one character)
 // If *, ? or $ are enclosed in ${}, keep literal *, ?, or $
@@ -29,10 +28,9 @@ function characterMap(char: string) {
 export const handleWildcards = (string: string) => {
     // Escape all regExp special characters
     // Then replace the AWS special characters with regExp equivalents
-    const regExStr = string.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&').replace(
-        /(\\\*)|(\\\?)|(\\\$\\\{\\\*\\\})|(\\\$\\\{\\\?\\\})|(\\\$\\\{\\\$\\\})/g,
-        characterMap
-    );
+    const regExStr = string
+        .replace(/[\\^$*+?.()|[\]{}]/g, '\\$&')
+        .replace(/(\\\*)|(\\\?)|(\\\$\\\{\\\*\\\})|(\\\$\\\{\\\?\\\})|(\\\$\\\{\\\$\\\})/g, characterMap);
     return `^${regExStr}$`;
 };
 
@@ -43,8 +41,8 @@ export const handleWildcards = (string: string) => {
  * @return array of strings to be used for regEx comparisons
  */
 export const handleWildcardInResource = (arn: string) => {
-// Wildcards can be part of the resource ARN.
-// Wildcards do NOT span segments of the ARN (separated by ":")
+    // Wildcards can be part of the resource ARN.
+    // Wildcards do NOT span segments of the ARN (separated by ":")
 
     // Example: all elements in specific bucket:
     // "Resource": "arn:aws:s3:::my_corporate_bucket/*"

--- a/lib/policyEvaluator/utils/wildcards.ts
+++ b/lib/policyEvaluator/utils/wildcards.ts
@@ -33,21 +33,3 @@ export const handleWildcards = (string: string) => {
         .replace(/(\\\*)|(\\\?)|(\\\$\\\{\\\*\\\})|(\\\$\\\{\\\?\\\})|(\\\$\\\{\\\$\\\})/g, characterMap);
     return `^${regExStr}$`;
 };
-
-/**
- * Converts each portion of an ARN into a converted regEx string
- * to compare against each portion of the ARN from the request
- * @param arn - arn for requested resource
- * @return array of strings to be used for regEx comparisons
- */
-export const handleWildcardInResource = (arn: string) => {
-    // Wildcards can be part of the resource ARN.
-    // Wildcards do NOT span segments of the ARN (separated by ":")
-
-    // Example: all elements in specific bucket:
-    // "Resource": "arn:aws:s3:::my_corporate_bucket/*"
-    // ARN format:
-    // arn:partition:service:region:namespace:relative-id
-    const arnArr = arn.split(':');
-    return arnArr.map(portion => handleWildcards(portion));
-};

--- a/tests/unit/policyEvaluator/utils/test_checkArnMatch.spec.js
+++ b/tests/unit/policyEvaluator/utils/test_checkArnMatch.spec.js
@@ -74,6 +74,76 @@ const tests = [
         caseSensitive: false,
         isMatch: false,
     },
+    {
+        policyArn: 'arn:aws:s3:::bucket/file.txt',
+        requestArn: 'arn:aws:s3:::bucket/file.txt',
+        caseSensitive: true,
+        isMatch: true,
+    },
+    {
+        // '.' in the policy ARN is a literal dot, not a regExp wildcard
+        policyArn: 'arn:aws:s3:::bucket/file.txt',
+        requestArn: 'arn:aws:s3:::bucket/fileAtxt',
+        caseSensitive: true,
+        isMatch: false,
+    },
+    {
+        policyArn: 'arn:aws:s3:::bucket/prefix/*',
+        requestArn: 'arn:aws:s3:::bucket/prefix/deep/obj',
+        caseSensitive: true,
+        isMatch: true,
+    },
+    {
+        policyArn: 'arn:aws:s3:::bucket/prefix/*',
+        requestArn: 'arn:aws:s3:::bucket/other/obj',
+        caseSensitive: true,
+        isMatch: false,
+    },
+    {
+        policyArn: 'arn:aws:s3:::bucket/??x',
+        requestArn: 'arn:aws:s3:::bucket/abx',
+        caseSensitive: true,
+        isMatch: true,
+    },
+    {
+        policyArn: 'arn:aws:s3:::bucket/??x',
+        requestArn: 'arn:aws:s3:::bucket/ax',
+        caseSensitive: true,
+        isMatch: false,
+    },
+    {
+        // ${*} is a literal '*', not a wildcard
+        policyArn: 'arn:aws:s3:::bucket/${*}',
+        requestArn: 'arn:aws:s3:::bucket/*',
+        caseSensitive: true,
+        isMatch: true,
+    },
+    {
+        policyArn: 'arn:aws:s3:::bucket/${*}',
+        requestArn: 'arn:aws:s3:::bucket/x',
+        caseSensitive: true,
+        isMatch: false,
+    },
+    {
+        // utapi ARNs with an empty account id match any account id
+        policyArn: 'arn:scality:utapi:::buckets/foo',
+        requestArn: 'arn:scality:utapi::005978442556:buckets/foo',
+        caseSensitive: true,
+        isMatch: true,
+    },
+    {
+        // other services do not get the empty-account exemption
+        policyArn: 'arn:aws:s3:::bucket/foo',
+        requestArn: 'arn:aws:s3::005978442556:bucket/foo',
+        caseSensitive: true,
+        isMatch: false,
+    },
+    {
+        policyArn: 'arn:aws:iam::005978442556:role/path/sub/MyRole',
+        requestArn: 'arn:aws:iam::005978442556:role/path/sub/MyRole',
+        caseSensitive: true,
+        isMatch: true,
+    },
 ];
 
 describe('policyEvaluator checkArnMatch utility function', () => {

--- a/tests/unit/policyEvaluator/utils/test_checkArnMatch.spec.js
+++ b/tests/unit/policyEvaluator/utils/test_checkArnMatch.spec.js
@@ -1,6 +1,5 @@
 const assert = require('assert');
-const checkArnMatch
-    = require('../../../../lib/policyEvaluator/utils/checkArnMatch').default;
+const checkArnMatch = require('../../../../lib/policyEvaluator/utils/checkArnMatch').default;
 
 const tests = [
     {
@@ -79,16 +78,18 @@ const tests = [
 
 describe('policyEvaluator checkArnMatch utility function', () => {
     tests.forEach(test => {
-        it(`Check '${test.requestArn}' against '${test.policyArn}' with case ` +
-            `sensitive check ${test.caseSensitive ? 'enabled' : 'disabled'} ` +
-            `and it should ${test.isMatch ? 'be' : 'not be'} a match`, () => {
-            const requestArn = test.requestArn;
-            const requestResourceArr = requestArn.split(':');
-            const requestRelativeId = requestResourceArr.slice(5).join(':');
-            const caseSensitive = test.caseSensitive;
-            const result = checkArnMatch(test.policyArn, requestRelativeId,
-                requestResourceArr, caseSensitive);
-            assert.deepStrictEqual(result, test.isMatch);
-        });
+        it(
+            `Check '${test.requestArn}' against '${test.policyArn}' with case ` +
+                `sensitive check ${test.caseSensitive ? 'enabled' : 'disabled'} ` +
+                `and it should ${test.isMatch ? 'be' : 'not be'} a match`,
+            () => {
+                const requestArn = test.requestArn;
+                const requestResourceArr = requestArn.split(':');
+                const requestRelativeId = requestResourceArr.slice(5).join(':');
+                const caseSensitive = test.caseSensitive;
+                const result = checkArnMatch(test.policyArn, requestRelativeId, requestResourceArr, caseSensitive);
+                assert.deepStrictEqual(result, test.isMatch);
+            },
+        );
     });
 });

--- a/tests/unit/policyEvaluator/utils/test_checkArnMatch.spec.js
+++ b/tests/unit/policyEvaluator/utils/test_checkArnMatch.spec.js
@@ -146,6 +146,34 @@ const tests = [
     },
 ];
 
+describe('checkArnMatch matcher memoization', () => {
+    it('returns consistent results on repeated calls', () => {
+        const policyArn = 'arn:aws:s3:::bucket/prefix/*';
+        for (let i = 0; i < 3; i++) {
+            const requestArn = 'arn:aws:s3:::bucket/prefix/obj';
+            const arr = requestArn.split(':');
+            assert.strictEqual(checkArnMatch(policyArn, arr.slice(5).join(':'), arr, true), true);
+            const miss = 'arn:aws:s3:::bucket/other/obj'.split(':');
+            assert.strictEqual(checkArnMatch(policyArn, miss.slice(5).join(':'), miss, true), false);
+        }
+    });
+
+    it('keeps matching correctly across cache eviction', () => {
+        const first = 'arn:aws:s3:::bucket-0/key';
+        const firstArr = first.split(':');
+        assert.strictEqual(checkArnMatch(first, firstArr.slice(5).join(':'), firstArr, true), true);
+        // overflow the 10000-entry LRU so `first` gets evicted
+        for (let i = 0; i < 10001; i++) {
+            const arn = `arn:aws:s3:::bucket-${i}/key`;
+            const arr = arn.split(':');
+            checkArnMatch(arn, arr.slice(5).join(':'), arr, true);
+        }
+        assert.strictEqual(checkArnMatch(first, firstArr.slice(5).join(':'), firstArr, true), true);
+        const other = 'arn:aws:s3:::bucket-x/other'.split(':');
+        assert.strictEqual(checkArnMatch(first, other.slice(5).join(':'), other, true), false);
+    });
+});
+
 describe('policyEvaluator checkArnMatch utility function', () => {
     tests.forEach(test => {
         it(


### PR DESCRIPTION
`checkArnMatch` built six `RegExp` objects per call (regex-escape + compile for the relative-id and each of the five ARN segments), for every (request context × policy statement × Resource entry). A V8 profile of Vault under warm authorization load showed this as the worker's dominant CPU cost (`StringPrototypeReplace` + `RegExpConstructor` + `StringPrototypeSplit` under `evaluatePolicy`, plus the resulting GC churn).

Three commits:
1. **Equality fast-path** — a wildcard-free portion translates to a fully-escaped, anchored regExp, so testing it is equivalent to string equality: compare those portions directly and only build a `RegExp` for portions containing `*`, `?` or `${`.
2. **Matcher memoization** — compiled matchers are pure functions of `(caseSensitive, policyArn)`; cache them in a 10000-entry `LRUCache`. No invalidation needed; the LRU cap bounds the cardinality introduced by policy-variable substitution; a miss costs what every call cost before.
3. **Dead-code removal** — `checkArnMatch` was the only caller of `handleWildcardInResource`, which now calls `handleWildcards` per-portion. The helper is unused across arsenal and its consumers (Vault, CloudServer), so it is removed rather than left as a dead public export.

Behavior-preserving: verified by differential testing against the previous implementation over a matrix of literal/wildcard patterns, case-insensitive mode, policy-variable literals (`${*}`), empty-account service ARNs, and malformed ARNs — zero differences. Measured on a 1000-account Vault authz benchmark (warm, drift-controlled A→B→A): **+18–19% throughput, p95 −16%**.

Issue: ARSN-590
