### PR TITLE
ARSN-623: guard missing data backend client in protectAzureBlocks

### DIFF
--- a/lib/storage/data/MultipleBackendGateway.js
+++ b/lib/storage/data/MultipleBackendGateway.js
@@ -436,9 +436,22 @@ class MultipleBackendGateway {
 
     protectAzureBlocks(bucketName, objectKey, location, log, cb) {
         const client = this.clients[location];
+
+        // An object can still reference a deleted location
+        if (!client) {
+            log.warn('no data backend client for location, ' + 'skipping azure block protection', {
+                method: 'MultipleBackendGateway.protectAzureBlocks',
+                location,
+                bucketName,
+                objectKey,
+            });
+            return cb();
+        }
+
         if (client.protectAzureBlocks) {
             return client.protectAzureBlocks(this.metadata, bucketName, objectKey, location, log, cb);
         }
+
         return cb();
     }
 

--- a/tests/unit/storage/data/protectAzureBlocks.spec.js
+++ b/tests/unit/storage/data/protectAzureBlocks.spec.js
@@ -1,0 +1,48 @@
+const assert = require('assert');
+
+const MultipleBackendGateway = require('../../../../lib/storage/data/MultipleBackendGateway');
+const DummyRequestLogger = require('../../helpers').DummyRequestLogger;
+
+const bucketName = 'dummybucket';
+const objectKey = 'dummykey';
+const log = new DummyRequestLogger();
+
+describe('MultipleBackendGateway::protectAzureBlocks', () => {
+    it('should not throw when the location has no configured client', done => {
+        const gateway = new MultipleBackendGateway({}, null, null);
+        gateway.protectAzureBlocks(bucketName, objectKey, 'deleted-location', log, err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+
+    it('should skip clients that do not implement protectAzureBlocks', done => {
+        const gateway = new MultipleBackendGateway({ somewhere: {} }, null, null);
+        gateway.protectAzureBlocks(bucketName, objectKey, 'somewhere', log, err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+
+    it('should delegate to the client when it implements protectAzureBlocks', done => {
+        let called = null;
+        const clients = {
+            azurelocation: {
+                protectAzureBlocks: (metadata, bucket, key, location, logger, cb) => {
+                    called = { bucket, key, location };
+                    return cb();
+                },
+            },
+        };
+        const gateway = new MultipleBackendGateway(clients, null, null);
+        gateway.protectAzureBlocks(bucketName, objectKey, 'azurelocation', log, err => {
+            assert.ifError(err);
+            assert.deepStrictEqual(called, {
+                bucket: bucketName,
+                key: objectKey,
+                location: 'azurelocation',
+            });
+            done();
+        });
+    });
+});


### PR DESCRIPTION
Issue: [ARSN-623](https://scality.atlassian.net/browse/ARSN-623)

## Problem

`MultipleBackendGateway.protectAzureBlocks()` dereferences `this.clients[location]` without checking that the client exists:

```js
const client = this.clients[location];
if (client.protectAzureBlocks) {   // TypeError when client is undefined
```

The `if` guards whether the client *implements* the method, but never whether it *exists*.

When a location is removed from the config overlay, objects that still reference it keep `dataStoreName` pointing at it, and `cloudserver/lib/data/wrapper.js` rebuilds the clients map without it. Deleting one of those objects then throws a `TypeError`, which crosses an `async` callback that has already fired, becomes `Error: Callback was already called.`, is raised as an `unhandledRejection` — and Node exits the process.

**Impact observed in the field:** a single `delete-objects` call took every cloudserver pod into CrashLoopBackOff and the ARTESCA S3 endpoint fully offline, because each client retry landed on and killed a fresh pod. Found during the IronMountain XDM scale campaign (OS-1095) on ARTESCA 4.3.0-rc2 / `cloudserver:9.3.9` with arsenal 8.4.4.

This is not Azure-specific: `protectAzureBlocks` runs on the shared object-delete path for **every** delete when `backends.data === 'multiple'` (the Zenko/XDM default). The Azure logic is inside the client, past the lookup that crashes.

## Change

Return early when no client is configured for the location, and log it. Skipping is correct here — the call exists only to protect Azure blocks, and a location with no configured client cannot be an Azure backend.

[ARSN-623]: https://scality.atlassian.net/browse/ARSN-623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ