### PR TITLE
Publish releases under a per-line dist-tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -137,7 +137,7 @@ jobs:
           if [ -n "$(npm view "@scality/arsenal@$VERSION" version 2>/dev/null)" ]; then
             echo "::notice::@scality/arsenal@$VERSION already on GitHub Packages; skipping"
           else
-            npm publish *.tgz --tag "v${VERSION%.*}"
+            npm publish *.tgz --tag "latest-${VERSION%.*}"
           fi
 
   publish-npm:
@@ -166,7 +166,7 @@ jobs:
           if [ -n "$(npm view "@scality/arsenal@$VERSION" version 2>/dev/null)" ]; then
             echo "::notice::@scality/arsenal@$VERSION already on npm; skipping"
           else
-            npm publish *.tgz --provenance --tag "v${VERSION%.*}"
+            npm publish *.tgz --provenance --tag "latest-${VERSION%.*}"
           fi
 
   release:


### PR DESCRIPTION
## Summary

The release workflow's publish jobs failed on every run with:

```
npm error Tag name must not be a valid SemVer range: v8.4
```

`--tag "v${VERSION%.*}"` produces `v8.4` / `v8.5`, and npm rejects any dist-tag that parses as a semver range. Publish under a **per-line tag `latest-${VERSION%.*}`** (`latest-8.4`, `latest-8.5`) in both `publish-github` and `publish-npm` instead:

- npm-valid — a `<word>-<version>` tag isn't a semver range, unlike `v8.4`;
- marks the newest release of each maintained line, without an older line moving the shared `latest` tag;
- mirrors express's `latest-<major>` dist-tag convention.

A plain `latest` was considered but rejected (an older line released after a newer one would move `latest` backward).

Surfaced by the first live releases after ARSN-605 (`8.4.20`, `8.5.10`) — both built fine and died at the publish step. The `npm view` idempotency check is unchanged.

Issue: ARSN-616
