### PR TITLE
Publish arsenal to GitHub Packages and npm on release

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     name: Static analysis with CodeQL
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   prettier:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,8 @@ run-name: release ${{ github.ref_name }}
 
 on:
   workflow_dispatch:
+  release:
+    types: [published]
 
 permissions: {}
 
@@ -19,7 +21,8 @@ jobs:
     steps:
       - name: Reject disallowed branch
         if: >-
-          ${{ !startsWith(github.ref, 'refs/heads/development/')
+          ${{ github.event_name == 'workflow_dispatch'
+          && !startsWith(github.ref, 'refs/heads/development/')
           && !startsWith(github.ref, 'refs/heads/hotfix/') }}
         env:
           REF_NAME: ${{ github.ref_name }}
@@ -44,7 +47,21 @@ jobs:
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
+      - name: Verify tag matches package.json version
+        if: ${{ github.event_name == 'release' }}
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          tag=${TAG#v}
+          if [ "$tag" != "$VERSION" ]; then
+            echo "::error::Release tag $TAG does not match package.json" \
+              "version $VERSION"
+            exit 1
+          fi
+
       - name: Fail if release already exists
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.version.outputs.version }}
@@ -56,6 +73,7 @@ jobs:
           fi
 
       - name: Fail if tag already exists
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
@@ -154,6 +172,7 @@ jobs:
   release:
     needs: [build, publish-github, publish-npm]
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,12 +5,17 @@ run-name: release ${{ github.ref_name }}
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
-  release:
+  build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Reject disallowed branch
         if: >-
@@ -60,12 +65,108 @@ jobs:
             exit 1
           fi
 
+      - name: Install NodeJS
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --prefer-offline
+
+      - name: Build
+        run: yarn build
+
+      - name: Pack tarball
+        run: npm pack --ignore-scripts
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: '*.tgz'
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: package
+          path: '*.tgz'
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-github:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Download package artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: package
+
+      - name: Install NodeJS
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@scality'
+
+      - name: Publish to GitHub Packages
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          if [ -n "$(npm view "@scality/arsenal@$VERSION" version 2>/dev/null)" ]; then
+            echo "::notice::@scality/arsenal@$VERSION already on GitHub Packages; skipping"
+          else
+            npm publish *.tgz --tag "v${VERSION%.*}"
+          fi
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download package artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: package
+
+      - name: Install NodeJS
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@scality'
+
+      - name: Publish to npm
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          if [ -n "$(npm view "@scality/arsenal@$VERSION" version 2>/dev/null)" ]; then
+            echo "::notice::@scality/arsenal@$VERSION already on npm; skipping"
+          else
+            npm publish *.tgz --provenance --tag "v${VERSION%.*}"
+          fi
+
+  release:
+    needs: [build, publish-github, publish-npm]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
       - name: Create Release
         uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          name: ${{ steps.version.outputs.version }}
-          tag_name: ${{ steps.version.outputs.version }}
+          name: ${{ needs.build.outputs.version }}
+          tag_name: ${{ needs.build.outputs.version }}
           generate_release_notes: true
+          append_body: true
+          body: |
+            GitHub Packages: https://github.com/${{ github.repository }}/pkgs/npm/arsenal
+            npm: https://www.npmjs.com/package/@scality/arsenal
           target_commitish: ${{ github.sha }}

--- a/.github/workflows/tests-kmip.yaml
+++ b/.github/workflows/tests-kmip.yaml
@@ -4,56 +4,56 @@ name: tests-kmip
 on:
   pull_request:
     branches:
-    - development/*
-    - hotfix/*
+      - development/*
+      - hotfix/*
     paths:
-    - .github/workflows/tests-kmip.yaml
-    - .github/docker-compose.yaml
-    - .github/pykmip/**
-    - lib/network/kmip/**
-    - tests/functional/kmip/**
+      - .github/workflows/tests-kmip.yaml
+      - .github/docker-compose.yaml
+      - .github/pykmip/**
+      - lib/network/kmip/**
+      - tests/functional/kmip/**
   push:
     branches:
-    - q/*
-    - w/**
+      - q/*
+      - w/**
     paths:
-    - .github/workflows/tests-kmip.yaml
-    - .github/docker-compose.yaml
-    - .github/pykmip/**
-    - lib/network/kmip/**
-    - tests/functional/kmip/**
+      - .github/workflows/tests-kmip.yaml
+      - .github/docker-compose.yaml
+      - .github/pykmip/**
+      - lib/network/kmip/**
+      - tests/functional/kmip/**
 
 jobs:
   test-kmip:
     runs-on: ubuntu-22.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
-      with:
-        node-version: '22'
-        cache: 'yarn'
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'yarn'
 
-    - name: Install socat (tunnel to help create disconnect and reconnect to pykmip)
-      run: sudo apt-get install -y socat
+      - name: Install socat (tunnel to help create disconnect and reconnect to pykmip)
+        run: sudo apt-get install -y socat
 
-    - name: Setup pykmip.local in etc/hosts
-      shell: bash
-      run: |
-        sudo echo "127.0.0.1 pykmip.local" | sudo tee -a /etc/hosts
-        for i in `seq 1 50`; do sudo echo "127.0.0.$i $i.pykmip.local" | sudo tee -a /etc/hosts ; done
+      - name: Setup pykmip.local in etc/hosts
+        shell: bash
+        run: |
+          sudo echo "127.0.0.1 pykmip.local" | sudo tee -a /etc/hosts
+          for i in `seq 1 50`; do sudo echo "127.0.0.$i $i.pykmip.local" | sudo tee -a /etc/hosts ; done
 
-    - name: Start docker pykmip
-      run: docker compose --profile pykmip up -d
-      working-directory: .github
+      - name: Start docker pykmip
+        run: docker compose --profile pykmip up -d
+        working-directory: .github
 
-    - name: install dependencies
-      run: yarn install --frozen-lockfile --prefer-offline --network-concurrency 1
+      - name: install dependencies
+        run: yarn install --frozen-lockfile --prefer-offline --network-concurrency 1
 
-    - name: run kmip ClusterClient functional tests on pykmip
-      run: yarn ft_pykmip_test
+      - name: run kmip ClusterClient functional tests on pykmip
+        run: yarn ft_pykmip_test
 
-    - uses: actions/upload-artifact@v4
-      with:
-        name: pykmip_logs
-        path: /tmp/artifacts/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pykmip_logs
+          path: /tmp/artifacts/

--- a/.github/workflows/tests-kmip.yaml
+++ b/.github/workflows/tests-kmip.yaml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   test-kmip:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,7 +4,7 @@ name: tests
 on:
   push:
     branches-ignore:
-    - 'development/**'
+      - 'development/**'
 
 jobs:
   test:
@@ -24,73 +24,73 @@ jobs:
           # Maps port 6379 on service container to the host
           - 6379:6379
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
-      with:
-        node-version: '22'
-        cache: 'yarn'
-    - name: install dependencies
-      run: yarn install --frozen-lockfile --prefer-offline --network-concurrency 1
-    - name: lint yaml
-      run: yarn --silent lint_yml
-    - name: lint javascript
-      run: yarn --silent lint --max-warnings 0
-    - name: lint markdown
-      run: yarn --silent lint_md
-    - name: add hostname
-      run: |
-        sudo sh -c "echo '127.0.0.1 testrequestbucket.localhost' >> /etc/hosts"
-    - name: test and coverage
-      run: yarn --silent coverage
-    - name: run functional tests
-      run: yarn ft_test
-    - uses: codecov/codecov-action@v4
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-    - name: run executables tests
-      run: yarn install && yarn test
-      working-directory: 'lib/executables/pensieveCreds/'
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'yarn'
+      - name: install dependencies
+        run: yarn install --frozen-lockfile --prefer-offline --network-concurrency 1
+      - name: lint yaml
+        run: yarn --silent lint_yml
+      - name: lint javascript
+        run: yarn --silent lint --max-warnings 0
+      - name: lint markdown
+        run: yarn --silent lint_md
+      - name: add hostname
+        run: |
+          sudo sh -c "echo '127.0.0.1 testrequestbucket.localhost' >> /etc/hosts"
+      - name: test and coverage
+        run: yarn --silent coverage
+      - name: run functional tests
+        run: yarn ft_test
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: run executables tests
+        run: yarn install && yarn test
+        working-directory: 'lib/executables/pensieveCreds/'
 
   compile:
     name: Compile and upload build artifacts
     needs: test
     runs-on: ubuntu-22.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Install NodeJS
-      uses: actions/setup-node@v4
-      with:
-        node-version: '22'
-        cache: yarn
-    - name: Install dependencies
-      run: yarn install --frozen-lockfile --prefer-offline
-    - name: Compile
-      run: yarn build
-    - name: Upload artifacts
-      uses: scality/action-artifacts@v4
-      with:
-        url: https://artifacts.scality.net
-        user: ${{ secrets.ARTIFACTS_USER }}
-        password: ${{ secrets.ARTIFACTS_PASSWORD }}
-        source: ./build
-        method: upload
-      if: success()
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install NodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: yarn
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --prefer-offline
+      - name: Compile
+        run: yarn build
+      - name: Upload artifacts
+        uses: scality/action-artifacts@v4
+        with:
+          url: https://artifacts.scality.net
+          user: ${{ secrets.ARTIFACTS_USER }}
+          password: ${{ secrets.ARTIFACTS_PASSWORD }}
+          source: ./build
+          method: upload
+        if: success()
 
   test-workflows:
     name: Test GitHub Actions workflows
     runs-on: ubuntu-22.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-    - name: Install NodeJS
-      uses: actions/setup-node@v6
-      with:
-        node-version: '24'
-        cache: yarn
-        cache-dependency-path: tests/workflows/yarn.lock
-    - name: Install dependencies
-      run: yarn --cwd tests/workflows install --frozen-lockfile
-    - name: Run workflow tests
-      run: yarn --cwd tests/workflows test
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install NodeJS
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: yarn
+          cache-dependency-path: tests/workflows/yarn.lock
+      - name: Install dependencies
+        run: yarn --cwd tests/workflows install --frozen-lockfile
+      - name: Run workflow tests
+        run: yarn --cwd tests/workflows test

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     services:
       # Label used to access the service container
       redis:
@@ -55,7 +55,7 @@ jobs:
   compile:
     name: Compile and upload build artifacts
     needs: test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -80,7 +80,7 @@ jobs:
 
   test-workflows:
     name: Test GitHub Actions workflows
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "engines": {
         "node": ">=20"
     },
-    "version": "8.4.18",
+    "version": "8.4.19",
     "config": {
         "mongodbMemoryServer": {
             "version": "8.0.23"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "arsenal",
+    "name": "@scality/arsenal",
     "engines": {
         "node": ">=20"
     },
@@ -11,6 +11,13 @@
     },
     "description": "Common utilities for the S3 project components",
     "main": "build/index.js",
+    "types": "build/index.d.ts",
+    "files": [
+        "build"
+    ],
+    "publishConfig": {
+        "access": "public"
+    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/scality/Arsenal.git"
@@ -114,7 +121,6 @@
         "prepare": "yarn build",
         "test": "export NODE_OPTIONS=\"--tls-max-v1.2\" && jest tests/unit --detectOpenHandles"
     },
-    "private": true,
     "jest": {
         "maxWorkers": 1,
         "coverageReporters": [

--- a/tests/workflows/release.spec.ts
+++ b/tests/workflows/release.spec.ts
@@ -1,52 +1,55 @@
-import { Act } from "@kie/act-js";
-import { MockGithub } from "@kie/mock-github";
-import path from "path";
-import { exec as execCb } from "node:child_process";
-import { promisify } from "node:util";
-import { mkdtempSync } from "node:fs";
-import os from "node:os";
+import { Act } from '@kie/act-js';
+import { MockGithub } from '@kie/mock-github';
+import path from 'path';
+import { exec as execCb } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtempSync } from 'node:fs';
+import os from 'node:os';
 
 const exec = promisify(execCb);
-const IMAGE = "ghcr.io/catthehacker/ubuntu:act-latest";
+const IMAGE = 'ghcr.io/catthehacker/ubuntu:act-latest';
 
 let github: MockGithub;
 
 async function setup(versionFixture: string, branch: string): Promise<Act> {
     // unique setup path per test so act's checkout residue can't collide with another test's repo
-    const setupPath = mkdtempSync(path.join(os.tmpdir(), "arsenal-workflows-"));
-    github = new MockGithub({
-        repo: {
-            arsenal: {
-                currentBranch: branch,
-                files: [
-                    { src: path.resolve(__dirname, "../..", ".github"), dest: ".github" },
-                    { src: path.resolve(__dirname, "fixtures", versionFixture), dest: "package.json" },
-                ],
+    const setupPath = mkdtempSync(path.join(os.tmpdir(), 'arsenal-workflows-'));
+    github = new MockGithub(
+        {
+            repo: {
+                arsenal: {
+                    currentBranch: branch,
+                    files: [
+                        { src: path.resolve(__dirname, '../..', '.github'), dest: '.github' },
+                        { src: path.resolve(__dirname, 'fixtures', versionFixture), dest: 'package.json' },
+                    ],
+                },
             },
         },
-    }, setupPath);
+        setupPath,
+    );
     await github.setup();
-    const act = new Act(github.repo.getPath("arsenal"));
-    act.setWorkflowFile(".github/workflows/release.yaml");
-    act.setPlatforms("ubuntu-latest", IMAGE);
-    act.setEnv("GITHUB_REPOSITORY", "scality/Arsenal");
-    act.setEnv("GITHUB_REF", `refs/heads/${branch}`);
+    const act = new Act(github.repo.getPath('arsenal'));
+    act.setWorkflowFile('.github/workflows/release.yaml');
+    act.setPlatforms('ubuntu-latest', IMAGE);
+    act.setEnv('GITHUB_REPOSITORY', 'scality/Arsenal');
+    act.setEnv('GITHUB_REF', `refs/heads/${branch}`);
     return act;
 }
 
 async function createTag(tag: string) {
-    await exec(`git -C ${github.repo.getPath("arsenal")} tag --no-sign -m test ${tag}`);
+    await exec(`git -C ${github.repo.getPath('arsenal')} tag --no-sign -m test ${tag}`);
 }
 
 const mockSteps = {
     release: [
-        { name: "Fail if release already exists", mockWith: "echo no-release-found" },
-        { name: "Create Release", mockWith: "echo skip-create-release" },
+        { name: 'Fail if release already exists', mockWith: 'echo no-release-found' },
+        { name: 'Create Release', mockWith: 'echo skip-create-release' },
     ],
 };
 
 function run(act: Act) {
-    return act.runEvent("workflow_dispatch", { mockSteps });
+    return act.runEvent('workflow_dispatch', { mockSteps });
 }
 
 function step(result: { name: string; status: number }[], name: string) {
@@ -57,37 +60,37 @@ afterEach(async () => {
     await github.teardown();
 });
 
-test("rejects a release dispatched from a disallowed branch", async () => {
-    const act = await setup("package-versioned.json", "feature/not-a-release-branch");
+test('rejects a release dispatched from a disallowed branch', async () => {
+    const act = await setup('package-versioned.json', 'feature/not-a-release-branch');
     const result = await run(act);
-    expect(step(result, "Reject disallowed branch")?.status).toBe(1);
+    expect(step(result, 'Reject disallowed branch')?.status).toBe(1);
 });
 
-test("allows a development/* branch and runs through to the release step", async () => {
-    const act = await setup("package-versioned.json", "development/8.3");
+test('allows a development/* branch and runs through to the release step', async () => {
+    const act = await setup('package-versioned.json', 'development/8.3');
     const result = await run(act);
     // the branch guard is `if`-gated, so it is skipped (absent) on an allowed branch
-    expect(step(result, "Reject disallowed branch")).toBeUndefined();
+    expect(step(result, 'Reject disallowed branch')).toBeUndefined();
     expect(result.every(r => r.status === 0)).toBe(true);
-    expect(step(result, "Create Release")?.status).toBe(0);
+    expect(step(result, 'Create Release')?.status).toBe(0);
 });
 
-test("allows a hotfix/* branch", async () => {
-    const act = await setup("package-versioned.json", "hotfix/8.3.1");
+test('allows a hotfix/* branch', async () => {
+    const act = await setup('package-versioned.json', 'hotfix/8.3.1');
     const result = await run(act);
-    expect(step(result, "Reject disallowed branch")).toBeUndefined();
-    expect(step(result, "Create Release")?.status).toBe(0);
+    expect(step(result, 'Reject disallowed branch')).toBeUndefined();
+    expect(step(result, 'Create Release')?.status).toBe(0);
 });
 
-test("fails when package.json has no version", async () => {
-    const act = await setup("package-no-version.json", "development/8.3");
+test('fails when package.json has no version', async () => {
+    const act = await setup('package-no-version.json', 'development/8.3');
     const result = await run(act);
-    expect(step(result, "Read version from package.json")?.status).toBe(1);
+    expect(step(result, 'Read version from package.json')?.status).toBe(1);
 });
 
-test("fails when the tag already exists", async () => {
-    const act = await setup("package-versioned.json", "development/8.3");
-    await createTag("8.3.12");
+test('fails when the tag already exists', async () => {
+    const act = await setup('package-versioned.json', 'development/8.3');
+    await createTag('8.3.12');
     const result = await run(act);
-    expect(step(result, "Fail if tag already exists")?.status).toBe(1);
+    expect(step(result, 'Fail if tag already exists')?.status).toBe(1);
 });

--- a/tests/workflows/release.spec.ts
+++ b/tests/workflows/release.spec.ts
@@ -42,10 +42,26 @@ async function createTag(tag: string) {
 }
 
 const mockSteps = {
-    release: [
+    build: [
         { name: 'Fail if release already exists', mockWith: 'echo no-release-found' },
-        { name: 'Create Release', mockWith: 'echo skip-create-release' },
+        { name: 'Install NodeJS', mockWith: 'echo skip-setup-node' },
+        { name: 'Install dependencies', mockWith: 'echo skip-install' },
+        { name: 'Build', mockWith: 'echo skip-build' },
+        { name: 'Pack tarball', mockWith: 'echo skip-pack' },
+        { name: 'Attest build provenance', mockWith: 'echo skip-attest' },
+        { name: 'Upload package artifact', mockWith: 'echo skip-upload' },
     ],
+    'publish-github': [
+        { name: 'Download package artifact', mockWith: 'echo skip-download' },
+        { name: 'Install NodeJS', mockWith: 'echo skip-setup-node' },
+        { name: 'Publish to GitHub Packages', mockWith: 'echo skip-publish' },
+    ],
+    'publish-npm': [
+        { name: 'Download package artifact', mockWith: 'echo skip-download' },
+        { name: 'Install NodeJS', mockWith: 'echo skip-setup-node' },
+        { name: 'Publish to npm', mockWith: 'echo skip-publish' },
+    ],
+    release: [{ name: 'Create Release', mockWith: 'echo skip-create-release' }],
 };
 
 function run(act: Act) {

--- a/tests/workflows/release.spec.ts
+++ b/tests/workflows/release.spec.ts
@@ -110,3 +110,26 @@ test('fails when the tag already exists', async () => {
     const result = await run(act);
     expect(step(result, 'Fail if tag already exists')?.status).toBe(1);
 });
+
+test('publishes on a release event without the manual-dispatch guards', async () => {
+    const act = await setup('package-versioned.json', 'development/8.3');
+    act.setEvent({ action: 'published', release: { tag_name: '8.3.12' } });
+    const result = await act.runEvent('release', { mockSteps });
+    // the dispatch-only guards and the Create Release job are skipped on a release event
+    expect(step(result, 'Reject disallowed branch')).toBeUndefined();
+    expect(step(result, 'Fail if release already exists')).toBeUndefined();
+    expect(step(result, 'Fail if tag already exists')).toBeUndefined();
+    expect(step(result, 'Create Release')).toBeUndefined();
+    // the tag/version check runs and the package is published
+    expect(step(result, 'Verify tag matches package.json version')?.status).toBe(0);
+    expect(step(result, 'Publish to GitHub Packages')?.status).toBe(0);
+    expect(step(result, 'Publish to npm')?.status).toBe(0);
+    expect(result.every(r => r.status === 0)).toBe(true);
+});
+
+test('fails a release event whose tag does not match the version', async () => {
+    const act = await setup('package-versioned.json', 'development/8.3');
+    act.setEvent({ action: 'published', release: { tag_name: '9.9.9' } });
+    const result = await act.runEvent('release', { mockSteps });
+    expect(step(result, 'Verify tag matches package.json version')?.status).toBe(1);
+});


### PR DESCRIPTION
## Summary

Builds on the manual release workflow from ARSN-604 (#2656): on release, **build and dual-publish `@scality/arsenal` to GitHub Packages and npmjs**. arsenal is a public, Apache-2.0 library, so per the DevEx TAD it goes to both registries. Non-breaking — existing git-dependency consumers (cloudserver, backbeat, vault2) are untouched; migrating them to the registry is a later, organic step.

`release.yaml` is split into jobs so the build is produced once and each publish can be retried independently of it and of the other:

- **build** — after the branch / version / tag guards: install, `yarn build`, `npm pack`, generate a signed build-provenance attestation for the tarball (`actions/attest-build-provenance`), and upload the `.tgz` as the artifact.
- **publish-github** — download the tarball and publish it to GitHub Packages with the built-in `GITHUB_TOKEN`.
- **publish-npm** — publish the same tarball to npmjs via **OIDC trusted publishing** (`id-token: write`, no stored token) with `--provenance`.
- **release** — create the GitHub release + tag, linking to both packages.

Both publish jobs use the committed `package.json` version (no auto-bump), check the registry with `npm view` first and **skip if that version is already published** — so a partial dual-publish can be re-run cleanly — and publish under a `v<major.minor>` dist-tag so an older release line never moves `latest`. Building and packing once, then attesting and publishing the same tarball to both registries, gives a single GitHub attestation (`gh attestation verify <tarball> --repo scality/Arsenal`) covering whatever lands in either registry, plus npm-native provenance on npmjs.

### Name: committed, not stamped

`package.json` is renamed to **`@scality/arsenal`** directly — no publish-time name stamp / `jq`. Git-dependency consumers resolve arsenal by their dependency **key**, not the package's `name`, so committing the scoped name keeps `require('arsenal')` working for cloudserver/backbeat/vault2 (verified end-to-end: real arsenal committed as `@scality/arsenal`, consumed under the unchanged bare `arsenal` git key, installs to `node_modules/arsenal` and resolves both bare and deep `arsenal/build/...` imports). `package.json` also drops `private` and adds `types`/`files` + `publishConfig.access: public`. The version stays committed / manually bumped — auto-stamping is deferred to a later step.

The workflow tests under `tests/workflows` stub the publish path, so the guard coverage is unchanged.

### Prerequisite (npmjs trusted publishing)

The npm publish uses **OIDC trusted publishing** — no `NPM_TOKEN`. Before the first npm release, a **trusted publisher** must be registered for `@scality/arsenal`: GitHub org `scality`, repo `Arsenal`, workflow `release.yaml` (the same setup Sylvain did for `@scality/cloudserverclient`). Since `@scality/arsenal` isn't on npm yet, bootstrap it one of two ways:

- **One-time manual publish** by anyone with `@scality` publish rights (`yarn build && npm publish --access public`) to create the package, then register the trusted publisher. That first version has no provenance (local publish); the workflow provenance-signs every release after it and skips the bootstrapped version via its `npm view` check.
- **Org-level trusted publishing**, if the `@scality` npm org allows creating packages via OIDC — then the first workflow run creates it, no manual step.

GitHub Packages needs no bootstrap (built-in `GITHUB_TOKEN`).

Aligned with the DevEx initiative (S3C-9725); mirrors the dual-publish model of `hdclient` / `cloudserverclient`.

Issue: ARSN-605
