### PR TITLE
ARSN-596: treat NamespaceExists as idempotent success in createBucket

### DIFF
--- a/lib/storage/metadata/mongoclient/MongoClientInterface.ts
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.ts
@@ -466,21 +466,28 @@ class MongoClientInterface {
                 // "constants.usersBucket" and "PENSIEVE" since it has already
                 // been created
                 if (bucketName !== constants.usersBucket && bucketName !== PENSIEVE) {
-                    return this.db!.createCollection(bucketName).then(() => {
-                        if (this.shardCollections) {
-                            const cmd = {
-                                shardCollection: `${this.database}.${bucketName}`,
-                                key: { _id: 1 },
-                            };
-                            return this.adminDb!.command(cmd, {})
-                                .then(() => cb(null))
-                                .catch(err => {
-                                    log.error('createBucket: enabling sharding', { error: err });
-                                    return cb(errors.InternalError);
-                                });
-                        }
-                        return cb(null);
-                    });
+                    return this.db!.createCollection(bucketName)
+                        .catch(err => {
+                            if (err.codeName === 'NamespaceExists') {
+                                return;
+                            }
+                            throw err;
+                        })
+                        .then(() => {
+                            if (this.shardCollections) {
+                                const cmd = {
+                                    shardCollection: `${this.database}.${bucketName}`,
+                                    key: { _id: 1 },
+                                };
+                                return this.adminDb!.command(cmd, {})
+                                    .then(() => cb(null))
+                                    .catch(err => {
+                                        log.error('createBucket: enabling sharding', { error: err });
+                                        return cb(errors.InternalError);
+                                    });
+                            }
+                            return cb(null);
+                        });
                 }
                 return cb(null);
             })

--- a/tests/unit/storage/metadata/mongoclient/MongoClientInterface.spec.js
+++ b/tests/unit/storage/metadata/mongoclient/MongoClientInterface.spec.js
@@ -1900,6 +1900,26 @@ describe('MongoClientInterface, createBucket', () => {
         });
     });
 
+    it('should succeed when createCollection returns NamespaceExists', done => {
+        const bucketName = 'test-bucket-namespace-exists';
+        const nsExistsError = Object.assign(
+            new Error('Collection already exists. NS: metadata.mpuShadowBucketbucket1'),
+            { codeName: 'NamespaceExists', code: 48 },
+        );
+        const originalCreateCollection = client.db.createCollection;
+        client.db.createCollection = () => Promise.reject(nsExistsError);
+
+        client.createBucket(bucketName, baseBucket, logger, err => {
+            client.db.createCollection = originalCreateCollection;
+            try {
+                assert.ifError(err);
+                done();
+            } catch (assertionError) {
+                done(assertionError);
+            }
+        });
+    });
+
     it('should handle modifiedCount 0 and upsertedCount 0 in createBucket', done => {
         const bucketName = 'test-bucket-createbucket';
 


### PR DESCRIPTION
MongoDB returns error code 48 (`NamespaceExists`) when `createCollection` is called on a collection that already exists - a benign outcome under concurrent create/drop/create sequences on MPU shadow buckets. The existing code let this error fall through to the outer catch, which converted every `createCollection` error into `InternalError`. That 500 response was the root cause of `mongo-v0-ft-tests` and `mongo-v1-ft-tests` failing very frequently in cloudserver.

A unit test was added that stubs `createCollection` to reject with a `NamespaceExists` error and asserts the callback receives no error. We ran the cloudserver mongo functional test suite 20 times in parallel. 4 runs failed on pre-existing unrelated flakes; the target failure did not appear in any run. Full results: https://github.com/scality/cloudserver/actions/runs/27648800616

Issue: ARSN-596