### PR TITLE
Bump package.json to 8.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "engines": {
         "node": ">=20"
     },
-    "version": "8.4.10",
+    "version": "8.5.0",
     "config": {
         "mongodbMemoryServer": {
             "version": "8.0.23"


### PR DESCRIPTION
Set the 8.5 line version to `8.5.0` on `development/8.5`.

The 8.5 line keeps the multi-destination CRR feature that ARSN-600 reverts on 8.4. This bump also makes `development/8.5` diverge from `development/8.4`, which lets the ARSN-600 revert (#2651) cascade to 8.5 as a no-op (keeping CRR) via a manually-resolved integration branch.

Issue: ARSN-600
