### PR TITLE
ARSN-601: Promote OTEL SDK packages from optionalDependencies to dependencies

### DIFF
--- a/lib/tracing/README.md
+++ b/lib/tracing/README.md
@@ -127,8 +127,8 @@ try {
 
 ## Dependencies
 
-`@opentelemetry/api` is a hard dependency (inert until an SDK is registered).
-The SDK-core packages (`sdk-node`, `sdk-trace-base`, `resources`,
-`exporter-trace-otlp-http`) are **optional** dependencies, required lazily in
-`init()`. The `instrumentation-*` packages are **not** arsenal dependencies —
-consumers bring their own and pass them via the `instrumentations` thunk.
+`@opentelemetry/api` plus the SDK-core packages (`sdk-node`, `sdk-trace-base`,
+`resources`, `exporter-trace-otlp-http`) are hard dependencies, lazy-required
+inside `init()` so OTEL-off processes never load them. The `instrumentation-*`
+packages are **not** arsenal dependencies — consumers bring their own and pass
+them via the `instrumentations` thunk.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "engines": {
         "node": ">=20"
     },
-    "version": "8.4.11",
+    "version": "8.4.12",
     "config": {
         "mongodbMemoryServer": {
             "version": "8.0.23"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
         "@azure/storage-blob": "^12.31.0",
         "@js-sdsl/ordered-set": "^4.4.2",
         "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
+        "@opentelemetry/resources": "^2.8.0",
+        "@opentelemetry/sdk-node": "^0.219.0",
+        "@opentelemetry/sdk-trace-base": "^2.8.0",
         "@scality/hdclient": "^1.3.2",
         "@smithy/node-http-handler": "^4.3.0",
         "@smithy/protocol-http": "^5.3.5",
@@ -62,10 +66,6 @@
         "xml2js": "^0.6.2"
     },
     "optionalDependencies": {
-        "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
-        "@opentelemetry/resources": "^2.8.0",
-        "@opentelemetry/sdk-node": "^0.219.0",
-        "@opentelemetry/sdk-trace-base": "^2.8.0",
         "ioctl": "^2.0.2"
     },
     "devDependencies": {


### PR DESCRIPTION
## Summary

Move the four OTEL SDK packages — `@opentelemetry/sdk-node`, `sdk-trace-base`, `resources`, `exporter-trace-otlp-http` — from `optionalDependencies` to `dependencies`. `ioctl` stays optional.

## Problem

ARSN-586 classified the SDK packages as `optionalDependencies`, intending to mean "consumers who don't use tracing skip the ~20 MB install cost". That misuses the npm semantic.

`optionalDependencies` is for packages that **may fail to install** (typically native binaries on unsupported platforms) and whose absence the **calling code tolerates gracefully**. Canonical examples: `fsevents`, `ioctl`.

`lib/tracing/bootstrap.ts:41` does:

```ts
const { NodeSDK } = require('@opentelemetry/sdk-node');
```

A bare `require()`. If the SDK is missing, the process crashes — that's regular `dependencies` semantics, not optional.

The symptom surfaced via CLDSRV-937: cloudserver's production Dockerfile uses `yarn install --ignore-optional` (added in 2019 during the npm→yarn migration with no commit-message rationale, never revisited). Images built that way ship without the SDK, then crash at startup when `ENABLE_OTEL=true`:

```
Error: Cannot find module '@opentelemetry/sdk-node'
Require stack:
- /usr/src/app/node_modules/arsenal/build/lib/tracing/bootstrap.js
```

Thanks to @DarkIsDude for flagging the optional-dep misclassification in [CLDSRV-937's review](https://github.com/scality/cloudserver/pull/6203).

## Fix

```diff
 "dependencies": {
+    "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
+    "@opentelemetry/resources": "^2.8.0",
+    "@opentelemetry/sdk-node": "^0.219.0",
+    "@opentelemetry/sdk-trace-base": "^2.8.0",
     ...
 },
 "optionalDependencies": {
-    "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
-    "@opentelemetry/resources": "^2.8.0",
-    "@opentelemetry/sdk-node": "^0.219.0",
-    "@opentelemetry/sdk-trace-base": "^2.8.0",
     "ioctl": "^2.0.2"
 }
```

`ioctl` is the only remaining `optionalDependencies` entry — its usage at `lib/storage/utils.js:46-51` is wrapped in `try/catch` with a warning fallback, so the optional semantic is honored.

`lib/tracing/README.md` is updated to reflect the new classification with the rationale.

## Precedent in arsenal

Arsenal already ships packages as regular `dependencies` that not every consumer uses:

- `mongodb` — some deployments use bucketd, not mongo
- `ioredis` — some consumers don't use redis
- `socket.io`, `sproxydclient`, `@aws-sdk/*`

There's no in-tree precedent for "opt-in feature SDK as `optionalDependencies`" — that was a novel (and incorrect) classification introduced by ARSN-586.

## Why not the alternatives

- **try/catch around the requires in bootstrap.ts**: would silently disable tracing when `ENABLE_OTEL=true` and SDK is missing. Worse UX — operator explicitly asked for tracing; fail-fast is preferable. Also doesn't address `--ignore-optional` — just papers over it.
- **Declare SDK packages in each consumer's `package.json`**: doesn't isolate anything (other arsenal consumers without `--ignore-optional` already pull them in), adds friction for every future tracing consumer.
- **`peerDependencies` with `optional: true`**: arsenal is git-pinned in consumers via yarn 1, which has rough handling of peer deps for git URLs. Not pragmatic.

## Cost

~20 MB to backbeat / vault / sproxyd installs. Acceptable — backbeat already consumes arsenal's `kafka.*` tracing helpers, and broader OTEL adoption is the direction the stack is moving.

## Verification

Sandbox test (`yarn install --ignore-optional` against this branch via `file:` dep):

- `node_modules/@opentelemetry/sdk-node` present ✓ (the fix)
- `node_modules/ioctl` absent ✓ (still optional, no regression)

Plus locally: `yarn build`, `yarn lint`, `yarn jest tests/unit/tracing/` all green (71/71).

Relates to: ARSN-586, CLDSRV-937

Issue: ARSN-601