### PR TITLE
fix matching of resource ARNs whose relative-id contains a colon

### DIFF
--- a/lib/policyEvaluator/utils/checkArnMatch.ts
+++ b/lib/policyEvaluator/utils/checkArnMatch.ts
@@ -40,7 +40,9 @@ function compileArnMatcher(policyArn: string, caseSensitive: boolean): ArnMatche
             literal: caseSensitive ? policyArnArr[5] : policyArnArr[5].toLowerCase(),
         };
     } else {
-        const source = policyArnArr.slice(5).map(handleWildcards).join(':');
+        // Translate the joined relative-id as one anchored unit so an embedded
+        // ':' (legal in S3 keys) matches; <6-portion ARNs have none, match any.
+        const source = policyArnArr.length >= 6 ? handleWildcards(policyArnArr.slice(5).join(':')) : '';
         relativeId = {
             regExp: new RegExp(caseSensitive ? source : source.toLowerCase()),
         };

--- a/tests/unit/policyEvaluator/utils/test_checkArnMatch.spec.js
+++ b/tests/unit/policyEvaluator/utils/test_checkArnMatch.spec.js
@@ -144,6 +144,43 @@ const tests = [
         caseSensitive: true,
         isMatch: true,
     },
+    // relative-ids may legally contain ':' (e.g. S3 object keys)
+    {
+        policyArn: 'arn:aws:s3:::bucket/a:b',
+        requestArn: 'arn:aws:s3:::bucket/a:b',
+        caseSensitive: true,
+        isMatch: true,
+    },
+    {
+        policyArn: 'arn:aws:s3:::bucket/data:2024/*',
+        requestArn: 'arn:aws:s3:::bucket/data:2024/report.csv',
+        caseSensitive: true,
+        isMatch: true,
+    },
+    {
+        policyArn: 'arn:aws:s3:::bucket/a:b:c',
+        requestArn: 'arn:aws:s3:::bucket/a:b:c',
+        caseSensitive: true,
+        isMatch: true,
+    },
+    {
+        policyArn: 'arn:aws:s3:::bucket/A:B',
+        requestArn: 'arn:aws:s3:::bucket/a:b',
+        caseSensitive: false,
+        isMatch: true,
+    },
+    {
+        policyArn: 'arn:aws:s3:::bucket/a:b',
+        requestArn: 'arn:aws:s3:::bucket/a:c',
+        caseSensitive: true,
+        isMatch: false,
+    },
+    {
+        policyArn: 'arn:aws:s3:::bucket/a:b',
+        requestArn: 'arn:aws:s3:::bucket/ab',
+        caseSensitive: true,
+        isMatch: false,
+    },
 ];
 
 describe('checkArnMatch matcher memoization', () => {


### PR DESCRIPTION
A policy `Resource` ARN whose relative-id contains `':'` (legal in S3 object keys, e.g. `bucket/data:2024/report.csv`) never matched any request — not even a byte-identical ARN. `checkArnMatch` anchors each `':'`-split portion individually (`^…$`) and then re-joins the relative-id portions, producing an unsatisfiable pattern like `^bucket/data$:^2024/….$` (`$` = end-of-input, so a required `':'` after it can never match). The request side already re-joins split portions correctly; only the policy side was broken.

Fix: wildcard-translate the **joined** relative-id as one unit, yielding a single anchored pattern. Six-portion ARNs compile to byte-identical patterns — no behavior change for them (all pre-existing tests pass unchanged); ARNs with fewer than six portions keep their previous behavior.

⚠ **Behavior change**: policy statements on colon-containing resources that were silently dead start applying after upgrade — `Allow` statements start granting (as their authors intended) and `Deny` statements start denying (they previously failed open).

Issue: ARSN-591