### PR TITLE
Add initializeBucketCapacity to seed empty-bucket metrics

### DIFF
--- a/lib/storage/metadata/MetadataWrapper.js
+++ b/lib/storage/metadata/MetadataWrapper.js
@@ -462,6 +462,16 @@ class MetadataWrapper {
         return this.client.getUUID(log, cb);
     }
 
+    initializeBucketCapacity(bucketName, creationDate, log, cb) {
+        if (!this.client.initializeBucketCapacity) {
+            log.debug('initializeBucketCapacity not supported by backend, skipping', {
+                implName: this.implName,
+            });
+            return cb(null);
+        }
+        return this.client.initializeBucketCapacity(bucketName, creationDate, log, cb);
+    }
+
     getDiskUsage(log, cb) {
         if (!this.client.getDiskUsage) {
             log.debug('returning empty disk usage as fallback', {

--- a/lib/storage/metadata/MetadataWrapper.js
+++ b/lib/storage/metadata/MetadataWrapper.js
@@ -32,7 +32,7 @@ function _parseListEntries(entries) {
                 acc[k] = tmp[k];
                 return acc;
             }, {});
-      
+
         let restoreStatus = undefined;
         if (tmp.archive) {
             restoreStatus = {
@@ -128,8 +128,7 @@ class MetadataWrapper {
             this.client = new BucketFileInterface(params, logger);
             this.implName = 'bucketfile';
         } else if (clientName === 'scality') {
-            this.client = new BucketClientInterface(params, bucketclient,
-                logger);
+            this.client = new BucketClientInterface(params, bucketclient, logger);
             this.implName = 'bucketclient';
         } else if (clientName === 'mongodb') {
             this.client = new MongoClientInterface({
@@ -174,8 +173,7 @@ class MetadataWrapper {
         log.debug('creating bucket in metadata');
         this.client.createBucket(bucketName, bucketMD, log, err => {
             if (err) {
-                log.debug('error from metadata', { implName: this.implName,
-                    error: err });
+                log.debug('error from metadata', { implName: this.implName, error: err });
                 return cb(err);
             }
             log.trace('bucket created in metadata');
@@ -190,8 +188,7 @@ class MetadataWrapper {
         log.debug('updating bucket in metadata');
         this.client.putBucketAttributes(bucketName, bucketMD, log, err => {
             if (err) {
-                log.debug('error from metadata', { implName: this.implName,
-                    error: err });
+                log.debug('error from metadata', { implName: this.implName, error: err });
                 return cb(err);
             }
             log.trace('bucket updated in metadata');
@@ -205,16 +202,21 @@ class MetadataWrapper {
         if (!this.client.putBucketAttributesCapabilities) {
             return this.updateBucket(bucketName, bucketMD, log, cb);
         }
-        return this.client.putBucketAttributesCapabilities(bucketName, capabilityName, capacityField, capability,
-            log, err => {
+        return this.client.putBucketAttributesCapabilities(
+            bucketName,
+            capabilityName,
+            capacityField,
+            capability,
+            log,
+            err => {
                 if (err) {
-                    log.debug('error from metadata', { implName: this.implName,
-                        error: err });
+                    log.debug('error from metadata', { implName: this.implName, error: err });
                     return cb(err);
                 }
                 log.trace('bucket capabilities updated in metadata');
                 return cb(err);
-            });
+            },
+        );
     }
 
     deleteBucketCapabilities(bucketName, bucketMD, capabilityName, capacityField, log, cb) {
@@ -223,24 +225,21 @@ class MetadataWrapper {
         if (!this.client.deleteBucketAttributesCapability) {
             return this.updateBucket(bucketName, bucketMD, log, cb);
         }
-        return this.client.deleteBucketAttributesCapability(bucketName, capabilityName, capacityField,
-            log, err => {
-                if (err) {
-                    log.debug('error from metadata', { implName: this.implName,
-                        error: err });
-                    return cb(err);
-                }
-                log.trace('bucket capabilities deleted in metadata');
+        return this.client.deleteBucketAttributesCapability(bucketName, capabilityName, capacityField, log, err => {
+            if (err) {
+                log.debug('error from metadata', { implName: this.implName, error: err });
                 return cb(err);
-            });
+            }
+            log.trace('bucket capabilities deleted in metadata');
+            return cb(err);
+        });
     }
 
     getBucket(bucketName, log, cb) {
         log.debug('getting bucket from metadata');
         this.client.getBucketAttributes(bucketName, log, (err, data, raftSessionId) => {
             if (err) {
-                log.debug('error from metadata', { implName: this.implName,
-                    error: err });
+                log.debug('error from metadata', { implName: this.implName, error: err });
                 return cb(err);
             }
             log.trace('bucket retrieved from metadata');
@@ -252,8 +251,7 @@ class MetadataWrapper {
         log.debug('getting bucket quota from metadata');
         this.client.getBucketAttributes(bucketName, log, (err, data) => {
             if (err) {
-                log.debug('error from metadata', { implName: this.implName,
-                    error: err });
+                log.debug('error from metadata', { implName: this.implName, error: err });
                 return cb(err);
             }
             const bucketInfo = BucketInfo.fromObj(data);
@@ -265,8 +263,7 @@ class MetadataWrapper {
         log.debug('deleting bucket from metadata');
         this.client.deleteBucket(bucketName, log, err => {
             if (err) {
-                log.debug('error from metadata', { implName: this.implName,
-                    error: err });
+                log.debug('error from metadata', { implName: this.implName, error: err });
                 return cb(err);
             }
             log.debug('Deleted bucket from Metadata');
@@ -279,39 +276,35 @@ class MetadataWrapper {
 
     putObjectMD(bucketName, objName, objVal, params, log, cb) {
         log.debug('putting object in metadata');
-        const value = typeof objVal.getValue === 'function' ?
-            objVal.getValue() : objVal;
-        this.client.putObject(bucketName, objName, value, params, log,
-            (err, data) => {
-                if (err) {
-                    log.debug('error from metadata', { implName: this.implName,
-                        error: err });
-                    return cb(err);
-                }
-                if (data) {
-                    log.debug('object version successfully put in metadata',
-                        { version: data });
-                } else {
-                    log.debug('object successfully put in metadata');
-                }
-                return cb(err, data);
-            });
+        const value = typeof objVal.getValue === 'function' ? objVal.getValue() : objVal;
+        this.client.putObject(bucketName, objName, value, params, log, (err, data) => {
+            if (err) {
+                log.debug('error from metadata', { implName: this.implName, error: err });
+                return cb(err);
+            }
+            if (data) {
+                log.debug('object version successfully put in metadata', { version: data });
+            } else {
+                log.debug('object successfully put in metadata');
+            }
+            return cb(err, data);
+        });
     }
 
     getBucketAndObjectMD(bucketName, objName, params, log, cb) {
-        log.debug('getting bucket and object from metadata',
-            { database: bucketName, object: objName });
-        this.client.getBucketAndObject(bucketName, objName, params, log,
-            (err, data, raftSessionId) => {
-                if (err) {
-                    log.debug('error from metadata', { implName: this.implName,
-                        err });
-                    return cb(err);
-                }
-                log.debug('bucket and object retrieved from metadata',
-                    { database: bucketName, object: objName, raftSessionId });
-                return cb(err, data, raftSessionId);
+        log.debug('getting bucket and object from metadata', { database: bucketName, object: objName });
+        this.client.getBucketAndObject(bucketName, objName, params, log, (err, data, raftSessionId) => {
+            if (err) {
+                log.debug('error from metadata', { implName: this.implName, err });
+                return cb(err);
+            }
+            log.debug('bucket and object retrieved from metadata', {
+                database: bucketName,
+                object: objName,
+                raftSessionId,
             });
+            return cb(err, data, raftSessionId);
+        });
     }
 
     getObjectsMD(bucketName, objNamesWithParams, log, cb) {
@@ -324,8 +317,11 @@ class MetadataWrapper {
         log.debug('getting objects from metadata', { objects: objNamesWithParams });
         return this.client.getObjects(bucketName, objNamesWithParams, log, (err, data) => {
             if (err) {
-                log.debug('error getting objects from metadata', { implName: this.implName, objects: objNamesWithParams,
-                    err });
+                log.debug('error getting objects from metadata', {
+                    implName: this.implName,
+                    objects: objNamesWithParams,
+                    err,
+                });
                 return cb(err);
             }
             log.debug('objects retrieved from metadata', { objects: objNamesWithParams });
@@ -337,8 +333,7 @@ class MetadataWrapper {
         log.debug('getting object from metadata');
         this.client.getObject(bucketName, objName, params, log, (err, data) => {
             if (err) {
-                log.debug('error from metadata', { implName: this.implName,
-                    err });
+                log.debug('error from metadata', { implName: this.implName, err });
                 return cb(err);
             }
             log.debug('object retrieved from metadata');
@@ -348,32 +343,35 @@ class MetadataWrapper {
 
     deleteObjectMD(bucketName, objName, params, log, cb, originOp = 's3:ObjectRemoved:Delete') {
         log.debug('deleting object from metadata');
-        this.client.deleteObject(bucketName, objName, params, log, err => {
-            if (err) {
-                log.debug('error from metadata', { implName: this.implName,
-                    err });
+        this.client.deleteObject(
+            bucketName,
+            objName,
+            params,
+            log,
+            err => {
+                if (err) {
+                    log.debug('error from metadata', { implName: this.implName, err });
+                    return cb(err);
+                }
+                log.debug('object deleted from metadata');
                 return cb(err);
-            }
-            log.debug('object deleted from metadata');
-            return cb(err);
-        }, originOp);
+            },
+            originOp,
+        );
     }
 
     listObject(bucketName, listingParams, log, cb) {
         if (listingParams.listingType === undefined) {
-             
             listingParams.listingType = 'Delimiter';
         }
         this.client.listObject(bucketName, listingParams, log, (err, data) => {
             log.debug('getting object listing from metadata');
             if (err) {
-                log.debug('error from metadata', { implName: this.implName,
-                    err });
+                log.debug('error from metadata', { implName: this.implName, err });
                 return cb(err);
             }
             log.debug('object listing retrieved from metadata');
             if (listingParams.listingType === 'DelimiterVersions') {
-                 
                 data.Versions = parseListEntries(data.Versions, this._listingParser);
                 if (data.Versions instanceof Error) {
                     log.error('error parsing metadata listing', {
@@ -385,7 +383,7 @@ class MetadataWrapper {
                 }
                 return cb(null, data);
             }
-             
+
             data.Contents = parseListEntries(data.Contents, this._listingParser);
             if (data.Contents instanceof Error) {
                 log.error('error parsing metadata listing', {
@@ -403,12 +401,11 @@ class MetadataWrapper {
         log.debug('getting object listing for lifecycle from metadata');
         this.client.listLifecycleObject(bucketName, listingParams, log, (err, data) => {
             if (err) {
-                log.error('error from metadata', { implName: this.implName,
-                    err });
+                log.error('error from metadata', { implName: this.implName, err });
                 return cb(err);
             }
             log.debug('object listing for lifecycle retrieved from metadata');
-             
+
             data.Contents = parseListEntries(data.Contents, _parseLifecycleListEntries);
             if (data.Contents instanceof Error) {
                 log.error('error parsing metadata listing for lifecycle', {
@@ -423,17 +420,15 @@ class MetadataWrapper {
     }
 
     listMultipartUploads(bucketName, listingParams, log, cb) {
-        this.client.listMultipartUploads(bucketName, listingParams, log,
-            (err, data) => {
-                log.debug('getting mpu listing from metadata');
-                if (err) {
-                    log.debug('error from metadata', { implName: this.implName,
-                        err });
-                    return cb(err);
-                }
-                log.debug('mpu listing retrieved from metadata');
-                return cb(err, data);
-            });
+        this.client.listMultipartUploads(bucketName, listingParams, log, (err, data) => {
+            log.debug('getting mpu listing from metadata');
+            if (err) {
+                log.debug('error from metadata', { implName: this.implName, err });
+                return cb(err);
+            }
+            log.debug('mpu listing retrieved from metadata');
+            return cb(err, data);
+        });
     }
 
     switch(newClient, cb) {
@@ -460,7 +455,8 @@ class MetadataWrapper {
     getUUID(log, cb) {
         if (!this.client.getUUID) {
             log.debug('returning empty uuid as fallback', {
-                implName: this.implName });
+                implName: this.implName,
+            });
             return cb(null, '');
         }
         return this.client.getUUID(log, cb);
@@ -469,7 +465,8 @@ class MetadataWrapper {
     getDiskUsage(log, cb) {
         if (!this.client.getDiskUsage) {
             log.debug('returning empty disk usage as fallback', {
-                implName: this.implName });
+                implName: this.implName,
+            });
             return cb(null, {});
         }
         return this.client.getDiskUsage(cb);
@@ -478,7 +475,8 @@ class MetadataWrapper {
     countItems(log, cb) {
         if (!this.client.countItems) {
             log.debug('returning zero item counts as fallback', {
-                implName: this.implName });
+                implName: this.implName,
+            });
             return cb(null, {
                 buckets: 0,
                 objects: 0,
@@ -491,7 +489,8 @@ class MetadataWrapper {
     getIngestionBuckets(log, cb) {
         if (this.implName !== 'mongoclient') {
             log.debug('error getting ingestion buckets', {
-                implName: this.implName });
+                implName: this.implName,
+            });
             return cb(errors.NotImplemented);
         }
         return this.client.getIngestionBuckets(log, cb);
@@ -526,17 +525,16 @@ class MetadataWrapper {
             });
             return cb(errors.NotImplemented);
         }
-        return this.client.deleteObjectWithCond(bucketName, objName,
-            params, log, err => {
-                if (err) {
-                    log.debug('error from metadata', {
-                        implName: this.implName,
-                    });
-                    return cb(err);
-                }
-                log.debug('object deleted from metadata');
-                return cb();
-            });
+        return this.client.deleteObjectWithCond(bucketName, objName, params, log, err => {
+            if (err) {
+                log.debug('error from metadata', {
+                    implName: this.implName,
+                });
+                return cb(err);
+            }
+            log.debug('object deleted from metadata');
+            return cb();
+        });
     }
 
     /**
@@ -558,17 +556,16 @@ class MetadataWrapper {
             });
             return cb(errors.NotImplemented);
         }
-        return this.client.putObjectWithCond(bucketName, objName, objVal,
-            params, log, err => {
-                if (err) {
-                    log.debug('error from metadata', {
-                        implName: this.implName,
-                    });
-                    return cb(err);
-                }
-                log.debug('object successfully updated in metadata');
-                return cb();
-            });
+        return this.client.putObjectWithCond(bucketName, objName, objVal, params, log, err => {
+            if (err) {
+                log.debug('error from metadata', {
+                    implName: this.implName,
+                });
+                return cb(err);
+            }
+            log.debug('object successfully updated in metadata');
+            return cb();
+        });
     }
 
     /**
@@ -612,7 +609,6 @@ class MetadataWrapper {
             return cb(null);
         });
     }
-
 
     /**
      * Delete bucket indexes

--- a/lib/storage/metadata/mongoclient/MongoClientInterface.ts
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.ts
@@ -151,62 +151,74 @@ export type InternalListObjectParams = {
     gt?: undefined;
 };
 
+export interface UsedCapacityMetrics {
+    current: Long | number;
+    nonCurrent: Long | number;
+    _currentCold: Long | number;
+    _nonCurrentCold: Long | number;
+    _currentRestored: Long | number;
+    _currentRestoring: Long | number;
+    _nonCurrentRestored: Long | number;
+    _nonCurrentRestoring: Long | number;
+    _incompleteMPUParts: Long | number;
+    // present on per-location and inflight-tagged bucket entries
+    _inflightsPreScan?: Long | number;
+}
+
+export interface ObjectCountMetrics {
+    current: Long | number;
+    nonCurrent: Long | number;
+    deleteMarker: Long | number;
+    _currentCold: Long | number;
+    _nonCurrentCold: Long | number;
+    _currentRestored: Long | number;
+    _currentRestoring: Long | number;
+    _nonCurrentRestored: Long | number;
+    _nonCurrentRestoring: Long | number;
+    _incompleteMPUUploads: Long | number;
+}
+
 export interface InfostoreDocument extends Document {
     _id: string | 'uuid';
     value?: string | ObjectMDStats;
     measuredOn?: string;
-    objectCount?: {
-        current: Long | number;
-        _currentCold: Long | number;
-        deleteMarker: Long | number;
-        nonCurrent: Long | number;
-        _nonCurrentCold: Long | number;
-        _currentRestored: Long | number;
-        _currentRestoring: Long | number;
-        _nonCurrentRestored: Long | number;
-        _nonCurrentRestoring: Long | number;
-        _incompleteMPUUploads: Long | number;
-    };
-    usedCapacity?: {
-        current: Long | number;
-        _currentCold: Long | number;
-        nonCurrent: Long | number;
-        _nonCurrentCold: Long | number;
-        _currentRestored: Long | number;
-        _currentRestoring: Long | number;
-        _nonCurrentRestored: Long | number;
-        _nonCurrentRestoring: Long | number;
-        _incompleteMPUParts: Long | number;
-    };
+    objectCount?: ObjectCountMetrics;
+    usedCapacity?: UsedCapacityMetrics;
     locations: {
         [key: string]: {
-            usedCapacity: {
-                current: Long | number;
-                nonCurrent: Long | number;
-                _currentCold: Long | number;
-                _nonCurrentCold: Long | number;
-                _currentRestored: Long | number;
-                _currentRestoring: Long | number;
-                _nonCurrentRestored: Long | number;
-                _nonCurrentRestoring: Long | number;
-                _inflightsPreScan: Long | number;
-                _incompleteMPUParts: Long | number;
-            };
-            objectCount: {
-                current: Long | number;
-                nonCurrent: Long | number;
-                _currentCold: Long | number;
-                _nonCurrentCold: Long | number;
-                _currentRestored: Long | number;
-                _currentRestoring: Long | number;
-                _nonCurrentRestored: Long | number;
-                _nonCurrentRestoring: Long | number;
-                _incompleteMPUUploads: Long | number;
-                deleteMarker: Long | number;
-            };
+            usedCapacity: UsedCapacityMetrics;
+            objectCount: ObjectCountMetrics;
         };
     };
 }
+
+// Canonical zero-value capacity/count metrics for an empty bucket, matching the
+// structure downstream metric readers expect.
+const emptyBucketCapacityMetrics: { usedCapacity: UsedCapacityMetrics; objectCount: ObjectCountMetrics } = {
+    usedCapacity: {
+        current: 0,
+        nonCurrent: 0,
+        _currentCold: 0,
+        _nonCurrentCold: 0,
+        _currentRestored: 0,
+        _currentRestoring: 0,
+        _nonCurrentRestored: 0,
+        _nonCurrentRestoring: 0,
+        _incompleteMPUParts: 0,
+    },
+    objectCount: {
+        current: 0,
+        nonCurrent: 0,
+        deleteMarker: 0,
+        _currentCold: 0,
+        _nonCurrentCold: 0,
+        _currentRestored: 0,
+        _currentRestoring: 0,
+        _nonCurrentRestored: 0,
+        _nonCurrentRestoring: 0,
+        _incompleteMPUUploads: 0,
+    },
+};
 
 export type ObjectMDStats = {
     versions: number;
@@ -2707,6 +2719,57 @@ class MongoClientInterface {
                     return cb(errors.KeyAlreadyExists);
                 }
                 log.error('writeUUIDIfNotExists: error writing UUID', { error: err.message });
+                return cb(errors.InternalError);
+            });
+    }
+
+    /**
+     * Initialize a zero-value bucket capacity metric document in the
+     * `__infostore` collection, unless one already exists. This lets quota
+     * checks be served for a freshly created (or newly quota-enabled empty)
+     * bucket before the periodic metrics job has produced real values.
+     *
+     * Idempotent: an existing document (e.g. one already holding real metrics)
+     * is never overwritten, thanks to `$setOnInsert`.
+     *
+     * @param bucketName - name of the bucket
+     * @param creationDate - bucket creation date used to build the metric id;
+     *   must match the id the metrics job uses so lookups resolve to the same
+     *   document
+     * @param log - logger instance
+     * @param cb - callback
+     * @returns undefined
+     */
+    initializeBucketCapacity(
+        bucketName: string,
+        creationDate: string,
+        log: werelogs.Logger,
+        cb: ArsenalCallback<void>,
+    ) {
+        const i = this.getCollection<InfostoreDocument>(INFOSTORE);
+        if (!i) {
+            log.error('initializeBucketCapacity: error getting infostore collection');
+            return cb(errors.InternalError);
+        }
+        const timestamp = new Date(creationDate).getTime();
+        if (Number.isNaN(timestamp)) {
+            log.error('initializeBucketCapacity: invalid creationDate', { bucketName, creationDate });
+            return cb(errors.InternalError);
+        }
+        const _id = `bucket_${bucketName}_${timestamp}`;
+        const doc = <InfostoreDocument>{
+            _id,
+            measuredOn: new Date().toJSON(),
+            ...emptyBucketCapacityMetrics,
+        };
+        return i
+            .updateOne({ _id }, { $setOnInsert: doc }, { upsert: true })
+            .then(() => cb(null))
+            .catch(err => {
+                log.error('initializeBucketCapacity: error initializing bucket capacity', {
+                    error: err.message,
+                    bucketName,
+                });
                 return cb(errors.InternalError);
             });
     }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "engines": {
         "node": ">=20"
     },
-    "version": "8.5.10",
+    "version": "8.5.11",
     "config": {
         "mongodbMemoryServer": {
             "version": "8.0.23"

--- a/tests/unit/storage/metadata/mongoclient/MongoClientInterface.spec.js
+++ b/tests/unit/storage/metadata/mongoclient/MongoClientInterface.spec.js
@@ -1609,6 +1609,81 @@ describe('MongoClientInterface, readUUID', () => {
     });
 });
 
+describe('MongoClientInterface, initializeBucketCapacity', () => {
+    let client;
+    let sandbox;
+
+    beforeEach(async () => {
+        sandbox = sinon.createSandbox();
+        client = createClient();
+        await promisify(client.setup).bind(client)();
+    });
+
+    afterEach(async () => {
+        sandbox.restore();
+        if (client) {
+            await promisify(client.close).bind(client)();
+        }
+    });
+
+    it('should insert a zero-value bucket capacity document', async () => {
+        const bucketName = 'init-capacity-bucket';
+        const creationDate = new Date('2023-03-08T14:13:28.000Z').toJSON();
+        const expectedId = `bucket_${bucketName}_${new Date(creationDate).getTime()}`;
+        await promisify(client.initializeBucketCapacity).bind(client)(bucketName, creationDate, logger);
+        const doc = await client.getCollection('__infostore').findOne({ _id: expectedId });
+        assert(doc, 'Expected the capacity document to be inserted');
+        assert.strictEqual(doc.usedCapacity.current, 0);
+        assert.strictEqual(doc.usedCapacity.nonCurrent, 0);
+        assert.strictEqual(doc.objectCount.current, 0);
+        assert.strictEqual(doc.objectCount.deleteMarker, 0);
+        assert(doc.measuredOn, 'Expected measuredOn to be set');
+    });
+
+    it('should not overwrite an existing capacity document (idempotent)', async () => {
+        const bucketName = 'existing-capacity-bucket';
+        const creationDate = new Date('2023-03-08T14:13:28.000Z').toJSON();
+        const expectedId = `bucket_${bucketName}_${new Date(creationDate).getTime()}`;
+        const coll = client.getCollection('__infostore');
+        await coll.insertOne({
+            _id: expectedId,
+            measuredOn: new Date().toJSON(),
+            usedCapacity: { current: 12345, nonCurrent: 0 },
+            objectCount: { current: 7, deleteMarker: 0 },
+        });
+        await promisify(client.initializeBucketCapacity).bind(client)(bucketName, creationDate, logger);
+        const doc = await coll.findOne({ _id: expectedId });
+        assert.strictEqual(doc.usedCapacity.current, 12345, 'Existing capacity must not be overwritten');
+        assert.strictEqual(doc.objectCount.current, 7);
+    });
+
+    it('should return InternalError when the update fails', async () => {
+        const mockCollection = {
+            updateOne: sandbox.stub().rejects(new Error('Simulated MongoDB error')),
+        };
+        sandbox.stub(client, 'getCollection').returns(mockCollection);
+        await assert.rejects(
+            promisify(client.initializeBucketCapacity).bind(client)('b', new Date().toJSON(), logger),
+            err => err.code === 500,
+        );
+    });
+
+    it('should return InternalError when creationDate is invalid', async () => {
+        await assert.rejects(
+            promisify(client.initializeBucketCapacity).bind(client)('b', 'not-a-date', logger),
+            err => err.code === 500,
+        );
+    });
+
+    it('should return InternalError when the infostore collection is unavailable', async () => {
+        sandbox.stub(client, 'getCollection').returns(null);
+        await assert.rejects(
+            promisify(client.initializeBucketCapacity).bind(client)('b', new Date().toJSON(), logger),
+            err => err.code === 500,
+        );
+    });
+});
+
 describe('MongoClientInterface, writeUUIDIfNotExists', () => {
     let client;
     let sandbox;


### PR DESCRIPTION
## Context

Bucket quota metrics live in the `__infostore` collection, keyed `bucket_<name>_<creationTimestamp>`, and are written today only by the s3utils `count-items` cron. A freshly created bucket — or a quota enabled on an empty bucket — has no metric document until the next cron run (up to 24h), so CloudServer's bucket-quota check finds nothing in Scuba and fails open (ARTESCA-17063).

`MongoClientInterface` already touches `__infostore` internally (`writeUUIDIfNotExists`), so this is a natural home for the write.

## Change

- Add `MongoClientInterface.initializeBucketCapacity(bucketName, creationDate, log, cb)` — idempotently inserts a zero-value bucket metric document via `updateOne({_id}, {$setOnInsert: zeroDoc}, {upsert: true})`. An existing document (e.g. one written by count-items with real values) is **never** overwritten.
  - `_id` = `bucket_<name>_<new Date(creationDate).getTime()>`.
  - Document shape matches what count-items produces / Scuba reads: `measuredOn` plus all-zero `usedCapacity` and `objectCount`, built from the module-level `emptyBucketCapacityMetrics` constant.
- Expose it through `MetadataWrapper` with a capability guard (no-op for non-mongodb backends, matching the existing `getUUID`/`countItems` pattern).

The consumer is CloudServer (CLDSRV-949, https://github.com/scality/cloudserver/pull/6221), which calls this on `createBucket` and on `bucketUpdateQuota` of a verifiably-empty bucket.

## Tests

Unit tests (`MongoClientInterface.spec.js`, real `mongodb-memory-server`): inserts a zero document and reads it back; confirms an existing document is not overwritten (idempotent); returns `InternalError` on update failure.

Issue: ARSN-610