### PR TITLE
feat(ARSN-592): expose manual instrumentation API in lib/tracing

### DIFF
--- a/lib/tracing/index.ts
+++ b/lib/tracing/index.ts
@@ -1,7 +1,8 @@
 import * as bootstrap from './bootstrap';
 
 export { makeHttpInstrumentationConfig } from './httpHooks';
-export { instrumentApiMethod, endSpan } from './instrumentation';
+export { instrumentApiMethod, endSpan, startApiSpan } from './instrumentation';
+export type { ApiSpan } from './instrumentation';
 export type { InitOptions } from './bootstrap';
 export * as kafka from './kafkaTraceContext';
 

--- a/lib/tracing/instrumentation.ts
+++ b/lib/tracing/instrumentation.ts
@@ -119,3 +119,31 @@ export function instrumentApiMethod<T extends (...args: any[]) => any>(apiMethod
         return instrumentAsyncHandler(this, apiMethod, spanName, args);
     } as T;
 }
+
+// Manual span lifecycle for consumers whose dispatch owns the start + end sites
+// directly (e.g. a centralized Router method). Prefer `instrumentApiMethod` for
+// flat dispatch tables where wrap-once-at-module-load fits naturally.
+export interface ApiSpan {
+    // `end()` marks the span OK; `end(err)` marks it ERROR + records the
+    // exception (same err-as-optional shape as `endSpan` above).
+    end(err?: any): void;
+    // Runs `fn` with the span set as the active context so child auto-spans
+    // (mongo, ioredis, http) nest underneath.
+    withContext<T>(fn: () => T): T;
+}
+
+export function startApiSpan(action: string): ApiSpan {
+    if (!isEnabled()) {
+        return {
+            end: () => {},
+            withContext: fn => fn(),
+        };
+    }
+    const { trace, context, SpanKind } = getApi();
+    const span = getTracer().startSpan(`${SPAN_PREFIX}${action}`, { kind: SpanKind.INTERNAL });
+    const ctx = trace.setSpan(context.active(), span);
+    return {
+        end: err => endSpan(span, err),
+        withContext: fn => context.with(ctx, fn),
+    };
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "engines": {
         "node": ">=20"
     },
-    "version": "8.4.7",
+    "version": "8.4.8",
     "config": {
         "mongodbMemoryServer": {
             "version": "8.0.23"

--- a/tests/unit/tracing/index.spec.js
+++ b/tests/unit/tracing/index.spec.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const assert = require('assert');
+
+const tracing = require('../../../lib/tracing');
+
+describe('lib/tracing barrel', () => {
+    it('should re-export the public API surface', () => {
+        assert.strictEqual(typeof tracing.isEnabled, 'function');
+        assert.strictEqual(typeof tracing.init, 'function');
+        assert.strictEqual(typeof tracing.close, 'function');
+        assert.strictEqual(typeof tracing.instrumentApiMethod, 'function');
+        assert.strictEqual(typeof tracing.startApiSpan, 'function');
+        assert.strictEqual(typeof tracing.endSpan, 'function');
+        assert.strictEqual(typeof tracing.makeHttpInstrumentationConfig, 'function');
+        assert.strictEqual(typeof tracing.kafka, 'object');
+    });
+});

--- a/tests/unit/tracing/instrumentation.spec.js
+++ b/tests/unit/tracing/instrumentation.spec.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const assert = require('assert');
-const { trace, SpanStatusCode } = require('@opentelemetry/api');
+const { trace, context, SpanStatusCode } = require('@opentelemetry/api');
+const { AsyncLocalStorageContextManager } = require('@opentelemetry/context-async-hooks');
 const {
     BasicTracerProvider,
     InMemorySpanExporter,
@@ -9,7 +10,7 @@ const {
     AlwaysOnSampler,
 } = require('@opentelemetry/sdk-trace-base');
 
-const { instrumentApiMethod, resetTracer } = require('../../../lib/tracing/instrumentation');
+const { instrumentApiMethod, startApiSpan, resetTracer } = require('../../../lib/tracing/instrumentation');
 
 describe('instrumentApiMethod', () => {
     let exporter;
@@ -152,6 +153,109 @@ describe('instrumentApiMethod', () => {
             process.env.ENABLE_OTEL = 'false';
             const handler = () => 'identity';
             assert.strictEqual(instrumentApiMethod(handler, 'foo'), handler);
+        });
+    });
+});
+
+describe('startApiSpan', () => {
+    let exporter;
+    let provider;
+    let contextManager;
+
+    beforeAll(() => {
+        process.env.ENABLE_OTEL = 'true';
+        exporter = new InMemorySpanExporter();
+        provider = new BasicTracerProvider({
+            sampler: new AlwaysOnSampler(),
+            spanProcessors: [new SimpleSpanProcessor(exporter)],
+        });
+        trace.setGlobalTracerProvider(provider);
+        // Default ContextManager is a no-op (returns ROOT), so context.with
+        // wouldn't actually propagate. Real-world NodeSDK installs one;
+        // mirror that for the withContext assertion below.
+        contextManager = new AsyncLocalStorageContextManager().enable();
+        context.setGlobalContextManager(contextManager);
+        resetTracer();
+    });
+
+    afterAll(async () => {
+        delete process.env.ENABLE_OTEL;
+        resetTracer();
+        contextManager.disable();
+        context.disable();
+        await provider.shutdown();
+        trace.disable();
+    });
+
+    describe('OTEL on', () => {
+        afterEach(() => exporter.reset());
+
+        it('should end with status OK on end() with no error', () => {
+            const span = startApiSpan('AuthV4');
+            span.end();
+
+            const spans = exporter.getFinishedSpans();
+            assert.strictEqual(spans.length, 1);
+            assert.strictEqual(spans[0].name, 'api.AuthV4');
+            assert.strictEqual(spans[0].status.code, SpanStatusCode.OK);
+        });
+
+        it('should end with status ERROR + error.type on end(err)', () => {
+            const span = startApiSpan('AssumeRole');
+            const err = Object.assign(new Error('denied'), { code: 'AccessDenied' });
+            span.end(err);
+
+            const spans = exporter.getFinishedSpans();
+            assert.strictEqual(spans.length, 1);
+            assert.strictEqual(spans[0].status.code, SpanStatusCode.ERROR);
+            assert.strictEqual(spans[0].attributes['error.type'], 'AccessDenied');
+        });
+
+        it('should set the started span as the active context inside withContext(fn)', () => {
+            // Run inside an outer span so the active span is not the same as
+            // ours before withContext fires — that's how we tell the inner
+            // span is the one that propagated through context.with.
+            const outerSpan = trace.getTracer('outer').startSpan('outer');
+            context.with(trace.setSpan(context.active(), outerSpan), () => {
+                const before = trace.getActiveSpan();
+                const span = startApiSpan('CheckPolicies');
+                let inside;
+                span.withContext(() => {
+                    inside = trace.getActiveSpan();
+                });
+                const after = trace.getActiveSpan();
+                span.end();
+
+                assert.strictEqual(before, outerSpan);
+                assert.ok(inside, 'expected an active span inside withContext');
+                assert.notStrictEqual(inside, outerSpan);
+                assert.strictEqual(after, outerSpan);
+            });
+            outerSpan.end();
+        });
+
+        it('should return the value `fn` returns from withContext', () => {
+            const span = startApiSpan('GetCallerIdentity');
+            const value = span.withContext(() => 42);
+            span.end();
+            assert.strictEqual(value, 42);
+        });
+    });
+
+    describe('OTEL off', () => {
+        afterEach(() => {
+            process.env.ENABLE_OTEL = 'true';
+        });
+
+        it('returns a no-op span — end()/end(err)/withContext do not throw', () => {
+            process.env.ENABLE_OTEL = 'false';
+            const span = startApiSpan('AuthV4');
+            assert.doesNotThrow(() => span.end());
+            assert.doesNotThrow(() => span.end(new Error('boom')));
+            assert.strictEqual(
+                span.withContext(() => 'value'),
+                'value',
+            );
         });
     });
 });


### PR DESCRIPTION
## Summary

Adds `startApiSpan(action)` to `lib/tracing` alongside the existing `instrumentApiMethod` — a manual-lifecycle helper for consumers whose dispatch site owns the span start + end points directly.

```ts
export interface ApiSpan {
    end(err?: any): void;
    withContext<T>(fn: () => T): T;
}

export function startApiSpan(action: string): ApiSpan;
```

- Span name `api.<action>` (same `SPAN_PREFIX` as `instrumentApiMethod`).
- `end(err?)` reuses the existing exported `endSpan(span, err?)` so the `recordException` + status + `error.type` ceremony stays in one place. Same err-as-optional convention.
- `withContext(fn)` runs `fn` with the span set on the active context so child auto-spans (mongo, ioredis, http) nest underneath.
- OTEL-off: returns a no-op object — no `@opentelemetry/api` load.

## Motivation

[VAULT-708](https://scality.atlassian.net/browse/VAULT-708) consumes the tracing module via vault PR [#203](https://github.com/scality/vault2/pull/203). Reviewer feedback ([thread](https://github.com/scality/vault2/pull/203#discussion_r3387477976)) pointed out that `instrumentApiMethod`'s wrap-once-at-module-load shape — natural for cloudserver's flat \`api[name]=handler\` table — forces vault to add a per-Route wrap cache + a static-this \`.bind\` dance + a new lazy method on Route just to amortize a wrap on a single centralized dispatch site (\`Router._startRequest\`). \`startApiSpan\` lets vault call the helper inline at the dispatch site instead, no caching layer needed.

Both APIs produce the same span output and share the underlying \`endSpan\` ceremony; the choice is stylistic at the consumer.

## Tests

5 new unit tests in \`tests/unit/tracing/instrumentation.spec.js\` (13 total in the file):

- \`end()\` on success → span ends with status OK
- \`end(err)\` → span ends with status ERROR + \`error.type\` from \`err.code\`
- \`withContext(fn)\` sets the started span as the active context inside \`fn\` (asserted by running inside an outer span and checking the active span flips correctly before / inside / after)
- \`withContext(fn)\` returns the value \`fn\` returns
- OTEL-off returns a no-op object — \`end()\`, \`end(err)\`, \`withContext\` all safe

## Related

- Parent: ARSN-586 — the original tracing module ([#2632](https://github.com/scality/Arsenal/pull/2632))
- Consumer: VAULT-708 / scality/vault2#203

Issue: ARSN-592

[VAULT-708]: https://scality.atlassian.net/browse/VAULT-708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ