### PR TITLE
Skip head-check for scality backends in MultipleBackendGateway

### DIFF
--- a/lib/storage/data/MultipleBackendGateway.js
+++ b/lib/storage/data/MultipleBackendGateway.js
@@ -92,8 +92,11 @@ class MultipleBackendGateway {
         }
         const objectGetInfo = objectGetInfoArr[0];
         const client = this.clients[objectGetInfo.dataStoreName];
-        if (client.head === undefined) {
-            // no-op if unsupported client method
+        if (client.head === undefined || client.clientType === 'scality') {
+            // no-op if the client does not support head, or for scality
+            // (sproxyd) backends: the head-check only verifies external cloud
+            // backend data state, and sproxyd's head expects a string key
+            // rather than the objectGetInfo object (see get()/delete()).
             return process.nextTick(callback);
         }
         return client.head(objectGetInfo, reqUids, callback);

--- a/lib/storage/data/MultipleBackendGateway.js
+++ b/lib/storage/data/MultipleBackendGateway.js
@@ -24,13 +24,11 @@ class MultipleBackendGateway {
     }
 
     put(hashedStream, size, keyContext, backendInfo, reqUids, callback) {
-        const controllingLocationConstraint =
-            backendInfo.getControllingLocationConstraint();
+        const controllingLocationConstraint = backendInfo.getControllingLocationConstraint();
         const client = this.clients[controllingLocationConstraint];
         if (!client) {
             const log = createLogger(reqUids);
-            log.error('no data backend matching controlling locationConstraint',
-                { controllingLocationConstraint });
+            log.error('no data backend matching controlling locationConstraint', { controllingLocationConstraint });
             return process.nextTick(() => {
                 callback(errors.InternalError);
             });
@@ -53,13 +51,16 @@ class MultipleBackendGateway {
                 return callback(errors.InternalError);
             }
         }
-        return client.put(writeStream, size, keyContext, reqUids,
+        return client.put(
+            writeStream,
+            size,
+            keyContext,
+            reqUids,
             (err, key, dataStoreVersionId, dataStoreSize, dataStoreMD5) => {
                 const log = createLogger(reqUids);
                 log.debug('put to location', { controllingLocationConstraint });
                 if (err) {
-                    log.error('error from datastore',
-                        { error: err, dataStoreType: client.clientType });
+                    log.error('error from datastore', { error: err, dataStoreType: client.clientType });
                     return callback(errors.ServiceUnavailable);
                 }
                 const dataRetrievalInfo = {
@@ -71,14 +72,21 @@ class MultipleBackendGateway {
                     dataStoreMD5,
                 };
                 return callback(null, dataRetrievalInfo);
-            // sproxyd accepts keyschema, send as null so sproxyd generates key
-            // send metadata as param for AzureClient in Arsenal
-            }, null, this.metadata);
+                // sproxyd accepts keyschema, send as null so sproxyd generates key
+                // send metadata as param for AzureClient in Arsenal
+            },
+            null,
+            this.metadata,
+        );
     }
 
     head(objectGetInfoArr, reqUids, callback) {
-        if (!objectGetInfoArr || !Array.isArray(objectGetInfoArr)
-        || !objectGetInfoArr[0] || !objectGetInfoArr[0].dataStoreName) {
+        if (
+            !objectGetInfoArr ||
+            !Array.isArray(objectGetInfoArr) ||
+            !objectGetInfoArr[0] ||
+            !objectGetInfoArr[0].dataStoreName
+        ) {
             // no-op if no stored data store name
             return process.nextTick(callback);
         }
@@ -139,67 +147,110 @@ class MultipleBackendGateway {
         const awsArray = [];
         const azureArray = [];
         const gcpArray = [];
-        async.each(Object.keys(this.clients), (location, cb) => {
-            const client = this.clients[location];
-            if (client.clientType === 'scality') {
-                return client.healthcheck(log, (err, res) => {
-                    if (err) {
-                        multBackendResp[location] = { error: err };
-                    } else {
-                        multBackendResp[location] = { code: res.statusCode,
-                            message: res.statusMessage };
-                    }
+        async.each(
+            Object.keys(this.clients),
+            (location, cb) => {
+                const client = this.clients[location];
+                if (client.clientType === 'scality') {
+                    return client.healthcheck(log, (err, res) => {
+                        if (err) {
+                            multBackendResp[location] = { error: err };
+                        } else {
+                            multBackendResp[location] = { code: res.statusCode, message: res.statusMessage };
+                        }
+                        return cb();
+                    });
+                } else if (client.clientType === 'aws_s3') {
+                    awsArray.push(location);
                     return cb();
-                });
-            } else if (client.clientType === 'aws_s3') {
-                awsArray.push(location);
+                } else if (client.clientType === 'azure') {
+                    azureArray.push(location);
+                    return cb();
+                } else if (client.clientType === 'gcp') {
+                    gcpArray.push(location);
+                    return cb();
+                }
+                // if backend type isn't 'scality' or an external backend, it will
+                // be 'mem' or 'file', for which the default response is 200 OK
+                multBackendResp[location] = { code: 200, message: 'OK' };
                 return cb();
-            } else if (client.clientType === 'azure') {
-                azureArray.push(location);
-                return cb();
-            } else if (client.clientType === 'gcp') {
-                gcpArray.push(location);
-                return cb();
-            }
-            // if backend type isn't 'scality' or an external backend, it will
-            // be 'mem' or 'file', for which the default response is 200 OK
-            multBackendResp[location] = { code: 200, message: 'OK' };
-            return cb();
-        }, () => {
-            async.parallel([
-                next => checkExternalBackend(
-                    this.clients, awsArray, 'aws_s3', flightCheckOnStartUp,
-                    externalBackendHealthCheckInterval, next),
-                next => checkExternalBackend(
-                    this.clients, azureArray, 'azure', flightCheckOnStartUp,
-                    externalBackendHealthCheckInterval, next),
-                next => checkExternalBackend(
-                    this.clients, gcpArray, 'gcp', flightCheckOnStartUp,
-                    externalBackendHealthCheckInterval, next),
-            ], (errNull, externalResp) => {
-                const externalLocResults = [];
-                externalResp.forEach(resp => externalLocResults.push(...resp));
-                externalLocResults.forEach(locationResult =>
-                    Object.assign(multBackendResp, locationResult));
-                callback(null, multBackendResp);
-            });
-        });
+            },
+            () => {
+                async.parallel(
+                    [
+                        next =>
+                            checkExternalBackend(
+                                this.clients,
+                                awsArray,
+                                'aws_s3',
+                                flightCheckOnStartUp,
+                                externalBackendHealthCheckInterval,
+                                next,
+                            ),
+                        next =>
+                            checkExternalBackend(
+                                this.clients,
+                                azureArray,
+                                'azure',
+                                flightCheckOnStartUp,
+                                externalBackendHealthCheckInterval,
+                                next,
+                            ),
+                        next =>
+                            checkExternalBackend(
+                                this.clients,
+                                gcpArray,
+                                'gcp',
+                                flightCheckOnStartUp,
+                                externalBackendHealthCheckInterval,
+                                next,
+                            ),
+                    ],
+                    (errNull, externalResp) => {
+                        const externalLocResults = [];
+                        externalResp.forEach(resp => externalLocResults.push(...resp));
+                        externalLocResults.forEach(locationResult => Object.assign(multBackendResp, locationResult));
+                        callback(null, multBackendResp);
+                    },
+                );
+            },
+        );
     }
 
-    createMPU(key, metaHeaders, bucketName, websiteRedirectHeader,
-        location, contentType, cacheControl, contentDisposition,
-        contentEncoding, tagging, log, cb) {
+    createMPU(
+        key,
+        metaHeaders,
+        bucketName,
+        websiteRedirectHeader,
+        location,
+        contentType,
+        cacheControl,
+        contentDisposition,
+        contentEncoding,
+        tagging,
+        log,
+        cb,
+    ) {
         const client = this.clients[location];
         if (client.clientType === 'aws_s3' || client.clientType === 'gcp') {
-            return client.createMPU(key, metaHeaders, bucketName,
-                websiteRedirectHeader, contentType, cacheControl,
-                contentDisposition, contentEncoding, tagging, log, cb);
+            return client.createMPU(
+                key,
+                metaHeaders,
+                bucketName,
+                websiteRedirectHeader,
+                contentType,
+                cacheControl,
+                contentDisposition,
+                contentEncoding,
+                tagging,
+                log,
+                cb,
+            );
         }
         return cb();
     }
 
-    uploadPart(request, streamingV4Params, stream, size, location, key,
-        uploadId, partNumber, bucketName, log, cb) {
+    uploadPart(request, streamingV4Params, stream, size, location, key, uploadId, partNumber, bucketName, log, cb) {
         const client = this.clients[location];
         const cbOnce = jsutil.once(cb);
 
@@ -208,41 +259,58 @@ class MultipleBackendGateway {
                 if (err) {
                     return cbOnce(err);
                 }
-                return client.uploadPart(request, streamingV4Params, stream,
-                    size, key, uploadId, partNumber, bucketName, log,
+                return client.uploadPart(
+                    request,
+                    streamingV4Params,
+                    stream,
+                    size,
+                    key,
+                    uploadId,
+                    partNumber,
+                    bucketName,
+                    log,
                     (err, partInfo) => {
                         if (err) {
-                        // if error putting part, counter should be decremented
-                            return this.locStorageCheckFn(location, -size, log,
-                                error => {
-                                    if (error) {
-                                        log.error('Error decrementing location ' +
-                                    'metric following object PUT failure',
-                                        { error: error.message });
-                                    }
-                                    return cbOnce(err);
-                                });
+                            // if error putting part, counter should be decremented
+                            return this.locStorageCheckFn(location, -size, log, error => {
+                                if (error) {
+                                    log.error('Error decrementing location metric following object PUT failure', {
+                                        error: error.message,
+                                    });
+                                }
+                                return cbOnce(err);
+                            });
                         }
                         return cbOnce(null, partInfo);
-                    });
+                    },
+                );
             });
         }
         return cbOnce();
     }
 
-    listParts(key, uploadId, location, bucketName, partNumberMarker, maxParts,
-        log, cb) {
+    listParts(key, uploadId, location, bucketName, partNumberMarker, maxParts, log, cb) {
         const client = this.clients[location];
 
         if (client.listParts) {
-            return client.listParts(key, uploadId, bucketName, partNumberMarker,
-                maxParts, log, cb);
+            return client.listParts(key, uploadId, bucketName, partNumberMarker, maxParts, log, cb);
         }
         return cb();
     }
 
-    completeMPU(key, uploadId, location, jsonList, mdInfo, bucketName,
-        userMetadata, contentSettings, tagging, log, cb) {
+    completeMPU(
+        key,
+        uploadId,
+        location,
+        jsonList,
+        mdInfo,
+        bucketName,
+        userMetadata,
+        contentSettings,
+        tagging,
+        log,
+        cb,
+    ) {
         const client = this.clients[location];
         if (client.completeMPU) {
             const args = [jsonList, mdInfo, key, uploadId, bucketName];
@@ -285,73 +353,88 @@ class MultipleBackendGateway {
         // if legacy, objectMD will not contain dataStoreName, so just return
         const client = this.clients[objectMD.dataStoreName];
         if (client && client[`object${method}Tagging`]) {
-            return client[`object${method}Tagging`](key, bucket, objectMD, log,
-                cb);
+            return client[`object${method}Tagging`](key, bucket, objectMD, log, cb);
         }
         return cb();
     }
 
     // NOTE: using copyObject only if copying object from one external
     // backend to the same external backend
-    copyObject(request, destLocationConstraintName, externalSourceKey,
-        sourceLocationConstraintName, storeMetadataParams, config, log, cb) {
+    copyObject(
+        request,
+        destLocationConstraintName,
+        externalSourceKey,
+        sourceLocationConstraintName,
+        storeMetadataParams,
+        config,
+        log,
+        cb,
+    ) {
         const client = this.clients[destLocationConstraintName];
         if (client.copyObject) {
-            return this.locStorageCheckFn(destLocationConstraintName,
-                storeMetadataParams.size, log, err => {
-                    if (err) {
-                        cb(err);
-                    }
-                    return client.copyObject(request, destLocationConstraintName,
-                        externalSourceKey, sourceLocationConstraintName,
-                        storeMetadataParams, config, log,
-                        (err, key, dataStoreVersionId) => {
-                            const dataRetrievalInfo = {
-                                key,
-                                dataStoreName: destLocationConstraintName,
-                                dataStoreType: client.clientType,
-                                dataStoreVersionId,
-                            };
-                            if (err) {
-                                // if error copying obj, counter should be decremented
-                                return this.locStorageCheckFn(
-                                    destLocationConstraintName, -storeMetadataParams.size,
-                                    log, error => {
-                                        if (error) {
-                                            log.error('Error decrementing location ' +
-                                    'metric following object PUT failure',
-                                            { error: error.message });
-                                        }
-                                        return cb(err);
-                                    });
-                            }
-                            return cb(null, dataRetrievalInfo);
-                        });
-                });
+            return this.locStorageCheckFn(destLocationConstraintName, storeMetadataParams.size, log, err => {
+                if (err) {
+                    cb(err);
+                }
+                return client.copyObject(
+                    request,
+                    destLocationConstraintName,
+                    externalSourceKey,
+                    sourceLocationConstraintName,
+                    storeMetadataParams,
+                    config,
+                    log,
+                    (err, key, dataStoreVersionId) => {
+                        const dataRetrievalInfo = {
+                            key,
+                            dataStoreName: destLocationConstraintName,
+                            dataStoreType: client.clientType,
+                            dataStoreVersionId,
+                        };
+                        if (err) {
+                            // if error copying obj, counter should be decremented
+                            return this.locStorageCheckFn(
+                                destLocationConstraintName,
+                                -storeMetadataParams.size,
+                                log,
+                                error => {
+                                    if (error) {
+                                        log.error('Error decrementing location metric following object PUT failure', {
+                                            error: error.message,
+                                        });
+                                    }
+                                    return cb(err);
+                                },
+                            );
+                        }
+                        return cb(null, dataRetrievalInfo);
+                    },
+                );
+            });
         }
-        return cb(errorInstances.NotImplemented
-            .customizeDescription('Can not copy object from ' +
-            `${client.clientType} to ${client.clientType}`));
+        return cb(
+            errorInstances.NotImplemented.customizeDescription(
+                `Can not copy object from ${client.clientType} to ${client.clientType}`,
+            ),
+        );
     }
 
-    uploadPartCopy(request, location, awsSourceKey,
-        sourceLocationConstraintName, config, log, cb) {
+    uploadPartCopy(request, location, awsSourceKey, sourceLocationConstraintName, config, log, cb) {
         const client = this.clients[location];
         if (client.uploadPartCopy) {
-            return client.uploadPartCopy(request, awsSourceKey,
-                sourceLocationConstraintName, config,
-                log, cb);
+            return client.uploadPartCopy(request, awsSourceKey, sourceLocationConstraintName, config, log, cb);
         }
-        return cb(errorInstances.NotImplemented.customizeDescription(
-            'Can not copy object from ' +
-          `${client.clientType} to ${client.clientType}`));
+        return cb(
+            errorInstances.NotImplemented.customizeDescription(
+                `Can not copy object from ${client.clientType} to ${client.clientType}`,
+            ),
+        );
     }
 
     protectAzureBlocks(bucketName, objectKey, location, log, cb) {
         const client = this.clients[location];
         if (client.protectAzureBlocks) {
-            return client.protectAzureBlocks(this.metadata, bucketName,
-                objectKey, location, log, cb);
+            return client.protectAzureBlocks(this.metadata, bucketName, objectKey, location, log, cb);
         }
         return cb();
     }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "engines": {
         "node": ">=20"
     },
-    "version": "8.4.15",
+    "version": "8.4.16",
     "config": {
         "mongodbMemoryServer": {
             "version": "8.0.23"

--- a/tests/unit/storage/data/mockClients/MockAzureClient.js
+++ b/tests/unit/storage/data/mockClients/MockAzureClient.js
@@ -41,6 +41,16 @@ class MockAzureClient {
         assert.strictEqual(typeof callback, 'function');
         return callback();
     }
+
+    head(objectGetInfo, reqUids, callback) {
+        assert.strictEqual(typeof objectGetInfo, 'object');
+        const { key, bucketName } = objectGetInfo;
+        assert.strictEqual(typeof key, 'string');
+        assert.strictEqual(typeof bucketName, 'string');
+        assert.strictEqual(typeof reqUids, 'string');
+        assert.strictEqual(typeof callback, 'function');
+        return callback(null, {});
+    }
 }
 
 module.exports = MockAzureClient;

--- a/tests/unit/storage/data/mockClients/MockAzureClient.js
+++ b/tests/unit/storage/data/mockClients/MockAzureClient.js
@@ -1,7 +1,6 @@
 const assert = require('assert');
 const http = require('http');
-const MetadataWrapper =
-    require('../../../../../lib/storage/metadata/MetadataWrapper');
+const MetadataWrapper = require('../../../../../lib/storage/metadata/MetadataWrapper');
 
 class MockAzureClient {
     put(stream, size, keyContext, reqUids, callback, skey, metadata) {

--- a/tests/unit/storage/data/mockClients/MockSproxydClient.js
+++ b/tests/unit/storage/data/mockClients/MockSproxydClient.js
@@ -44,6 +44,14 @@ class MockSproxydclient {
         assert.strictEqual(typeof callback, 'function');
         return callback();
     }
+
+    head(key, reqUids, callback) {
+        assert.strictEqual(typeof key, 'string');
+        assert.strictEqual(key.length, 40);
+        assert.strictEqual(typeof reqUids, 'string');
+        assert.strictEqual(typeof callback, 'function');
+        return callback(null, {});
+    }
 }
 
 module.exports = MockSproxydclient;

--- a/tests/unit/storage/data/wrapperClientRoutes.spec.js
+++ b/tests/unit/storage/data/wrapperClientRoutes.spec.js
@@ -74,46 +74,59 @@ function getDataWrapper(clients) {
     return new DataWrapper(mbg, implName, config, kms, metadata, fn, vault);
 }
 
+let clients;
+let failingClients;
 let dw;
 let fdw;
 
 describe('Routes from DataWrapper to backend client', () => {
     beforeAll(() => {
-        const clients = genExternalClients(sproxydLocation, azureLocation);
+        clients = genExternalClients(sproxydLocation, azureLocation);
         dw = getDataWrapper(clients);
 
-        const failingClients = genFailingClients(sproxydLocation);
+        failingClients = genFailingClients(sproxydLocation);
         fdw = getDataWrapper(failingClients);
     });
 
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
     it('should follow object put path successfully for sproxyd backend', () => {
+        const putSpy = jest.spyOn(clients[sproxydLocation], 'put');
         const backendInfo = new BackendInfo(null, null, sproxydLocation);
         dw.put(cipherBundle, value, size, keyContext, backendInfo, log, (err, data) => {
             assert.ifError(err);
             assert(typeof data, 'object');
         });
+        expect(putSpy).toHaveBeenCalled();
     });
 
     it('should follow object get path successfully for sproxyd backend', () => {
+        const getSpy = jest.spyOn(clients[sproxydLocation], 'get');
         const objectGetInfo = genObjGetInfo('sproxyd');
-        const response = null;
-        dw.get(objectGetInfo, response, log, err => {
+        dw.get(objectGetInfo, null, log, err => {
             assert.ifError(err);
         });
+        expect(getSpy).toHaveBeenCalled();
     });
 
     it('should follow object delete path successfully for sproxyd backend', () => {
+        const deleteSpy = jest.spyOn(clients[sproxydLocation], 'delete');
         const objectGetInfo = genObjGetInfo('sproxyd');
         dw.delete(objectGetInfo, log, err => {
             assert.ifError(err);
         });
+        expect(deleteSpy).toHaveBeenCalled();
     });
 
     it('should handle failing sproxyd request', () => {
+        const deleteSpy = jest.spyOn(failingClients[sproxydLocation], 'delete');
         const objectGetInfo = genObjGetInfo('sproxyd');
         fdw.delete(objectGetInfo, log, err => {
             assert.deepStrictEqual(err, errors.ObjNotFound);
         });
+        expect(deleteSpy).toHaveBeenCalled();
     });
 
     // ARSN-607: the head-check only verifies external cloud backend data
@@ -121,40 +134,49 @@ describe('Routes from DataWrapper to backend client', () => {
     // gateway holds the objectGetInfo object; it must skip scality backends
     // rather than pass them the object (which crashed object GET).
     it('should not send a head request to a sproxyd (scality) backend', done => {
+        const headSpy = jest.spyOn(clients[sproxydLocation], 'head');
         const objectGetInfo = genObjGetInfo('sproxyd');
         dw.head([objectGetInfo], log, err => {
             assert.ifError(err);
+            expect(headSpy).not.toHaveBeenCalled();
             done();
         });
     });
 
     it('should follow object put path successfully for Azure backend', () => {
+        const putSpy = jest.spyOn(clients[azureLocation], 'put');
         const backendInfo = new BackendInfo(null, null, azureLocation);
         dw.put(cipherBundle, value, size, keyContext, backendInfo, log, (err, data) => {
             assert.ifError(err);
             assert(typeof data, 'object');
         });
+        expect(putSpy).toHaveBeenCalled();
     });
 
     it('should follow object get path successfully for Azure backend', () => {
+        const getSpy = jest.spyOn(clients[azureLocation], 'get');
         const objectGetInfo = genObjGetInfo('azure', objectKey);
-        const response = null;
-        dw.get(objectGetInfo, response, log, err => {
+        dw.get(objectGetInfo, null, log, err => {
             assert.ifError(err);
         });
+        expect(getSpy).toHaveBeenCalled();
     });
 
     it('should follow object delete path successfully for Azure backend', () => {
+        const deleteSpy = jest.spyOn(clients[azureLocation], 'delete');
         const objectGetInfo = genObjGetInfo('azure', objectKey);
         dw.delete(objectGetInfo, log, err => {
             assert.ifError(err);
         });
+        expect(deleteSpy).toHaveBeenCalled();
     });
 
     it('should send a head request to an external (Azure) backend', done => {
+        const headSpy = jest.spyOn(clients[azureLocation], 'head');
         const objectGetInfo = genObjGetInfo('azure', objectKey);
         dw.head([objectGetInfo], log, err => {
             assert.ifError(err);
+            expect(headSpy).toHaveBeenCalled();
             done();
         });
     });

--- a/tests/unit/storage/data/wrapperClientRoutes.spec.js
+++ b/tests/unit/storage/data/wrapperClientRoutes.spec.js
@@ -4,10 +4,8 @@ const crypto = require('crypto');
 const BackendInfo = require('../../../../lib/models/BackendInfo').default;
 const DataWrapper = require('../../../../lib/storage/data/DataWrapper');
 const DummyRequestLogger = require('../../helpers').DummyRequestLogger;
-const MetadataWrapper =
-    require('../../../../lib/storage/metadata/MetadataWrapper');
-const MultipleBackendGateway =
-    require('../../../../lib/storage/data/MultipleBackendGateway');
+const MetadataWrapper = require('../../../../lib/storage/metadata/MetadataWrapper');
+const MultipleBackendGateway = require('../../../../lib/storage/data/MultipleBackendGateway');
 const errors = require('../../../../lib/errors').default;
 
 const clientName = 'mem';
@@ -66,9 +64,7 @@ function dummyStorageCheckFn(location, size, log, cb) {
 }
 
 function getDataWrapper(clients) {
-    const mbg = new MultipleBackendGateway(
-        clients,
-        new MetadataWrapper(clientName, {}));
+    const mbg = new MultipleBackendGateway(clients, new MetadataWrapper(clientName, {}));
     const implName = 'multipleBackends';
     const config = null;
     const kms = null;
@@ -92,11 +88,10 @@ describe('Routes from DataWrapper to backend client', () => {
 
     it('should follow object put path successfully for sproxyd backend', () => {
         const backendInfo = new BackendInfo(null, null, sproxydLocation);
-        dw.put(cipherBundle, value, size, keyContext, backendInfo, log,
-            (err, data) => {
-                assert.ifError(err);
-                assert(typeof data, 'object');
-            });
+        dw.put(cipherBundle, value, size, keyContext, backendInfo, log, (err, data) => {
+            assert.ifError(err);
+            assert(typeof data, 'object');
+        });
     });
 
     it('should follow object get path successfully for sproxyd backend', () => {
@@ -107,29 +102,26 @@ describe('Routes from DataWrapper to backend client', () => {
         });
     });
 
-    it('should follow object delete path successfully for sproxyd backend',
-        () => {
-            const objectGetInfo = genObjGetInfo('sproxyd');
-            dw.delete(objectGetInfo, log, err => {
-                assert.ifError(err);
-            });
+    it('should follow object delete path successfully for sproxyd backend', () => {
+        const objectGetInfo = genObjGetInfo('sproxyd');
+        dw.delete(objectGetInfo, log, err => {
+            assert.ifError(err);
         });
+    });
 
-    it('should handle failing sproxyd request',
-        () => {
-            const objectGetInfo = genObjGetInfo('sproxyd');
-            fdw.delete(objectGetInfo, log, err => {
-                assert.deepStrictEqual(err, errors.ObjNotFound);
-            });
+    it('should handle failing sproxyd request', () => {
+        const objectGetInfo = genObjGetInfo('sproxyd');
+        fdw.delete(objectGetInfo, log, err => {
+            assert.deepStrictEqual(err, errors.ObjNotFound);
         });
+    });
 
     it('should follow object put path successfully for Azure backend', () => {
         const backendInfo = new BackendInfo(null, null, azureLocation);
-        dw.put(cipherBundle, value, size, keyContext, backendInfo, log,
-            (err, data) => {
-                assert.ifError(err);
-                assert(typeof data, 'object');
-            });
+        dw.put(cipherBundle, value, size, keyContext, backendInfo, log, (err, data) => {
+            assert.ifError(err);
+            assert(typeof data, 'object');
+        });
     });
 
     it('should follow object get path successfully for Azure backend', () => {
@@ -140,11 +132,10 @@ describe('Routes from DataWrapper to backend client', () => {
         });
     });
 
-    it('should follow object delete path successfully for Azure backend',
-        () => {
-            const objectGetInfo = genObjGetInfo('azure', objectKey);
-            dw.delete(objectGetInfo, log, err => {
-                assert.ifError(err);
-            });
+    it('should follow object delete path successfully for Azure backend', () => {
+        const objectGetInfo = genObjGetInfo('azure', objectKey);
+        dw.delete(objectGetInfo, log, err => {
+            assert.ifError(err);
         });
+    });
 });

--- a/tests/unit/storage/data/wrapperClientRoutes.spec.js
+++ b/tests/unit/storage/data/wrapperClientRoutes.spec.js
@@ -116,6 +116,18 @@ describe('Routes from DataWrapper to backend client', () => {
         });
     });
 
+    // ARSN-607: the head-check only verifies external cloud backend data
+    // state. sproxydclient's head() expects a 40-char string key, but the
+    // gateway holds the objectGetInfo object; it must skip scality backends
+    // rather than pass them the object (which crashed object GET).
+    it('should not send a head request to a sproxyd (scality) backend', done => {
+        const objectGetInfo = genObjGetInfo('sproxyd');
+        dw.head([objectGetInfo], log, err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+
     it('should follow object put path successfully for Azure backend', () => {
         const backendInfo = new BackendInfo(null, null, azureLocation);
         dw.put(cipherBundle, value, size, keyContext, backendInfo, log, (err, data) => {
@@ -136,6 +148,14 @@ describe('Routes from DataWrapper to backend client', () => {
         const objectGetInfo = genObjGetInfo('azure', objectKey);
         dw.delete(objectGetInfo, log, err => {
             assert.ifError(err);
+        });
+    });
+
+    it('should send a head request to an external (Azure) backend', done => {
+        const objectGetInfo = genObjGetInfo('azure', objectKey);
+        dw.head([objectGetInfo], log, err => {
+            assert.ifError(err);
+            done();
         });
     });
 });


### PR DESCRIPTION
## Problem

`MultipleBackendGateway.head()` feature-detects the location client's `head()` method and then passes it the whole `objectGetInfo` **object**. sproxydclient 8.2.0+ added a `head(key)` method that `assert`s a 40-char string key. Once arsenal bumped to sproxydclient 8.2.1 (ARSN-606), the head-check performed during object GET began crashing the CloudServer worker with an uncaught `AssertionError: 'object' !== 'string'` on multiple-backend sproxyd locations (`S3DATA=scality`), taking down object reads (reproduced on MPU / partNumber GETs).

Before 8.2.0 sproxydclient had no `head()`, so the feature-detect skipped it for sproxyd and this path stayed dormant. The buggy caller dates back to ARSN-128.

Affected released versions: `8.4.14` (sproxydclient 8.2.0), `8.4.15` (8.2.1), and the unreleased `development/8.5` tip. Targeting `development/8.4` so the fix waterfalls up to 8.5.

## Approaches considered (discussion)

The head-check exists only to verify **external cloud backend** data state — arsenal's own comment: `// head is used during get just to check external backend data state`. sproxyd was never head-checked before 8.2.0, and object reads worked fine; the crash comes from that check being *accidentally* activated for sproxyd the moment sproxydclient grew a `head()`.

Three ways to fix it:

| | Change | Effect | Trade-off |
|---|---|---|---|
| **(A) — this PR** | Skip `scality` clients in `MultipleBackendGateway.head()` | Restores pre-8.2.0 behavior: sproxyd is not head-checked | Minimal, behavior-preserving, no new round-trip; mirrors the `clientType === 'scality'` handling already in `get()`/`delete()` |
| (B) | Extract `objectGetInfo.key` in `head()` and call sproxyd's `head` with the string | Sends a real HEAD to sproxyd on **every** GET | Introduces a per-read round-trip that never existed; sproxyd doesn't need this existence check |
| (C) | Make `sproxydclient.head()` accept an `objectGetInfo` object | Same as (B) | Same extra round-trip, and pushes caller-shaped logic into a low-level, string-keyed API (its `get`/`put`/`delete` are all string-keyed) |

**This PR implements (A)** — the minimal regression fix. (B) and (C) make the accidental call *succeed* rather than not making it, at the cost of a HEAD-per-GET to sproxyd that never existed. Flagging for discussion: happy to switch to (B)/(C) if there's a reason sproxyd *should* be HEAD-checked before reads, or if reviewers prefer consistency with `get()`/`delete()`.

Note: sproxydclient's `head()` (SPRXCLT-21) stays available for a deliberate future use; this PR only stops the GET path from invoking it by accident.

## Fix

Skip `scality` clients in `MultipleBackendGateway.head()` (option A above). Adds `head()` to the sproxyd/azure mock clients and two regression tests: sproxyd `head` is skipped (guards the crash), external azure `head` is still invoked.

Issue: ARSN-607
