### PR TITLE
Bound external healthcheck probe with a timeout

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -119,6 +119,8 @@ export const legacyLocations = ['sproxyd', 'legacy'];
 // for external backends, don't call unless at least 1 minute
 // (60,000 milliseconds) since last call
 export const externalBackendHealthCheckInterval = 60000;
+// bound each healthcheck probe so an unreachable endpoint can't hang startup
+export const externalBackendHealthCheckTimeout = 5000;
 // some of the available data backends  (if called directly rather
 // than through the multiple backend gateway) need a key provided
 // as a string as first parameter of the get/delete methods.

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -105,8 +105,7 @@ export const zenkoSeparator = ':';
 export const externalBackends = { aws_s3: true, azure: true, gcp: true, pfs: true };
 export const replicationBackends = { aws_s3: true, azure: true, gcp: true };
 // hex digest of sha256 hash of empty string:
-export const emptyStringHash = crypto.createHash('sha256')
-    .update('', 'binary').digest('hex');
+export const emptyStringHash = crypto.createHash('sha256').update('', 'binary').digest('hex');
 export const mpuMDStoredExternallyBackend = { aws_s3: true, gcp: true };
 // AWS sets a minimum size limit for parts except for the last part.
 // http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadComplete.html
@@ -170,8 +169,9 @@ export const notificationArnPrefix = 'arn:scality:bucketnotif';
 export const httpServerKeepAliveTimeout = 60000;
 export const httpClientFreeSocketTimeout = 55000;
 // Maximum number of buckets to cache (bucket metadata)
-export const maxCachedBuckets = process.env.METADATA_MAX_CACHED_BUCKETS ?
-    Number(process.env.METADATA_MAX_CACHED_BUCKETS) : 1000;
+export const maxCachedBuckets = process.env.METADATA_MAX_CACHED_BUCKETS
+    ? Number(process.env.METADATA_MAX_CACHED_BUCKETS)
+    : 1000;
 
 export const validRestoreObjectTiers = new Set(['Expedited', 'Standard', 'Bulk']);
 export const maxBatchingConcurrentOperations = 5;

--- a/lib/storage/data/external/AwsClient.js
+++ b/lib/storage/data/external/AwsClient.js
@@ -28,6 +28,7 @@ const getMetaHeaders = require('../../../s3middleware/userMetadata').getMetaHead
 const { prepareStream } = require('../../../s3middleware/prepareStream');
 const { createLogger, logHelper, removeQuotes, trimXMetaPrefix } = require('./utils');
 const jsutil = require('../../../jsutil');
+const { externalBackendHealthCheckTimeout } = require('../../../constants');
 const { callbackify } = require('util');
 
 const missingVerIdInternalError = errorInstances.InternalError.customizeDescription(
@@ -341,20 +342,29 @@ class AwsClient {
 
     healthcheck(location, callback) {
         const awsResp = {};
+
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), externalBackendHealthCheckTimeout);
+        const done = (err, resp) => {
+            clearTimeout(timer);
+            return callback(err, resp);
+        };
+
         this._client
-            .send(new HeadBucketCommand({ Bucket: this._awsBucketName }))
+            .send(new HeadBucketCommand({ Bucket: this._awsBucketName }), { abortSignal: controller.signal })
             .then(() => {
                 if (!this._supportsVersioning) {
                     awsResp[location] = {
                         message: 'Congrats! You own the bucket',
                     };
-                    return callback(null, awsResp);
+                    return done(null, awsResp);
                 }
                 return this._client
                     .send(
                         new GetBucketVersioningCommand({
                             Bucket: this._awsBucketName,
                         }),
+                        { abortSignal: controller.signal },
                     )
                     .then(data => {
                         if (!data.Status || data.Status === 'Suspended') {
@@ -369,12 +379,12 @@ class AwsClient {
                                 message: 'Congrats! You own the bucket',
                             };
                         }
-                        return callback(null, awsResp);
+                        return done(null, awsResp);
                     });
             })
             .catch(err => {
                 awsResp[location] = { error: err, external: true };
-                return callback(null, awsResp);
+                return done(null, awsResp);
             });
     }
     createMPU(

--- a/lib/storage/data/external/AwsClient.js
+++ b/lib/storage/data/external/AwsClient.js
@@ -1,4 +1,5 @@
-const { S3Client,
+const {
+    S3Client,
     PutObjectCommand,
     HeadObjectCommand,
     HeadBucketCommand,
@@ -13,26 +14,24 @@ const { S3Client,
     PutObjectTaggingCommand,
     DeleteObjectTaggingCommand,
     CopyObjectCommand,
-    GetBucketLocationCommand, 
+    GetBucketLocationCommand,
     GetBucketVersioningCommand,
     NoSuchKey,
-    NotFound } = require('@aws-sdk/client-s3');
+    NotFound,
+} = require('@aws-sdk/client-s3');
 const { Upload } = require('@aws-sdk/lib-storage');
 const werelogs = require('werelogs');
 const errors = require('../../../errors').default;
 const errorInstances = require('../../../errors').errorInstances;
 const MD5Sum = require('../../../s3middleware/MD5Sum').default;
-const getMetaHeaders = 
-    require('../../../s3middleware/userMetadata').getMetaHeaders;
+const getMetaHeaders = require('../../../s3middleware/userMetadata').getMetaHeaders;
 const { prepareStream } = require('../../../s3middleware/prepareStream');
-const { createLogger, logHelper, removeQuotes, trimXMetaPrefix } = 
-    require('./utils');
+const { createLogger, logHelper, removeQuotes, trimXMetaPrefix } = require('./utils');
 const jsutil = require('../../../jsutil');
 const { callbackify } = require('util');
 
 const missingVerIdInternalError = errorInstances.InternalError.customizeDescription(
-    'Invalid state. Please ensure versioning is enabled ' +
-    'in AWS for the location constraint and try again.',
+    'Invalid state. Please ensure versioning is enabled in AWS for the location constraint and try again.',
 );
 const awsPartChecksumFields = {
     ChecksumCRC32: 'crc32',
@@ -52,7 +51,7 @@ class AwsClient {
         this._dataStoreName = config.dataStoreName;
         this._serverSideEncryption = config.serverSideEncryption;
         this._supportsVersioning = config.supportsVersioning;
-        this._vault = config.vault;        
+        this._vault = config.vault;
         this._client = new S3Client(this._s3Params);
         this._logger = new werelogs.Logger('AwsClient');
     }
@@ -93,17 +92,14 @@ class AwsClient {
             };
 
             try {
-                const res = await usEast1Client.send(
-                    new GetBucketLocationCommand({ Bucket: this._awsBucketName })
-                );
+                const res = await usEast1Client.send(new GetBucketLocationCommand({ Bucket: this._awsBucketName }));
                 applyRegion(res.LocationConstraint);
             } catch (err) {
                 if (err.name === 'AuthorizationHeaderMalformed') {
                     applyRegion(err.region);
                     return;
                 }
-                logHelper(this._logger, 'error', 'error during setup',
-                    err, this._dataStoreName, this.clientType);
+                logHelper(this._logger, 'error', 'error during setup', err, this._dataStoreName, this.clientType);
                 throw err;
             }
         });
@@ -111,8 +107,7 @@ class AwsClient {
         return run(cb);
     }
 
-    _createAwsKey(requestBucketName, requestObjectKey,
-        bucketMatch) {
+    _createAwsKey(requestBucketName, requestObjectKey, bucketMatch) {
         if (bucketMatch) {
             return requestObjectKey;
         }
@@ -127,24 +122,29 @@ class AwsClient {
     }
 
     put(stream, size, keyContext, reqUids, callback) {
-        const awsKey = this._createAwsKey(keyContext.bucketName,
-            keyContext.objectKey, this._bucketMatch);
+        const awsKey = this._createAwsKey(keyContext.bucketName, keyContext.objectKey, this._bucketMatch);
         const metaHeaders = trimXMetaPrefix(keyContext.metaHeaders);
         const log = createLogger(reqUids);
 
         const putCb = (err, data) => {
             if (err) {
-                logHelper(log, 'error', 'err from data backend',
-                    err, this._dataStoreName, this.clientType);
-                return callback(errorInstances.ServiceUnavailable
-                    .customizeDescription(`Error returned from ${this.type}: ${err.message}`),
+                logHelper(log, 'error', 'err from data backend', err, this._dataStoreName, this.clientType);
+                return callback(
+                    errorInstances.ServiceUnavailable.customizeDescription(
+                        `Error returned from ${this.type}: ${err.message}`,
+                    ),
                 );
             }
             let dataStoreVersionId = data.VersionId;
             if (!dataStoreVersionId && this._supportsVersioning) {
-                logHelper(log, 'error', 'missing version id for data ' +
-                    'backend object', missingVerIdInternalError,
-                this._dataStoreName, this.clientType);
+                logHelper(
+                    log,
+                    'error',
+                    'missing version id for data ' + 'backend object',
+                    missingVerIdInternalError,
+                    this._dataStoreName,
+                    this.clientType,
+                );
                 return callback(missingVerIdInternalError);
             }
             return callback(null, awsKey, dataStoreVersionId);
@@ -154,15 +154,16 @@ class AwsClient {
             Bucket: this._awsBucketName,
             Key: awsKey,
         };
-        
+
         // Handle delete marker case
         if (keyContext.isDeleteMarker) {
             const command = new DeleteObjectCommand(params);
-            return this._client.send(command)
+            return this._client
+                .send(command)
                 .then(data => putCb(null, data))
                 .catch(err => putCb(err));
         }
-        
+
         const uploadParams = { ...params };
         uploadParams.Metadata = metaHeaders;
         uploadParams.ContentLength = size;
@@ -186,19 +187,21 @@ class AwsClient {
         }
         if (!stream) {
             const command = new PutObjectCommand(uploadParams);
-            return this._client.send(command)
+            return this._client
+                .send(command)
                 .then(data => putCb(null, data))
                 .catch(err => putCb(err));
         }
-        
+
         // Handle stream upload using Upload from @aws-sdk/lib-storage
         uploadParams.Body = stream;
         const upload = new Upload({
             client: this._client,
             params: uploadParams,
         });
-        
-        return upload.done()
+
+        return upload
+            .done()
             .then(data => putCb(null, data))
             .catch(err => putCb(err));
     }
@@ -206,11 +209,14 @@ class AwsClient {
     head(objectGetInfo, reqUids, callback) {
         const log = createLogger(reqUids);
         const { key, dataStoreVersionId } = objectGetInfo;
-        return this._client.send(new HeadObjectCommand({
-            Bucket: this._awsBucketName,
-            Key: key,
-            VersionId: dataStoreVersionId,
-            }))
+        return this._client
+            .send(
+                new HeadObjectCommand({
+                    Bucket: this._awsBucketName,
+                    Key: key,
+                    VersionId: dataStoreVersionId,
+                }),
+            )
             .then(data => callback(null, data))
             .catch(err => {
                 let logLevel;
@@ -221,13 +227,12 @@ class AwsClient {
                 } else {
                     logLevel = 'error';
                     retError = errorInstances.ServiceUnavailable.customizeDescription(
-                        `Error returned from ${this.type}: ${err.message}`);
+                        `Error returned from ${this.type}: ${err.message}`,
+                    );
                 }
-                logHelper(log, logLevel, 'error heading object ' +
-                    'from datastore', err, this._dataStoreName);
+                logHelper(log, logLevel, 'error heading object ' + 'from datastore', err, this._dataStoreName);
                 return callback(retError);
-            }
-        );
+            });
     }
     get(objectGetInfo, range, reqUids, callback) {
         const log = createLogger(reqUids);
@@ -241,7 +246,8 @@ class AwsClient {
         };
         const command = new GetObjectCommand(params);
         const abortController = new AbortController();
-        this._client.send(command, { abortSignal: abortController.signal })
+        this._client
+            .send(command, { abortSignal: abortController.signal })
             .then(data => {
                 const stream = data.Body;
                 if (!stream) {
@@ -252,8 +258,11 @@ class AwsClient {
                         dataStoreName: this._dataStoreName,
                         bodyType,
                     });
-                    return cbOnce(errorInstances.InternalError
-                        .customizeDescription('Unsupported response body type returned from AWS SDK'));
+                    return cbOnce(
+                        errorInstances.InternalError.customizeDescription(
+                            'Unsupported response body type returned from AWS SDK',
+                        ),
+                    );
                 }
 
                 if (data.$metadata?.httpHeaders) {
@@ -279,7 +288,7 @@ class AwsClient {
                         `error streaming data from ${this.type}`,
                         err,
                         this._dataStoreName,
-                        this.clientType
+                        this.clientType,
                     );
                 });
 
@@ -288,8 +297,7 @@ class AwsClient {
             .catch(err => {
                 if (err instanceof NoSuchKey || err instanceof NotFound) {
                     logHelper(log, 'info', 'object not found', err, this._dataStoreName);
-                }
-                else {
+                } else {
                     logHelper(log, 'error', 'error getting object from datastore', err, this._dataStoreName);
                 }
                 return cbOnce(err);
@@ -305,25 +313,36 @@ class AwsClient {
         if (deleteVersion) {
             params.VersionId = dataStoreVersionId;
         }
-        return this._client.send(new DeleteObjectCommand(params)).then(() => callback())
-        .catch(err => {
-            logHelper(log, 'error', 'error deleting object from ' +
-                'datastore', err, this._dataStoreName, this.clientType);
-            if (err.name === 'NoSuchVersion' || err instanceof NoSuchKey) {
-                // data may have been deleted directly from the AWS backend
-                // don't want to retry the delete and errors are not
-                // sent back to client anyway, so no need to return err
-                return callback();
-            }
-            return callback(errorInstances.ServiceUnavailable
-                .customizeDescription('Error returned from ' +
-                `${this.type}: ${err.message}`));
-        });
+        return this._client
+            .send(new DeleteObjectCommand(params))
+            .then(() => callback())
+            .catch(err => {
+                logHelper(
+                    log,
+                    'error',
+                    'error deleting object from ' + 'datastore',
+                    err,
+                    this._dataStoreName,
+                    this.clientType,
+                );
+                if (err.name === 'NoSuchVersion' || err instanceof NoSuchKey) {
+                    // data may have been deleted directly from the AWS backend
+                    // don't want to retry the delete and errors are not
+                    // sent back to client anyway, so no need to return err
+                    return callback();
+                }
+                return callback(
+                    errorInstances.ServiceUnavailable.customizeDescription(
+                        'Error returned from ' + `${this.type}: ${err.message}`,
+                    ),
+                );
+            });
     }
 
     healthcheck(location, callback) {
         const awsResp = {};
-        this._client.send(new HeadBucketCommand({ Bucket: this._awsBucketName }))
+        this._client
+            .send(new HeadBucketCommand({ Bucket: this._awsBucketName }))
             .then(() => {
                 if (!this._supportsVersioning) {
                     awsResp[location] = {
@@ -331,31 +350,46 @@ class AwsClient {
                     };
                     return callback(null, awsResp);
                 }
-                return this._client.send(new GetBucketVersioningCommand({
-                    Bucket: this._awsBucketName
-            })).then(data => {
-                if (!data.Status ||
-                    data.Status === 'Suspended') {
-                    awsResp[location] = {
-                        versioningStatus: data.Status,
-                        error: 'Versioning must be enabled',
-                        external: true,
-                    };
-                }
-                else {
-                    awsResp[location] = {
-                        versioningStatus: data.Status,
-                        message: 'Congrats! You own the bucket',
-                    };
-                }
+                return this._client
+                    .send(
+                        new GetBucketVersioningCommand({
+                            Bucket: this._awsBucketName,
+                        }),
+                    )
+                    .then(data => {
+                        if (!data.Status || data.Status === 'Suspended') {
+                            awsResp[location] = {
+                                versioningStatus: data.Status,
+                                error: 'Versioning must be enabled',
+                                external: true,
+                            };
+                        } else {
+                            awsResp[location] = {
+                                versioningStatus: data.Status,
+                                message: 'Congrats! You own the bucket',
+                            };
+                        }
+                        return callback(null, awsResp);
+                    });
+            })
+            .catch(err => {
+                awsResp[location] = { error: err, external: true };
                 return callback(null, awsResp);
             });
-        }).catch(err => {
-            awsResp[location] = { error: err, external: true };
-            return callback(null, awsResp);
-        });
     }
-    createMPU(key, metaHeaders, bucketName, websiteRedirectHeader, contentType, cacheControl, contentDisposition, contentEncoding, tagging, log, callback) {
+    createMPU(
+        key,
+        metaHeaders,
+        bucketName,
+        websiteRedirectHeader,
+        contentType,
+        cacheControl,
+        contentDisposition,
+        contentEncoding,
+        tagging,
+        log,
+        callback,
+    ) {
         const metaHeadersTrimmed = {};
         Object.keys(metaHeaders).forEach(header => {
             if (header.startsWith('x-amz-meta-')) {
@@ -376,49 +410,66 @@ class AwsClient {
             ContentEncoding: contentEncoding,
             Tagging: tagging,
         };
-        return this._client.send(new CreateMultipartUploadCommand(params)).then(mpuResObj =>
-            callback(null, mpuResObj)
-        ).catch(err => {
-            logHelper(log, 'error', 'err from data backend', 
-                err, this._dataStoreName, this.clientType);
-            callback(errorInstances.ServiceUnavailable
-                .customizeDescription('Error returned from ' +
-                `${this.type}: ${err.message}`));
-        });
+        return this._client
+            .send(new CreateMultipartUploadCommand(params))
+            .then(mpuResObj => callback(null, mpuResObj))
+            .catch(err => {
+                logHelper(log, 'error', 'err from data backend', err, this._dataStoreName, this.clientType);
+                callback(
+                    errorInstances.ServiceUnavailable.customizeDescription(
+                        'Error returned from ' + `${this.type}: ${err.message}`,
+                    ),
+                );
+            });
     }
 
     uploadPart(request, streamingV4Params, stream, size, key, uploadId, partNumber, bucketName, log, callback) {
         let hashedStream = stream;
         const cbOnce = jsutil.once(callback);
         if (request) {
-            const partStream = prepareStream(request, streamingV4Params, 
-                this._vault, log, cbOnce);
+            const partStream = prepareStream(request, streamingV4Params, this._vault, log, cbOnce);
             hashedStream = new MD5Sum();
             partStream.pipe(hashedStream);
         }
 
         const awsBucket = this._awsBucketName;
         const awsKey = this._createAwsKey(bucketName, key, this._bucketMatch);
-        const params = { Bucket: awsBucket, Key: awsKey, UploadId: uploadId,
-            Body: hashedStream, ContentLength: size,
-            PartNumber: partNumber };
-        return this._client.send(new UploadPartCommand(params)).then(partResObj => {
-            // Because we manually add quotes to ETag later, remove quotes here
-            const noQuotesETag = partResObj?.ETag?.substring(1, partResObj.ETag.length - 1);
-            const dataRetrievalInfo = {
-                key: awsKey,
-                dataStoreType: 'aws_s3',
-                dataStoreName: this._dataStoreName,
-                dataStoreETag: noQuotesETag,
-            };
-            return cbOnce(null, dataRetrievalInfo);
-        }).catch(err => {
-            logHelper(log, 'error', 'err from data backend ' +
-                'on uploadPart', err, this._dataStoreName, this.clientType);
-            return cbOnce(errorInstances.ServiceUnavailable
-                .customizeDescription('Error returned from ' +
-                `${this.type}: ${err.message}`));
-        });
+        const params = {
+            Bucket: awsBucket,
+            Key: awsKey,
+            UploadId: uploadId,
+            Body: hashedStream,
+            ContentLength: size,
+            PartNumber: partNumber,
+        };
+        return this._client
+            .send(new UploadPartCommand(params))
+            .then(partResObj => {
+                // Because we manually add quotes to ETag later, remove quotes here
+                const noQuotesETag = partResObj?.ETag?.substring(1, partResObj.ETag.length - 1);
+                const dataRetrievalInfo = {
+                    key: awsKey,
+                    dataStoreType: 'aws_s3',
+                    dataStoreName: this._dataStoreName,
+                    dataStoreETag: noQuotesETag,
+                };
+                return cbOnce(null, dataRetrievalInfo);
+            })
+            .catch(err => {
+                logHelper(
+                    log,
+                    'error',
+                    'err from data backend on uploadPart',
+                    err,
+                    this._dataStoreName,
+                    this.clientType,
+                );
+                return cbOnce(
+                    errorInstances.ServiceUnavailable.customizeDescription(
+                        'Error returned from ' + `${this.type}: ${err.message}`,
+                    ),
+                );
+            });
     }
 
     listParts(key, uploadId, bucketName, partNumberMarker, maxParts, log, callback) {
@@ -428,45 +479,48 @@ class AwsClient {
             Bucket: awsBucket,
             Key: awsKey,
             UploadId: uploadId,
-            MaxParts: maxParts
+            MaxParts: maxParts,
         };
         if (partNumberMarker && partNumberMarker > 0) {
             params.PartNumberMarker = String(partNumberMarker);
         }
-        return this._client.send(new ListPartsCommand(params)).then(partList => {
-            const storedParts = {};
-            storedParts.IsTruncated = partList.IsTruncated;
-            storedParts.Contents = [];
-            storedParts.Contents = partList.Parts.map(item => {
-                // We manually add quotes to ETag later, so remove quotes here
-                const noQuotesETag = 
-                item.ETag.substring(1, item.ETag.length - 1);
-                const value = {
-                    Size: item.Size,
-                    ETag: noQuotesETag,
-                    LastModified: item.LastModified,
-                };
-                Object.entries(awsPartChecksumFields).some(([field, algorithm]) => {
-                    if (item[field] !== undefined) {
-                        value.ChecksumAlgorithm = algorithm;
-                        value.ChecksumValue = item[field];
-                        return true;
-                    }
-                    return false;
+        return this._client
+            .send(new ListPartsCommand(params))
+            .then(partList => {
+                const storedParts = {};
+                storedParts.IsTruncated = partList.IsTruncated;
+                storedParts.Contents = [];
+                storedParts.Contents = partList.Parts.map(item => {
+                    // We manually add quotes to ETag later, so remove quotes here
+                    const noQuotesETag = item.ETag.substring(1, item.ETag.length - 1);
+                    const value = {
+                        Size: item.Size,
+                        ETag: noQuotesETag,
+                        LastModified: item.LastModified,
+                    };
+                    Object.entries(awsPartChecksumFields).some(([field, algorithm]) => {
+                        if (item[field] !== undefined) {
+                            value.ChecksumAlgorithm = algorithm;
+                            value.ChecksumValue = item[field];
+                            return true;
+                        }
+                        return false;
+                    });
+                    return {
+                        partNumber: item.PartNumber,
+                        value,
+                    };
                 });
-                return {
-                    partNumber: item.PartNumber,
-                    value,
-                };
+                return callback(null, storedParts);
+            })
+            .catch(err => {
+                logHelper(log, 'error', 'err from data backend on listPart', err, this._dataStoreName, this.clientType);
+                return callback(
+                    errorInstances.ServiceUnavailable.customizeDescription(
+                        'Error returned from ' + `${this.type}: ${err.message}`,
+                    ),
+                );
             });
-            return callback(null, storedParts);
-        })
-        .catch(err => {
-            logHelper(log, 'error', 'err from data backend on listPart', err, this._dataStoreName, this.clientType);
-            return callback(errorInstances.ServiceUnavailable
-                .customizeDescription('Error returned from ' +
-                `${this.type}: ${err.message}`));
-        });
     }
 
     /**
@@ -494,70 +548,117 @@ class AwsClient {
         const partArray = [];
         const partList = jsonList.Part;
         partList.forEach(partObj => {
-            const partParams = { PartNumber: partObj.PartNumber[0],
-                ETag: partObj.ETag[0] };
+            const partParams = { PartNumber: partObj.PartNumber[0], ETag: partObj.ETag[0] };
             partArray.push(partParams);
         });
         const mpuParams = {
-            Bucket: awsBucket, Key: awsKey, UploadId: uploadId,
+            Bucket: awsBucket,
+            Key: awsKey,
+            UploadId: uploadId,
             MultipartUpload: {
                 Parts: partArray,
             },
         };
         const completeObjData = { key: awsKey };
-        return this._client.send(new CompleteMultipartUploadCommand(mpuParams)).then(completeMpuRes => {
-            if (!completeMpuRes.VersionId && this._supportsVersioning) {
-                logHelper(log, 'error', 'missing version id for data ' +
-                    'backend object', missingVerIdInternalError, this._dataStoreName, this.clientType);
-                return callback(missingVerIdInternalError);
-            }
-            // need to get content length of new object to store
-            // in our metadata
-            return this._client.send(new HeadObjectCommand({ Bucket: awsBucket, Key: awsKey })).then(objHeaders => {
-                // remove quotes from eTag because they're added later
-                completeObjData.eTag = completeMpuRes.ETag
-                    .substring(1, completeMpuRes.ETag.length - 1);
-                completeObjData.dataStoreVersionId = completeMpuRes.VersionId;
-                completeObjData.contentLength =
-                    Number.parseInt(objHeaders.ContentLength, 10);
-                return callback(null, completeObjData);
-            }).catch(err => {
-                logHelper(log, 'trace', 'err from data backend on ' +
-                    'headObject', err, this._dataStoreName, this.clientType);
-                return callback(errorInstances.ServiceUnavailable
-                    .customizeDescription('Error returned from ' +
-                    `${this.type}: ${err.message}`));
+        return this._client
+            .send(new CompleteMultipartUploadCommand(mpuParams))
+            .then(completeMpuRes => {
+                if (!completeMpuRes.VersionId && this._supportsVersioning) {
+                    logHelper(
+                        log,
+                        'error',
+                        'missing version id for data ' + 'backend object',
+                        missingVerIdInternalError,
+                        this._dataStoreName,
+                        this.clientType,
+                    );
+                    return callback(missingVerIdInternalError);
+                }
+                // need to get content length of new object to store
+                // in our metadata
+                return this._client
+                    .send(new HeadObjectCommand({ Bucket: awsBucket, Key: awsKey }))
+                    .then(objHeaders => {
+                        // remove quotes from eTag because they're added later
+                        completeObjData.eTag = completeMpuRes.ETag.substring(1, completeMpuRes.ETag.length - 1);
+                        completeObjData.dataStoreVersionId = completeMpuRes.VersionId;
+                        completeObjData.contentLength = Number.parseInt(objHeaders.ContentLength, 10);
+                        return callback(null, completeObjData);
+                    })
+                    .catch(err => {
+                        logHelper(
+                            log,
+                            'trace',
+                            'err from data backend on ' + 'headObject',
+                            err,
+                            this._dataStoreName,
+                            this.clientType,
+                        );
+                        return callback(
+                            errorInstances.ServiceUnavailable.customizeDescription(
+                                'Error returned from ' + `${this.type}: ${err.message}`,
+                            ),
+                        );
+                    });
+            })
+            .catch(err => {
+                if (mpuError[err.name]) {
+                    logHelper(
+                        log,
+                        'trace',
+                        'err from data backend on ' + 'completeMPU',
+                        err,
+                        this._dataStoreName,
+                        this.clientType,
+                    );
+                    return callback(errors[err.name]);
+                }
+                logHelper(
+                    log,
+                    'error',
+                    'err from data backend on ' + 'completeMPU',
+                    err,
+                    this._dataStoreName,
+                    this.clientType,
+                );
+                return callback(
+                    errorInstances.ServiceUnavailable.customizeDescription(
+                        'Error returned from ' + `${this.type}: ${err.message}`,
+                    ),
+                );
             });
-        }).catch(err => {
-            if (mpuError[err.name]) {
-                logHelper(log, 'trace', 'err from data backend on ' +
-                    'completeMPU', err, this._dataStoreName, this.clientType);
-                return callback(errors[err.name]);
-            }
-            logHelper(log, 'error', 'err from data backend on ' +
-                'completeMPU', err, this._dataStoreName, this.clientType);
-            return callback(errorInstances.ServiceUnavailable
-                .customizeDescription('Error returned from ' +
-                `${this.type}: ${err.message}`));
-        });
     }
 
     abortMPU(key, uploadId, bucketName, log, callback) {
         const awsBucket = this._awsBucketName;
         const awsKey = this._createAwsKey(bucketName, key, this._bucketMatch);
         const abortParams = {
-            Bucket: awsBucket, Key: awsKey, UploadId: uploadId,
+            Bucket: awsBucket,
+            Key: awsKey,
+            UploadId: uploadId,
         };
-        return this._client.send(new AbortMultipartUploadCommand(abortParams)).then(() => {
-            return callback();
-        }).catch(err => {
-            logHelper(log, 'error', 'There was an error aborting ' +
-                'the MPU on AWS S3. You should abort directly on AWS S3 ' +
-                'using the same uploadId.', err, this._dataStoreName, this.clientType);
-            return callback(errorInstances.ServiceUnavailable
-                .customizeDescription('Error returned from ' +
-                `${this.type}: ${err.message}`));
-        });
+        return this._client
+            .send(new AbortMultipartUploadCommand(abortParams))
+            .then(() => {
+                return callback();
+            })
+            .catch(err => {
+                logHelper(
+                    log,
+                    'error',
+                    'There was an error aborting ' +
+                        'the MPU on AWS S3. You should abort directly on AWS S3 ' +
+                        'using the same uploadId.',
+                    err,
+                    this._dataStoreName,
+                    this.clientType,
+                );
+                return callback(
+                    errorInstances.ServiceUnavailable.customizeDescription(
+                        'Error returned from ' + `${this.type}: ${err.message}`,
+                    ),
+                );
+            });
     }
 
     objectPutTagging(key, bucketName, objectMD, log, callback) {
@@ -575,15 +676,26 @@ class AwsClient {
             const value = objectMD.tags[key];
             return { Key: key, Value: value };
         });
-        return this._client.send(new PutObjectTaggingCommand(tagParams)).then(() => {
-            return callback();
-        }).catch(err => {
-            logHelper(log, 'error', 'error from data backend on ' +
-                'putObjectTagging', err, this._dataStoreName, this.clientType);
-            return callback(errorInstances.ServiceUnavailable
-                .customizeDescription('Error returned from ' +
-                `${this.type}: ${err.message}`));
-        });
+        return this._client
+            .send(new PutObjectTaggingCommand(tagParams))
+            .then(() => {
+                return callback();
+            })
+            .catch(err => {
+                logHelper(
+                    log,
+                    'error',
+                    'error from data backend on ' + 'putObjectTagging',
+                    err,
+                    this._dataStoreName,
+                    this.clientType,
+                );
+                return callback(
+                    errorInstances.ServiceUnavailable.customizeDescription(
+                        'Error returned from ' + `${this.type}: ${err.message}`,
+                    ),
+                );
+            });
     }
 
     objectDeleteTagging(key, bucketName, objectMD, log, callback) {
@@ -595,19 +707,38 @@ class AwsClient {
             Key: awsKey,
             VersionId: dataStoreVersionId,
         };
-        return this._client.send(new DeleteObjectTaggingCommand(tagParams)).then(() => {
-            return callback();
-        }).catch(err => {
-            logHelper(log, 'error', 'error from data backend on ' +
-                'deleteObjectTagging', err, this._dataStoreName, this.clientType);
-            return callback(errorInstances.ServiceUnavailable
-                .customizeDescription('Error returned from ' +
-                `${this.type}: ${err.message}`));
-        });
+        return this._client
+            .send(new DeleteObjectTaggingCommand(tagParams))
+            .then(() => {
+                return callback();
+            })
+            .catch(err => {
+                logHelper(
+                    log,
+                    'error',
+                    'error from data backend on ' + 'deleteObjectTagging',
+                    err,
+                    this._dataStoreName,
+                    this.clientType,
+                );
+                return callback(
+                    errorInstances.ServiceUnavailable.customizeDescription(
+                        'Error returned from ' + `${this.type}: ${err.message}`,
+                    ),
+                );
+            });
     }
 
-    copyObject(request, destLocationConstraintName, sourceKey, 
-        sourceLocationConstraintName, storeMetadataParams, config, log, callback) {
+    copyObject(
+        request,
+        destLocationConstraintName,
+        sourceKey,
+        sourceLocationConstraintName,
+        storeMetadataParams,
+        config,
+        log,
+        callback,
+    ) {
         const destBucketName = request.bucketName;
         const destObjectKey = request.objectKey;
         const destAwsKey = this._createAwsKey(destBucketName, destObjectKey, this._bucketMatch);
@@ -621,46 +752,71 @@ class AwsClient {
             Metadata: metaHeaders,
             MetadataDirective: metadataDirective,
         };
-        if (destLocationConstraintName &&
-            config.isAWSServerSideEncryption(destLocationConstraintName)) {
+        if (destLocationConstraintName && config.isAWSServerSideEncryption(destLocationConstraintName)) {
             awsParams.ServerSideEncryption = 'AES256';
         }
-        return this._client.send(new CopyObjectCommand(awsParams)).then(copyResult => {
-            if (!copyResult.VersionId && this._supportsVersioning) {
-                this._logger.debug('No VersionId found in response, ' +
-                    'calling headObject to resolve');
-                return this._client.send(new HeadObjectCommand({
-                    Bucket: this._awsBucketName,
-                    Key: destAwsKey,
-                }))
-                .then(data => {
-                    if (!data.VersionId) {
-                        return callback(missingVerIdInternalError);
-                    }
-                    return callback(null, destAwsKey, data.VersionId);
-                })
-                .catch(err => {
-                    logHelper(log, 'error', 'missing version id for data ' +
-                        'backend object', missingVerIdInternalError, this._dataStoreName, this.clientType);
-                    return callback(missingVerIdInternalError);
-                });
-            }
-            return callback(null, destAwsKey, copyResult.VersionId);
-        })
-        .catch(err => {
-            if (err.name == "AccessDenied") {
-                logHelper(log, 'error', 'Unable to access ' +
-                    `${sourceAwsBucketName} ${this.type} bucket`, err, this._dataStoreName, this.clientType);
-                return callback(errorInstances.AccessDenied
-                    .customizeDescription('Error: Unable to access ' +
-                    `${sourceAwsBucketName} ${this.type} bucket`));
-            }
-            logHelper(log, 'error', 'error from data backend on ' +
-                'copyObject', err, this._dataStoreName, this.clientType);
-            return callback(errorInstances.ServiceUnavailable
-                .customizeDescription('Error returned from ' +
-                `${this.type}: ${err.message}`));
-        });
+        return this._client
+            .send(new CopyObjectCommand(awsParams))
+            .then(copyResult => {
+                if (!copyResult.VersionId && this._supportsVersioning) {
+                    this._logger.debug('No VersionId found in response, ' + 'calling headObject to resolve');
+                    return this._client
+                        .send(
+                            new HeadObjectCommand({
+                                Bucket: this._awsBucketName,
+                                Key: destAwsKey,
+                            }),
+                        )
+                        .then(data => {
+                            if (!data.VersionId) {
+                                return callback(missingVerIdInternalError);
+                            }
+                            return callback(null, destAwsKey, data.VersionId);
+                        })
+                        .catch(err => {
+                            logHelper(
+                                log,
+                                'error',
+                                'missing version id for data ' + 'backend object',
+                                missingVerIdInternalError,
+                                this._dataStoreName,
+                                this.clientType,
+                            );
+                            return callback(missingVerIdInternalError);
+                        });
+                }
+                return callback(null, destAwsKey, copyResult.VersionId);
+            })
+            .catch(err => {
+                if (err.name == 'AccessDenied') {
+                    logHelper(
+                        log,
+                        'error',
+                        'Unable to access ' + `${sourceAwsBucketName} ${this.type} bucket`,
+                        err,
+                        this._dataStoreName,
+                        this.clientType,
+                    );
+                    return callback(
+                        errorInstances.AccessDenied.customizeDescription(
+                            'Error: Unable to access ' + `${sourceAwsBucketName} ${this.type} bucket`,
+                        ),
+                    );
+                }
+                logHelper(
+                    log,
+                    'error',
+                    'error from data backend on ' + 'copyObject',
+                    err,
+                    this._dataStoreName,
+                    this.clientType,
+                );
+                return callback(
+                    errorInstances.ServiceUnavailable.customizeDescription(
+                        'Error returned from ' + `${this.type}: ${err.message}`,
+                    ),
+                );
+            });
     }
 
     uploadPartCopy(request, awsSourceKey, sourceLocationConstraintName, config, log, callback) {
@@ -679,26 +835,50 @@ class AwsClient {
             PartNumber: partNumber,
             UploadId: uploadId,
         };
-        return this._client.send(new UploadPartCopyCommand(params)).then(res => {
-            const eTag = removeQuotes(res?.CopyPartResult?.ETag);
-            return callback(null, eTag);
-        })
-        .catch(err => {
-            logHelper(log, 'error', 'Error occurred while uploading part copy', 
-                err, this._dataStoreName, this.clientType);
-            if (err.name === "AccessDenied") {
-                logHelper(log, 'error', 'Unable to access ' +
-                    `${sourceAwsBucketName} AWS bucket`, err, this._dataStoreName, this.clientType);
-                return callback(errorInstances.AccessDenied
-                    .customizeDescription('Error: Unable to access ' +
-                    `${sourceAwsBucketName} AWS bucket`));
-            }
-            logHelper(log, 'error', 'error from data backend on ' +
-                'uploadPartCopy', err, this._dataStoreName, this.clientType);
-            return callback(errorInstances.ServiceUnavailable
-                .customizeDescription('Error returned from ' +
-                `${this.type}: ${err.message}`));
-        });
+        return this._client
+            .send(new UploadPartCopyCommand(params))
+            .then(res => {
+                const eTag = removeQuotes(res?.CopyPartResult?.ETag);
+                return callback(null, eTag);
+            })
+            .catch(err => {
+                logHelper(
+                    log,
+                    'error',
+                    'Error occurred while uploading part copy',
+                    err,
+                    this._dataStoreName,
+                    this.clientType,
+                );
+                if (err.name === 'AccessDenied') {
+                    logHelper(
+                        log,
+                        'error',
+                        'Unable to access ' + `${sourceAwsBucketName} AWS bucket`,
+                        err,
+                        this._dataStoreName,
+                        this.clientType,
+                    );
+                    return callback(
+                        errorInstances.AccessDenied.customizeDescription(
+                            'Error: Unable to access ' + `${sourceAwsBucketName} AWS bucket`,
+                        ),
+                    );
+                }
+                logHelper(
+                    log,
+                    'error',
+                    'error from data backend on ' + 'uploadPartCopy',
+                    err,
+                    this._dataStoreName,
+                    this.clientType,
+                );
+                return callback(
+                    errorInstances.ServiceUnavailable.customizeDescription(
+                        'Error returned from ' + `${this.type}: ${err.message}`,
+                    ),
+                );
+            });
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "engines": {
         "node": ">=20"
     },
-    "version": "8.5.7",
+    "version": "8.5.8",
     "config": {
         "mongodbMemoryServer": {
             "version": "8.0.23"

--- a/tests/unit/storage/data/external/ExternalClients.spec.js
+++ b/tests/unit/storage/data/external/ExternalClients.spec.js
@@ -10,6 +10,7 @@ const DummyService = require('../DummyService');
 const { DummyRequestLogger } = require('../../../helpers');
 const BucketInfo = require('../../../../../lib/models/BucketInfo').default;
 const { HeadBucketCommand } = require('@aws-sdk/client-s3');
+const { externalBackendHealthCheckTimeout } = require('../../../../../lib/constants');
 
 const backendClients = [
     {
@@ -179,6 +180,36 @@ describe('external backend clients', () => {
 
             const entry = resp[backend.config.dataStoreName];
             assert.ok(entry.error);
+            assert.strictEqual(entry.external, true);
+        });
+
+        itIfAws(`${backend.name} healthcheck should pass an abort signal to bound the probe`, async () => {
+            const sendStub = sandbox.stub(testClient._client, 'send').resolves({});
+            await promisify(testClient.healthcheck.bind(testClient))(backend.config.dataStoreName);
+
+            const opts = sendStub.firstCall.args[1];
+            assert.ok(
+                opts && opts.abortSignal instanceof AbortSignal,
+                'expected healthcheck to pass an AbortSignal to send',
+            );
+        });
+
+        itIfAws(`${backend.name} healthcheck should abort a hanging probe and report an error`, async () => {
+            const clock = sandbox.useFakeTimers();
+            // unreachable endpoint: settles only when aborted
+            sandbox.stub(testClient._client, 'send').callsFake(
+                (_cmd, opts) =>
+                    new Promise((_resolve, reject) => {
+                        opts.abortSignal.addEventListener('abort', () => reject(new Error('aborted')));
+                    }),
+            );
+            const healthcheckPromise = promisify(testClient.healthcheck.bind(testClient))(backend.config.dataStoreName);
+
+            await clock.tickAsync(externalBackendHealthCheckTimeout);
+            const resp = await healthcheckPromise;
+
+            const entry = resp[backend.config.dataStoreName];
+            assert.ok(entry.error, 'expected the aborted probe to report an error');
             assert.strictEqual(entry.external, true);
         });
 

--- a/tests/unit/storage/data/external/ExternalClients.spec.js
+++ b/tests/unit/storage/data/external/ExternalClients.spec.js
@@ -5,8 +5,7 @@ const { promisify } = require('util');
 
 const AwsClient = require('../../../../../lib/storage/data/external/AwsClient');
 const GcpClient = require('../../../../../lib/storage/data/external/GcpClient');
-const AzureClient =
-    require('../../../../../lib/storage/data/external/AzureClient');
+const AzureClient = require('../../../../../lib/storage/data/external/AzureClient');
 const DummyService = require('../DummyService');
 const { DummyRequestLogger } = require('../../../helpers');
 const BucketInfo = require('../../../../../lib/models/BucketInfo').default;
@@ -71,13 +70,20 @@ describe('external backend clients', () => {
 
     backendClients.forEach(backend => {
         let testClient;
-        let headAsync, getAsync, deleteAsync, objectPutTaggingAsync, objectDeleteTaggingAsync,
-            createMPUAsync, uploadPartAsync, abortMPUAsync, listPartsAsync;
+        let headAsync,
+            getAsync,
+            deleteAsync,
+            objectPutTaggingAsync,
+            objectDeleteTaggingAsync,
+            createMPUAsync,
+            uploadPartAsync,
+            abortMPUAsync,
+            listPartsAsync;
 
         beforeAll(() => {
             testClient = new backend.Class(backend.config);
             testClient._client = new DummyService({ versioning: true });
-            
+
             // Promisify the client methods
             headAsync = promisify(testClient.head.bind(testClient));
             getAsync = promisify(testClient.get.bind(testClient));
@@ -115,17 +121,16 @@ describe('external backend clients', () => {
                 const key = 'externalBackendTestKey';
                 const bucketName = 'externalBackendTestBucket';
                 const uploadId = 'externalBackendTestUploadId';
-                testClient.completeMPU(jsonList, null, key,
-                    uploadId, bucketName, log, (err, res) => {
-                        if (err) {
-                            return done(err);
-                        }
-                        assert.strictEqual(typeof res.key, 'string');
-                        assert.strictEqual(typeof res.eTag, 'string');
-                        assert.strictEqual(typeof res.dataStoreVersionId, 'string');
-                        assert.strictEqual(typeof res.contentLength, 'number');
-                        return done();
-                    });
+                testClient.completeMPU(jsonList, null, key, uploadId, bucketName, log, (err, res) => {
+                    if (err) {
+                        return done(err);
+                    }
+                    assert.strictEqual(typeof res.key, 'string');
+                    assert.strictEqual(typeof res.eTag, 'string');
+                    assert.strictEqual(typeof res.dataStoreVersionId, 'string');
+                    assert.strictEqual(typeof res.contentLength, 'number');
+                    return done();
+                });
             });
         }
 
@@ -141,10 +146,13 @@ describe('external backend clients', () => {
 
         it(`${backend.name} head() should return HTTP 424 if location does not exist`, async () => {
             try {
-                await headAsync({
-                    key: 'externalBackendTestBucket/externalBackendMissingKey',
-                    dataStoreName: backend.config.dataStoreName,
-                }, null);
+                await headAsync(
+                    {
+                        key: 'externalBackendTestBucket/externalBackendMissingKey',
+                        dataStoreName: backend.config.dataStoreName,
+                    },
+                    null,
+                );
                 assert.fail('Expected an error to be thrown');
             } catch (err) {
                 assert(err);
@@ -175,15 +183,19 @@ describe('external backend clients', () => {
         });
 
         it(`${backend.name} get() should stream a range of data`, async () => {
-            const readable = await getAsync({
-                key: 'externalBackendTestBucket/externalBackendTestKey',
-                dataStoreName: backend.config.dataStoreName,
-                response: new stream.PassThrough(),
-            }, [10000000, 10000050], '');
+            const readable = await getAsync(
+                {
+                    key: 'externalBackendTestBucket/externalBackendTestKey',
+                    dataStoreName: backend.config.dataStoreName,
+                    response: new stream.PassThrough(),
+                },
+                [10000000, 10000050],
+                '',
+            );
             let data = '';
             const streamToRead = readable;
             await new Promise((resolve, reject) => {
-                streamToRead.on('data', (chunk) => {
+                streamToRead.on('data', chunk => {
                     data += chunk.toString();
                 });
                 streamToRead.on('end', () => {
@@ -195,12 +207,16 @@ describe('external backend clients', () => {
         });
 
         it(`${backend.name} get() should not call the callback again on stream error`, async () => {
-            const result = await getAsync({
-                key: 'externalBackendTestBucket/externalBackendTestKey',
-                dataStoreName: backend.config.dataStoreName,
-                response: new stream.PassThrough(),
-            }, [10000000, 10000050], '');
-            const readable = result
+            const result = await getAsync(
+                {
+                    key: 'externalBackendTestBucket/externalBackendTestKey',
+                    dataStoreName: backend.config.dataStoreName,
+                    response: new stream.PassThrough(),
+                },
+                [10000000, 10000050],
+                '',
+            );
+            const readable = result;
             let errorHandled = false;
             await new Promise(resolve => {
                 readable
@@ -211,16 +227,19 @@ describe('external backend clients', () => {
                         resolve();
                     });
             });
-            
+
             assert.strictEqual(errorHandled, true);
         });
 
         it(`${backend.name} delete() should delete the requested key without error`, async () => {
             const key = 'externalBackendTestKey';
             const bucketName = 'externalBackendTestBucket';
-            const objectInfo = Object.assign({
-                deleteVersion: false,
-            }, testClient.toObjectGetInfo(key, bucketName));
+            const objectInfo = Object.assign(
+                {
+                    deleteVersion: false,
+                },
+                testClient.toObjectGetInfo(key, bucketName),
+            );
             const result = await deleteAsync(objectInfo, '');
             assert.strictEqual(result, undefined);
         });
@@ -283,9 +302,17 @@ describe('external backend clients', () => {
             it(`${backend.name} uploadPart() should return sanitized data retrieval info`, async () => {
                 const key = 'externalBackendTestKey';
                 const bucketName = 'externalBackendTestBucket';
-                const result = await uploadPartAsync(null, null,
+                const result = await uploadPartAsync(
+                    null,
+                    null,
                     stream.Readable.from(['part data']),
-                    9, key, 'uploadId-123', 1, bucketName, log);
+                    9,
+                    key,
+                    'uploadId-123',
+                    1,
+                    bucketName,
+                    log,
+                );
 
                 assert.strictEqual(result.key, `${bucketName}/${key}`);
                 assert.strictEqual(result.dataStoreName, backend.config.dataStoreName);


### PR DESCRIPTION
AwsClient.healthcheck HeadBucket probe uses the shared client with
requestTimeout: 0, so an unreachable endpoint hangs clientCheck and
blocks cloudserver startup. Bound it with an AbortController and a new
externalBackendHealthCheckTimeout (5s) so a dead location fails fast.

Issue: ARSN-612