### PR TITLE
ARSN-606: Bump sproxydclient to support chordCos=0 HF S3C 9.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "simple-glob": "^0.2.0",
     "socket.io": "^4.8.0",
     "socket.io-client": "^4.8.0",
-    "sproxydclient": "github:scality/sproxydclient#8.2.0",
+    "sproxydclient": "github:scality/sproxydclient#8.2.1",
     "utf8": "^3.0.0",
     "uuid": "^10.0.0",
     "werelogs": "scality/werelogs#8.2.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=20"
   },
-  "version": "8.2.48.1",
+  "version": "8.2.48-1",
   "description": "Common utilities for the S3 project components",
   "main": "build/index.js",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6496,9 +6496,9 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
-"sproxydclient@github:scality/sproxydclient#8.2.0":
-  version "8.2.0"
-  resolved "https://codeload.github.com/scality/sproxydclient/tar.gz/9b7ff3b511410117d0012d1319f1d942ecc474f8"
+"sproxydclient@github:scality/sproxydclient#8.2.1":
+  version "8.2.1"
+  resolved "https://codeload.github.com/scality/sproxydclient/tar.gz/501829f5521787e7e946de6792f5806ffa6ec437"
   dependencies:
     async "^3.2.6"
     httpagent "github:scality/httpagent#1.1.0"


### PR DESCRIPTION
Previous bump to 8.2.0 was not enough, it's 8.2.1