### PR TITLE
Support conditional writes on versioned puts in putObjectVerCase3

### DIFF
--- a/lib/storage/metadata/conditions.js
+++ b/lib/storage/metadata/conditions.js
@@ -12,6 +12,7 @@ const supportedOperators = {
 
 const supportedStructuralOperators = {
     $or: true,
+    $and: true,
 };
 
 // supports strings and numbers

--- a/lib/storage/metadata/conditions.js
+++ b/lib/storage/metadata/conditions.js
@@ -16,45 +16,27 @@ const supportedStructuralOperators = {
 };
 
 // supports strings and numbers
-const _operatorType1 = joi.string().valid(
-    '$gt',
-    '$gte',
-    '$lt',
-    '$lte',
-);
+const _operatorType1 = joi.string().valid('$gt', '$gte', '$lt', '$lte');
 
 // supports strings, numbers, and boolean
-const _operatorType2 = joi.string().valid(
-    '$eq',
-    '$ne',
-);
+const _operatorType2 = joi.string().valid('$eq', '$ne');
 
 const _operatorType3 = joi.string().valid('$exists');
 
-const _valueType1 = joi.alternatives([
-    joi.string(),
-    joi.number(),
-]);
+const _valueType1 = joi.alternatives([joi.string(), joi.number()]);
 
-const _valueType2 = joi.alternatives([
-    joi.string(),
-    joi.number(),
-    joi.boolean(),
-]);
+const _valueType2 = joi.alternatives([joi.string(), joi.number(), joi.boolean()]);
 
 const _valueType3 = joi.boolean();
 
-const queryObject = joi.object({})
+const queryObject = joi
+    .object({})
     .pattern(_operatorType1, _valueType1)
     .pattern(_operatorType2, _valueType2)
     .pattern(_operatorType3, _valueType3)
     .xor(...Object.keys(supportedOperators));
 
-const metadataCondObject = joi.alternatives([
-    _valueType1,
-    _valueType2,
-    queryObject,
-]);
+const metadataCondObject = joi.alternatives([_valueType1, _valueType2, queryObject]);
 
 function validateConditionsObject(obj) {
     if (obj === undefined) {

--- a/lib/storage/metadata/conditions.js
+++ b/lib/storage/metadata/conditions.js
@@ -7,6 +7,11 @@ const supportedOperators = {
     $gte: true,
     $lt: true,
     $lte: true,
+    $exists: true,
+};
+
+const supportedStructuralOperators = {
+    $or: true,
 };
 
 // supports strings and numbers
@@ -23,6 +28,8 @@ const _operatorType2 = joi.string().valid(
     '$ne',
 );
 
+const _operatorType3 = joi.string().valid('$exists');
+
 const _valueType1 = joi.alternatives([
     joi.string(),
     joi.number(),
@@ -34,9 +41,12 @@ const _valueType2 = joi.alternatives([
     joi.boolean(),
 ]);
 
+const _valueType3 = joi.boolean();
+
 const queryObject = joi.object({})
     .pattern(_operatorType1, _valueType1)
     .pattern(_operatorType2, _valueType2)
+    .pattern(_operatorType3, _valueType3)
     .xor(...Object.keys(supportedOperators));
 
 const metadataCondObject = joi.alternatives([
@@ -58,5 +68,6 @@ function validateConditionsObject(obj) {
 
 module.exports = {
     supportedOperators,
+    supportedStructuralOperators,
     validateConditionsObject,
 };

--- a/lib/storage/metadata/mongoclient/MongoClientInterface.ts
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.ts
@@ -62,6 +62,7 @@ const __UUID = 'uuid';
 const PENSIEVE = 'PENSIEVE';
 const __COUNT_ITEMS = 'countitems';
 const ASYNC_REPAIR_TIMEOUT = 15000;
+const MONGODB_DUPLICATE_KEY_ERROR = 11000;
 
 const MONGO_CONNECT_TIMEOUT_MS = process.env.MONGO_CONNECT_TIMEOUT_MS;
 const MONGO_SOCKET_TIMEOUT_MS = process.env.MONGO_SOCKET_TIMEOUT_MS;
@@ -952,7 +953,7 @@ class MongoClientInterface {
                  * are the same (affecting the first operation), or if the master
                  * version is updated concurrently.
                  */
-                if (err.code === 11000) {
+                if (err.code === MONGODB_DUPLICATE_KEY_ERROR) {
                     log.debug('putObjectVerCase1: error putting object version', {
                         code: err.code,
                         error: err.errmsg,
@@ -1072,7 +1073,7 @@ class MongoClientInterface {
             })
                 .then(() => callback(null, `{"versionId": "${objVal.versionId}"}`))
                 .catch(err => {
-                    if (err.code === 11000) {
+                    if (err.code === MONGODB_DUPLICATE_KEY_ERROR) {
                         // Failed condition turns the version upsert into an insert of an existing
                         // _id (dup-key). index 0 = version op in the ordered bulkWrite, so it's
                         // the version write that failed the condition.
@@ -1270,7 +1271,7 @@ class MongoClientInterface {
                             // we accept that the update fails if
                             // condition is not met, meaning that a more
                             // recent master was already in place
-                            if (err.code === 11000) {
+                            if (err.code === MONGODB_DUPLICATE_KEY_ERROR) {
                                 return cb(null, `{"versionId": "${objVal.versionId}"}`);
                             }
                             log.error('putObjectVerCase4: error upserting master', { error: err.message });
@@ -2731,7 +2732,7 @@ class MongoClientInterface {
                 return cb(null);
             })
             .catch(err => {
-                if (err.code === 11000) {
+                if (err.code === MONGODB_DUPLICATE_KEY_ERROR) {
                     // duplicate key error
                     return cb(errors.KeyAlreadyExists);
                 }

--- a/lib/storage/metadata/mongoclient/MongoClientInterface.ts
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.ts
@@ -1107,7 +1107,8 @@ class MongoClientInterface {
             }
         }
 
-        return c.findOne({ _id: masterKey })
+        return c
+            .findOne({ _id: masterKey })
             .then(checkObj => {
                 const objUpsert = !checkObj;
                 // initiating array of operations with version creation/update

--- a/lib/storage/metadata/mongoclient/MongoClientInterface.ts
+++ b/lib/storage/metadata/mongoclient/MongoClientInterface.ts
@@ -1072,28 +1072,48 @@ class MongoClientInterface {
             })
                 .then(() => callback(null, `{"versionId": "${objVal.versionId}"}`))
                 .catch(err => {
-                    log.error('putObjectVerCase3: error putting object version', { error: err.message });
                     if (err.code === 11000) {
+                        // Failed condition turns the version upsert into an insert of an existing
+                        // _id (dup-key). index 0 = version op in the ordered bulkWrite, so it's
+                        // the version write that failed the condition.
+                        if (params.conditions && err.writeErrors?.[0]?.index === 0) {
+                            log.info('putObjectVerCase3: version condition not met, rejecting write', {
+                                versionKey,
+                            });
+                            return callback(errors.PreconditionFailed);
+                        }
                         // We want duplicate key error logged however in
                         // case of the race condition mentioned above, the
                         // InternalError will allow for automatic retries
                         log.error('putObjectVerCase3:', errors.KeyAlreadyExists);
                         return callback(errors.InternalError);
                     }
+                    log.error('putObjectVerCase3: error putting object version', { error: err.message });
                     return callback(errors.NoSuchVersion);
                 });
         };
 
-        c.findOne({ _id: masterKey })
+        // a version failing the condition degenerates the upsert into an insert, raising a duplicate key error
+        const versionFilter: Record<string, any> = { _id: versionKey };
+        if (params.conditions && Object.keys(params.conditions).length > 0) {
+            try {
+                MongoUtils.translateConditions(0, 'value', versionFilter, params.conditions);
+            } catch (err) {
+                log.error('putObjectVerCase3: error creating mongodb filter', {
+                    error: reshapeExceptionError(err as ErrorLike),
+                });
+                return cb(errors.InternalError);
+            }
+        }
+
+        return c.findOne({ _id: masterKey })
             .then(checkObj => {
                 const objUpsert = !checkObj;
                 // initiating array of operations with version creation/update
                 const ops: AnyBulkWriteOperation<ObjectMetastoreDocument>[] = [
                     {
                         updateOne: {
-                            filter: {
-                                _id: versionKey,
-                            },
+                            filter: versionFilter,
                             update: {
                                 $set: {
                                     _id: versionKey,

--- a/lib/storage/metadata/mongoclient/utils.ts
+++ b/lib/storage/metadata/mongoclient/utils.ts
@@ -79,8 +79,13 @@ function _assignCondition(prefix: string, object: Record<string, any>, cond: Con
  * Translates a structural operator into a mongodb filter.
  * Each item is translated on its own, sharing the parent prefix.
  */
-function _assignStructuralOperator(depth: number, prefix: string, object: Record<string, any>, op: string,
-    items: Condition): void {
+function _assignStructuralOperator(
+    depth: number,
+    prefix: string,
+    object: Record<string, any>,
+    op: string,
+    items: Condition,
+): void {
     if (!Array.isArray(items) || items.length === 0) {
         throw errors.InternalError;
     }

--- a/lib/storage/metadata/mongoclient/utils.ts
+++ b/lib/storage/metadata/mongoclient/utils.ts
@@ -1,4 +1,4 @@
-import { supportedOperators, validateConditionsObject } from '../conditions';
+import { supportedOperators, supportedStructuralOperators, validateConditionsObject } from '../conditions';
 import { VersioningConstants } from '../../../versioning/constants';
 import errors from '../../../errors';
 import { stampActiveTraceContext } from '../captureTraceContext';
@@ -76,6 +76,25 @@ function _assignCondition(prefix: string, object: Record<string, any>, cond: Con
 }
 
 /*
+ * Translates a structural operator into a mongodb filter.
+ * Each item is translated on its own, sharing the parent prefix.
+ */
+function _assignStructuralOperator(depth: number, prefix: string, object: Record<string, any>, op: string,
+    items: Condition): void {
+    if (!Array.isArray(items) || items.length === 0) {
+        throw errors.InternalError;
+    }
+    if (object[op] !== undefined) {
+        throw errors.InternalError;
+    }
+    object[op] = items.map((item: Condition) => {
+        const subFilter: Record<string, any> = {};
+        translateConditions(depth + 1, prefix, subFilter, item);
+        return subFilter;
+    });
+}
+
+/*
  * converts conditions object into mongodb-usable filters
  * Ex:
  *  {                              {
@@ -116,6 +135,10 @@ function translateConditions(depth: number, prefix: string, object: Record<strin
 
     if (opFields.length === 0) {
         for (const f of fields) {
+            if (supportedStructuralOperators[f]) {
+                _assignStructuralOperator(depth, prefix, object, f, (cond as Record<string, any>)[f]);
+                continue;
+            }
             if (f.startsWith('$')) {
                 throw errors.InternalError;
             }

--- a/lib/storage/metadata/mongoclient/utils.ts
+++ b/lib/storage/metadata/mongoclient/utils.ts
@@ -85,6 +85,9 @@ function _assignStructuralOperator(depth: number, prefix: string, object: Record
         throw errors.InternalError;
     }
     if (object[op] !== undefined) {
+        // Two sibling fields both containing the same structural operator cannot be
+        // merged into a single JS object without losing one. Use $and at the caller
+        // level to express this: { $and: [{ fieldA: { $or: [...] } }, { fieldB: { $or: [...] } }] }
         throw errors.InternalError;
     }
     object[op] = items.map((item: Condition) => {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "engines": {
         "node": ">=20"
     },
-    "version": "8.5.13",
+    "version": "8.5.14",
     "config": {
         "mongodbMemoryServer": {
             "version": "8.0.23"

--- a/tests/functional/metadata/mongodb/putObject.spec.js
+++ b/tests/functional/metadata/mongodb/putObject.spec.js
@@ -7,8 +7,7 @@ const { MongoMemoryReplSet } = require('mongodb-memory-server');
 const { errors, versioning } = require('../../../../index');
 const logger = new werelogs.Logger('MongoClientInterface', 'debug', 'debug');
 const BucketInfo = require('../../../../lib/models/BucketInfo').default;
-const MetadataWrapper =
-    require('../../../../lib/storage/metadata/MetadataWrapper');
+const MetadataWrapper = require('../../../../lib/storage/metadata/MetadataWrapper');
 const { formatVersionKey } = require('../../../../lib/storage/metadata/mongoclient/utils');
 const { VersionID } = require('../../../../lib/versioning');
 const { BucketVersioningKeyFormat } = versioning.VersioningConstants;
@@ -21,9 +20,7 @@ const VERSION_ID = '98451712418844999999RG001  22019.0';
 
 const mongoserver = new MongoMemoryReplSet({
     debug: false,
-    instanceOpts: [
-        { port: 27021 },
-    ],
+    instanceOpts: [{ port: 27021 }],
     replSet: {
         name: 'rs0',
         count: 1,
@@ -42,18 +39,25 @@ describe('MongoClientInterface:metadata.putObjectMD', () => {
     let collection;
 
     function getObject(key, cb) {
-        collection.findOne({
-            _id: key,
-        }, {}).then(doc => {
-            if (!doc) {
-                return cb(errors.NoSuchKey);
-            }
-            return cb(null, doc.value);
-        }).catch(err => cb(err));
+        collection
+            .findOne(
+                {
+                    _id: key,
+                },
+                {},
+            )
+            .then(doc => {
+                if (!doc) {
+                    return cb(errors.NoSuchKey);
+                }
+                return cb(null, doc.value);
+            })
+            .catch(err => cb(err));
     }
 
     function getObjectCount(cb) {
-        collection.countDocuments()
+        collection
+            .countDocuments()
             .then(count => cb(null, count))
             .catch(err => cb(err));
     }
@@ -77,12 +81,17 @@ describe('MongoClientInterface:metadata.putObjectMD', () => {
     });
 
     afterAll(done => {
-        async.series([
-            next => metadata.close(next),
-            next => mongoserver.stop()
-                .then(() => next())
-                .catch(next),
-        ], done);
+        async.series(
+            [
+                next => metadata.close(next),
+                next =>
+                    mongoserver
+                        .stop()
+                        .then(() => next())
+                        .catch(next),
+            ],
+            done,
+        );
     });
 
     variations.forEach(variation => {
@@ -116,19 +125,23 @@ describe('MongoClientInterface:metadata.putObjectMD', () => {
                     _isNFS: null,
                     ingestion: null,
                 });
-                async.series([
-                    next => {
-                        metadata.client.defaultBucketKeyFormat = variation.vFormat;
-                        return next();
-                    },
-                    next => metadata.createBucket(BUCKET_NAME, bucketMD, logger, err => {
-                        if (err) {
-                            return next(err);
-                        }
-                        collection = metadata.client.getCollection(BUCKET_NAME);
-                        return next();
-                    }),
-                ], done);
+                async.series(
+                    [
+                        next => {
+                            metadata.client.defaultBucketKeyFormat = variation.vFormat;
+                            return next();
+                        },
+                        next =>
+                            metadata.createBucket(BUCKET_NAME, bucketMD, logger, err => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                collection = metadata.client.getCollection(BUCKET_NAME);
+                                return next();
+                            }),
+                    ],
+                    done,
+                );
             });
 
             afterEach(done => {
@@ -147,23 +160,27 @@ describe('MongoClientInterface:metadata.putObjectMD', () => {
                     versionId: null,
                     repairMaster: null,
                 };
-                async.series([
-                    next => metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next),
-                    next => {
-                        const key = variation.vFormat === 'v0' ? 'test-object' : '\x7fMtest-object';
-                        getObject(key, (err, object) => {
-                            assert.deepStrictEqual(err, null);
-                            assert.strictEqual(object.key, OBJECT_NAME);
-                            return next();
-                        });
-                    },
-                    // When versionning not active only one document is created (master)
-                    next => getObjectCount((err, count) => {
-                        assert.deepStrictEqual(err, null);
-                        assert.strictEqual(count, 1);
-                        return next();
-                    }),
-                ], done);
+                async.series(
+                    [
+                        next => metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next),
+                        next => {
+                            const key = variation.vFormat === 'v0' ? 'test-object' : '\x7fMtest-object';
+                            getObject(key, (err, object) => {
+                                assert.deepStrictEqual(err, null);
+                                assert.strictEqual(object.key, OBJECT_NAME);
+                                return next();
+                            });
+                        },
+                        // When versionning not active only one document is created (master)
+                        next =>
+                            getObjectCount((err, count) => {
+                                assert.deepStrictEqual(err, null);
+                                assert.strictEqual(count, 1);
+                                return next();
+                            }),
+                    ],
+                    done,
+                );
             });
 
             it(`Should update the metadata ${variation.it}`, done => {
@@ -177,29 +194,33 @@ describe('MongoClientInterface:metadata.putObjectMD', () => {
                     versionId: null,
                     repairMaster: null,
                 };
-                async.series([
-                    next => metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next),
-                    next => {
-                        objVal.updated = true;
-                        metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next);
-                    },
-                    // object metadata must be updated
-                    next => {
-                        const key = variation.vFormat === 'v0' ? 'test-object' : '\x7fMtest-object';
-                        getObject(key, (err, object) => {
-                            assert.deepStrictEqual(err, null);
-                            assert.strictEqual(object.key, OBJECT_NAME);
-                            assert.strictEqual(object.updated, true);
-                            return next();
-                        });
-                    },
-                    // Only a master version should be created
-                    next => getObjectCount((err, count) => {
-                        assert.deepStrictEqual(err, null);
-                        assert.strictEqual(count, 1);
-                        return next();
-                    }),
-                ], done);
+                async.series(
+                    [
+                        next => metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next),
+                        next => {
+                            objVal.updated = true;
+                            metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next);
+                        },
+                        // object metadata must be updated
+                        next => {
+                            const key = variation.vFormat === 'v0' ? 'test-object' : '\x7fMtest-object';
+                            getObject(key, (err, object) => {
+                                assert.deepStrictEqual(err, null);
+                                assert.strictEqual(object.key, OBJECT_NAME);
+                                assert.strictEqual(object.updated, true);
+                                return next();
+                            });
+                        },
+                        // Only a master version should be created
+                        next =>
+                            getObjectCount((err, count) => {
+                                assert.deepStrictEqual(err, null);
+                                assert.strictEqual(count, 1);
+                                return next();
+                            }),
+                    ],
+                    done,
+                );
             });
 
             it(`Should put versionned object with the specific versionId ${variation.it}`, done => {
@@ -213,25 +234,29 @@ describe('MongoClientInterface:metadata.putObjectMD', () => {
                     versionId: VERSION_ID,
                     repairMaster: null,
                 };
-                async.series([
-                    next => metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next),
-                    // checking if metadata corresponds to what was given to the function
-                    next => {
-                        const key = variation.vFormat === 'v0' ? 'test-object' : '\x7fMtest-object';
-                        getObject(key, (err, object) => {
-                            assert.deepStrictEqual(err, null);
-                            assert.strictEqual(object.key, OBJECT_NAME);
-                            assert.strictEqual(object.versionId, VERSION_ID);
-                            return next();
-                        });
-                    },
-                    // We'll have one master and one version
-                    next => getObjectCount((err, count) => {
-                        assert.deepStrictEqual(err, null);
-                        assert.strictEqual(count, 2);
-                        return next();
-                    }),
-                ], done);
+                async.series(
+                    [
+                        next => metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next),
+                        // checking if metadata corresponds to what was given to the function
+                        next => {
+                            const key = variation.vFormat === 'v0' ? 'test-object' : '\x7fMtest-object';
+                            getObject(key, (err, object) => {
+                                assert.deepStrictEqual(err, null);
+                                assert.strictEqual(object.key, OBJECT_NAME);
+                                assert.strictEqual(object.versionId, VERSION_ID);
+                                return next();
+                            });
+                        },
+                        // We'll have one master and one version
+                        next =>
+                            getObjectCount((err, count) => {
+                                assert.deepStrictEqual(err, null);
+                                assert.strictEqual(count, 2);
+                                return next();
+                            }),
+                    ],
+                    done,
+                );
             });
 
             it(`Should put new version and update master ${variation.it}`, done => {
@@ -247,32 +272,37 @@ describe('MongoClientInterface:metadata.putObjectMD', () => {
                 };
                 let versionId = null;
 
-                async.series([
-                    // We first create a master and a version
-                    next => metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, (err, data) => {
-                        assert.deepStrictEqual(err, null);
-                        versionId = JSON.parse(data).versionId;
-                        return next();
-                    }),
-                    // We put another version of the object
-                    next => metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next),
-                    // Master must be updated
-                    next => {
-                        const key = variation.vFormat === 'v0' ? 'test-object' : '\x7fMtest-object';
-                        getObject(key, (err, object) => {
-                            assert.deepStrictEqual(err, null);
-                            assert.strictEqual(object.key, OBJECT_NAME);
-                            assert.notStrictEqual(object.versionId, versionId);
-                            return next();
-                        });
-                    },
-                    // we'll have two versions and one master
-                    next => getObjectCount((err, count) => {
-                        assert.deepStrictEqual(err, null);
-                        assert.strictEqual(count, 3);
-                        return next();
-                    }),
-                ], done);
+                async.series(
+                    [
+                        // We first create a master and a version
+                        next =>
+                            metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, (err, data) => {
+                                assert.deepStrictEqual(err, null);
+                                versionId = JSON.parse(data).versionId;
+                                return next();
+                            }),
+                        // We put another version of the object
+                        next => metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next),
+                        // Master must be updated
+                        next => {
+                            const key = variation.vFormat === 'v0' ? 'test-object' : '\x7fMtest-object';
+                            getObject(key, (err, object) => {
+                                assert.deepStrictEqual(err, null);
+                                assert.strictEqual(object.key, OBJECT_NAME);
+                                assert.notStrictEqual(object.versionId, versionId);
+                                return next();
+                            });
+                        },
+                        // we'll have two versions and one master
+                        next =>
+                            getObjectCount((err, count) => {
+                                assert.deepStrictEqual(err, null);
+                                assert.strictEqual(count, 3);
+                                return next();
+                            }),
+                    ],
+                    done,
+                );
             });
 
             it(`Should update master when versionning is disabled ${variation.it}`, done => {
@@ -287,36 +317,41 @@ describe('MongoClientInterface:metadata.putObjectMD', () => {
                     repairMaster: null,
                 };
                 let versionId = null;
-                async.series([
-                    // We first create a new version and master
-                    next => metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, (err, data) => {
-                        assert.deepStrictEqual(err, null);
-                        versionId = JSON.parse(data).versionId;
-                        return next();
-                    }),
-                    next => {
-                        // Disabling versionning and putting new version
-                        params.versioning = false;
-                        params.versionId = '';
-                        return metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next);
-                    },
-                    // Master must be updated
-                    next => {
-                        const key = variation.vFormat === 'v0' ? 'test-object' : '\x7fMtest-object';
-                        getObject(key, (err, object) => {
-                            assert.deepStrictEqual(err, null);
-                            assert.strictEqual(object.key, OBJECT_NAME);
-                            assert.notStrictEqual(object.versionId, versionId);
-                            return next();
-                        });
-                    },
-                    // The second put shouldn't create a new version
-                    next => getObjectCount((err, count) => {
-                        assert.deepStrictEqual(err, null);
-                        assert.strictEqual(count, 2);
-                        return next();
-                    }),
-                ], done);
+                async.series(
+                    [
+                        // We first create a new version and master
+                        next =>
+                            metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, (err, data) => {
+                                assert.deepStrictEqual(err, null);
+                                versionId = JSON.parse(data).versionId;
+                                return next();
+                            }),
+                        next => {
+                            // Disabling versionning and putting new version
+                            params.versioning = false;
+                            params.versionId = '';
+                            return metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next);
+                        },
+                        // Master must be updated
+                        next => {
+                            const key = variation.vFormat === 'v0' ? 'test-object' : '\x7fMtest-object';
+                            getObject(key, (err, object) => {
+                                assert.deepStrictEqual(err, null);
+                                assert.strictEqual(object.key, OBJECT_NAME);
+                                assert.notStrictEqual(object.versionId, versionId);
+                                return next();
+                            });
+                        },
+                        // The second put shouldn't create a new version
+                        next =>
+                            getObjectCount((err, count) => {
+                                assert.deepStrictEqual(err, null);
+                                assert.strictEqual(count, 2);
+                                return next();
+                            }),
+                    ],
+                    done,
+                );
             });
 
             it(`Should update latest version and repair master ${variation.it}`, done => {
@@ -330,33 +365,37 @@ describe('MongoClientInterface:metadata.putObjectMD', () => {
                     versionId: VERSION_ID,
                     repairMaster: null,
                 };
-                async.series([
-                    // We first create a new version and master
-                    next => metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next),
-                    next => {
-                        // Updating the version and repairing master
-                        params.repairMaster = true;
-                        objVal.updated = true;
-                        return metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next);
-                    },
-                    // Master must be updated
-                    next => {
-                        const key = variation.vFormat === 'v0' ? 'test-object' : '\x7fMtest-object';
-                        getObject(key, (err, object) => {
-                            assert.deepStrictEqual(err, null);
-                            assert.strictEqual(object.key, OBJECT_NAME);
-                            assert.strictEqual(object.versionId, VERSION_ID);
-                            assert.strictEqual(object.updated, true);
-                            return next();
-                        });
-                    },
-                    // The second put shouldn't create a new version
-                    next => getObjectCount((err, count) => {
-                        assert.deepStrictEqual(err, null);
-                        assert.strictEqual(count, 2);
-                        return next();
-                    }),
-                ], done);
+                async.series(
+                    [
+                        // We first create a new version and master
+                        next => metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next),
+                        next => {
+                            // Updating the version and repairing master
+                            params.repairMaster = true;
+                            objVal.updated = true;
+                            return metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next);
+                        },
+                        // Master must be updated
+                        next => {
+                            const key = variation.vFormat === 'v0' ? 'test-object' : '\x7fMtest-object';
+                            getObject(key, (err, object) => {
+                                assert.deepStrictEqual(err, null);
+                                assert.strictEqual(object.key, OBJECT_NAME);
+                                assert.strictEqual(object.versionId, VERSION_ID);
+                                assert.strictEqual(object.updated, true);
+                                return next();
+                            });
+                        },
+                        // The second put shouldn't create a new version
+                        next =>
+                            getObjectCount((err, count) => {
+                                assert.deepStrictEqual(err, null);
+                                assert.strictEqual(count, 2);
+                                return next();
+                            }),
+                    ],
+                    done,
+                );
             });
 
             it(`should fail on versionID conflict when putting a new version ${variation.it}`, done => {
@@ -370,23 +409,28 @@ describe('MongoClientInterface:metadata.putObjectMD', () => {
                 };
 
                 // simulate a versionId collision by always generating the same versionId
-                const genVID = sinon.stub(VersionID, 'generateVersionId')
-                    .returns('test-version-id');
+                const genVID = sinon.stub(VersionID, 'generateVersionId').returns('test-version-id');
 
-                async.series([
-                    // We first create a master and a version
-                    next => metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next),
-                    // We put another version of the object with the same versionId
-                    next => metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next),
-                ], err => {
-                    assert(err.is.InternalError,
-                        `expected InternalError, got ${err.name} with message: ${err.message}`,
-                    );
-                    // make sure the retry triggered on the first collision detection
-                    assert(genVID.calledThrice,
-                        `expected generateVersionId to be called thrice, got ${genVID.callCount} times`);
-                    done();
-                });
+                async.series(
+                    [
+                        // We first create a master and a version
+                        next => metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next),
+                        // We put another version of the object with the same versionId
+                        next => metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next),
+                    ],
+                    err => {
+                        assert(
+                            err.is.InternalError,
+                            `expected InternalError, got ${err.name} with message: ${err.message}`,
+                        );
+                        // make sure the retry triggered on the first collision detection
+                        assert(
+                            genVID.calledThrice,
+                            `expected generateVersionId to be called thrice, got ${genVID.callCount} times`,
+                        );
+                        done();
+                    },
+                );
             });
 
             it(`should succeed on version creation after a versionId collision ${variation.it}`, done => {
@@ -400,28 +444,36 @@ describe('MongoClientInterface:metadata.putObjectMD', () => {
                 };
 
                 // simulate a versionId collision by always generating the same versionId
-                const genVID = sinon.stub(VersionID, 'generateVersionId')
-                    .onFirstCall().returns('test-version-id')
-                    .onSecondCall().returns('test-version-id') // trigger collision
-                    .onThirdCall().returns('test-version-id-retry'); // change versionId on retry
+                const genVID = sinon
+                    .stub(VersionID, 'generateVersionId')
+                    .onFirstCall()
+                    .returns('test-version-id')
+                    .onSecondCall()
+                    .returns('test-version-id') // trigger collision
+                    .onThirdCall()
+                    .returns('test-version-id-retry'); // change versionId on retry
 
-                async.series([
-                    // We first create a master and a version
-                    next => metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next),
-                    // We put another version of the object with the same versionId
-                    next => metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next),
-                ], (err, res) => {
-                    assert.ifError(err, `expected no error, got ${err}`);
-                    // make sure the retry triggered on the first collision detection
-                    assert(genVID.calledThrice,
-                        `expected generateVersionId to be called thrice, got ${genVID.callCount} times`);
-                    // make sure the last call returned a different versionId
-                    const vid1 = JSON.parse(res[0]).versionId;
-                    const vid2 = JSON.parse(res[1]).versionId;
-                    assert.notStrictEqual(vid1, vid2,
-                        `expected different versionIds, got ${vid1} and ${vid2}`);
-                    done();
-                });
+                async.series(
+                    [
+                        // We first create a master and a version
+                        next => metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next),
+                        // We put another version of the object with the same versionId
+                        next => metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next),
+                    ],
+                    (err, res) => {
+                        assert.ifError(err, `expected no error, got ${err}`);
+                        // make sure the retry triggered on the first collision detection
+                        assert(
+                            genVID.calledThrice,
+                            `expected generateVersionId to be called thrice, got ${genVID.callCount} times`,
+                        );
+                        // make sure the last call returned a different versionId
+                        const vid1 = JSON.parse(res[0]).versionId;
+                        const vid2 = JSON.parse(res[1]).versionId;
+                        assert.notStrictEqual(vid1, vid2, `expected different versionIds, got ${vid1} and ${vid2}`);
+                        done();
+                    },
+                );
             });
 
             itOnlyInV1(`Should delete master when last version is delete marker ${variation.it}`, done => {
@@ -436,21 +488,25 @@ describe('MongoClientInterface:metadata.putObjectMD', () => {
                     versionId: VERSION_ID,
                     repairMaster: null,
                 };
-                async.series([
-                    // We first create a new version and master
-                    next => metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next),
-                    // putting a delete marker as last version
-                    next => {
-                        objVal.isDeleteMarker = true;
-                        params.versionId = null;
-                        return metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next);
-                    },
-                    // master must be deleted
-                    next => getObject('\x7fMtest-object', err => {
-                        assert.deepStrictEqual(err, errors.NoSuchKey);
-                        return next();
-                    }),
-                ], done);
+                async.series(
+                    [
+                        // We first create a new version and master
+                        next => metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next),
+                        // putting a delete marker as last version
+                        next => {
+                            objVal.isDeleteMarker = true;
+                            params.versionId = null;
+                            return metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next);
+                        },
+                        // master must be deleted
+                        next =>
+                            getObject('\x7fMtest-object', err => {
+                                assert.deepStrictEqual(err, errors.NoSuchKey);
+                                return next();
+                            }),
+                    ],
+                    done,
+                );
             });
 
             itOnlyInV1(`Should create master when new version is put on top of delete marker ${variation.it}`, done => {
@@ -465,32 +521,36 @@ describe('MongoClientInterface:metadata.putObjectMD', () => {
                     versionId: VERSION_ID,
                     repairMaster: null,
                 };
-                async.series([
-                    // We first create a new version and master
-                    next => metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next),
-                    // putting a delete marker as last version
-                    next => {
-                        objVal.isDeleteMarker = true;
-                        params.versionId = null;
-                        return metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next);
-                    },
-                    // We put a new version on top of delete marker
-                    next => {
-                        objVal.isDeleteMarker = false;
-                        objVal.updated = true;
-                        objVal.versionId = null;
-                        return metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next);
-                    },
-                    // master must be created
-                    next => getObject('\x7fMtest-object', (err, object) => {
-                        assert.deepStrictEqual(err, null);
-                        assert.strictEqual(object.key, OBJECT_NAME);
-                        assert.strictEqual(object.updated, true);
-                        assert.strictEqual(object.isDeleteMarker, false);
-                        assert.notEqual(object.versionId, VERSION_ID);
-                        return next();
-                    }),
-                ], done);
+                async.series(
+                    [
+                        // We first create a new version and master
+                        next => metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next),
+                        // putting a delete marker as last version
+                        next => {
+                            objVal.isDeleteMarker = true;
+                            params.versionId = null;
+                            return metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next);
+                        },
+                        // We put a new version on top of delete marker
+                        next => {
+                            objVal.isDeleteMarker = false;
+                            objVal.updated = true;
+                            objVal.versionId = null;
+                            return metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next);
+                        },
+                        // master must be created
+                        next =>
+                            getObject('\x7fMtest-object', (err, object) => {
+                                assert.deepStrictEqual(err, null);
+                                assert.strictEqual(object.key, OBJECT_NAME);
+                                assert.strictEqual(object.updated, true);
+                                assert.strictEqual(object.isDeleteMarker, false);
+                                assert.notEqual(object.versionId, VERSION_ID);
+                                return next();
+                            }),
+                    ],
+                    done,
+                );
             });
 
             itOnlyInV1(`Should not create master when previous version is updated ${variation.it}`, done => {
@@ -505,27 +565,31 @@ describe('MongoClientInterface:metadata.putObjectMD', () => {
                     repairMaster: null,
                     versionId: VERSION_ID,
                 };
-                async.series([
-                    // We first create a new version and master
-                    next => metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next),
-                    // putting a delete marker as last version
-                    next => {
-                        objVal.isDeleteMarker = true;
-                        params.versionId = null;
-                        return metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next);
-                    },
-                    // update previous version
-                    next => {
-                        objVal.isDeleteMarker = false;
-                        objVal.updated = true;
-                        params.versionId = VERSION_ID;
-                        return metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next);
-                    },
-                    next => getObject('\x7fMtest-object', err => {
-                        assert.deepStrictEqual(err, errors.NoSuchKey);
-                        return next();
-                    }),
-                ], done);
+                async.series(
+                    [
+                        // We first create a new version and master
+                        next => metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next),
+                        // putting a delete marker as last version
+                        next => {
+                            objVal.isDeleteMarker = true;
+                            params.versionId = null;
+                            return metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next);
+                        },
+                        // update previous version
+                        next => {
+                            objVal.isDeleteMarker = false;
+                            objVal.updated = true;
+                            params.versionId = VERSION_ID;
+                            return metadata.putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger, next);
+                        },
+                        next =>
+                            getObject('\x7fMtest-object', err => {
+                                assert.deepStrictEqual(err, errors.NoSuchKey);
+                                return next();
+                            }),
+                    ],
+                    done,
+                );
             });
 
             describe(`params.conditions on a version put ${variation.it}`, () => {
@@ -551,15 +615,18 @@ describe('MongoClientInterface:metadata.putObjectMD', () => {
                 ].forEach(({ desc, conditions }) => {
                     it(`should keep the stored version when ${desc} condition is not met ${variation.it}`, async () => {
                         const objVal = {
-                            key: OBJECT_NAME, versionId: VERSION_ID,
-                            number: 24, string: 'twenty-four', nested: { field: 24 },
+                            key: OBJECT_NAME,
+                            versionId: VERSION_ID,
+                            number: 24,
+                            string: 'twenty-four',
+                            nested: { field: 24 },
                         };
                         await putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, baseParams, logger);
                         const newVal = { ...objVal, updated: true };
                         await assert.rejects(
-                            putObjectMD(BUCKET_NAME, OBJECT_NAME, newVal,
-                                { ...baseParams, conditions }, logger),
-                            err => err.is.PreconditionFailed);
+                            putObjectMD(BUCKET_NAME, OBJECT_NAME, newVal, { ...baseParams, conditions }, logger),
+                            err => err.is.PreconditionFailed,
+                        );
                         const object = await getObjectP(versionKey);
                         assert.strictEqual(object.updated, undefined);
                     });
@@ -567,8 +634,10 @@ describe('MongoClientInterface:metadata.putObjectMD', () => {
 
                 it(`should update the version when the condition holds ${variation.it}`, async () => {
                     const objVal = {
-                        key: OBJECT_NAME, versionId: VERSION_ID,
-                        number: 24, string: 'twenty-four',
+                        key: OBJECT_NAME,
+                        versionId: VERSION_ID,
+                        number: 24,
+                        string: 'twenty-four',
                     };
                     await putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, baseParams, logger);
                     const params = {
@@ -612,10 +681,7 @@ describe('MongoClientInterface:metadata.putObjectMD', () => {
                     const firstParams = {
                         ...baseParams,
                         conditions: {
-                            $or: [
-                                { microVersionId: { $exists: false } },
-                                { microVersionId: { $gt: incoming } },
-                            ],
+                            $or: [{ microVersionId: { $exists: false } }, { microVersionId: { $gt: incoming } }],
                         },
                     };
                     const firstVal = { ...initialVal, microVersionId: incoming };

--- a/tests/functional/metadata/mongodb/putObject.spec.js
+++ b/tests/functional/metadata/mongodb/putObject.spec.js
@@ -1,5 +1,6 @@
 const async = require('async');
 const assert = require('assert');
+const { promisify } = require('util');
 const sinon = require('sinon');
 const werelogs = require('werelogs');
 const { MongoMemoryReplSet } = require('mongodb-memory-server');
@@ -8,6 +9,7 @@ const logger = new werelogs.Logger('MongoClientInterface', 'debug', 'debug');
 const BucketInfo = require('../../../../lib/models/BucketInfo').default;
 const MetadataWrapper =
     require('../../../../lib/storage/metadata/MetadataWrapper');
+const { formatVersionKey } = require('../../../../lib/storage/metadata/mongoclient/utils');
 const { VersionID } = require('../../../../lib/versioning');
 const { BucketVersioningKeyFormat } = versioning.VersioningConstants;
 
@@ -524,6 +526,113 @@ describe('MongoClientInterface:metadata.putObjectMD', () => {
                         return next();
                     }),
                 ], done);
+            });
+
+            describe(`params.conditions on a version put ${variation.it}`, () => {
+                let putObjectMD;
+                let getObjectP;
+                let versionKey;
+                const baseParams = {
+                    versioning: true,
+                    versionId: VERSION_ID,
+                    repairMaster: null,
+                };
+
+                beforeEach(() => {
+                    putObjectMD = promisify(metadata.putObjectMD.bind(metadata));
+                    getObjectP = promisify(getObject);
+                    versionKey = formatVersionKey(OBJECT_NAME, VERSION_ID, variation.vFormat);
+                });
+
+                [
+                    { desc: 'a comparison', conditions: { number: { $gt: 42 } } },
+                    { desc: 'an equality', conditions: { string: 'forty-two' } },
+                    { desc: 'a nested field', conditions: { 'nested.field': { $lte: 10 } } },
+                ].forEach(({ desc, conditions }) => {
+                    it(`should keep the stored version when ${desc} condition is not met ${variation.it}`, async () => {
+                        const objVal = {
+                            key: OBJECT_NAME, versionId: VERSION_ID,
+                            number: 24, string: 'twenty-four', nested: { field: 24 },
+                        };
+                        await putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, baseParams, logger);
+                        const newVal = { ...objVal, updated: true };
+                        await assert.rejects(
+                            putObjectMD(BUCKET_NAME, OBJECT_NAME, newVal,
+                                { ...baseParams, conditions }, logger),
+                            err => err.is.PreconditionFailed);
+                        const object = await getObjectP(versionKey);
+                        assert.strictEqual(object.updated, undefined);
+                    });
+                });
+
+                it(`should update the version when the condition holds ${variation.it}`, async () => {
+                    const objVal = {
+                        key: OBJECT_NAME, versionId: VERSION_ID,
+                        number: 24, string: 'twenty-four',
+                    };
+                    await putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, baseParams, logger);
+                    const params = {
+                        ...baseParams,
+                        conditions: { number: { $lt: 42 }, string: 'twenty-four' },
+                    };
+                    const newVal = { ...objVal, updated: true };
+                    await putObjectMD(BUCKET_NAME, OBJECT_NAME, newVal, params, logger);
+                    const object = await getObjectP(versionKey);
+                    assert.strictEqual(object.updated, true);
+                });
+
+                it(`should insert a missing version despite the condition ${variation.it}`, async () => {
+                    const params = { ...baseParams, conditions: { number: { $gt: 42 } } };
+                    const objVal = { key: OBJECT_NAME, versionId: VERSION_ID, number: 24 };
+                    await putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, params, logger);
+                    const object = await getObjectP(versionKey);
+                    assert.strictEqual(object.number, 24);
+                });
+
+                it(`should keep the stored version when the condition references a missing field ${variation.it}`, async () => {
+                    const objVal = { key: OBJECT_NAME, versionId: VERSION_ID };
+                    await putObjectMD(BUCKET_NAME, OBJECT_NAME, objVal, baseParams, logger);
+                    const params = { ...baseParams, conditions: { number: { $gt: 42 } } };
+                    const newVal = { ...objVal, updated: true };
+                    await assert.rejects(
+                        putObjectMD(BUCKET_NAME, OBJECT_NAME, newVal, params, logger),
+                        err => err.is.PreconditionFailed,
+                    );
+                    const object = await getObjectP(versionKey);
+                    assert.strictEqual(object.updated, undefined);
+                });
+
+                it(`should allow write and then reject on same field with $or + $exists ${variation.it}`, async () => {
+                    // Object stored without the tracked field
+                    const initialVal = { key: OBJECT_NAME, versionId: VERSION_ID };
+                    await putObjectMD(BUCKET_NAME, OBJECT_NAME, initialVal, baseParams, logger);
+
+                    // First conditional write: $exists: false matches, so it goes through
+                    const incoming = 'test-micro-version-id';
+                    const firstParams = {
+                        ...baseParams,
+                        conditions: {
+                            $or: [
+                                { microVersionId: { $exists: false } },
+                                { microVersionId: { $gt: incoming } },
+                            ],
+                        },
+                    };
+                    const firstVal = { ...initialVal, microVersionId: incoming };
+                    await putObjectMD(BUCKET_NAME, OBJECT_NAME, firstVal, firstParams, logger);
+                    const afterFirst = await getObjectP(versionKey);
+                    assert.strictEqual(afterFirst.microVersionId, incoming);
+
+                    // Second write with same condition: field now exists and is not > incoming,
+                    // so both $or arms fail → PreconditionFailed
+                    const secondVal = { ...initialVal, microVersionId: incoming, secondWrite: true };
+                    await assert.rejects(
+                        putObjectMD(BUCKET_NAME, OBJECT_NAME, secondVal, firstParams, logger),
+                        err => err.is.PreconditionFailed,
+                    );
+                    const afterSecond = await getObjectP(versionKey);
+                    assert.strictEqual(afterSecond.secondWrite, undefined);
+                });
             });
         });
     });

--- a/tests/unit/storage/metadata/mongoclient/putObject.spec.js
+++ b/tests/unit/storage/metadata/mongoclient/putObject.spec.js
@@ -550,7 +550,8 @@ describe('MongoClientInterface:putObjectVerCase3', () => {
         const putObjectVerCase3 = promisify(client.putObjectVerCase3.bind(client));
         await assert.rejects(
             putObjectVerCase3(collection, 'example-bucket', 'example-object', {}, params, logger),
-            err => err.is.PreconditionFailed);
+            err => err.is.PreconditionFailed,
+        );
     });
 
     it('should return a retryable InternalError when the master op races, even with params.conditions', async () => {
@@ -563,7 +564,8 @@ describe('MongoClientInterface:putObjectVerCase3', () => {
         const putObjectVerCase3 = promisify(client.putObjectVerCase3.bind(client));
         await assert.rejects(
             putObjectVerCase3(collection, 'example-bucket', 'example-object', {}, params, logger),
-            err => err.is.InternalError);
+            err => err.is.InternalError,
+        );
     });
 });
 

--- a/tests/unit/storage/metadata/mongoclient/putObject.spec.js
+++ b/tests/unit/storage/metadata/mongoclient/putObject.spec.js
@@ -12,6 +12,7 @@ jest.mock('@opentelemetry/api', () => ({
 }));
 
 const assert = require('assert');
+const { promisify } = require('util');
 const werelogs = require('werelogs');
 const logger = new werelogs.Logger('MongoClientInterface', 'debug', 'debug');
 const errors = require('../../../../../lib/errors').default;
@@ -518,6 +519,51 @@ describe('MongoClientInterface:putObjectVerCase3', () => {
             assert(res.includes('{"versionId": '));
             return done();
         });
+    });
+
+    it('should apply params.conditions to the version filter', async () => {
+        let capturedOps;
+        const collection = {
+            findOne: () => Promise.resolve({}),
+            bulkWrite: ops => {
+                capturedOps = ops;
+                return Promise.resolve();
+            },
+        };
+        const params = { conditions: { number: { $gt: 42 }, string: 'forty-two' } };
+        const putObjectVerCase3 = promisify(client.putObjectVerCase3.bind(client));
+        await putObjectVerCase3(collection, 'example-bucket', 'example-object', {}, params, logger);
+        assert.deepStrictEqual(capturedOps[0].updateOne.filter, {
+            _id: 'example-version-key',
+            'value.number': { $gt: 42 },
+            'value.string': 'forty-two',
+        });
+    });
+
+    it('should return PreconditionFailed when the existing version does not satisfy params.conditions', async () => {
+        const error = { code: 11000, writeErrors: [{ index: 0 }] };
+        const collection = {
+            findOne: () => Promise.resolve({}),
+            bulkWrite: () => Promise.reject(error),
+        };
+        const params = { conditions: { number: { $gt: 42 } } };
+        const putObjectVerCase3 = promisify(client.putObjectVerCase3.bind(client));
+        await assert.rejects(
+            putObjectVerCase3(collection, 'example-bucket', 'example-object', {}, params, logger),
+            err => err.is.PreconditionFailed);
+    });
+
+    it('should return a retryable InternalError when the master op races, even with params.conditions', async () => {
+        const error = { code: 11000, writeErrors: [{ index: 1 }] };
+        const collection = {
+            findOne: () => Promise.resolve({}),
+            bulkWrite: () => Promise.reject(error),
+        };
+        const params = { conditions: { number: { $gt: 42 } } };
+        const putObjectVerCase3 = promisify(client.putObjectVerCase3.bind(client));
+        await assert.rejects(
+            putObjectVerCase3(collection, 'example-bucket', 'example-object', {}, params, logger),
+            err => err.is.InternalError);
     });
 });
 

--- a/tests/unit/storage/metadata/mongoclient/utils.spec.js
+++ b/tests/unit/storage/metadata/mongoclient/utils.spec.js
@@ -215,6 +215,127 @@ describe('translate query object', () => {
                 },
             },
         ],
+        [
+            'should throw when $exists value is not a boolean',
+            {
+                depth: 0,
+                prefix: 'value',
+                query: { microVersionId: { $exists: 'yes' } },
+                error: errors.InternalError,
+                result: null,
+            },
+        ],
+        [
+            'should translate $exists operator',
+            {
+                depth: 0,
+                prefix: 'value',
+                query: { microVersionId: { $exists: false } },
+                error: null,
+                result: { 'value.microVersionId': { $exists: false } },
+            },
+        ],
+        [
+            'should translate $or with $exists and $gt',
+            {
+                depth: 0,
+                prefix: 'value',
+                query: {
+                    $or: [
+                        { microVersionId: { $exists: false } },
+                        { microVersionId: { $gt: 'abc' } },
+                    ],
+                },
+                error: null,
+                result: {
+                    $or: [
+                        { 'value.microVersionId': { $exists: false } },
+                        { 'value.microVersionId': { $gt: 'abc' } },
+                    ],
+                },
+            },
+        ],
+        [
+            'should translate nested $or',
+            {
+                depth: 0,
+                prefix: 'value',
+                query: {
+                    $or: [
+                        { $or: [{ microVersionId: { $exists: false } }] },
+                    ],
+                },
+                error: null,
+                result: {
+                    $or: [{ $or: [{ 'value.microVersionId': { $exists: false } }] }],
+                },
+            },
+        ],
+        [
+            'should translate $or with mixed plain and nested $or items',
+            {
+                depth: 0,
+                prefix: 'value',
+                query: {
+                    $or: [
+                        { fieldA: { $gt: 1 } },
+                        { $or: [
+                            { fieldB: { $exists: false } },
+                            { fieldC: { $lte: 'xyz' } },
+                        ] },
+                    ],
+                },
+                error: null,
+                result: {
+                    $or: [
+                        { 'value.fieldA': { $gt: 1 } },
+                        { $or: [
+                            { 'value.fieldB': { $exists: false } },
+                            { 'value.fieldC': { $lte: 'xyz' } },
+                        ] },
+                    ],
+                },
+            },
+        ],
+        [
+            'should throw when two sibling fields both contain a structural operator of the same type',
+            {
+                depth: 0,
+                prefix: 'value',
+                query: {
+                    fieldA: { $or: [{ x: 1 }] },
+                    fieldB: { $or: [{ y: 2 }] },
+                },
+                error: errors.InternalError,
+                result: null,
+            },
+        ],
+        [
+            'should throw on empty $or array',
+            {
+                depth: 0,
+                prefix: 'value',
+                query: { $or: [] },
+                error: errors.InternalError,
+                result: null,
+            },
+        ],
+        [
+            'should translate $or nested under a field',
+            {
+                depth: 0,
+                prefix: 'value',
+                query: {
+                    $or: [
+                        { foo: { $or: [{ microVersionId: { $exists: false } }] } },
+                    ],
+                },
+                error: null,
+                result: {
+                    $or: [{ $or: [{ 'value.foo.microVersionId': { $exists: false } }] }],
+                },
+            },
+        ],
     ];
     tests.forEach(([msg, params]) => it(msg, () => {
         const { depth, prefix, query, error, result } = params;

--- a/tests/unit/storage/metadata/mongoclient/utils.spec.js
+++ b/tests/unit/storage/metadata/mongoclient/utils.spec.js
@@ -272,6 +272,26 @@ describe('translate query object', () => {
             },
         ],
         [
+            'should translate $and',
+            {
+                depth: 0,
+                prefix: 'value',
+                query: {
+                    $and: [
+                        { fieldA: { $gt: 1 } },
+                        { fieldB: { $exists: true } },
+                    ],
+                },
+                error: null,
+                result: {
+                    $and: [
+                        { 'value.fieldA': { $gt: 1 } },
+                        { 'value.fieldB': { $exists: true } },
+                    ],
+                },
+            },
+        ],
+        [
             'should translate $or with mixed plain and nested $or items',
             {
                 depth: 0,

--- a/tests/unit/storage/metadata/mongoclient/utils.spec.js
+++ b/tests/unit/storage/metadata/mongoclient/utils.spec.js
@@ -241,17 +241,11 @@ describe('translate query object', () => {
                 depth: 0,
                 prefix: 'value',
                 query: {
-                    $or: [
-                        { microVersionId: { $exists: false } },
-                        { microVersionId: { $gt: 'abc' } },
-                    ],
+                    $or: [{ microVersionId: { $exists: false } }, { microVersionId: { $gt: 'abc' } }],
                 },
                 error: null,
                 result: {
-                    $or: [
-                        { 'value.microVersionId': { $exists: false } },
-                        { 'value.microVersionId': { $gt: 'abc' } },
-                    ],
+                    $or: [{ 'value.microVersionId': { $exists: false } }, { 'value.microVersionId': { $gt: 'abc' } }],
                 },
             },
         ],
@@ -261,9 +255,7 @@ describe('translate query object', () => {
                 depth: 0,
                 prefix: 'value',
                 query: {
-                    $or: [
-                        { $or: [{ microVersionId: { $exists: false } }] },
-                    ],
+                    $or: [{ $or: [{ microVersionId: { $exists: false } }] }],
                 },
                 error: null,
                 result: {
@@ -277,17 +269,11 @@ describe('translate query object', () => {
                 depth: 0,
                 prefix: 'value',
                 query: {
-                    $and: [
-                        { fieldA: { $gt: 1 } },
-                        { fieldB: { $exists: true } },
-                    ],
+                    $and: [{ fieldA: { $gt: 1 } }, { fieldB: { $exists: true } }],
                 },
                 error: null,
                 result: {
-                    $and: [
-                        { 'value.fieldA': { $gt: 1 } },
-                        { 'value.fieldB': { $exists: true } },
-                    ],
+                    $and: [{ 'value.fieldA': { $gt: 1 } }, { 'value.fieldB': { $exists: true } }],
                 },
             },
         ],
@@ -299,20 +285,14 @@ describe('translate query object', () => {
                 query: {
                     $or: [
                         { fieldA: { $gt: 1 } },
-                        { $or: [
-                            { fieldB: { $exists: false } },
-                            { fieldC: { $lte: 'xyz' } },
-                        ] },
+                        { $or: [{ fieldB: { $exists: false } }, { fieldC: { $lte: 'xyz' } }] },
                     ],
                 },
                 error: null,
                 result: {
                     $or: [
                         { 'value.fieldA': { $gt: 1 } },
-                        { $or: [
-                            { 'value.fieldB': { $exists: false } },
-                            { 'value.fieldC': { $lte: 'xyz' } },
-                        ] },
+                        { $or: [{ 'value.fieldB': { $exists: false } }, { 'value.fieldC': { $lte: 'xyz' } }] },
                     ],
                 },
             },
@@ -346,9 +326,7 @@ describe('translate query object', () => {
                 depth: 0,
                 prefix: 'value',
                 query: {
-                    $or: [
-                        { foo: { $or: [{ microVersionId: { $exists: false } }] } },
-                    ],
+                    $or: [{ foo: { $or: [{ microVersionId: { $exists: false } }] } }],
                 },
                 error: null,
                 result: {
@@ -357,17 +335,19 @@ describe('translate query object', () => {
             },
         ],
     ];
-    tests.forEach(([msg, params]) => it(msg, () => {
-        const { depth, prefix, query, error, result } = params;
-        if (error) {
-            const thrower = () => translateConditions(depth, prefix, {}, query);
-            expect(thrower).toThrowError(error.message);
-            return;
-        }
-        const filter = {};
-        translateConditions(depth, prefix, filter, query);
-        assert.deepStrictEqual(filter, result);
-    }));
+    tests.forEach(([msg, params]) =>
+        it(msg, () => {
+            const { depth, prefix, query, error, result } = params;
+            if (error) {
+                const thrower = () => translateConditions(depth, prefix, {}, query);
+                expect(thrower).toThrowError(error.message);
+                return;
+            }
+            const filter = {};
+            translateConditions(depth, prefix, filter, query);
+            assert.deepStrictEqual(filter, result);
+        }),
+    );
 });
 
 describe('object key formating', () => {
@@ -428,7 +408,6 @@ describe('object key formating', () => {
     });
 });
 
-
 describe('Index object transforms', () => {
     const indexObjIn = [
         {
@@ -473,7 +452,7 @@ describe('Index object transforms', () => {
             name: 'index1',
             key: {
                 'value.last-modified': 1,
-                '_id': 1,
+                _id: 1,
             },
         },
         {
@@ -481,7 +460,7 @@ describe('Index object transforms', () => {
             key: {
                 'value.dataStoreName': 1,
                 'value.last-modified': 1,
-                '_id': 1,
+                _id: 1,
             },
         },
     ];
@@ -503,7 +482,6 @@ describe('Index object transforms', () => {
             name: 'index2',
         },
     ];
-
 
     it('should convert index object to mongo index object', done => {
         assert.deepStrictEqual(indexFormatObjectToMongoArray(indexObjIn), mongoIndexObjOut);


### PR DESCRIPTION
Adds params.conditions support to putObjectVerCase3 so a version-specific put
becomes an atomic compare-and-write, failing with PreconditionFailed when the
stored version does not satisfy the condition. 
Needed by CLDSRV-952.

Issue: ARSN-619