### PR TITLE
Build pykmip test image with pip install

### DIFF
--- a/.github/pykmip/Dockerfile
+++ b/.github/pykmip/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --no-cache \
         git && \
     git clone https://github.com/openkmip/pykmip.git && \
     cd pykmip && \
-    python3 setup.py install && \
+    pip install . && \
     apk del .build-deps && \
     rm -rf /pykmip && \
     mkdir /pykmip


### PR DESCRIPTION
## Summary

Build the pykmip functional-test image with `pip install .` instead of the deprecated `python3 setup.py install`.

`.github/pykmip/Dockerfile` clones pykmip and installs it via `python3 setup.py install` (setuptools `easy_install`), which resolves dependencies greedily with no backtracking. A recent `cryptography` release requires `typing-extensions>=4.13.2`, but easy_install has already installed `4.12.2`, so the image build now fails:

```
error: typing-extensions 4.12.2 is installed but typing-extensions>=4.13.2 is required by {'cryptography'}
```

`pip install .` uses pip's resolver, which installs a coherent set (`typing-extensions>=4.13.2`) and builds cleanly. `setup.py install` is deprecated in modern setuptools regardless.

Verified locally with podman: the current Dockerfile reproduces the failure (exit 1); the `pip install .` variant builds and tags successfully (exit 0). This PR touches `.github/pykmip/Dockerfile`, which is in the `test-kmip` job's `paths:` trigger, so CI exercises the fix.

Issue: ARSN-611
