### PR TITLE
ARSN-626: bump sproxydclient to 8.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "engines": {
         "node": ">=20"
     },
-    "version": "8.4.23",
+    "version": "8.4.24",
     "config": {
         "mongodbMemoryServer": {
             "version": "8.0.23"
@@ -66,7 +66,7 @@
         "simple-glob": "^0.2.0",
         "socket.io": "^4.8.0",
         "socket.io-client": "^4.8.0",
-        "sproxydclient": "github:scality/sproxydclient#8.2.1",
+        "sproxydclient": "github:scality/sproxydclient#8.2.2",
         "utf8": "^3.0.0",
         "uuid": "^10.0.0",
         "werelogs": "scality/werelogs#8.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8172,9 +8172,9 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
-"sproxydclient@github:scality/sproxydclient#8.2.1":
-  version "8.2.1"
-  resolved "https://codeload.github.com/scality/sproxydclient/tar.gz/501829f5521787e7e946de6792f5806ffa6ec437"
+"sproxydclient@github:scality/sproxydclient#8.2.2":
+  version "8.2.2"
+  resolved "https://codeload.github.com/scality/sproxydclient/tar.gz/62d3aac1c844beda2286f33a1a7c7f2a31937579"
   dependencies:
     async "^3.2.6"
     httpagent "github:scality/httpagent#1.1.0"


### PR DESCRIPTION
sproxyd now answers DELETE and batch-delete requests with 204 No Content. The sproxyd client Arsenal depends on only accepted 200 and 206 as success, so those replies were treated as failures, retried, and eventually surfaced to callers as internal errors. This picks up the client version that accepts any 2xx, so deletes succeed again.