### PR TITLE
ARSN-594: guarantee a single callback in RESTClient

### DIFF
--- a/lib/network/rest/RESTClient.ts
+++ b/lib/network/rest/RESTClient.ts
@@ -6,6 +6,7 @@ import * as utils from './utils';
 import errors, { ArsenalError } from '../../errors';
 import { http as HttpAgent } from 'httpagent';
 import * as stream from 'stream';
+import { once } from '../../jsutil';
 
 function setRequestUids(reqHeaders: http.IncomingHttpHeaders, reqUids: string) {
     // inhibit 'assignment to property of function parameter' -
@@ -160,6 +161,9 @@ export default class RESTClient {
         reqUids: string,
         callback: (error: Error | null, key?: string) => void,
     ) {
+        // Guarantee a single callback invocation across the response and
+        // request 'error' paths (see get()).
+        const cbOnce = once(callback);
         const log = this.createLogger(reqUids);
         const headers = {};
         setRequestUids(headers, reqUids);
@@ -170,22 +174,22 @@ export default class RESTClient {
             response.once('readable', () => {
                 // expects '201 Created'
                 if (response.statusCode !== 201) {
-                    return callback(makeErrorFromHTTPResponse(response));
+                    return cbOnce(makeErrorFromHTTPResponse(response));
                 }
                 // retrieve the key from the Location response header
                 // containing the complete URL to the object, like
                 // /DataFile/abcdef.
                 const location = response.headers.location;
                 if (location === undefined) {
-                    return callback(new Error(
+                    return cbOnce(new Error(
                         'missing Location header in the response'));
                 }
                 const locationInfo = utils.explodePath(location);
                 if (!locationInfo) {
-                    return callback(new Error(
+                    return cbOnce(new Error(
                         `bad Location response header: ${location}`));
                 }
-                return callback(null, locationInfo.key);
+                return cbOnce(null, locationInfo.key);
             });
         }).on('finish', () => {
             log.debug('finished sending PUT data to the REST server', {
@@ -193,7 +197,7 @@ export default class RESTClient {
                 method: 'put',
                 contentLength: size,
             });
-        }).on('error', callback);
+        }).on('error', cbOnce);
 
         stream.pipe(request);
         stream.on('error', err => {
@@ -221,6 +225,10 @@ export default class RESTClient {
         reqUids: string,
         callback: (error: Error | null, stream?: stream.Readable) => void,
     ) {
+        // The success path (response received) and the request 'error' path
+        // are independent; a socket error after the response would otherwise
+        // invoke the callback a second time. Guarantee a single invocation.
+        const cbOnce = once(callback);
         const log = this.createLogger(reqUids);
         const headers = {};
         setRequestUids(headers, reqUids);
@@ -231,11 +239,11 @@ export default class RESTClient {
             response.once('readable', () => {
                 if (response.statusCode !== 200 &&
                     response.statusCode !== 206) {
-                    return callback(makeErrorFromHTTPResponse(response));
+                    return cbOnce(makeErrorFromHTTPResponse(response));
                 }
-                return callback(null, response);
+                return cbOnce(null, response);
             });
-        }).on('error', callback);
+        }).on('error', cbOnce);
 
         request.end();
     }
@@ -254,6 +262,9 @@ export default class RESTClient {
         reqUids: string,
         callback: (error: Error | null, stream?: stream.Readable) => void,
     ) {
+        // Guarantee a single callback invocation across the response and
+        // request 'error' paths (see get()).
+        const cbOnce = once(callback);
         const log = this.createLogger(reqUids);
         const headers = {};
         setRequestUids(headers, reqUids);
@@ -275,11 +286,11 @@ export default class RESTClient {
             response.once('readable', () => {
                 if (response.statusCode !== 200 &&
                     response.statusCode !== 206) {
-                    return callback(makeErrorFromHTTPResponse(response));
+                    return cbOnce(makeErrorFromHTTPResponse(response));
                 }
-                return callback(null, response.read().toString());
+                return cbOnce(null, response.read().toString());
             });
-        }).on('error', callback);
+        }).on('error', cbOnce);
 
         request.end();
     }
@@ -295,6 +306,9 @@ export default class RESTClient {
         reqUids: string,
         callback: (error: Error | null) => void,
     ) {
+        // Guarantee a single callback invocation across the response and
+        // request 'error' paths (see get()).
+        const cbOnce = once(callback);
         const log = this.createLogger(reqUids);
         const headers = {};
         setRequestUids(headers, reqUids);
@@ -304,11 +318,11 @@ export default class RESTClient {
                 response.once('readable', () => {
                     if (response.statusCode !== 200 &&
                         response.statusCode !== 204) {
-                        return callback(makeErrorFromHTTPResponse(response));
+                        return cbOnce(makeErrorFromHTTPResponse(response));
                     }
-                    return callback(null);
+                    return cbOnce(null);
                 });
-            }).on('error', callback);
+            }).on('error', cbOnce);
         request.end();
     }
 }

--- a/tests/unit/network/rest/RESTClient.spec.js
+++ b/tests/unit/network/rest/RESTClient.spec.js
@@ -1,0 +1,79 @@
+const assert = require('assert');
+const http = require('http');
+const stream = require('stream');
+const EventEmitter = require('events');
+const sinon = require('sinon');
+const werelogs = require('werelogs');
+
+const RESTClient = require('../../../../lib/network/rest/RESTClient').default;
+
+const clientLogApi = new werelogs.Werelogs({
+    level: 'info',
+    dump: 'error',
+});
+
+// Regression test for ARSN-594: a data backend client must invoke its
+// callback at most once. RESTClient.get() has two independent completion
+// paths - the response handler and the request 'error' handler - and a socket
+// error arriving after the response would otherwise call the callback a second
+// time. The higher-level retrieveData() converges every backend's callback
+// into an async.eachSeries iteration callback, and a double invocation there
+// throws "Callback was already called", crashing the server process.
+describe('RESTClient single-callback guarantee (ARSN-594)', () => {
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('get() must invoke its callback at most once when the socket errors ' +
+       'after the response was received', done => {
+        const client = new RESTClient({
+            host: 'localhost', port: 6677, logApi: clientLogApi,
+        });
+
+        // Fake ClientRequest we can drive: deliver a successful response,
+        // then emit a socket 'error' afterwards (connection reset mid-stream).
+        const fakeRequest = new EventEmitter();
+        fakeRequest.setNoDelay = () => {};
+        fakeRequest.end = () => {};
+
+        const fakeResponse = new stream.Readable({ read() {} });
+        fakeResponse.statusCode = 200;
+
+        sinon.stub(http, 'request').callsFake((reqParams, responseCb) => {
+            // Deliver on the next tick so the caller has attached its 'error'
+            // handler to the returned request first.
+            process.nextTick(() => {
+                responseCb(fakeResponse);
+                // 'readable' fires -> success path -> callback invocation #1
+                fakeResponse.push('data');
+                fakeResponse.push(null);
+                // a socket error arrives AFTER the response -> this would be a
+                // second callback invocation without the once() guard
+                process.nextTick(() =>
+                    fakeRequest.emit('error', new Error('socket hang up')));
+            });
+            return fakeRequest;
+        });
+
+        let callCount = 0;
+        let firstErr;
+        let firstRes;
+        client.get('0'.repeat(40), undefined, 'requid-arsn594', (err, res) => {
+            callCount += 1;
+            if (callCount === 1) {
+                firstErr = err;
+                firstRes = res;
+            }
+        });
+
+        setTimeout(() => {
+            client.destroy();
+            assert.strictEqual(callCount, 1,
+                'get callback should be called exactly once, was called ' +
+                `${callCount} times`);
+            assert.ifError(firstErr);
+            assert.strictEqual(firstRes, fakeResponse);
+            done();
+        }, 100);
+    });
+});


### PR DESCRIPTION
RESTClient's request methods have two independent completion paths - the response handler and the request 'error' handler - with no guard between them, so a socket error arriving after the response was received invokes the callback a second time. When the file data backend (DataFileInterface) is consumed by retrieveData, that double invocation reaches the async.eachSeries iteration callback and throws "Callback was already called", surfacing as an uncaughtException that crashes the server process on a mid-stream client disconnect. This was reproduced in cloudserver's file-ft-tests.

This guarantees each RESTClient method's callback fires at most once, mirroring the guarantee sproxydclient already provides at its request layer. A unit test reproduces the response-then-socket-error double call.

A broader data-layer backstop - enforcing the single-callback contract once at the DataWrapper.get boundary so every consumer and any future backend is covered by a single guard - is tracked separately in ARSN-595.