### PR TITLE
Add a shared newRequestLoggerFromRequest helper for x-scal-request-uids seeding

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -15,6 +15,8 @@ export const fifteenMinutesInMilliseconds = 900_000;
 
 export const authChecksumUnsignedPayload = 'UNSIGNED-PAYLOAD';
 
+export const maxRequestUidsLength = 128;
+
 // info about the iam security token
 export const iamSecurityToken = {
     min: vaultGeneratedIamSecurityTokenSizeMin,

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -105,8 +105,7 @@ export const zenkoSeparator = ':';
 export const externalBackends = { aws_s3: true, azure: true, gcp: true, pfs: true };
 export const replicationBackends = { aws_s3: true, azure: true, gcp: true };
 // hex digest of sha256 hash of empty string:
-export const emptyStringHash = crypto.createHash('sha256')
-    .update('', 'binary').digest('hex');
+export const emptyStringHash = crypto.createHash('sha256').update('', 'binary').digest('hex');
 export const mpuMDStoredExternallyBackend = { aws_s3: true, gcp: true };
 // AWS sets a minimum size limit for parts except for the last part.
 // http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadComplete.html
@@ -170,8 +169,9 @@ export const notificationArnPrefix = 'arn:scality:bucketnotif';
 export const httpServerKeepAliveTimeout = 60000;
 export const httpClientFreeSocketTimeout = 55000;
 // Maximum number of buckets to cache (bucket metadata)
-export const maxCachedBuckets = process.env.METADATA_MAX_CACHED_BUCKETS ?
-    Number(process.env.METADATA_MAX_CACHED_BUCKETS) : 1000;
+export const maxCachedBuckets = process.env.METADATA_MAX_CACHED_BUCKETS
+    ? Number(process.env.METADATA_MAX_CACHED_BUCKETS)
+    : 1000;
 
 export const validRestoreObjectTiers = new Set(['Expedited', 'Standard', 'Bulk']);
 export const maxBatchingConcurrentOperations = 5;

--- a/lib/s3routes/routes.ts
+++ b/lib/s3routes/routes.ts
@@ -53,12 +53,11 @@ function checkBucketAndKey(
     // if empty name and request not a List Buckets
     if (!bucketName && !(method === 'GET' && !objectKey)) {
         log.debug('empty bucket name', { method: 'routes' });
-        return (method !== 'OPTIONS') ?
-            errors.MethodNotAllowed : errorInstances.AccessForbidden
-                .customizeDescription('CORSResponse: Bucket not found');
+        return method !== 'OPTIONS'
+            ? errors.MethodNotAllowed
+            : errorInstances.AccessForbidden.customizeDescription('CORSResponse: Bucket not found');
     }
-    if (bucketName !== undefined && routesUtils.isValidBucketName(bucketName,
-        blacklistedPrefixes.bucket) === false) {
+    if (bucketName !== undefined && routesUtils.isValidBucketName(bucketName, blacklistedPrefixes.bucket) === false) {
         log.debug('invalid bucket name', { bucketName });
         if (method === 'DELETE') {
             return errors.NoSuchBucket;
@@ -66,24 +65,21 @@ function checkBucketAndKey(
         return errors.InvalidBucketName;
     }
     if (objectKey !== undefined) {
-        const result = routesUtils.isValidObjectKey(objectKey,
-            blacklistedPrefixes.object);
+        const result = routesUtils.isValidObjectKey(objectKey, blacklistedPrefixes.object);
         if (!result.isValid) {
             log.debug('invalid object key', { objectKey });
             if (result.invalidPrefix) {
-                return errorInstances.InvalidArgument.customizeDescription('Invalid ' +
-                    'prefix - object key cannot start with ' +
-                    `"${result.invalidPrefix}".`);
+                return errorInstances.InvalidArgument.customizeDescription(
+                    'Invalid ' + 'prefix - object key cannot start with ' + `"${result.invalidPrefix}".`,
+                );
             }
-            return errorInstances.KeyTooLong.customizeDescription('Object key is too ' +
-                'long. Maximum number of bytes allowed in keys is ' +
-                `${objectKeyByteLimit}.`);
+            return errorInstances.KeyTooLong.customizeDescription(
+                'Object key is too ' + 'long. Maximum number of bytes allowed in keys is ' + `${objectKeyByteLimit}.`,
+            );
         }
     }
-    if ((reqQuery.partNumber || reqQuery.uploadId)
-        && objectKey === undefined) {
-        return errorInstances.InvalidRequest
-            .customizeDescription('A key must be specified');
+    if ((reqQuery.partNumber || reqQuery.uploadId) && objectKey === undefined) {
+        return errorInstances.InvalidRequest.customizeDescription('A key must be specified');
     }
     return undefined;
 }
@@ -102,52 +98,60 @@ function checkTypes(
     if (!isDevMode) {
         return;
     }
-    assert.strictEqual(typeof req, 'object',
-        'bad routes param: req must be an object');
-    assert.strictEqual(typeof res, 'object',
-        'bad routes param: res must be an object');
-    assert.strictEqual(typeof logger, 'object',
-        'bad routes param: logger must be an object');
-    assert.strictEqual(typeof params.api, 'object',
-        'bad routes param: api must be an object');
-    assert.strictEqual(typeof params.api.callApiMethod, 'function',
-        'bad routes param: api.callApiMethod must be a defined function');
-    assert.strictEqual(typeof params.internalHandlers, 'object',
-        'bad routes param: internalHandlers must be an object');
+    assert.strictEqual(typeof req, 'object', 'bad routes param: req must be an object');
+    assert.strictEqual(typeof res, 'object', 'bad routes param: res must be an object');
+    assert.strictEqual(typeof logger, 'object', 'bad routes param: logger must be an object');
+    assert.strictEqual(typeof params.api, 'object', 'bad routes param: api must be an object');
+    assert.strictEqual(
+        typeof params.api.callApiMethod,
+        'function',
+        'bad routes param: api.callApiMethod must be a defined function',
+    );
+    assert.strictEqual(
+        typeof params.internalHandlers,
+        'object',
+        'bad routes param: internalHandlers must be an object',
+    );
     if (params.statsClient) {
-        assert.strictEqual(typeof params.statsClient, 'object',
-            'bad routes param: statsClient must be an object');
+        assert.strictEqual(typeof params.statsClient, 'object', 'bad routes param: statsClient must be an object');
     }
-    assert(Array.isArray(params.allEndpoints),
-        'bad routes param: allEndpoints must be an array');
-    assert(params.allEndpoints.length > 0,
-        'bad routes param: allEndpoints must have at least one endpoint');
+    assert(Array.isArray(params.allEndpoints), 'bad routes param: allEndpoints must be an array');
+    assert(params.allEndpoints.length > 0, 'bad routes param: allEndpoints must have at least one endpoint');
     params.allEndpoints.forEach(endpoint => {
-        assert.strictEqual(typeof endpoint, 'string',
-            'bad routes param: each item in allEndpoints must be a string');
+        assert.strictEqual(typeof endpoint, 'string', 'bad routes param: each item in allEndpoints must be a string');
     });
-    assert(Array.isArray(params.websiteEndpoints),
-        'bad routes param: allEndpoints must be an array');
+    assert(Array.isArray(params.websiteEndpoints), 'bad routes param: allEndpoints must be an array');
     params.websiteEndpoints.forEach(endpoint => {
-        assert.strictEqual(typeof endpoint, 'string',
-            'bad routes param: each item in websiteEndpoints must be a string');
+        assert.strictEqual(
+            typeof endpoint,
+            'string',
+            'bad routes param: each item in websiteEndpoints must be a string',
+        );
     });
-    assert.strictEqual(typeof params.blacklistedPrefixes, 'object',
-        'bad routes param: blacklistedPrefixes must be an object');
-    assert(Array.isArray(params.blacklistedPrefixes.bucket),
-        'bad routes param: blacklistedPrefixes.bucket must be an array');
+    assert.strictEqual(
+        typeof params.blacklistedPrefixes,
+        'object',
+        'bad routes param: blacklistedPrefixes must be an object',
+    );
+    assert(
+        Array.isArray(params.blacklistedPrefixes.bucket),
+        'bad routes param: blacklistedPrefixes.bucket must be an array',
+    );
     params.blacklistedPrefixes.bucket.forEach(pre => {
-        assert.strictEqual(typeof pre, 'string',
-            'bad routes param: each blacklisted bucket prefix must be a string');
+        assert.strictEqual(typeof pre, 'string', 'bad routes param: each blacklisted bucket prefix must be a string');
     });
-    assert(Array.isArray(params.blacklistedPrefixes.object),
-        'bad routes param: blacklistedPrefixes.object must be an array');
+    assert(
+        Array.isArray(params.blacklistedPrefixes.object),
+        'bad routes param: blacklistedPrefixes.object must be an array',
+    );
     params.blacklistedPrefixes.object.forEach(pre => {
-        assert.strictEqual(typeof pre, 'string',
-            'bad routes param: each blacklisted object prefix must be a string');
+        assert.strictEqual(typeof pre, 'string', 'bad routes param: each blacklisted object prefix must be a string');
     });
-    assert.strictEqual(typeof params.dataRetrievalParams, 'object',
-        'bad routes param: dataRetrievalParams must be a defined object');
+    assert.strictEqual(
+        typeof params.dataRetrievalParams,
+        'object',
+        'bad routes param: dataRetrievalParams must be a defined object',
+    );
     if (s3config) {
         assert.strictEqual(typeof s3config, 'object', 'bad routes param: s3config must be an object');
     }
@@ -165,7 +169,7 @@ export type Params = {
     };
     unsupportedQueries: any;
     api: { callApiMethod: routesUtils.CallApiMethod };
-}
+};
 
 /** routes - route request to appropriate method
  * @param req - http request object
@@ -225,12 +229,12 @@ export default function routes(
         // invalid request ID through a crafted header)
         reqUids = undefined;
     }
-    const log = (reqUids !== undefined ?
-        // @ts-ignore
-        logger.newRequestLoggerFromSerializedUids(reqUids) :
-        // @ts-ignore
-        logger.newRequestLogger());
-
+    const log =
+        reqUids !== undefined
+            ? // @ts-ignore
+              logger.newRequestLoggerFromSerializedUids(reqUids)
+            : // @ts-ignore
+              logger.newRequestLogger();
 
     // @ts-expect-error
     if (res.serverAccessLog) {
@@ -238,8 +242,7 @@ export default function routes(
         res.serverAccessLog.requestID = log.getSerializedUids();
     }
 
-    if (!req.url!.startsWith('/_/healthcheck') &&
-        !req.url!.startsWith('/_/report')) {
+    if (!req.url!.startsWith('/_/healthcheck') && !req.url!.startsWith('/_/report')) {
         log.debug('received request', clientInfo);
     }
 
@@ -253,11 +256,9 @@ export default function routes(
         }
         log.addDefaultFields({ internalServiceName });
         if (internalHandlers[internalServiceName] === undefined) {
-            return routesUtils.responseXMLBody(
-                errors.InvalidURI, null, res, log);
+            return routesUtils.responseXMLBody(errors.InvalidURI, null, res, log);
         }
-        return internalHandlers[internalServiceName](
-            clientInfo.clientIP, req, res, log, statsClient);
+        return internalHandlers[internalServiceName](clientInfo.clientIP, req, res, log, statsClient);
     }
 
     if (statsClient) {
@@ -272,9 +273,13 @@ export default function routes(
     } catch (err: any) {
         log.debug('could not normalize request', { error: err.stack });
         return routesUtils.responseXMLBody(
-            errorInstances.InvalidURI.customizeDescription('Could not parse the ' +
-                'specified URI. Check your restEndpoints configuration.'),
-            null, res, log);
+            errorInstances.InvalidURI.customizeDescription(
+                'Could not parse the ' + 'specified URI. Check your restEndpoints configuration.',
+            ),
+            null,
+            res,
+            log,
+        );
     }
 
     const { error, method } = checkUnsupportedRoutes(req.method);
@@ -284,12 +289,17 @@ export default function routes(
         return routesUtils.responseXMLBody(error, '', res, log);
     }
 
-    const bucketOrKeyError = checkBucketAndKey(req.bucketName, req.objectKey,
-        req.method, req.query, blacklistedPrefixes, log);
+    const bucketOrKeyError = checkBucketAndKey(
+        req.bucketName,
+        req.objectKey,
+        req.method,
+        req.query,
+        blacklistedPrefixes,
+        log,
+    );
 
     if (bucketOrKeyError) {
-        log.trace('error with bucket or key value',
-            { error: bucketOrKeyError });
+        log.trace('error with bucket or key value', { error: bucketOrKeyError });
         return routesUtils.responseXMLBody(bucketOrKeyError, null, res, log);
     }
 

--- a/lib/s3routes/routes.ts
+++ b/lib/s3routes/routes.ts
@@ -82,7 +82,7 @@ function checkTypes(
     req: http.IncomingMessage,
     res: http.ServerResponse,
     params: Params,
-    logger: RequestLogger,
+    logger: Logger,
     s3config?: any,
 ) {
     // In production mode, no need to dynamically assert all types
@@ -190,7 +190,7 @@ export default function routes(
     req: ArsenalRequest,
     res: http.ServerResponse,
     params: Params,
-    logger: RequestLogger,
+    logger: Logger,
     s3config?: any,
 ) {
     checkTypes(req, res, params, logger);
@@ -217,9 +217,7 @@ export default function routes(
         bodyLength: parseInt(req.headers['content-length'] || '0', 10) || 0,
     };
 
-    // logger is typed RequestLogger in this signature but is actually the
-    // parent Logger at runtime (it exposes newRequestLogger*).
-    const log = routesUtils.newRequestLoggerFromRequest(logger as unknown as Logger, req);
+    const log = routesUtils.newRequestLoggerFromRequest(logger, req);
 
     // @ts-expect-error
     if (res.serverAccessLog) {

--- a/lib/s3routes/routes.ts
+++ b/lib/s3routes/routes.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 
-import type { RequestLogger } from 'werelogs';
+import type { Logger, RequestLogger } from 'werelogs';
 
 import errors, { errorInstances } from '../errors';
 import routeGET from './routes/routeGET';
@@ -27,12 +27,6 @@ const routeMap = {
 };
 
 const isDevMode = process.env.NODE_ENV !== 'production';
-
-function isValidReqUids(reqUids: string | string[]) {
-    // baseline check, to avoid the risk of running into issues if
-    // users craft a large x-scal-request-uids header
-    return reqUids.length < 128;
-}
 
 function checkUnsupportedRoutes(reqMethod: keyof typeof routeMap) {
     const method = routeMap[reqMethod];
@@ -223,18 +217,9 @@ export default function routes(
         bodyLength: parseInt(req.headers['content-length'] || '0', 10) || 0,
     };
 
-    let reqUids = req.headers['x-scal-request-uids'];
-    if (reqUids !== undefined && !isValidReqUids(reqUids)) {
-        // simply ignore invalid id (any user can provide an
-        // invalid request ID through a crafted header)
-        reqUids = undefined;
-    }
-    const log =
-        reqUids !== undefined
-            ? // @ts-ignore
-              logger.newRequestLoggerFromSerializedUids(reqUids)
-            : // @ts-ignore
-              logger.newRequestLogger();
+    // logger is typed RequestLogger in this signature but is actually the
+    // parent Logger at runtime (it exposes newRequestLogger*).
+    const log = routesUtils.newRequestLoggerFromRequest(logger as unknown as Logger, req);
 
     // @ts-expect-error
     if (res.serverAccessLog) {

--- a/lib/s3routes/routesUtils.ts
+++ b/lib/s3routes/routesUtils.ts
@@ -63,12 +63,12 @@ export function toArsenalError(err: ArsenalError | VaultClientError | Error): Ar
     // For known error types, return the error instance as-is; otherwise, wrap it in an InternalError.
     // - VaultClient errors identify their type via the `code` property.
     // - ArsenalErrors received from external services (e.g., Metadata) use the `message` property for the error type.
-    return errorInstances[(err as Error).message || (err as VaultClientError).code] ||
+    return (
+        errorInstances[(err as Error).message || (err as VaultClientError).code] ||
         errorInstances.InternalError.customizeDescription(
-            (err as Error).message ||
-            (err as VaultClientError).description ||
-            errorInstances.InternalError.description,
-        );
+            (err as Error).message || (err as VaultClientError).description || errorInstances.InternalError.description,
+        )
+    );
 }
 
 /**
@@ -92,7 +92,8 @@ export function setCommonResponseHeaders(
                 } catch (e: any) {
                     log.debug('header can not be added to the response', {
                         header: headers[key],
-                        error: e.stack, method: 'setCommonResponseHeaders'
+                        error: e.stack,
+                        method: 'setCommonResponseHeaders',
                     });
                 }
             }
@@ -130,7 +131,6 @@ export function okHeaderResponse(
 }
 
 export const XMLResponseBackend = {
-
     /**
      * okXMLResponse - Response with XML body
      * @param xml - XML body as string
@@ -206,11 +206,7 @@ export const XMLResponseBackend = {
             xml.push(`<ArgumentName${counter}>${ArgumentName}</ArgumentName${counter}>`);
             xml.push(`<ArgumentValue${counter}>${ArgumentValue}</ArgumentValue${counter}>`);
         });
-        xml.push(
-            '<Resource></Resource>',
-            `<RequestId>${log.getSerializedUids()}</RequestId>`,
-            '</Error>',
-        );
+        xml.push('<Resource></Resource>', `<RequestId>${log.getSerializedUids()}</RequestId>`, '</Error>');
         const xmlStr = xml.join('');
         const bytesSent = Buffer.byteLength(xmlStr);
         log.addDefaultFields({ bytesSent });
@@ -228,7 +224,6 @@ export const XMLResponseBackend = {
 };
 
 export const JSONResponseBackend = {
-
     /**
      * okJSONResponse - Response with JSON body
      * @param json - JSON body as string
@@ -331,8 +326,7 @@ function okContentHeadersResponse(
             const headerName = headersArr[i];
             if (headerName.startsWith('x-amz-')) {
                 const translatedHeaderName = headerName.replace(/\//g, '|+2f');
-                resHeaders[translatedHeaderName] =
-                    resHeaders[headerName];
+                resHeaders[translatedHeaderName] = resHeaders[headerName];
                 if (translatedHeaderName !== headerName) {
                     delete resHeaders[headerName];
                 }
@@ -346,8 +340,7 @@ function okContentHeadersResponse(
         addHeaders['Content-Type'] = overrideParams['response-content-type'];
     }
     if (overrideParams['response-content-language']) {
-        addHeaders['Content-Language'] =
-            overrideParams['response-content-language'];
+        addHeaders['Content-Language'] = overrideParams['response-content-language'];
     }
     if (overrideParams['response-expires']) {
         addHeaders.Expires = overrideParams['response-expires'];
@@ -356,12 +349,10 @@ function okContentHeadersResponse(
         addHeaders['Cache-Control'] = overrideParams['response-cache-control'];
     }
     if (overrideParams['response-content-disposition']) {
-        addHeaders['Content-Disposition'] =
-            overrideParams['response-content-disposition'];
+        addHeaders['Content-Disposition'] = overrideParams['response-content-disposition'];
     }
     if (overrideParams['response-content-encoding']) {
-        addHeaders['Content-Encoding'] =
-            overrideParams['response-content-encoding'];
+        addHeaders['Content-Encoding'] = overrideParams['response-content-encoding'];
     }
     setCommonResponseHeaders(addHeaders, response, log);
     return response;
@@ -375,24 +366,17 @@ function retrieveDataAzure(
     response: http.ServerResponse,
     logger: RequestLogger,
 ) {
-    const errorHandlerFn = () => { response.socket?.destroy(); };
+    const errorHandlerFn = () => {
+        response.socket?.destroy();
+    };
     const current = locations.shift();
 
     response.on('error', () => {
         logger.error('error piping data from source');
         errorHandlerFn();
     });
-    const {
-        client,
-        implName,
-        config,
-        kms,
-        metadata,
-        locStorageCheckFn,
-        vault,
-    } = retrieveDataParams;
-    const data = new DataWrapper(
-        client, implName, config, kms, metadata, locStorageCheckFn, vault);
+    const { client, implName, config, kms, metadata, locStorageCheckFn, vault } = retrieveDataParams;
+    const data = new DataWrapper(client, implName, config, kms, metadata, locStorageCheckFn, vault);
     return data.get(current, response, logger, (err: Error | null) => {
         if (err) {
             logger.error('failed to get object from source', {
@@ -449,20 +433,12 @@ export function retrieveData(
 
     let first_byte_sent_timestamp: bigint = process.hrtime.bigint();
 
-    const {
-        client,
-        implName,
-        config,
-        kms,
-        metadata,
-        locStorageCheckFn,
-        vault,
-    } = retrieveDataParams;
-    const data = new DataWrapper(
-        client, implName, config, kms, metadata, locStorageCheckFn, vault);
-    return eachSeries(locations,
-        (current, next) => data.get(current, response, log,
-            (err: Error, readable: http.IncomingMessage) => {
+    const { client, implName, config, kms, metadata, locStorageCheckFn, vault } = retrieveDataParams;
+    const data = new DataWrapper(client, implName, config, kms, metadata, locStorageCheckFn, vault);
+    return eachSeries(
+        locations,
+        (current, next) =>
+            data.get(current, response, log, (err: Error, readable: http.IncomingMessage) => {
                 const cbOnce = jsutil.once(next);
                 // NB: readable is of IncomingMessage type
                 if (err) {
@@ -481,8 +457,7 @@ export function retrieveData(
                 // to the backend is started.
                 // @ts-expect-error
                 if (responseDestroyed || response.isclosed) {
-                    log.debug(
-                        'response destroyed before readable could stream');
+                    log.debug('response destroyed before readable could stream');
                     _destroyReadable(readable);
                     const responseErr = new Error();
                     // @ts-ignore
@@ -517,8 +492,8 @@ export function retrieveData(
                 currentStream = readable;
 
                 return readable.pipe(response, { end: false });
-            }
-        ), err => {
+            }),
+        err => {
             currentStream = null;
             storeServerAccessLogFields(
                 response,
@@ -555,19 +530,15 @@ function _responseBody(
     additionalHeaders?: Record<string, string> | null,
 ) {
     if (errCode && !response.headersSent) {
-        return responseBackend.errorResponse(errCode, response, log,
-            additionalHeaders);
+        return responseBackend.errorResponse(errCode, response, log, additionalHeaders);
     }
     if (!response.headersSent && payload) {
-        return responseBackend.okResponse(payload, response, log,
-            additionalHeaders);
+        return responseBackend.okResponse(payload, response, log, additionalHeaders);
     }
     return undefined;
 }
 
-function _computeContentLengthFromLocation(
-    dataLocations: { size: string | number }[],
-) {
+function _computeContentLengthFromLocation(dataLocations: { size: string | number }[]) {
     return dataLocations.reduce<number | undefined>((sum, location) => {
         if (sum !== undefined) {
             if (typeof location.size === 'number') {
@@ -580,13 +551,9 @@ function _computeContentLengthFromLocation(
     }, 0);
 }
 
-function _contentLengthMatchesLocations(
-    contentLength: string,
-    dataLocations: { size: string | number }[],
-) {
+function _contentLengthMatchesLocations(contentLength: string, dataLocations: { size: string | number }[]) {
     const sumSizes = _computeContentLengthFromLocation(dataLocations);
-    return sumSizes === undefined ||
-        sumSizes === Number.parseInt(contentLength, 10);
+    return sumSizes === undefined || sumSizes === Number.parseInt(contentLength, 10);
 }
 
 /**
@@ -605,8 +572,7 @@ export function responseXMLBody(
     log: RequestLogger,
     additionalHeaders?: Record<string, string>,
 ) {
-    return _responseBody(XMLResponseBackend, errCode, xml, response,
-        log, additionalHeaders);
+    return _responseBody(XMLResponseBackend, errCode, xml, response, log, additionalHeaders);
 }
 
 /**
@@ -625,8 +591,7 @@ export function responseJSONBody(
     log: RequestLogger,
     additionalHeaders?: Record<string, string> | null,
 ) {
-    return _responseBody(JSONResponseBackend, errCode, json, response,
-        log, additionalHeaders);
+    return _responseBody(JSONResponseBackend, errCode, json, response, log, additionalHeaders);
 }
 
 /**
@@ -646,8 +611,7 @@ export function responseNoBody(
     log: RequestLogger,
 ) {
     if (errCode && !response.headersSent) {
-        return XMLResponseBackend.errorResponse(errCode, response, log,
-            resHeaders);
+        return XMLResponseBackend.errorResponse(errCode, response, log, resHeaders);
     }
     if (!response.headersSent) {
         return okHeaderResponse(resHeaders, response, httpCode, log);
@@ -673,14 +637,12 @@ export function responseContentHeaders(
     log: RequestLogger,
 ) {
     if (errCode && !response.headersSent) {
-        return XMLResponseBackend.errorResponse(errCode, response, log,
-            resHeaders);
+        return XMLResponseBackend.errorResponse(errCode, response, log, resHeaders);
     }
     if (!response.headersSent) {
         // Undefined added as an argument since need to send range to
         // okContentHeadersResponse in responseStreamData
-        okContentHeadersResponse(overrideParams, resHeaders, response,
-            undefined, log);
+        okContentHeadersResponse(overrideParams, resHeaders, response, undefined, log);
         log.debug('response http code', { httpCode: 200 });
         response.writeHead(200);
     }
@@ -719,33 +681,26 @@ export function responseStreamData(
     log: RequestLogger,
 ) {
     if (errCode && !response.headersSent) {
-        return XMLResponseBackend.errorResponse(errCode, response, log,
-            resHeaders);
+        return XMLResponseBackend.errorResponse(errCode, response, log, resHeaders);
     }
     if (dataLocations !== null && !response.headersSent) {
         // sanity check of content length against individual data
         // locations to fetch
         const contentLength = resHeaders && resHeaders['Content-Length'];
-        if (contentLength !== undefined &&
-            !_contentLengthMatchesLocations(contentLength,
-                dataLocations)) {
+        if (contentLength !== undefined && !_contentLengthMatchesLocations(contentLength, dataLocations)) {
             log.error(
-                'logic error: total length of fetched data ' +
-                'locations does not match returned content-length',
-                { contentLength, dataLocations });
-            return XMLResponseBackend.errorResponse(errors.InternalError,
-                response, log,
-                resHeaders);
+                'logic error: total length of fetched data ' + 'locations does not match returned content-length',
+                { contentLength, dataLocations },
+            );
+            return XMLResponseBackend.errorResponse(errors.InternalError, response, log, resHeaders);
         }
     }
     if (!response.headersSent) {
         // Prepare the headers, but do not send them
         // as errors might still happen when retrieving the data
-        okContentHeadersResponse(overrideParams, resHeaders, response,
-            range, log);
+        okContentHeadersResponse(overrideParams, resHeaders, response, range, log);
     }
     if (dataLocations === null || _computeContentLengthFromLocation(dataLocations) === 0) {
-
         storeServerAccessLogFields(response, process.hrtime.bigint());
         return response.end(() => {
             log.end().info('responded with only metadata', {
@@ -840,11 +795,7 @@ export function errorHtmlResponse(
             '</ul>',
         );
     }
-    html.push(
-        '<hr/>',
-        '</body>',
-        '</html>',
-    );
+    html.push('<hr/>', '</body>', '</html>');
 
     const body = html.join('');
     storeServerAccessLogFields(response, process.hrtime.bigint(), error.message, body.length);
@@ -924,9 +875,16 @@ export function redirectRequest(
     corsHeaders: Record<string, string>,
     log: RequestLogger,
 ) {
-    const { justPath, redirectLocationHeader, hostName, protocol,
-        httpRedirectCode, replaceKeyPrefixWith,
-        replaceKeyWith, prefixFromRule } = routingInfo;
+    const {
+        justPath,
+        redirectLocationHeader,
+        hostName,
+        protocol,
+        httpRedirectCode,
+        replaceKeyPrefixWith,
+        replaceKeyWith,
+        prefixFromRule,
+    } = routingInfo;
 
     const redirectProtocol = protocol || encrypted ? 'https' : 'http';
     const redirectCode = httpRedirectCode || 301;
@@ -946,14 +904,12 @@ export function redirectRequest(
             // passed condition
             // and objectKey starts with this prefix.  replace just first
             // instance in objectKey with the replaceKeyPrefixWith value
-            redirectKey = objectKey.replace(prefixFromRule,
-                replaceKeyPrefixWith);
+            redirectKey = objectKey.replace(prefixFromRule, replaceKeyPrefixWith);
         } else {
             redirectKey = replaceKeyPrefixWith + objectKey;
         }
     }
-    let redirectLocation = justPath ? `/${redirectKey}` :
-        `${redirectProtocol}://${redirectHostName}/${redirectKey}`;
+    let redirectLocation = justPath ? `/${redirectKey}` : `${redirectProtocol}://${redirectHostName}/${redirectKey}`;
     if (!redirectKey && redirectLocationHeader && redirectLocation !== '/') {
         // remove hanging slash
         redirectLocation = redirectLocation.slice(0, -1);
@@ -1013,8 +969,14 @@ export function redirectRequestOnError(
     // This is reached only for website error document (GET only)
     const overrideErrorCode = error.flatten();
     overrideErrorCode.code = 301;
-    return streamUserErrorPage(ArsenalError.unflatten(overrideErrorCode)!,
-        dataLocations || [], retrieveDataParams, response, corsHeaders, log);
+    return streamUserErrorPage(
+        ArsenalError.unflatten(overrideErrorCode)!,
+        dataLocations || [],
+        retrieveDataParams,
+        response,
+        corsHeaders,
+        log,
+    );
 }
 
 /**
@@ -1025,13 +987,8 @@ export function redirectRequestOnError(
  * @returns result - returns object containing bucket
  * name and objectKey as key
  */
-export function getResourceNames(
-    request: http.IncomingMessage,
-    pathname: string,
-    validHosts: string[],
-) {
-    return getNamesFromReq(request, pathname,
-        getBucketNameFromHost(request, validHosts)!);
+export function getResourceNames(request: http.IncomingMessage, pathname: string, validHosts: string[]) {
+    return getNamesFromReq(request, pathname, getBucketNameFromHost(request, validHosts)!);
 }
 
 /**
@@ -1041,11 +998,7 @@ export function getResourceNames(
  * @param bucketNameFromHost - name of bucket from host name
  * @returns resources - returns object w. bucket and object as keys
  */
-export function getNamesFromReq(
-    request: http.IncomingMessage,
-    pathname: string,
-    bucketNameFromHost: string,
-) {
+export function getNamesFromReq(request: http.IncomingMessage, pathname: string, bucketNameFromHost: string) {
     const resources = {
         bucket: undefined as string | undefined,
         object: undefined as string | undefined,
@@ -1065,8 +1018,7 @@ export function getNamesFromReq(
         const reqHost = request.headers.host;
         const bracketIndex = reqHost.indexOf(']');
         const colonIndex = reqHost.lastIndexOf(':');
-        const hostLength = colonIndex > bracketIndex ?
-            colonIndex : reqHost.length;
+        const hostLength = colonIndex > bracketIndex ? colonIndex : reqHost.length;
         fullHost = reqHost.slice(0, hostLength);
     } else {
         fullHost = undefined;
@@ -1107,10 +1059,7 @@ export function getNamesFromReq(
  * @param validHosts - all region endpoints + websiteEndpoints
  * @throws in case the type of query could not be infered
  */
-export function getBucketNameFromHost(
-    request: http.IncomingMessage,
-    validHosts: string[],
-) {
+export function getBucketNameFromHost(request: http.IncomingMessage, validHosts: string[]) {
     const headers = request.headers;
     if (headers === undefined || headers.host === undefined) {
         throw new Error('bad request: no host in headers');
@@ -1119,12 +1068,10 @@ export function getBucketNameFromHost(
     const bracketIndex = reqHost.indexOf(']');
     const colonIndex = reqHost.lastIndexOf(':');
 
-    const hostLength = colonIndex > bracketIndex ?
-        colonIndex : reqHost.length;
+    const hostLength = colonIndex > bracketIndex ? colonIndex : reqHost.length;
     // If request is made using IPv6 (indicated by presence of brackets),
     // surrounding brackets should not be included in host var
-    const host = bracketIndex > -1 ?
-        reqHost.slice(1, hostLength - 1) : reqHost.slice(0, hostLength);
+    const host = bracketIndex > -1 ? reqHost.slice(1, hostLength - 1) : reqHost.slice(0, hostLength);
     // parseIp returns empty object if host is not valid IP
     // If host is an IP address, it's path-style
     if (Object.keys(ipCheck.parseIp(host)).length !== 0) {
@@ -1143,18 +1090,14 @@ export function getBucketNameFromHost(
             } else {
                 // bucketName should be shortest so that takes into account
                 // most specific potential hostname
-                bucketName =
-                    potentialBucketName.length < bucketName.length ?
-                        potentialBucketName : bucketName;
+                bucketName = potentialBucketName.length < bucketName.length ? potentialBucketName : bucketName;
             }
         }
     }
     if (bucketName) {
         return bucketName;
     }
-    throw new Error(
-        `bad request: hostname ${host} is not in valid endpoints`,
-    );
+    throw new Error(`bad request: hostname ${host} is not in valid endpoints`);
 }
 
 /**
@@ -1163,17 +1106,13 @@ export function getBucketNameFromHost(
  * @param validHosts - all region endpoints + websiteEndpoints
  * @return request object with additional attributes
  */
-export function normalizeRequest(
-    request: ArsenalRequest,
-    validHosts: string[],
-) {
+export function normalizeRequest(request: ArsenalRequest, validHosts: string[]) {
     const parsedUrl = url.parse(request.url!, true);
     request.query = parsedUrl.query as Record<string, string>;
     // TODO: make the namespace come from a config variable.
     request.namespace = 'default';
     // Parse bucket and/or object names from request
-    const resources = getResourceNames(request, parsedUrl.pathname!,
-        validHosts);
+    const resources = getResourceNames(request, parsedUrl.pathname!, validHosts);
     request.gotBucketNameFromHost = resources.gotBucketNameFromHost ?? false;
     request.bucketName = resources.bucket;
     request.objectKey = resources.object;
@@ -1182,11 +1121,10 @@ export function normalizeRequest(
     // For streaming v4 auth, the total body content length
     // without the chunk metadata is sent as
     // the x-amz-decoded-content-length
-    const contentLength = request.headers['x-amz-decoded-content-length'] ?
-        request.headers['x-amz-decoded-content-length'] :
-        request.headers['content-length'];
-    request.parsedContentLength =
-        Number.parseInt(contentLength?.toString() ?? '', 10);
+    const contentLength = request.headers['x-amz-decoded-content-length']
+        ? request.headers['x-amz-decoded-content-length']
+        : request.headers['content-length'];
+    request.parsedContentLength = Number.parseInt(contentLength?.toString() ?? '', 10);
 
     if (ALLOW_INVALID_META_HEADERS) {
         const headersArr = Object.keys(request.headers);
@@ -1195,10 +1133,8 @@ export function normalizeRequest(
             for (let i = 0; i < length; i++) {
                 const headerName = headersArr[i];
                 if (headerName.startsWith('x-amz-')) {
-                    const translatedHeaderName =
-                        headerName.replace(/\|\+2f/g, '/');
-                    request.headers[translatedHeaderName] =
-                        request.headers[headerName];
+                    const translatedHeaderName = headerName.replace(/\|\+2f/g, '/');
+                    request.headers[translatedHeaderName] = request.headers[headerName];
                     if (translatedHeaderName !== headerName) {
                         delete request.headers[headerName];
                     }
@@ -1217,8 +1153,7 @@ export function normalizeRequest(
  *  if false
  */
 export function isValidObjectKey(objectKey: string, prefixBlacklist: string[]) {
-    const invalidPrefix = prefixBlacklist.find(prefix =>
-        objectKey.startsWith(prefix));
+    const invalidPrefix = prefixBlacklist.find(prefix => objectKey.startsWith(prefix));
     if (invalidPrefix) {
         return { isValid: false, invalidPrefix };
     }
@@ -1228,9 +1163,11 @@ export function isValidObjectKey(objectKey: string, prefixBlacklist: string[]) {
 // To be validated only for key creation, such as PutObject, CopyObject, MPU
 export function validateObjectKeyLength(objectKey: string, maxByteLength?: number) {
     if (maxByteLength !== 0 && Buffer.byteLength(objectKey, 'utf8') > (maxByteLength || objectKeyByteLimit)) {
-        return errorInstances.KeyTooLong.customizeDescription('Object key is too ' +
-            'long. Maximum number of bytes allowed in keys is ' +
-            `${maxByteLength || objectKeyByteLimit}.`);
+        return errorInstances.KeyTooLong.customizeDescription(
+            'Object key is too ' +
+                'long. Maximum number of bytes allowed in keys is ' +
+                `${maxByteLength || objectKeyByteLimit}.`,
+        );
     }
     return null;
 }
@@ -1241,10 +1178,7 @@ export function validateObjectKeyLength(objectKey: string, maxByteLength?: numbe
  * @param prefixBlacklist - prefixes reserved for internal use
  * @return - returns true/false by testing bucket name against validation rules
  */
-export function isValidBucketName(
-    bucketname: string,
-    prefixBlacklist: string[],
-) {
+export function isValidBucketName(bucketname: string, prefixBlacklist: string[]) {
     if (constants.permittedCapitalizedBuckets[bucketname]) {
         return true;
     }
@@ -1292,10 +1226,10 @@ export function parseContentMD5(headers: http.IncomingHttpHeaders) {
 }
 
 /**
-* Report 500 to stats when an Internal Error occurs
-* @param err - Arsenal error
-* @param statsClient - StatsClient instance
-*/
+ * Report 500 to stats when an Internal Error occurs
+ * @param err - Arsenal error
+ * @param statsClient - StatsClient instance
+ */
 export function statsReport500(err?: ArsenalError | Error | null, statsClient?: StatsClient | null) {
     if (statsClient && err instanceof ArsenalError && err?.code === 500) {
         statsClient.report500('s3');

--- a/lib/s3routes/routesUtils.ts
+++ b/lib/s3routes/routesUtils.ts
@@ -2,7 +2,7 @@ import * as url from 'url';
 import * as http from 'http';
 import { eachSeries } from 'async';
 
-import type { RequestLogger } from 'werelogs';
+import type { Logger, RequestLogger } from 'werelogs';
 
 import * as ipCheck from '../ipCheck';
 import errors, { ArsenalError, errorInstances } from '../errors';
@@ -19,6 +19,18 @@ let serverHeaderValue = 'S3 Server';
 
 export function setServerHeader(value: string) {
     serverHeaderValue = value;
+}
+
+/**
+ * Build a request logger for an incoming request, seeding the werelogs UID
+ * chain from the `x-scal-request-uids` header when it carries a usable value.
+ */
+export function newRequestLoggerFromRequest(logger: Logger, req: http.IncomingMessage): RequestLogger {
+    const reqUids = req.headers['x-scal-request-uids'];
+    if (typeof reqUids !== 'string' || reqUids.length === 0 || reqUids.length >= constants.maxRequestUidsLength) {
+        return logger.newRequestLogger();
+    }
+    return logger.newRequestLoggerFromSerializedUids(reqUids);
 }
 
 function storeServerAccessLogFields(

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "engines": {
         "node": ">=20"
     },
-    "version": "8.4.19",
+    "version": "8.4.20",
     "config": {
         "mongodbMemoryServer": {
             "version": "8.0.23"

--- a/tests/unit/s3routes/routes.spec.js
+++ b/tests/unit/s3routes/routes.spec.js
@@ -3,6 +3,7 @@ const assert = require('assert');
 const sinon = require('sinon');
 const { routesUtils, routes } = require('../../../lib/s3routes');
 const { errorInstances } = require('../../../lib/errors');
+const { maxRequestUidsLength } = require('../../../lib/constants');
 
 const logger = new werelogs.Logger('routePut', 'debug', 'debug');
 
@@ -141,5 +142,80 @@ describe('routes', () => {
         expect(params.api.callApiMethod.calledOnce).toBe(true);
 
         routesUtils.isValidBucketName.restore();
+    });
+});
+
+describe('routesUtils.newRequestLoggerFromRequest', () => {
+    const parentLogger = new werelogs.Logger('reqUids', 'debug', 'debug');
+
+    const reqWith = headers => ({ headers });
+
+    it('seeds the chain from a valid x-scal-request-uids header', () => {
+        const fromUids = sinon.spy(parentLogger, 'newRequestLoggerFromSerializedUids');
+
+        routesUtils.newRequestLoggerFromRequest(parentLogger, reqWith({ 'x-scal-request-uids': 'parent-uid' }));
+
+        expect(fromUids.calledOnceWithExactly('parent-uid')).toBe(true);
+
+        fromUids.restore();
+    });
+
+    it('starts a fresh chain when the header is absent', () => {
+        const fromUids = sinon.spy(parentLogger, 'newRequestLoggerFromSerializedUids');
+        const fresh = sinon.spy(parentLogger, 'newRequestLogger');
+
+        routesUtils.newRequestLoggerFromRequest(parentLogger, reqWith({}));
+
+        expect(fromUids.called).toBe(false);
+        expect(fresh.calledOnce).toBe(true);
+
+        fromUids.restore();
+        fresh.restore();
+    });
+
+    it('starts a fresh chain when the header is empty', () => {
+        const fromUids = sinon.spy(parentLogger, 'newRequestLoggerFromSerializedUids');
+        const fresh = sinon.spy(parentLogger, 'newRequestLogger');
+
+        routesUtils.newRequestLoggerFromRequest(parentLogger, reqWith({ 'x-scal-request-uids': '' }));
+
+        expect(fromUids.called).toBe(false);
+        expect(fresh.calledOnce).toBe(true);
+
+        fromUids.restore();
+        fresh.restore();
+    });
+
+    it('ignores a header sent multiple times (array value)', () => {
+        const fromUids = sinon.spy(parentLogger, 'newRequestLoggerFromSerializedUids');
+        const fresh = sinon.spy(parentLogger, 'newRequestLogger');
+
+        routesUtils.newRequestLoggerFromRequest(parentLogger, reqWith({ 'x-scal-request-uids': ['a', 'b'] }));
+
+        expect(fromUids.called).toBe(false);
+        expect(fresh.calledOnce).toBe(true);
+
+        fromUids.restore();
+        fresh.restore();
+    });
+
+    it('seeds just under maxRequestUidsLength but ignores at/above it', () => {
+        const fromUids = sinon.spy(parentLogger, 'newRequestLoggerFromSerializedUids');
+        const fresh = sinon.spy(parentLogger, 'newRequestLogger');
+
+        routesUtils.newRequestLoggerFromRequest(
+            parentLogger,
+            reqWith({ 'x-scal-request-uids': 'x'.repeat(maxRequestUidsLength - 1) }),
+        );
+        routesUtils.newRequestLoggerFromRequest(
+            parentLogger,
+            reqWith({ 'x-scal-request-uids': 'x'.repeat(maxRequestUidsLength) }),
+        );
+
+        expect(fromUids.calledOnce).toBe(true);
+        expect(fresh.calledOnce).toBe(true);
+
+        fromUids.restore();
+        fresh.restore();
     });
 });

--- a/tests/unit/s3routes/routes.spec.js
+++ b/tests/unit/s3routes/routes.spec.js
@@ -107,8 +107,7 @@ describe('routes', () => {
 
         routes(req, res, params, logger, s3config);
 
-        assert.strictEqual(typeof res, 'object',
-            'bad routes param: res must be an object');
+        assert.strictEqual(typeof res, 'object', 'bad routes param: res must be an object');
         expect(params.api.callApiMethod.calledOnce).toBe(true);
 
         routesUtils.isValidBucketName.restore();
@@ -124,13 +123,11 @@ describe('routes', () => {
 
         routes(req, res, params, logger, s3config);
 
-        assert.strictEqual(typeof res, 'object',
-            'bad routes param: res must be an object');
+        assert.strictEqual(typeof res, 'object', 'bad routes param: res must be an object');
         expect(params.api.callApiMethod.calledOnce).toBe(true);
 
         routesUtils.isValidBucketName.restore();
     });
-
 
     it('should call the appropriate route method', () => {
         req.method = 'GET';
@@ -140,8 +137,7 @@ describe('routes', () => {
 
         routes(req, res, params, logger, s3config);
 
-        assert.strictEqual(typeof res, 'object',
-            'bad routes param: res must be an object');
+        assert.strictEqual(typeof res, 'object', 'bad routes param: res must be an object');
         expect(params.api.callApiMethod.calledOnce).toBe(true);
 
         routesUtils.isValidBucketName.restore();


### PR DESCRIPTION
`routes.ts` built a request logger from the inbound `x-scal-request-uids` header inline — read the header, guard its length (a bare `128` literal), then seed the werelogs UID chain or start a fresh one. Consumers that need the same behaviour (e.g. vault2's SSO/SAML request-logger seeding in scality/vault2#217) had to reimplement the whole pattern, and the copies had already drifted on edge cases.

This centralizes it:
- Export `maxRequestUidsLength = 128` from `lib/constants.ts`.
- Add `routesUtils.newRequestLoggerFromRequest(logger, req)` that owns the header name, the length cap, and the seed-or-fresh decision; `routes.ts` now uses it (dropping the private `isValidReqUids` and the inline block, plus two `@ts-ignore`s).

Consumers (scality/vault2#217) collapse their copy to a one-line delegate.

The shared helper also tightens two edge cases the old inline code handled loosely, so the S3 path now matches the intended policy:
- an empty header value starts a fresh chain instead of seeding from `''`;
- a header sent multiple times (array value) starts a fresh chain instead of passing an array to `newRequestLoggerFromSerializedUids`.

Tests: direct coverage of the helper (valid / absent / empty / array / length boundary).

The touched files were prettier-dirty on the base branch, so the first commit reformats them and the functional change lands prettier-clean on top.

Issue: ARSN-615